### PR TITLE
HEC-373: Command dry-run mode

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -112,6 +112,8 @@
 - `app.use { }` — register command bus middleware
 - `Hecks.boot(__dir__)` auto-detects multi-domain when `bluebook/` has multiple Bluebook files
 - `Hecks.shared_event_bus` — access the shared cross-domain event bus after multi-domain boot
+- `app.dry_run("CommandName", attrs)` — preview command result without side effects (no persist, no events)
+- Dry-run validates guards, preconditions, postconditions and traces the reactive policy chain
 
 ## Code Generation
 

--- a/docs/usage/dry_run.md
+++ b/docs/usage/dry_run.md
@@ -1,0 +1,67 @@
+# Command Dry-Run Mode
+
+Preview what a command would do — without persisting state or firing events.
+
+## Usage
+
+```ruby
+require "hecks"
+app = Hecks.boot(__dir__)
+
+result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+
+result.valid?          # => true
+result.aggregate.name  # => "Margherita"
+result.event           # => #<PizzasDomain::Pizza::Events::CreatedPizza ...>
+result.event.name      # => "Margherita"
+```
+
+## What it checks
+
+Dry-run executes the full validation pipeline:
+
+1. **Guards** — authorization policies (raises `GuardRejected`)
+2. **Handler** — optional handler callback
+3. **Preconditions** — business rule checks (raises `PreconditionError`)
+4. **Call** — domain logic that builds the aggregate
+5. **Postconditions** — before/after state assertions (raises `PostconditionError`)
+
+## What it skips
+
+- Persist — no `repository.save`
+- Emit — no `event_bus.publish`
+- Record — no event recorder entry
+
+## Reactive chain preview
+
+Dry-run traces which policies would fire and what downstream commands they'd trigger:
+
+```ruby
+result = app.dry_run("PlaceOrder", pizza: pizza_id, quantity: 3)
+
+result.triggers_policies?  # => true
+result.reactive_chain
+# => [{type: :policy, policy: "NotifyKitchen", event: "PlacedOrder",
+#      command: "NotifyChef", aggregate: "Order"}]
+```
+
+## Error handling
+
+Validation errors raise normally — rescue them to inspect failures:
+
+```ruby
+begin
+  app.dry_run("ApproveLoan", loan_id: "123")
+rescue Hecks::GuardRejected => e
+  puts "Not authorized: #{e.message}"
+rescue Hecks::PreconditionError => e
+  puts "Precondition failed: #{e.message}"
+end
+```
+
+## Use cases
+
+- Form validation before submit
+- Approval workflow previews
+- What-if analysis ("what would happen if I run this?")
+- CI/CD pipeline checks

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -134,6 +134,7 @@ module Hecks
   end
 
   # Runtime and port components
+  autoload :DryRunResult,      "hecks/dry_run_result"
   autoload :Runtime,           "hecks/runtime"
   autoload :Application,       "hecks/runtime"
   # PortWiring is included directly in Runtime, no autoload needed

--- a/hecksties/lib/hecks/dry_run_result.rb
+++ b/hecksties/lib/hecks/dry_run_result.rb
@@ -1,0 +1,40 @@
+# = Hecks::DryRunResult
+#
+# Value object returned by +Runtime#dry_run+. Contains the aggregate
+# and event that WOULD result from executing a command, plus the
+# reactive chain of policies that WOULD fire — without any side effects.
+#
+#   result = app.dry_run("CreatePizza", name: "Margherita")
+#   result.valid?             # => true
+#   result.aggregate.name     # => "Margherita"
+#   result.event              # => #<CreatedPizza ...>
+#   result.reactive_chain     # => [{type: :policy, ...}]
+#   result.triggers_policies? # => true
+#
+module Hecks
+  class DryRunResult
+    attr_reader :command, :aggregate, :event, :reactive_chain
+
+    def initialize(command:, aggregate:, event:, reactive_chain: [])
+      @command = command
+      @aggregate = aggregate
+      @event = event
+      @reactive_chain = reactive_chain
+    end
+
+    def valid?
+      true
+    end
+
+    def triggers_policies?
+      reactive_chain.any? { |s| s[:type] == :policy }
+    end
+
+    def inspect
+      cmd = Hecks::Utils.const_short_name(command)
+      evt = Hecks::Utils.const_short_name(event)
+      policies = reactive_chain.select { |s| s[:type] == :policy }.map { |s| s[:policy] }
+      "#<DryRunResult command=#{cmd} event=#{evt} policies=#{policies}>"
+    end
+  end
+end

