### PR TITLE
HEC-263: Strip _id from reference column headers

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/aggregate_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/aggregate_generator.rb
@@ -52,6 +52,10 @@ module GoHecks
       @user_attrs.each do |attr|
         lines << "\t#{GoUtils.pascal_case(attr.name)} #{GoUtils.go_type(attr)} `json:\"#{GoUtils.json_tag(attr.name)}\"`"
       end
+      (@agg.references || []).each do |ref|
+        field = GoUtils.pascal_case(ref.name.to_s)
+        lines << "\t#{field} string `json:\"#{GoUtils.json_tag(ref.name)}\"`"
+      end
       lines << "}"
       lines << ""
       lines

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -29,7 +29,9 @@ module GoHecks
         ac = HecksTemplating::AggregateContract
         dc = HecksTemplating::DisplayContract
 
-        cols = attrs.map { |a| "{Label: \"#{HecksTemplating::UILabelContract.label(a.name)}\"}" }
+        refs = agg.references || []
+        ref_cols = refs.map { |r| "{Label: \"#{dc.reference_column_label(r)}\"}" }
+        cols = attrs.map { |a| "{Label: \"#{HecksTemplating::UILabelContract.label(a.name)}\"}" } + ref_cols
         create_cmds, update_cmds = ac.partition_commands(agg)
 
         btns = create_cmds.map { |c|
@@ -47,6 +49,11 @@ module GoHecks
         }
 
         cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :go) }
+        ref_cell_exprs = refs.map { |r|
+          field = GoUtils.pascal_case(dc.strip_id_suffix(r.name))
+          "fmt.Sprintf(\"%v\", obj.#{field})"
+        }
+        cell_exprs = cell_exprs + ref_cell_exprs
         desc = agg.description || ""
 
         lines = []
@@ -146,6 +153,12 @@ module GoHecks
             else
               lines << "\t\t\t{Label: \"#{label}\", Value: fmt.Sprintf(\"%v\", obj.#{field})},"
             end
+          end
+          # Reference fields
+          (agg.references || []).each do |ref|
+            label = dc.reference_column_label(ref)
+            field = GoUtils.pascal_case(dc.strip_id_suffix(ref.name))
+            lines << "\t\t\t{Label: \"#{label}\", Value: fmt.Sprintf(\"%v\", obj.#{field})},"
           end
           lines << "\t\t}"
 

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -1,5 +1,6 @@
 require_relative "ui_generator/form_routes"
 require_relative "ui_generator/config_routes"
+require_relative "ui_generator/data_routes"
 
 module HecksStatic
 # HecksStatic::UIGenerator
@@ -10,6 +11,7 @@ module HecksStatic
 class UIGenerator < Hecks::Generator
   include FormRoutes
   include ConfigRoutes
+  include DataRoutes
 
   def initialize(domain)
     @domain = domain
@@ -108,113 +110,5 @@ class UIGenerator < Hecks::Generator
     ]
   end
 
