### PR TITLE
HEC-387: Add MongoDB persistence adapter

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -73,6 +73,7 @@
 - `hecks_postgres` — PostgreSQL persistence
 - `hecks_mysql` — MySQL persistence
 - `hecks_cqrs` — named persistence connections for read/write separation
+- `hecks_mongodb` — MongoDB document persistence via the mongo Ruby driver
 
 ### Server Extensions
 - `hecks_serve` registers `:http` — adds `CatsDomain.serve(port: 9292)`

--- a/docs/usage/mongodb_adapter.md
+++ b/docs/usage/mongodb_adapter.md
@@ -1,0 +1,74 @@
+# MongoDB Persistence Adapter
+
+Store aggregates as MongoDB documents instead of in-memory hashes or SQL rows.
+
+## Setup
+
+Add the mongo gem to your Gemfile:
+
+```ruby
+gem "mongo"
+```
+
+## Usage
+
+### Default connection (localhost:27017/hecks)
+
+```ruby
+app = Hecks.boot(__dir__, adapter: :mongodb)
+```
+
+### Custom connection
+
+```ruby
+app = Hecks.boot(__dir__, adapter: {
+  type: :mongodb,
+  uri: "mongodb://user:pass@host:27017",
+  database: "my_app"
+})
+```
+
+## How it works
+
+Each aggregate maps to a MongoDB collection (pluralized snake_case):
+- `Pizza` → `pizzas` collection
+- `GovernancePolicy` → `governance_policies` collection
+
+Documents use `_id` as the aggregate UUID. All scalar attributes are stored as top-level fields.
+
+## Repository interface
+
+The generated `MongoRepository` implements the same interface as the memory adapter:
+
+```ruby
+app["Pizza"].find(id)           # find by UUID
+app["Pizza"].save(pizza)        # upsert (insert or replace)
+app["Pizza"].delete(id)         # delete by UUID
+app["Pizza"].all                # all documents
+app["Pizza"].count              # document count
+app["Pizza"].clear              # delete all
+app["Pizza"].query(             # filtered query
+  conditions: { style: "Classic" },
+  order_key: :name,
+  order_direction: :asc,
+  limit: 10,
+  offset: 0
+)
+```
+
+## Switching adapters
+
+You can swap between memory, SQL, and MongoDB at any time:
+
+```ruby
+# Memory (default)
+app = Hecks.boot(__dir__)
+
+# SQLite
+app = Hecks.boot(__dir__, adapter: :sqlite)
+
+# MongoDB
+app = Hecks.boot(__dir__, adapter: :mongodb)
+```
+
+The domain code is identical — only the adapter wiring changes.

--- a/hecksagon/lib/hecks_mongodb.rb
+++ b/hecksagon/lib/hecks_mongodb.rb
@@ -1,0 +1,15 @@
+# = HecksMongodb
+#
+# MongoDB persistence adapter for Hecks domains. Provides document-based
+# repository adapters using the mongo Ruby driver. Each aggregate maps
+# to a MongoDB collection.
+#
+# == Usage
+#
+#   app = Hecks.boot(__dir__, adapter: :mongodb)
+#   app = Hecks.boot(__dir__, adapter: { type: :mongodb, uri: "mongodb://localhost:27017/mydb" })
+#
+require "hecks_mongodb/mongo_boot"
+require "hecks_mongodb/mongo_adapter_generator"
+
+Hecks.register_adapter(:mongodb)

