### PR TITLE
HEC-392: Replace inline string transforms with naming helpers

### DIFF
--- a/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
@@ -86,7 +86,7 @@ module Hecks
         if req.path == "/events"
           # SSE not supported in basic WEBrick — return event list instead
           res["Content-Type"] = "application/json"
-          res.body = JSON.generate(@app.events.map { |e| { type: e.class.name.split("::").last, occurred_at: e.occurred_at.iso8601 } })
+          res.body = JSON.generate(@app.events.map { |e| { type: Hecks::Utils.const_short_name(e), occurred_at: e.occurred_at.iso8601 } })
           return
         end
 

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -158,7 +158,7 @@ module Hecks
       end
 
       def humanize(name)
-        name.to_s.split("_").map(&:capitalize).join(" ")
+        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(name))
       end
 
       def match?(pattern, path)

--- a/hecks_workshop/lib/hecks/workshop/playground.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground.rb
@@ -80,7 +80,7 @@ module Hecks
 
       event = @events.last
       if event
-        event_name = event.class.name.split("::").last
+        event_name = Hecks::Utils.const_short_name(event)
         puts "Command: #{command_name}"
         puts "  Event: #{event_name}"
         attrs.each { |k, v| puts "    #{k}: #{v.inspect}" }
@@ -114,7 +114,7 @@ module Hecks
     # @param type_name [String] the event class name (e.g. "CreatedPizza")
     # @return [Array] events whose class name matches
     def events_of(type_name)
-      @events.select { |e| e.class.name.split("::").last == type_name }
+      @events.select { |e| Hecks::Utils.const_short_name(e) == type_name }
     end
 
     # Clear all captured events and repository data.
@@ -144,7 +144,7 @@ module Hecks
       end
 
       @events.each_with_index do |event, i|
-        name = event.class.name.split("::").last
+        name = Hecks::Utils.const_short_name(event)
         puts "#{i + 1}. #{name} at #{event.occurred_at}"
       end
       nil

--- a/hecks_workshop/lib/hecks/workshop/playground/runtime_resolver.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground/runtime_resolver.rb
@@ -108,7 +108,7 @@ module Hecks
         # @param event [Object] an event instance with a class name like "PizzasDomain::Pizza::Events::CreatedPizza"
         # @return [Array<DomainModel::Structure::Policy>] policies triggered by this event
         def check_policies(event)
-          event_name = event.class.name.split("::").last
+          event_name = Hecks::Utils.const_short_name(event)
           @policies.select { |p| p.event_name == event_name }
         end
       end

--- a/hecks_workshop/lib/hecks/workshop/web_runner/state_serializer.rb
+++ b/hecks_workshop/lib/hecks/workshop/web_runner/state_serializer.rb
@@ -187,7 +187,7 @@ module Hecks
               next if %i[occurred_at aggregate_id].include?(m)
               attrs[m] = e.send(m).inspect rescue nil
             end
-            event_name = e.class.name.split("::").last
+            event_name = Hecks::Utils.const_short_name(e)
             command_name = event_name
               .sub(/\ACanceled/, "Cancel")
               .sub(/\ACreated/, "Create")

--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -126,6 +126,6 @@ module Hecks::Conventions
     end
 
     # Go field name helper — PascalCase.
-    GoFieldName = ->(name) { name.to_s.split("_").map(&:capitalize).join }
+    GoFieldName = ->(name) { Hecks::Utils.sanitize_constant(name) }
   end
 end

--- a/hecksties/lib/hecks/conventions/view_contract.rb
+++ b/hecksties/lib/hecks/conventions/view_contract.rb
@@ -14,7 +14,7 @@ module Hecks::Conventions
     # Maps a snake_case field name to a Go PascalCase name.
     # Centralizes the naming rule so templates and structs agree.
     def self.go_name(field)