-  def index_route(agg, mod)
-    safe = domain_constant_name(agg.name)
-    p = plural(agg)
-    attrs = user_attrs(agg)
-    agg_snake = domain_snake_name(agg.name)
-    ac = HecksTemplating::AggregateContract
-    dc = HecksTemplating::DisplayContract
-    create_cmds, update_cmds = ac.partition_commands(agg)
-
-    columns = attrs.map { |a| "{ label: \"#{humanize(a.name)}\" }" }
-    btns = create_cmds.map { |c| cm = domain_snake_name(c.name); "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }" }
-    row_acts = update_cmds.map do |c|
-      cm = domain_snake_name(c.name)
-      if ac.direct_action?(c, agg_snake)
-        self_id = ac.self_ref_attr(c, agg_snake)
-        "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href_prefix: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id&.name}\" }"
-      else
-        "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href_prefix: \"/#{p}/#{cm}/new?id=\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
-      end
-    end
-
-    cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :ruby) }
-    cells_code = cell_exprs.map { |e| e }.join(", ")
-
-    [
-      "        server.mount_proc \"/#{p}\" do |req, res|",
-      "          next unless req.path == \"/#{p}\"",
-      "          all_items = #{safe}.all",
-      "          items = all_items.map { |obj| { id: obj.id, short_id: #{HecksTemplating::ViewContract.ruby_short_id('obj.id')}, show_href: \"/#{p}/show?id=\" + obj.id, cells: [#{cells_code}] } }",
-      "          html = renderer.render(:index, title: \"#{safe}s — #{mod}\", brand: brand, nav_items: nav,",
-      "            aggregate_name: \"#{safe}\", items: items,",
-      "            columns: [#{columns.join(', ')}],",
-      "            buttons: [#{btns.join(', ')}],",
-      "            row_actions: [#{row_acts.join(', ')}])",
-      "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
-      "        end",
-      ""
-    ]
-  end
-
-  def show_route(agg, mod)
-    safe = domain_constant_name(agg.name)
-    p = plural(agg)
-    attrs = user_attrs(agg)
-    agg_snake = domain_snake_name(agg.name)
-
-    lc = agg.lifecycle
-    lc_field = lc&.field&.to_s
-
-    field_exprs = attrs.map do |a|
-      if a.list?
-        vo = agg.value_objects.find { |v| v.name == a.type.to_s }
-        if vo
-          vo_attrs = vo.attributes.map(&:name).map(&:to_s)
-          items_expr = "obj.#{a.name}.map { |v| #{vo_attrs.map { |va| "v.#{va}.to_s" }.join(' + " — " + ')} }"
-          "{ label: \"#{humanize(a.name)}\", type: :list, items: #{items_expr} }"
-        else
-          "{ label: \"#{humanize(a.name)}\", type: :list, items: obj.#{a.name}.map(&:to_s) }"
-        end
-      elsif lc_field && a.name.to_s == lc_field
-        transitions = HecksTemplating::DisplayContract.lifecycle_transitions(lc)
-        "{ label: \"#{humanize(a.name)}\", type: :lifecycle, value: obj.#{a.name}.to_s, transitions: #{transitions.inspect} }"
-      else
-        "{ label: \"#{humanize(a.name)}\", value: obj.#{a.name}.to_s }"
-      end
-    end
-
-    # Collect buttons — from contract
-    ac = HecksTemplating::AggregateContract
-    btn_parts = []
-    _, update_cmds = ac.partition_commands(agg)
-    update_cmds.each do |c|
-      cm = domain_snake_name(c.name)
-      if ac.direct_action?(c, agg_snake)
-        self_id = ac.self_ref_attr(c, agg_snake)
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id.name}\" }"
-      else
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
-      end
-    end
-    # Cross-aggregate commands
-    snake = domain_snake_name(agg.name)
-    @domain.aggregates.each do |other|
-      next if other.name == agg.name
-      other_safe = domain_constant_name(other.name)
-      other_p = plural(other)
-      other.commands.each do |cmd|
-        next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
-        cm = domain_snake_name(cmd.name)
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", href: \"/#{other_p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{other_safe}\", \"#{cm}\") }"
-      end
-    end
-
-    [
-      "        server.mount_proc \"/#{p}/show\" do |req, res|",
-      "          obj = #{safe}.find(req.query[\"id\"])",
-      "          unless obj",
-      "            res.status = 404; res.body = \"Not found\"; next",
-      "          end",
-      "          html = renderer.render(:show, title: \"#{safe} — #{mod}\", brand: brand, nav_items: nav,",
-      "            aggregate_name: \"#{safe}\", back_href: \"/#{p}\",",
-      "            id: obj.id, fields: [#{field_exprs.join(', ')}],",
-      "            buttons: [#{btn_parts.join(', ')}])",
-      "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
-      "        end",
-      ""
-    ]
-  end
 end
 end

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/data_routes.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/data_routes.rb
@@ -1,0 +1,148 @@
+# HecksStatic::UIGenerator::DataRoutes
+#
+# Generates index and show route handlers. Includes reference columns
+# (from agg.references) in both index table and show field lists so that
+# foreign-key relationships appear with clean labels like "Pizza"
+# instead of raw "_id" field names.
+#
+module HecksStatic
+  class UIGenerator < Hecks::Generator
+    module DataRoutes
+      include HecksTemplating::NamingHelpers
+      private
+
+      def index_route(agg, mod)
+        safe = domain_constant_name(agg.name)
+        p = plural(agg)
+        attrs = user_attrs(agg)
+        agg_snake = domain_snake_name(agg.name)
+        ac = HecksTemplating::AggregateContract
+        dc = HecksTemplating::DisplayContract
+        create_cmds, update_cmds = ac.partition_commands(agg)
+
+        refs = agg.references || []
+        ref_columns = refs.map { |r| "{ label: \"#{dc.reference_column_label(r)}\" }" }
+        columns = attrs.map { |a| "{ label: \"#{humanize(a.name)}\" }" } + ref_columns
+        btns = create_cmds.map { |c|
+          cm = domain_snake_name(c.name)
+          "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
+        }
+        row_acts = update_cmds.map do |c|
+          cm = domain_snake_name(c.name)
+          if ac.direct_action?(c, agg_snake)
+            self_id = ac.self_ref_attr(c, agg_snake)
+            "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href_prefix: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id&.name}\" }"
+          else
+            "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href_prefix: \"/#{p}/#{cm}/new?id=\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
+          end
+        end
+
+        cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :ruby) }
+        ref_cell_exprs = refs.map { |r|
+          field = dc.strip_id_suffix(r.name)
+          "obj.respond_to?(:#{field}) ? obj.#{field}.to_s : \"\""
+        }
+        cells_code = (cell_exprs + ref_cell_exprs).join(", ")
+
+        [
+          "        server.mount_proc \"/#{p}\" do |req, res|",
+          "          next unless req.path == \"/#{p}\"",
+          "          all_items = #{safe}.all",
+          "          items = all_items.map { |obj| { id: obj.id, short_id: #{HecksTemplating::ViewContract.ruby_short_id('obj.id')}, show_href: \"/#{p}/show?id=\" + obj.id, cells: [#{cells_code}] } }",
+          "          html = renderer.render(:index, title: \"#{safe}s — #{mod}\", brand: brand, nav_items: nav,",
+          "            aggregate_name: \"#{safe}\", items: items,",
+          "            columns: [#{columns.join(', ')}],",
+          "            buttons: [#{btns.join(', ')}],",
+          "            row_actions: [#{row_acts.join(', ')}])",
+          "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
+          "        end",
+          ""
+        ]
+      end
+
+      def show_route(agg, mod)
+        safe = domain_constant_name(agg.name)
+        p = plural(agg)
+        attrs = user_attrs(agg)
+        agg_snake = domain_snake_name(agg.name)
+        ac = HecksTemplating::AggregateContract
+        dc = HecksTemplating::DisplayContract
+
+        lc = agg.lifecycle
+        lc_field = lc&.field&.to_s
+        field_exprs = build_attr_field_exprs(attrs, agg, lc, lc_field, dc) +
+                      build_ref_field_exprs(agg.references || [], dc)
+
+        btn_parts = build_show_buttons(agg, agg_snake, p, safe, mod, ac)
+
+        [
+          "        server.mount_proc \"/#{p}/show\" do |req, res|",
+          "          obj = #{safe}.find(req.query[\"id\"])",
+          "          unless obj",
+          "            res.status = 404; res.body = \"Not found\"; next",
+          "          end",
+          "          html = renderer.render(:show, title: \"#{safe} — #{mod}\", brand: brand, nav_items: nav,",
+          "            aggregate_name: \"#{safe}\", back_href: \"/#{p}\",",
+          "            id: obj.id, fields: [#{field_exprs.join(', ')}],",
+          "            buttons: [#{btn_parts.join(', ')}])",
+          "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
+          "        end",
+          ""
+        ]
+      end
+
+      def build_attr_field_exprs(attrs, agg, lc, lc_field, dc)
+        attrs.map do |a|
+          if a.list?
+            vo = agg.value_objects.find { |v| v.name == a.type.to_s }
+            if vo
+              vo_attrs = vo.attributes.map(&:name).map(&:to_s)
+              items_expr = "obj.#{a.name}.map { |v| #{vo_attrs.map { |va| "v.#{va}.to_s" }.join(' + " — " + ')} }"
+              "{ label: \"#{humanize(a.name)}\", type: :list, items: #{items_expr} }"
+            else
+              "{ label: \"#{humanize(a.name)}\", type: :list, items: obj.#{a.name}.map(&:to_s) }"
+            end
+          elsif lc_field && a.name.to_s == lc_field
+            transitions = HecksTemplating::DisplayContract.lifecycle_transitions(lc)
+            "{ label: \"#{humanize(a.name)}\", type: :lifecycle, value: obj.#{a.name}.to_s, transitions: #{transitions.inspect} }"
+          else
+            "{ label: \"#{humanize(a.name)}\", value: obj.#{a.name}.to_s }"
+          end
+        end
+      end
+
+      def build_ref_field_exprs(refs, dc)
+        refs.map do |r|
+          label = dc.reference_column_label(r)
+          field = dc.strip_id_suffix(r.name)
+          "{ label: \"#{label}\", value: obj.respond_to?(:#{field}) ? obj.#{field}.to_s : \"\" }"
+        end
+      end
+
+      def build_show_buttons(agg, agg_snake, p, safe, mod, ac)
+        _, update_cmds = ac.partition_commands(agg)
+        btn_parts = update_cmds.map do |c|
+          cm = domain_snake_name(c.name)
+          if ac.direct_action?(c, agg_snake)
+            self_id = ac.self_ref_attr(c, agg_snake)
+            "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id.name}\" }"
+          else
+            "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
+          end
+        end
+        snake = domain_snake_name(agg.name)
+        @domain.aggregates.each do |other|
+          next if other.name == agg.name
+          other_safe = domain_constant_name(other.name)
+          other_p = plural(other)
+          other.commands.each do |cmd|
+            next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
+            cm = domain_snake_name(cmd.name)
+            btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", href: \"/#{other_p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{other_safe}\", \"#{cm}\") }"
+          end
+        end
+        btn_parts
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -125,6 +125,26 @@ module Hecks::Conventions
       UILabelContract.label(domain_name.sub(/Domain$/, ""))
     end
 