--- a/hecksties/lib/hecks/mixins/command.rb
+++ b/hecksties/lib/hecks/mixins/command.rb
@@ -150,6 +150,19 @@ module Hecks
       def lifecycle_pipeline
         Command::LifecycleSteps::PIPELINE
       end
+
+      # Runs the command through validation steps (guard, precondition, call,
+      # postcondition) without persisting, emitting, or recording. Builds the
+      # event that would have been emitted and attaches it to the command.
+      #
+      # @param attrs [Hash] command attributes
+      # @return [self] the command instance with +#aggregate+ and +#event+ populated
+      def dry_call(**attrs)
+        cmd = new(**attrs)
+        Command::LifecycleSteps::DRY_RUN_PIPELINE.each { |step| step.call(cmd) }
+        cmd.instance_variable_set(:@event, cmd.send(:build_event))
+        cmd
+      end
     end
 
     # Chain commands fluently. Yields self to block, returns the block's
@@ -312,12 +325,12 @@ module Hecks
       repository.save(aggregate)
     end
 
-    # Builds and emits the event declared via +emits+. Introspects the event
-    # class constructor to map command attributes and aggregate attributes
-    # into event parameters. Publishes the event on the event bus.
+    # Constructs the event declared via +emits+ without publishing it.
+    # Introspects the event class constructor to map command and aggregate
+    # attributes into event parameters.
     #
     # @return [Object] the constructed event instance
-    def emit_event
+    def build_event
       event_class = self.class.event_class
       event_params = event_class.instance_method(:initialize).parameters.map { |_, n| n }
       attrs = {}
@@ -330,7 +343,14 @@ module Hecks
           attrs[param] = aggregate.send(param)
         end
       end
-      @event = event_class.new(**attrs)
+      event_class.new(**attrs)
+    end
+
+    # Builds and publishes the event on the event bus.
+    #
+    # @return [Object] the constructed event instance
+    def emit_event
+      @event = build_event
       self.class.event_bus&.publish(@event)
       @event
     end

--- a/hecksties/lib/hecks/mixins/command/lifecycle_steps.rb
+++ b/hecksties/lib/hecks/mixins/command/lifecycle_steps.rb
@@ -59,6 +59,10 @@ module Hecks
         GuardStep, HandlerStep, PreconditionStep, CallStep,
         PostconditionStep, PersistStep, EmitStep, RecordStep
       ].freeze
+
+      DRY_RUN_PIPELINE = [
+        GuardStep, HandlerStep, PreconditionStep, CallStep, PostconditionStep
+      ].freeze
     end
   end
 end

--- a/hecksties/lib/hecks/ports/commands/command_bus.rb
+++ b/hecksties/lib/hecks/ports/commands/command_bus.rb
@@ -107,7 +107,7 @@ module Hecks
       def dispatch(command_name, **attrs)
         agg_def, cmd_def, event_def = resolve(command_name)
 
-        cmd_class = resolve_command_class(agg_def.name, command_name)
+        cmd_class = resolve_class(agg_def.name, command_name)
         command = cmd_class.new(**attrs)
 
         # Build the innermost handler — creates and publishes the event
@@ -129,6 +129,15 @@ module Hecks
         chain.call
       end
 
+      # Resolves a command name to its Ruby class. Used by dry_run.
+      #
+      # @param command_name [String] the command name (e.g., "CreatePizza")
+      # @return [Class] the command class
+      def resolve_command_class(command_name)
+        agg_def, _, _ = resolve(command_name)
+        resolve_class(agg_def.name, command_name)
+      end
+
       private
 
       # Resolves a command name to its aggregate, command, and event definitions.
@@ -148,12 +157,10 @@ module Hecks
         raise "Unknown command: #{command_name}. Available: #{available.join(', ')}"
       end
 
-      # Resolves the Ruby command class from the domain module namespace.
-      #
       # @param agg_name [String] the aggregate name (e.g., "Pizza")
       # @param command_name [String, Symbol] the command name (e.g., "CreatePizza")
-      # @return [Class] the command class (e.g., +PizzasDomain::Pizza::Commands::CreatePizza+)
-      def resolve_command_class(agg_name, command_name)
+      # @return [Class] the command class
+      def resolve_class(agg_name, command_name)
         agg_mod = @mod.const_get(agg_name)
         agg_mod::Commands.const_get(command_name)
       end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -138,6 +138,25 @@ module Hecks
         @command_bus.dispatch(command_name, **attrs)
       end
 
