### PR TITLE
HEC-255: CommandContract — centralize command method name derivation

### DIFF
--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/command_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/command_spec.rb
@@ -118,17 +118,7 @@ module Hecks
           end
 
           def derive_command_method(cmd, aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, aggregate.name).to_s
           end
 
           def update_command?(cmd, aggregate)

--- a/hecks_targets/go/lib/go_hecks/generators/command_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/command_generator.rb
@@ -13,10 +13,7 @@ module GoHecks
       @agg = aggregate
       @event = event
       @package = package
-      agg_snake = GoUtils.snake_case(@agg.name)
-      suffixes = agg_snake.split("_").each_index.map { |i|
-        agg_snake.split("_").drop(i).join("_")
-      }.uniq
+      suffixes = HecksTemplating::CommandContract.agg_suffixes(@agg.name)
       @self_id = @cmd.attributes.find { |a|
         a.name.to_s.end_with?("_id") &&
           suffixes.any? { |s| a.name.to_s == "#{s}_id" }

--- a/hecksties/lib/hecks/conventions.rb
+++ b/hecksties/lib/hecks/conventions.rb
@@ -28,6 +28,8 @@ module Hecks
     MigrationContract = Hecks::Conventions::MigrationContract
     UILabelContract = Hecks::Conventions::UILabelContract
     NamingContract = Hecks::Conventions::Names
+    CommandContract = Hecks::Conventions::CommandContract
+    RouteContract = Hecks::Conventions::RouteContract
   end
 
   module Contracts
@@ -47,4 +49,6 @@ module Hecks
   Contracts.register(:naming,     Conventions::Names)
   Contracts.register(:migrations, Conventions::MigrationContract)
   Contracts.register(:ui_labels,  Conventions::UILabelContract)
+  Contracts.register(:commands,   Conventions::CommandContract)
+  Contracts.register(:routes,     Conventions::RouteContract)
 end

--- a/hecksties/lib/hecks/conventions/aggregate_contract.rb
+++ b/hecksties/lib/hecks/conventions/aggregate_contract.rb
@@ -71,9 +71,7 @@ module Hecks::Conventions
     # @param agg_snake [String] underscore aggregate name
     # @return [Array<String>] suffixes
     def self.agg_suffixes(agg_snake)
-      agg_snake.split("_").each_index.map { |i|
-        agg_snake.split("_").drop(i).join("_")
-      }.uniq
+      CommandContract.agg_suffixes(agg_snake)
     end
 
     # Find the self-referencing reference on a command.

--- a/hecksties/lib/hecks/conventions/command_contract.rb
+++ b/hecksties/lib/hecks/conventions/command_contract.rb
@@ -1,0 +1,42 @@
+# = Hecks::Conventions::CommandContract
+#
+# Canonical command method name derivation. Centralizes the suffix-stripping
+# logic that turns CreatePolicy into .create on GovernancePolicy.
+#
+# Used by the Ruby runtime, spec generator, and Go target to derive
+# identical method names from the same rule.
+#
+#   CommandContract.method_name("CreatePolicy", "GovernancePolicy")   # => :create
+#   CommandContract.method_name("ActivatePolicy", "GovernancePolicy") # => :activate
+#   CommandContract.method_name("CreatePizza", "Pizza")               # => :create
+#
+module Hecks::Conventions
+  module CommandContract
+    # Derives the short Ruby method name for a command on an aggregate.
+    # Strips the longest matching right-suffix of the aggregate name.
+    #
+    # @param cmd_name [String] the command class name e.g. "CreatePolicy"
+    # @param agg_name [String] the aggregate class name e.g. "GovernancePolicy"
+    # @return [Symbol] the derived method name e.g. :create
+    def self.method_name(cmd_name, agg_name)
+      full = Hecks::Utils.underscore(cmd_name)
+      agg_suffixes(agg_name).each do |suffix|
+        stripped = full.sub(/_#{suffix}$/, "")
+        return stripped.to_sym if stripped != full
+      end
+      full.to_sym
+    end
+
+    # Returns all right-suffix variants of the aggregate snake name.
+    # "governance_policy" => ["governance_policy", "policy"]
+    #
+    # @param agg_name [String] aggregate name (camel or snake case)
+    # @return [Array<String>] suffix variants, longest first
+    def self.agg_suffixes(agg_name)
+      agg_snake = Hecks::Utils.underscore(agg_name)
+      agg_snake.split("_").each_index.map { |i|
+        agg_snake.split("_").drop(i).join("_")
+      }.uniq
+    end
+  end
+end

--- a/hecksties/lib/hecks/conventions/naming_contract.rb
+++ b/hecksties/lib/hecks/conventions/naming_contract.rb
@@ -61,8 +61,7 @@ module Hecks::Conventions
 
       # "CreatePizza" on "Pizza" → :create
       def domain_command_method(cmd_name, agg_name)
-        Hecks::Utils.underscore(cmd_name)
-          .sub(/_#{Hecks::Utils.underscore(agg_name)}$/, "").to_sym
+        Hecks::Conventions::CommandContract.method_name(cmd_name, agg_name)
       end
 
       # ("Blog", "Post") → "/blog/posts"

--- a/hecksties/lib/hecks/ports/commands/command_methods.rb
+++ b/hecksties/lib/hecks/ports/commands/command_methods.rb
@@ -137,23 +137,9 @@ module Hecks
       # @yieldreturn [Proc] a proc that accepts a Hash of attributes and executes the command
       # @return [void]
       def self.bind_shortcuts(klass, aggregate)
-        agg_snake = domain_snake_name(aggregate.name)
-        agg_suffixes = agg_snake.split("_").each_index.map { |i|
-          agg_snake.split("_").drop(i).join("_")
-        }.uniq
-
         aggregate.commands.each do |cmd|
           executor = yield(cmd)
-          full_name = domain_snake_name(cmd.name)
-          method_name = full_name
-          agg_suffixes.each do |suffix|
-            stripped = full_name.sub(/_#{suffix}$/, "")
-            if stripped != full_name
-              method_name = stripped
-              break
-            end
-          end
-          method_name = method_name.to_sym
+          method_name = Hecks::Conventions::CommandContract.method_name(cmd.name, aggregate.name)
 
           # Class method: Pizza.create(name: "Margherita")
           klass.define_singleton_method(method_name) do |**attrs|

--- a/hecksties/spec/conventions/command_contract_spec.rb
+++ b/hecksties/spec/conventions/command_contract_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::CommandContract do
+  describe ".method_name" do
+    it { expect(described_class.method_name("CreatePolicy", "GovernancePolicy")).to eq(:create) }
+    it { expect(described_class.method_name("ActivatePolicy", "GovernancePolicy")).to eq(:activate) }
+    it { expect(described_class.method_name("SuspendPolicy", "GovernancePolicy")).to eq(:suspend) }
+    it { expect(described_class.method_name("CreatePizza", "Pizza")).to eq(:create) }
+    it { expect(described_class.method_name("UpdatePizza", "Pizza")).to eq(:update) }
+  end
+
+  describe ".agg_suffixes" do
+    it { expect(described_class.agg_suffixes("GovernancePolicy")).to eq(["governance_policy", "policy"]) }
+    it { expect(described_class.agg_suffixes("Pizza")).to eq(["pizza"]) }
+    it { expect(described_class.agg_suffixes("governance_policy")).to eq(["governance_policy", "policy"]) }
+  end
+end


### PR DESCRIPTION
Replaces 3 independent copies of the suffix-stripping logic with a single \`CommandContract.method_name\` call.

## Changes
- New \`command_contract.rb\` — \`method_name(cmd_name, agg_name)\` and \`agg_suffixes(agg_name)\`
- \`AggregateContract.agg_suffixes\` delegates to \`CommandContract\`
- \`Names.domain_command_method\` delegates to \`CommandContract\`
- \`command_methods.rb\` uses contract in \`bind_shortcuts\`
- \`command_spec.rb\` delegates \`derive_command_method\` to contract
- \`command_generator.rb\` (Go) uses \`CommandContract.agg_suffixes\`

## Test plan
- [x] 1199 specs pass
- [x] Smoke test passes