### PR TITLE
HEC-282: CLI auto-selects domain when only one exists

### DIFF
--- a/hecksties/lib/hecks_cli/domain_helpers.rb
+++ b/hecksties/lib/hecks_cli/domain_helpers.rb
@@ -21,14 +21,24 @@ module Hecks
         if file
           load_domain_file(file)
         else
-          domains = find_installed_domains
-          if domains.empty?
-            say "No Bluebook found and no --domain specified.", :red
+          installed = find_installed_domains
+          case installed.size
+          when 0
+            abort "No domain found. Create a Bluebook file or install a domain gem."
+          when 1
+            name, _ = installed.first
+            say "Auto-selected domain: #{name}", :green
+            resolve_domain(name)
           else
-            say "No Bluebook found. Use --domain to specify one:", :red
-            domains.each { |name, versions| say "  --domain #{name} (#{versions.map { |v| "v#{v}" }.join(", ")})", :yellow }
+            say "Multiple domains found:", :yellow
+            installed.each_with_index do |(name, versions), i|
+              say "  #{i + 1}. #{name} (#{versions.map { |v| "v#{v}" }.join(", ")})"
+            end
+            choice = ask("Select domain [1-#{installed.size}]:").to_i
+            abort "Invalid selection" unless choice.between?(1, installed.size)
+            name, _ = installed[choice - 1]
+            resolve_domain(name)
           end
-          nil
         end
       end
     end

--- a/hecksties/spec/cli/domain_resolution_spec.rb
+++ b/hecksties/spec/cli/domain_resolution_spec.rb
@@ -11,6 +11,41 @@ RSpec.describe "CLI domain resolution" do
     end
   end
 
+  describe "resolve_domain_option auto-selection" do
+    let(:cli) { Hecks::CLI.new }
+
+    before { allow(cli).to receive(:find_domain_file).and_return(nil) }
+
+    context "when no installed domains" do
+      it "aborts with a helpful message" do
+        allow(cli).to receive(:find_installed_domains).and_return([])
+        expect { cli.send(:resolve_domain_option) }.to raise_error(SystemExit)
+      end
+    end
+
+    context "when exactly one installed domain" do
+      it "auto-selects and prints a message" do
+        allow(cli).to receive(:find_installed_domains).and_return([["pizzas_domain", ["1.0.0"]]])
+        allow(cli).to receive(:say)
+        expect(cli).to receive(:resolve_domain).with("pizzas_domain")
+        cli.send(:resolve_domain_option)
+      end
+    end
+
+    context "when multiple installed domains" do
+      it "shows a numbered list and resolves the selection" do
+        allow(cli).to receive(:find_installed_domains).and_return([
+          ["pizzas_domain", ["1.0.0"]],
+          ["banking_domain", ["2.0.0"]]
+        ])
+        allow(cli).to receive(:say)
+        allow(cli).to receive(:ask).and_return("1")
+        expect(cli).to receive(:resolve_domain).with("pizzas_domain")
+        cli.send(:resolve_domain_option)
+      end
+    end
+  end
+
   describe "resolve_domain" do
     let(:cli) { Hecks::CLI.new }
 


### PR DESCRIPTION
Removes friction from every CLI workflow where \`--domain\` was previously required even with an obvious single domain.

## New behavior (when no local Bluebook and no \`--domain\`)
- **0 domains**: clear error message
- **1 domain**: auto-selects, prints "Auto-selected domain: pizzas_domain"
- **2+ domains**: numbered list, interactive prompt

## Changes
- \`domain_helpers.rb\`: rewrote the else-branch of \`resolve_domain_option\`
- \`domain_resolution_spec.rb\`: added 3 new tests for each scenario

## Test plan
- [x] 1199 specs pass
- [x] All 3 new domain resolution scenarios covered