+    # Returns the column header label for a reference on an aggregate.
+    # Uses the reference type name (e.g., "Pizza") rather than the raw
+    # field name (e.g., "pizza_id"), so index/show views show "Pizza"
+    # not "Pizza Id".
+    #
+    # @param ref [Reference] a reference IR object (responds to .type)
+    # @return [String] humanized label, e.g. "Pizza"
+    def self.reference_column_label(ref)
+      UILabelContract.label(ref.type)
+    end
+
+    # Strip "_id" suffix from a name string.
+    # "pizza_id" → "pizza", "order" → "order"
+    #
+    # @param name [String, Symbol]
+    # @return [String]
+    def self.strip_id_suffix(name)
+      name.to_s.sub(/_id$/, "")
+    end
+
     # Go field name helper — PascalCase.
     GoFieldName = ->(name) { Hecks::Utils.sanitize_constant(name) }
   end

--- a/hecksties/lib/hecks/conventions/ui_label_contract.rb
+++ b/hecksties/lib/hecks/conventions/ui_label_contract.rb
@@ -13,11 +13,15 @@ require "active_support/core_ext/string/inflections"
 module Hecks::Conventions
   module UILabelContract
     # Convert any name (snake_case or PascalCase) to a display label.
+    # Strips trailing "_id" from reference attribute names so that
+    # "pizza_id" renders as "Pizza" rather than "Pizza Id".
     def self.label(name)
       s = name.to_s
       s = s.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
            .gsub(/([a-z\d])([A-Z])/, '\1 \2')