--- a/hecksagon/lib/hecks_mongodb/mongo_adapter_generator.rb
+++ b/hecksagon/lib/hecks_mongodb/mongo_adapter_generator.rb
@@ -1,0 +1,126 @@
+# = Hecks::MongoAdapterGenerator
+#
+# Generates MongoDB repository adapter classes for each aggregate.
+# Each adapter wraps a Mongo::Collection and implements the standard
+# repository interface: find, save, delete, all, count, query, clear.
+#
+#   gen = MongoAdapterGenerator.new(agg, domain_module: "PizzasDomain")
+#   gen.generate  # => Ruby source string
+#
+module Hecks
+  class MongoAdapterGenerator
+    include HecksTemplating::NamingHelpers
+
+    def initialize(aggregate, domain_module:)
+      @aggregate = aggregate
+      @domain_module = domain_module
+      @safe_name = domain_constant_name(@aggregate.name)
+    end
+
+    def generate
+      snake = domain_snake_name(@safe_name)
+      lines = []
+      lines << "module #{@domain_module}"
+      lines << "  module Adapters"
+      lines << "    class #{@safe_name}MongoRepository"
+      lines << "      def initialize(collection)"
+      lines << "        @collection = collection"
+      lines << "      end"
+      lines << ""
+      lines << "      def find(id)"
+      lines << "        doc = @collection.find(_id: id).first"
+      lines << "        return nil unless doc"
+      lines << "        deserialize(doc)"
+      lines << "      end"
+      lines << ""
+      lines << "      def save(#{snake})"
+      lines << "        doc = serialize(#{snake})"
+      lines << "        @collection.replace_one({ _id: #{snake}.id }, doc, upsert: true)"
+      lines << "        #{snake}"
+      lines << "      end"
+      lines << ""
+      lines << "      def delete(id)"
+      lines << "        @collection.delete_one(_id: id)"
+      lines << "      end"
+      lines << ""
+      lines << "      def all"
+      lines << "        @collection.find.map { |doc| deserialize(doc) }"
+      lines << "      end"
+      lines << ""
+      lines << "      def count"
+      lines << "        @collection.count_documents({})"
+      lines << "      end"
+      lines << ""
+      lines.concat(query_lines(6))
+      lines << ""
+      lines << "      def clear"
+      lines << "        @collection.delete_many({})"
+      lines << "      end"
+      lines << ""
+      lines << "      private"
+      lines << ""
+      lines.concat(serialize_lines(6))
+      lines << ""
+      lines.concat(deserialize_lines(6))
+      lines << "    end"
+      lines << "  end"
+      lines << "end"
+      lines.join("\n") + "\n"
+    end
+
+    private
+
+    def query_lines(indent)
+      pad = " " * indent
+      [
+        "#{pad}def query(conditions: {}, order_key: nil, order_direction: :asc, limit: nil, offset: nil)",
+        "#{pad}  filter = {}",
+        "#{pad}  conditions.each do |k, v|",
+        "#{pad}    if v.respond_to?(:to_mongo_filter)",
+        "#{pad}      filter[k.to_s] = v.to_mongo_filter",
+        "#{pad}    else",
+        "#{pad}      filter[k.to_s] = v",
+        "#{pad}    end",
+        "#{pad}  end",
+        "#{pad}  cursor = @collection.find(filter)",
+        "#{pad}  cursor = cursor.sort(order_key.to_s => order_direction == :desc ? -1 : 1) if order_key",
+        "#{pad}  cursor = cursor.skip(offset) if offset && offset > 0",
+        "#{pad}  cursor = cursor.limit(limit) if limit && limit > 0",
+        "#{pad}  cursor.map { |doc| deserialize(doc) }",
+        "#{pad}end"
+      ]
+    end
+
+    def serialize_lines(indent)
+      pad = " " * indent
+      attrs = @aggregate.attributes.reject(&:list?)
+      refs = @aggregate.references || []
+      fields = attrs.map { |a| "\"#{a.name}\" => obj.#{a.name}" }
+      fields += refs.map { |r| "\"#{r.name}_id\" => obj.respond_to?(:#{r.name}_id) ? obj.#{r.name}_id : nil" }
+      [
+        "#{pad}def serialize(obj)",
+        "#{pad}  {",
+        "#{pad}    \"_id\" => obj.id,",
+        *fields.map { |f| "#{pad}    #{f}," },
+        "#{pad}    \"created_at\" => obj.respond_to?(:created_at) ? obj.created_at&.to_s : nil,",
+        "#{pad}    \"updated_at\" => obj.respond_to?(:updated_at) ? obj.updated_at&.to_s : nil",
+        "#{pad}  }",
+        "#{pad}end"
+      ]
+    end
+
+    def deserialize_lines(indent)
+      pad = " " * indent
+      attrs = @aggregate.attributes.reject(&:list?)
+      params = attrs.map { |a| "#{a.name}: doc[\"#{a.name}\"]" }
+      [
+        "#{pad}def deserialize(doc)",
+        "#{pad}  klass = #{@domain_module}.const_get(\"#{@safe_name}\")",
+        "#{pad}  obj = klass.new(#{params.join(", ")})",
+        "#{pad}  obj.instance_variable_set(:@id, doc[\"_id\"]) if doc[\"_id\"]",
+        "#{pad}  obj",
+        "#{pad}end"
+      ]
+    end
+  end
+end

--- a/hecksagon/lib/hecks_mongodb/mongo_boot.rb
+++ b/hecksagon/lib/hecks_mongodb/mongo_boot.rb
@@ -1,0 +1,72 @@
+# = Hecks::Boot::MongoBoot
+#
+# Handles MongoDB adapter lifecycle: connects to a MongoDB instance,
+# generates repository adapter classes for each aggregate, and returns
+# adapter instances keyed by aggregate name.
+#
+#   adapters = MongoBoot.setup(domain, client)
+#   # => { "Pizza" => #<PizzasDomain::Adapters::PizzaMongoRepository>, ... }
+#
+module Hecks
+  module Boot
+    module MongoBoot
+      extend HecksTemplating::NamingHelpers
+
+      module_function
+
+      # Connects to MongoDB using the mongo Ruby driver.
+      #
+      # @param config [Hash] connection config with :uri or defaults
+      # @return [Mongo::Client] the MongoDB client
+      def connect(config)
+        require_mongo!
+        uri = config[:uri] || "mongodb://localhost:27017"
+        db_name = config[:database] || "hecks"
+        Mongo::Client.new(uri, database: db_name)
+      end
+
+      # Performs full MongoDB setup: generates adapter classes and returns
+      # instantiated repository objects.
+      #
+      # @param domain [DomainModel::Structure::Domain] the domain model
+      # @param client [Mongo::Client] the MongoDB client
+      # @return [Hash<String, Object>] adapter instances keyed by aggregate name
+      def setup(domain, client)
+        mod_name = domain_module_name(domain.name)
+        generate_adapters(domain, mod_name)
+        instantiate_adapters(domain, client, mod_name)
+      end
+
+      # Generates and evals MongoDB repository classes for each aggregate.
+      def generate_adapters(domain, mod_name)
+        domain.aggregates.each do |agg|
+          gen = MongoAdapterGenerator.new(agg, domain_module: mod_name)
+          eval(gen.generate, TOPLEVEL_BINDING, "(mongo_adapter:#{agg.name})", 1)
+        end
+      end
+
+      # Instantiates MongoDB repository objects for all aggregates.
+      def instantiate_adapters(domain, client, mod_name)
+        mod = Object.const_get(mod_name)
+        adapters = {}
+        domain.aggregates.each do |agg|
+          safe_name = domain_constant_name(agg.name)
+          collection_name = domain_aggregate_slug(agg.name)
+          collection = client[collection_name]
+          repo_class = mod::Adapters.const_get("#{safe_name}MongoRepository")
+          adapters[agg.name] = repo_class.new(collection)
+        end
+        adapters
+      end
+
+      # Requires the mongo gem, raising a helpful error if missing.
+      def require_mongo!
+        require "mongo"
+      rescue LoadError
+        raise LoadError,
+          "The mongo gem is required for MongoDB adapters. " \
+          "Add gem \"mongo\" to your Gemfile."
+      end
+    end
+  end
+end

