### PR TITLE
HEC-259: Go form validation re-renders form on error

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -85,7 +85,10 @@ module GoHecks
       end
 
       def command_route(safe, plural, cmd)
+        ac = HecksTemplating::AggregateContract
         cmd_snake = GoUtils.snake_case(cmd.name)
+        agg_snake = GoUtils.snake_case(safe)
+        agg = @domain.aggregates.find { |a| a.name == safe }
         lines = []
         lines << "\tmux.HandleFunc(\"POST /#{plural}/#{cmd_snake}\", func(w http.ResponseWriter, r *http.Request) {"
         lines << "\t\tvar cmd domain.#{cmd.name}"
@@ -103,7 +106,14 @@ module GoHecks
         lines << "\t\tif event != nil { app.EventBus.Publish(event) }"
         lines << "\t\tif err != nil {"
         lines << "\t\t\tif r.Header.Get(\"Content-Type\")==\"application/json\" { jsonError(w, err); return }"
-        lines << "\t\t\thttp.Error(w, err.Error(), 422); return"
+        lines.concat(build_form_fields_go(cmd, agg, agg_snake, value_source: :form).map { |l| "\t" + l })
+        lines << "\t\t\tw.WriteHeader(422)"
+        lines << "\t\t\trenderer.Render(w, \"form\", \"#{cmd.name}\", FormData{"
+        lines << "\t\t\t\tCommandName: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\","
+        lines << "\t\t\t\tAction: \"/#{plural}/#{cmd_snake}\","
+        lines << "\t\t\t\tErrorMessage: err.Error(),"
+        lines << "\t\t\t\tFields: fields,"
+        lines << "\t\t\t}); return"
         lines << "\t\t}"
         lines << "\t\tif r.Header.Get(\"Content-Type\")==\"application/json\" { w.WriteHeader(201); jsonResponse(w, agg) } else {"
         lines << "\t\t\thttp.Redirect(w, r, \"/#{plural}/show?id=\"+agg.ID, http.StatusSeeOther)"

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
@@ -20,49 +20,9 @@ module GoHecks
 
           agg.commands.each do |cmd|
             cmd_snake = GoUtils.snake_case(cmd.name)
-            self_id = ac.self_ref_attr(cmd, agg_snake)
 
             lines << "\tmux.HandleFunc(\"GET /#{plural}/#{cmd_snake}/new\", func(w http.ResponseWriter, r *http.Request) {"
-            lines << "\t\tfields := []FormField{"
-            cmd.attributes.each do |a|
-              if a == self_id
-                lines << "\t\t\t{Type: \"hidden\", Name: \"#{a.name}\", Value: r.URL.Query().Get(\"id\")},"
-              else
-                agg_attr = agg.attributes.find { |aa| aa.name == a.name }
-                enum_values = agg_attr&.enum
-                label = HecksTemplating::UILabelContract.label(a.name)
-                if enum_values && !enum_values.empty?
-                  opts = enum_values.map { |v| "FormOption{Value: \"#{v}\", Label: \"#{v}\"}" }.join(", ")
-                  lines << "\t\t\t{Type: \"select\", Name: \"#{a.name}\", Label: \"#{label}\", Required: true, Options: []FormOption{#{opts}}},"
-                else
-                  go_type = GoUtils.go_type(a)
-                  input_type = HecksTemplating::FormParsingContract.input_type(go_type)
-                  step = HecksTemplating::FormParsingContract.step?(go_type) ? ", Step: true" : ""
-                  lines << "\t\t\t{Type: \"input\", Name: \"#{a.name}\", Label: \"#{label}\", InputType: \"#{input_type}\", Required: true#{step}},"
-                end
-              end
-            end
-            # Reference dropdowns (placeholders, built dynamically below)
-            (cmd.references || []).each do |ref|
-              lines << "\t\t\t// #{ref.type} dropdown built dynamically below"
-            end
-            lines << "\t\t}"
-
-            # Build dropdowns for reference fields
-            (cmd.references || []).each do |ref|
-              ref_agg = @domain.aggregates.find { |ra| ra.name == ref.type }
-              next unless ref_agg
-              ref_safe = ref_agg.name
-              display = HecksTemplating::DisplayContract.go_reference_display_field(ref_agg)
-              label = HecksTemplating::UILabelContract.label(ref.name.to_s)
-              lines << "\t\t#{ref_safe.downcase}s, _ := app.#{ref_safe}Repo.All()"
-              lines << "\t\tvar #{ref_safe.downcase}Opts []FormOption"
-              lines << "\t\tfor _, item := range #{ref_safe.downcase}s {"
-              lines << "\t\t\t#{ref_safe.downcase}Opts = append(#{ref_safe.downcase}Opts, FormOption{Value: item.ID, Label: fmt.Sprintf(\"%v\", item.#{display}), Selected: item.ID == r.URL.Query().Get(\"id\")})"
-              lines << "\t\t}"
-              lines << "\t\tfields = append(fields, FormField{Type: \"select\", Name: \"#{ref.name}\", Label: \"#{label}\", Required: true, Options: #{ref_safe.downcase}Opts})"
-            end
-
+            lines.concat(build_form_fields_go(cmd, agg, agg_snake, value_source: :query))
             lines << "\t\trenderer.Render(w, \"form\", \"#{cmd.name}\", FormData{"
             lines << "\t\t\tCommandName: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\","
             lines << "\t\t\tAction: \"/#{plural}/#{cmd_snake}\","