-      field.to_s.split("_").map(&:capitalize).join
+      Hecks::Utils.sanitize_constant(field)
     end
 
     # Display conventions shared by all targets.

--- a/hecksties/lib/hecks/errors.rb
+++ b/hecksties/lib/hecks/errors.rb
@@ -36,7 +36,7 @@ module Hecks
     #
     # @return [Hash] with :error (class name) and :message keys
     def as_json
-      { error: self.class.name.split("::").last, message: message }
+      { error: Hecks::Utils.const_short_name(self), message: message }
     end
 
     # Returns a JSON string representation of this error.

--- a/hecksties/lib/hecks/extensions/audit.rb
+++ b/hecksties/lib/hecks/extensions/audit.rb
@@ -56,7 +56,7 @@ class HecksAudit
   # @return [Object] the return value of +next_handler.call+
   def around_command(command, next_handler, actor: nil, tenant: nil)
     @pending_context = {
-      command: command.class.name.split("::").last,
+      command: Hecks::Utils.const_short_name(command),
       actor: actor,
       tenant: tenant
     }
@@ -94,7 +94,7 @@ class HecksAudit
       actor: @pending_context&.dig(:actor),
       tenant: @pending_context&.dig(:tenant),
       timestamp: Time.now,
-      event_name: event.class.name.split("::").last,
+      event_name: Hecks::Utils.const_short_name(event),
       event_data: extract_attrs(event)
     }
     @pending_context = nil

--- a/hecksties/lib/hecks/extensions/auth.rb
+++ b/hecksties/lib/hecks/extensions/auth.rb
@@ -59,10 +59,10 @@ Hecks.register_extension(:auth) do |domain_mod, domain, runtime|
 
     if required_roles
       actor = Hecks.actor
-      raise Hecks::Unauthenticated, "No actor set. Call Hecks.actor = user before running #{command.class.name.split('::').last}" unless actor
+      raise Hecks::Unauthenticated, "No actor set. Call Hecks.actor = user before running #{Hecks::Utils.const_short_name(command)}" unless actor
       role = actor.respond_to?(:role) ? actor.role.to_s : actor.to_s
       unless required_roles.include?(role)
-        raise Hecks::Unauthorized, "Actor '#{role}' is not authorized for #{command.class.name.split('::').last}. Required: #{required_roles.join(', ')}"
+        raise Hecks::Unauthorized, "Actor '#{role}' is not authorized for #{Hecks::Utils.const_short_name(command)}. Required: #{required_roles.join(', ')}"
       end
     end
 

--- a/hecksties/lib/hecks/extensions/logging.rb
+++ b/hecksties/lib/hecks/extensions/logging.rb
@@ -35,7 +35,7 @@ Hecks.register_extension(:logging) do |_domain_mod, _domain, runtime|
   # @param next_handler [#call] the next handler in the middleware chain
   # @return [Object] the return value of +next_handler.call+
   runtime.use :logging do |command, next_handler|
-    cmd_name = command.class.name.split("::").last
+    cmd_name = Hecks::Utils.const_short_name(command)
     actor = Hecks.actor&.respond_to?(:role) ? Hecks.actor.role : nil
     tenant = Hecks.tenant
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/hecksties/lib/hecks/extensions/queue.rb
+++ b/hecksties/lib/hecks/extensions/queue.rb
@@ -35,7 +35,7 @@ Hecks.register_extension(:queue) do |domain_mod, domain, runtime|
   queue_adapter = resolve_queue_adapter(adapter, domain)
 
   runtime.event_bus.on_any do |event|
-    event_name = event.class.name.split("::").last
+    event_name = Hecks::Utils.const_short_name(event)
     occurred = event.respond_to?(:occurred_at) ? event.occurred_at.iso8601 : Time.now.iso8601
     payload = { event: event_name, domain: domain.name, occurred_at: occurred }
 

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -86,7 +86,7 @@ module Hecks
         if req.path == "/events"
           # SSE not supported in basic WEBrick — return event list instead
           res["Content-Type"] = "application/json"