--- a/hecksagon/spec/mongodb_adapter_spec.rb
+++ b/hecksagon/spec/mongodb_adapter_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+require "hecks_mongodb/mongo_adapter_generator"
+
+RSpec.describe "MongoDB adapter generator" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :style, String
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :style, String
+        end
+      end
+    end
+  end
+
+  after { Hecks::Utils.cleanup_constants! }
+
+  it "generates a MongoRepository class" do
+    Hecks.load(domain)
+    agg = domain.aggregates.first
+    gen = Hecks::MongoAdapterGenerator.new(agg, domain_module: "PizzasDomain")
+    source = gen.generate
+
+    expect(source).to include("class PizzaMongoRepository")
+    expect(source).to include("def find(id)")
+    expect(source).to include("def save(pizza)")
+    expect(source).to include("def delete(id)")
+    expect(source).to include("def all")
+    expect(source).to include("def count")
+    expect(source).to include("def query(")
+    expect(source).to include("def clear")
+    expect(source).to include("def serialize(obj)")
+    expect(source).to include("def deserialize(doc)")
+  end
+
+  it "includes all aggregate attributes in serialize" do
+    Hecks.load(domain)
+    agg = domain.aggregates.first
+    gen = Hecks::MongoAdapterGenerator.new(agg, domain_module: "PizzasDomain")
+    source = gen.generate
+
+    expect(source).to include('"name" => obj.name')
+    expect(source).to include('"style" => obj.style')
+    expect(source).to include('"_id" => obj.id')
+  end
+
+  it "deserializes with keyword args from doc" do
+    Hecks.load(domain)
+    agg = domain.aggregates.first
+    gen = Hecks::MongoAdapterGenerator.new(agg, domain_module: "PizzasDomain")
+    source = gen.generate
+
+    expect(source).to include('name: doc["name"]')
+    expect(source).to include('style: doc["style"]')
+  end
+end

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -80,6 +80,9 @@ module Hecks
       hook = Hecks.extension_registry[effective[:type]]
       if hook
         hook.call(mod, domain, runtime)
+      elsif effective[:type] == :mongodb
+        require "hecks_mongodb"
+        boot_with_mongo(domain, effective, runtime)
       elsif sql_adapter_type?(effective[:type])
         require "hecks_persist/sql_boot"
         boot_with_sql(domain, effective, runtime)
@@ -159,6 +162,12 @@ module Hecks
     def boot_with_sql(domain, adapter_config, runtime)
       db = SqlBoot.connect(adapter_config)
       adapters = SqlBoot.setup(domain, db)
+      adapters.each { |name, repo| runtime.swap_adapter(name, repo) }
+    end
+
+    def boot_with_mongo(domain, adapter_config, runtime)
+      client = MongoBoot.connect(adapter_config)
+      adapters = MongoBoot.setup(domain, client)
       adapters.each { |name, repo| runtime.swap_adapter(name, repo) }
     end
   end


### PR DESCRIPTION
## Summary

- `hecks_mongodb` adapter: `Hecks.boot(__dir__, adapter: :mongodb)`
- MongoAdapterGenerator produces repository classes per aggregate
- MongoBoot connects to MongoDB, generates and wires adapters
- Same interface as memory/SQL: find, save, delete, all, count, query, clear
- Each aggregate → MongoDB collection (pluralized snake_case)

## Test plan

- [x] 3 specs verify generated adapter source (interface methods, serialize, deserialize)
- [x] Full suite: 1181 examples, 0 failures (0.84s)
- [x] Smoke test passes

Note: Integration tests with a real MongoDB instance are deferred — this PR validates the generated adapter code. End-to-end testing requires `gem "mongo"` and a running MongoDB.