@@ -71,6 +31,57 @@ module GoHecks
             lines << "\t})"
             lines << ""
           end
+        end
+        lines
+      end
+
+      def build_form_fields_go(cmd, agg, agg_snake, value_source: :query)
+        ac = HecksTemplating::AggregateContract
+        self_id = ac.self_ref_attr(cmd, agg_snake)
+        lines = []
+        lines << "\t\tfields := []FormField{"
+        cmd.attributes.each do |a|
+          if a == self_id
+            id_val = value_source == :form ? "r.FormValue(\"#{a.name}\")" : "r.URL.Query().Get(\"id\")"
+            lines << "\t\t\t{Type: \"hidden\", Name: \"#{a.name}\", Value: #{id_val}},"
+          else
+            agg_attr = agg.attributes.find { |aa| aa.name == a.name }
+            enum_values = agg_attr&.enum
+            label = HecksTemplating::UILabelContract.label(a.name)
+            if enum_values && !enum_values.empty?
+              opts = enum_values.map { |v| "FormOption{Value: \"#{v}\", Label: \"#{v}\"}" }.join(", ")
+              lines << "\t\t\t{Type: \"select\", Name: \"#{a.name}\", Label: \"#{label}\", Required: true, Options: []FormOption{#{opts}}},"
+            else
+              go_type = GoUtils.go_type(a)
+              input_type = HecksTemplating::FormParsingContract.input_type(go_type)
+              step = HecksTemplating::FormParsingContract.step?(go_type) ? ", Step: true" : ""
+              val = value_source == :form ? ", Value: r.FormValue(\"#{a.name}\")" : ""
+              lines << "\t\t\t{Type: \"input\", Name: \"#{a.name}\", Label: \"#{label}\", InputType: \"#{input_type}\", Required: true#{step}#{val}},"
+            end
+          end
+        end
+        # Reference dropdowns (placeholders, built dynamically below)
+        (cmd.references || []).each do |ref|
+          lines << "\t\t\t// #{ref.type} dropdown built dynamically below"
+        end
+        lines << "\t\t}"
+
+        # Build dropdowns for reference fields
+        (cmd.references || []).each do |ref|
+          ref_agg = @domain.aggregates.find { |ra| ra.name == ref.type }
+          next unless ref_agg
+          ref_safe = ref_agg.name
+          display = HecksTemplating::DisplayContract.go_reference_display_field(ref_agg)
+          label = HecksTemplating::UILabelContract.label(ref.name.to_s)
+          selected_expr = value_source == :form \
+            ? "item.ID == r.FormValue(\"#{ref.name}\")" \
+            : "item.ID == r.URL.Query().Get(\"id\")"
+          lines << "\t\t#{ref_safe.downcase}s, _ := app.#{ref_safe}Repo.All()"
+          lines << "\t\tvar #{ref_safe.downcase}Opts []FormOption"
+          lines << "\t\tfor _, item := range #{ref_safe.downcase}s {"
+          lines << "\t\t\t#{ref_safe.downcase}Opts = append(#{ref_safe.downcase}Opts, FormOption{Value: item.ID, Label: fmt.Sprintf(\"%v\", item.#{display}), Selected: #{selected_expr}})"
+          lines << "\t\t}"
+          lines << "\t\tfields = append(fields, FormField{Type: \"select\", Name: \"#{ref.name}\", Label: \"#{label}\", Required: true, Options: #{ref_safe.downcase}Opts})"
         end
         lines
       end

--- a/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
+++ b/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe GoHecks::ServerGenerator do
       expect(output).to include("json.NewDecoder(r.Body).Decode(&cmd)")
       expect(output).to include("r.ParseForm()")
     end
+
+    it "re-renders form with error message on validation failure instead of raw http.Error 422" do
+      expect(output).not_to include("http.Error(w, err.Error(), 422)")
+      expect(output).to include("ErrorMessage: err.Error()")
+      expect(output).to include('renderer.Render(w, "form"')
+      expect(output).to include("w.WriteHeader(422)")
+    end
+
+    it "preserves submitted field values in error re-render using r.FormValue" do
+      expect(output).to include('Value: r.FormValue("name")')
+    end
   end
 
   describe "show route" do


### PR DESCRIPTION
## Summary
- Replaces `http.Error(w, err.Error(), 422)` in generated Go POST handlers with a proper form re-render
- Adds `build_form_fields_go(cmd, agg, agg_snake, value_source:)` shared helper in `UIRoutes` — GET handlers use `value_source: :query`, POST error path uses `value_source: :form` (preserving submitted values via `r.FormValue`)
- Error re-render sets `w.WriteHeader(422)` and passes `ErrorMessage: err.Error()` to `FormData`, matching the existing `{{ if .ErrorMessage }}` template and the Ruby target behavior

## Test plan
- [ ] `bundle exec rspec hecks_targets/go/spec/` — all 1178 examples pass
- [ ] New spec asserts: no `http.Error(w, err.Error(), 422)`, includes `ErrorMessage: err.Error()`, includes `renderer.Render(w, "form"`, includes `w.WriteHeader(422)`, includes `Value: r.FormValue("name")`
- [ ] `bundle exec rspec` from project root — all pass under 1 second
- [ ] `ruby -Ilib examples/pizzas/app.rb` smoke test passes
- [ ] No lib file over 200 lines (ui_routes.rb: 128, data_routes.rb: 187)

🤖 Generated with [Claude Code](https://claude.com/claude-code)