-          res.body = JSON.generate(@app.events.map { |e| { type: e.class.name.split("::").last, occurred_at: e.occurred_at.iso8601 } })
+          res.body = JSON.generate(@app.events.map { |e| { type: Hecks::Utils.const_short_name(e), occurred_at: e.occurred_at.iso8601 } })
           return
         end
 

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -158,7 +158,7 @@ module Hecks
       end
 
       def humanize(name)
-        name.to_s.split("_").map(&:capitalize).join(" ")
+        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(name))
       end
 
       def match?(pattern, path)

--- a/hecksties/lib/hecks/extensions/slack.rb
+++ b/hecksties/lib/hecks/extensions/slack.rb
@@ -27,7 +27,7 @@ Hecks.register_extension(:slack) do |domain_mod, domain, runtime|
   next unless webhook
 
   runtime.event_bus.on_any do |event|
-    event_name = event.class.name.split("::").last
+    event_name = Hecks::Utils.const_short_name(event)
     occurred = event.respond_to?(:occurred_at) ? event.occurred_at.iso8601 : Time.now.iso8601
     payload = { text: "[#{domain.name}] #{event_name} at #{occurred}" }
 

--- a/hecksties/lib/hecks/ports/event_bus/event_bus.rb
+++ b/hecksties/lib/hecks/ports/event_bus/event_bus.rb
@@ -69,7 +69,7 @@ module Hecks
       # @return [void]
       def publish(event)
         @events << event
-        event_name = event.class.name.split("::").last
+        event_name = Hecks::Utils.const_short_name(event)
         @listeners[event_name].each { |handler| handler.call(event) }
         @global_listeners.each { |handler| handler.call(event) }
       end

--- a/hecksties/lib/hecks/ports/repository/event_recorder.rb
+++ b/hecksties/lib/hecks/ports/repository/event_recorder.rb
@@ -49,7 +49,7 @@ module Hecks
 
           @db[:domain_events].insert(
             stream_id: stream_id,
-            event_type: event.class.name.split("::").last,
+            event_type: Hecks::Utils.const_short_name(event),
             data: serialize_event(event),
             occurred_at: event.occurred_at.iso8601,
             version: version

--- a/hecksties/lib/hecks/smoke/smoke_test.rb
+++ b/hecksties/lib/hecks/smoke/smoke_test.rb
@@ -193,9 +193,7 @@ module HecksTemplating
     end
 
     def underscore(str)
-      str.to_s.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-         .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-         .downcase
+      Hecks::Utils.underscore(str)
     end
   end
 end

--- a/hecksties/lib/hecks/utils.rb
+++ b/hecksties/lib/hecks/utils.rb
@@ -121,6 +121,25 @@ module Hecks
          .downcase
     end
 
+    # Extracts the short class name from a fully-qualified constant path.
+    # Works with both string names and objects/classes.
+    #
+    # @param obj [String, Class, Object] a constant name, class, or instance
+    # @return [String] the last component (e.g., "CreatedPizza")
+    #
+    # @example
+    #   const_short_name("PizzasDomain::Pizza::Events::CreatedPizza")  # => "CreatedPizza"
+    #   const_short_name(PizzasDomain::Pizza)                          # => "Pizza"
+    #   const_short_name(some_event)                                   # => "PlacedOrder"
+    def const_short_name(obj)
+      name = case obj
+             when String then obj
+             when Class, Module then obj.name
+             else obj.class.name
+             end
+      name.to_s.split("::").last
+    end
+
     # Returns a human-readable type label for a domain attribute.
     # Wraps list and reference types in descriptive notation.
     #

--- a/hecksties/lib/hecks_cli/cli.rb
+++ b/hecksties/lib/hecks_cli/cli.rb
@@ -33,7 +33,7 @@ module Hecks
     # hecks_workshop → "Workshop", hecks_cli/commands/build.rb → "Cli"
     def self.infer_group(path)
       if path =~ /hecks_(\w+)/
-        $1.split("_").map(&:capitalize).join(" ")
+        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant($1))
       else
         "Commands"
       end

