### PR TITLE
HEC-252: Smoke test verifies form field count matches command attributes

### DIFF
--- a/hecksties/lib/hecks/smoke/form_submission.rb
+++ b/hecksties/lib/hecks/smoke/form_submission.rb
@@ -23,7 +23,7 @@ module HecksTemplating
       # @param strict [Boolean] if true, 422 is a failure
       # @return [Array<Result>] results for the GET and POST.
       #   The last result's error field contains the redirect ID if available.
-      def submit_form(form_path, cmd, label, strict: true)
+      def submit_form(form_path, cmd, label, strict: true, agg_snake: nil)
         results = []
 
         # 1. GET the form page
@@ -34,8 +34,24 @@ module HecksTemplating
         # 2. Parse the HTML
         uri = URI("#{@base}#{form_path}")
         html = Net::HTTP.get(uri)
-        action = parse_form_action(html) || form_path.sub(/\/new$/, "/submit")
+        plural, cmd_snake = form_path.split("/").drop(1).first(2)
+        action = parse_form_action(html) || HecksTemplating::RouteContract.submit_path(plural, cmd_snake)
         fields = parse_form_fields(html)
+
+        # Field count check — catch empty or broken forms
+        if agg_snake
+          expected = HecksTemplating::AggregateContract.user_fields(cmd, agg_snake)
+          if fields.size < expected.size
+            results << Result.new(
+              status: :fail,
+              method: "GET",
+              path: form_path,
+              http_code: 200,
+              error: "#{label} form has #{fields.size} fields, expected #{expected.size} (#{expected.map(&:name).join(", ")})"
+            )
+            return results
+          end
+        end
 
         # 3. Fill empty fields with sample data from command
         cmd.attributes.each do |attr|

--- a/hecksties/lib/hecks/smoke/smoke_test.rb
+++ b/hecksties/lib/hecks/smoke/smoke_test.rb
@@ -48,7 +48,7 @@ module HecksTemplating
         create_cmds.each do |cmd|
           cmd_snake = underscore(cmd.name)
           form_path = "/#{plural}/#{cmd_snake}/new"
-          results.concat(submit_form(form_path, cmd, cmd.name, strict: true))
+          results.concat(submit_form(form_path, cmd, cmd.name, strict: true, agg_snake: agg_snake))
           expected_events << cmd.inferred_event_name
         end
 
@@ -65,7 +65,7 @@ module HecksTemplating
           update_cmds.each do |cmd|
             cmd_snake = underscore(cmd.name)
             form_path = "/#{plural}/#{cmd_snake}/new?id=#{id}"
-            results.concat(submit_form(form_path, cmd, cmd.name, strict: false))
+            results.concat(submit_form(form_path, cmd, cmd.name, strict: false, agg_snake: agg_snake))
           end
         end
       end


### PR DESCRIPTION
Adds a field count assertion to the smoke test. When \`agg_snake\` is provided, verifies the parsed form has at least as many fields as the command's user-visible attributes. Catches empty/broken forms that previously passed silently.

## Changes
- \`form_submission.rb\`: new \`agg_snake:\` param, field count check after parsing
- \`smoke_test.rb\`: passes \`agg_snake:\` to both create and update \`submit_form\` calls

## Test plan
- [x] 1199 specs pass
- [x] Smoke test passes