+      # Preview what a command would do without persisting, emitting, or recording.
+      # Runs guards, preconditions, the call body, and postconditions. Returns a
+      # DryRunResult with the aggregate, event, and reactive chain that would fire.
+      #
+      #   result = app.dry_run("CreatePizza", name: "Margherita")
+      #   result.aggregate.name  # => "Margherita"
+      #   result.event           # => #<CreatedPizza ...>
+      #
+      # @param command_name [String] the command name (e.g., "CreatePizza")
+      # @param attrs [Hash] the command attributes
+      # @return [Hecks::DryRunResult]
+      # @raise [Hecks::GuardRejected, Hecks::PreconditionError, Hecks::PostconditionError]
+      def dry_run(command_name, **attrs)
+        cmd_class = @command_bus.resolve_command_class(command_name)
+        cmd = cmd_class.dry_call(**attrs)
+        chain = trace_reactive_chain(command_name)
+        DryRunResult.new(command: cmd, aggregate: cmd.aggregate, event: cmd.event, reactive_chain: chain)
+      end
+
       # Register an async handler for policies marked +async: true+ in the DSL.
       # The handler receives an event and is responsible for scheduling deferred work
       # (e.g., enqueuing a background job).
@@ -228,6 +247,14 @@ module Hecks
           domain: @domain,
           event_bus: @event_bus
         )
+      end
+
+      def trace_reactive_chain(command_name)
+        return [] unless defined?(Hecks::FlowGenerator)
+        flows = Hecks::FlowGenerator.new(@domain).trace_flows
+        flow = flows.find { |f| f[:steps]&.first&.dig(:command) == command_name.to_s }
+        return [] unless flow
+        flow[:steps].drop(1)
       end
     end
 

--- a/hecksties/spec/runtime/dry_run_spec.rb
+++ b/hecksties/spec/runtime/dry_run_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+RSpec.describe "Runtime#dry_run" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :style, String
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :style, String
+        end
+      end
+
+      aggregate "Order" do
+        reference_to "Pizza"
+        attribute :quantity, Integer
+
+        command "PlaceOrder" do
+          reference_to "Pizza"
+          attribute :quantity, Integer
+        end
+
+        command "NotifyChef" do
+          reference_to "Pizza"
+        end
+
+        policy "NotifyKitchen" do
+          on "PlacedOrder"
+          trigger "NotifyChef"
+        end
+      end
+    end
+  end
+
+  subject(:app) { Hecks.load(domain) }
+
+  after { Hecks::Utils.cleanup_constants! }
+
+  describe "basic dry run" do
+    it "returns a DryRunResult" do
+      result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(result).to be_a(Hecks::DryRunResult)
+    end
+
+    it "reports valid" do
+      result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(result.valid?).to be true
+    end
+
+    it "populates aggregate" do
+      result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(result.aggregate.name).to eq("Margherita")
+      expect(result.aggregate.style).to eq("Classic")
+    end
+
+    it "populates event" do
+      result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(result.event).to be_a(PizzasDomain::Pizza::Events::CreatedPizza)
+      expect(result.event.name).to eq("Margherita")
+    end
+  end
+
+  describe "no side effects" do
+    it "does not persist the aggregate" do
+      app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(app["Pizza"].all).to be_empty
+    end
+
+    it "does not publish events" do
+      app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(app.events).to be_empty
+    end
+  end
+
+  describe "reactive chain" do
+    it "traces downstream policies for PlaceOrder" do
+      result = app.dry_run("PlaceOrder", pizza: "fake-id", quantity: 3)
+      expect(result.triggers_policies?).to be true
+      policy_names = result.reactive_chain.select { |s| s[:type] == :policy }.map { |s| s[:policy] }
+      expect(policy_names).to include("NotifyKitchen")
+    end
+
+    it "returns empty chain when no policies react" do
+      result = app.dry_run("CreatePizza", name: "Margherita", style: "Classic")
+      expect(result.triggers_policies?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `app.dry_run("CreatePizza", name: "Margherita")` previews command results without side effects
- Runs full validation pipeline (guards, preconditions, call, postconditions)
- Skips persist, emit, and record steps
- Traces reactive policy chain via FlowGenerator
- Returns `DryRunResult` with aggregate, event, and reactive chain

## Test plan

- [x] 8 new specs covering basic usage, no side effects, reactive chain, empty chain
- [x] Full suite: 1178 examples, 0 failures (0.8s)
- [x] Smoke test passes