--- a/hecksties/lib/hecks_cli/commands/info.rb
+++ b/hecksties/lib/hecks_cli/commands/info.rb
@@ -61,7 +61,7 @@ Hecks::CLI.register_command(:info, "Show auto-wiring details for this project") 
     return if files.empty?
     say "Services (#{files.size}):", :green
     files.each do |f|
-      name = File.basename(f, ".rb").split("_").map(&:capitalize).join
+      name = Hecks::Utils.sanitize_constant(File.basename(f, ".rb"))
       say "  #{name}"
     end
     say ""

--- a/hecksties/lib/hecks_cli/commands/init.rb
+++ b/hecksties/lib/hecks_cli/commands/init.rb
@@ -4,7 +4,7 @@ Hecks::CLI.register_command(:init, "Initialize a Hecks domain in the current dir
   },
   args: ["NAME"]
 ) do |name = nil|
-  name ||= File.basename(Dir.pwd).split(/[_\-\s]/).map(&:capitalize).join
+  name ||= Hecks::Utils.sanitize_constant(File.basename(Dir.pwd))
   write_or_diff("#{name}Bluebook", domain_template(name))
   write_or_diff("verbs.txt", "# Add custom action verbs here (one per line)\n# WordNet handles most English verbs automatically\n")
   write_or_diff(".hecks_version", "")

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -1,7 +1,7 @@
 Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
   args: ["NAME"]
 ) do |name|
-  pascal = name.split(/[_\-\s]/).map(&:capitalize).join
+  pascal = Hecks::Utils.sanitize_constant(name)
   dir = name
 
   if File.exist?(dir)

--- a/hecksties/lib/hecks_cli/import.rb
+++ b/hecksties/lib/hecks_cli/import.rb
@@ -16,7 +16,7 @@ module Hecks
     def self.from_rails(app_path, domain_name: nil)
       schema_path = File.join(app_path, "db", "schema.rb")
       models_dir  = File.join(app_path, "app", "models")
-      domain_name ||= File.basename(File.expand_path(app_path)).split(/[-_]/).map(&:capitalize).join
+      domain_name ||= Hecks::Utils.sanitize_constant(File.basename(File.expand_path(app_path)))
 
       schema_data = SchemaParser.new(schema_path).parse
       model_data  = File.directory?(models_dir) ? ModelParser.new(models_dir).parse : {}

--- a/hecksties/lib/hecks_multidomain/cross_domain_view.rb
+++ b/hecksties/lib/hecks_multidomain/cross_domain_view.rb
@@ -88,7 +88,7 @@ module Hecks
     #   is used to find the matching projection
     # @return [void]
     def apply(event)
-      event_name = event.class.name.split("::").last
+      event_name = Hecks::Utils.const_short_name(event)
       projection = @projections[event_name]
       @state = projection.call(event, @state) if projection
     end


### PR DESCRIPTION
## Summary

- Add `Hecks::Utils.const_short_name` for extracting short class names from fully-qualified constants
- Replace 17 occurrences of `.class.name.split("::").last` across extensions, ports, and workshop
- Replace 5 inline PascalCase conversions in CLI with `Utils.sanitize_constant`
- Replace duplicate `underscore` implementation in smoke_test with `Utils.underscore`
- Replace `GoFieldName` lambda and `view_contract.go_name` with `sanitize_constant`
- Replace humanize inlines in multi_domain servers with `Utils.humanize`

## Test plan

- [x] All 1170 specs pass (0.83s)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] Multi-domain example works (`ruby -Ilib examples/multi_domain/app.rb`)
- [x] No remaining inline transforms in lib/ (only `event_log_contract.rb` which generates code strings)