-      s.split(/[_ ]+/).map(&:capitalize).join(" ")
+      result = s.split(/[_ ]+/).map(&:capitalize).join(" ")
+      result = result.sub(/ Id$/, "") if name.to_s.end_with?("_id")
+      result
     end
 
     # Humanized plural label for an aggregate or entity name.


### PR DESCRIPTION
## Summary

- `UILabelContract#label` now strips trailing " Id" when the name ends with `_id`, so `pizza_id` → "Pizza" not "Pizza Id"
- `DisplayContract` gains `reference_column_label(ref)` and `strip_id_suffix(name)` helpers
- Ruby `UIGenerator` index and show routes now iterate `agg.references` to include reference columns/fields alongside scalar attributes
- Go `DataRoutes` includes reference columns in index table and reference fields in show page
- Go `AggregateGenerator` adds reference fields to the generated struct definition
- Extracted `UIGenerator::DataRoutes` module into its own file to keep all files under the 200-line limit

## Test plan

- [ ] `bundle exec rspec hecksties/spec` — 1178 examples, 0 failures, under 1 second
- [ ] `bundle exec rspec hecks_targets/go/spec` — passes
- [ ] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes
- [ ] Generate a domain with a `reference_to` and confirm the index table shows "Pizza" column header instead of "Pizza Id"