### PR TITLE
HEC-394: MCP runtime boots from IR, no gem build required

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -381,6 +381,10 @@
 - Covers attributes with types, commands with parameters, validation rules, invariants, reactive chains
 
 ### MCP Server
+- MCP-compatible runtime boots domains from IR without gem building — no disk I/O, no tmpdir, no `Hecks.build`
+- `Hecks.load(domain)` is the public API for booting a Runtime from an IR object in memory
+- `execute_command` MCP tool auto-enters play mode if not already active — removes a round-trip
+- `Workshop#execute` delegates to the playground and auto-enters play mode when needed
 - `hecks mcp` exposes all domain commands, queries, and repository operations as typed MCP tools
 - `describe_domain` tool returns the entire domain model as structured JSON in one call
 - Tool descriptions include parameter constraints, example values, return shapes, and guard conditions

--- a/docs/usage/mcp_runtime_from_ir.md
+++ b/docs/usage/mcp_runtime_from_ir.md
@@ -1,0 +1,56 @@
+# MCP-Compatible Runtime: Boot from IR
+
+Load and run a domain without gem building, disk writes, or tmpdir.
+
+## Hecks.load
+
+```ruby
+require "hecks"
+
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+
+runtime = Hecks.load(domain)
+# => #<Hecks::Runtime ...>
+# PizzasDomain is now defined in memory
+```
+
+With a custom event bus:
+
+```ruby
+bus = Hecks::EventBus.new
+runtime = Hecks.load(domain, event_bus: bus)
+mod = Object.const_get("PizzasDomain")
+mod::Pizza.create(name: "Margherita")
+```
+
+## Workshop#execute
+
+`execute` auto-enters play mode if not already active:
+
+```ruby
+workshop = Hecks::Workshop.new("Pizzas")
+pizza = workshop.aggregate("Pizza")
+pizza.attr :name, String
+pizza.command("CreatePizza") { attribute :name, String }
+
+# No need to call play! first
+workshop.execute("CreatePizza", name: "Margherita")
+# => #<PizzasDomain::Pizza ...>
+workshop.play?  # => true
+```
+
+## MCP execute_command tool
+
+The `execute_command` MCP tool automatically enters play mode before running,
+removing the need for a separate `enter_play_mode` call:
+
+```json
+{ "tool": "execute_command", "command": "CreatePizza", "attrs": { "name": "Margherita" } }
+```

--- a/hecks_ai/lib/hecks_ai/domain_server.rb
+++ b/hecks_ai/lib/hecks_ai/domain_server.rb
@@ -1,5 +1,4 @@
 require "mcp"
-require "tmpdir"
 
 require_relative "domain_server/command_tools"
 require_relative "domain_server/query_tools"
@@ -19,9 +18,9 @@ module Hecks
     #   - +QueryTools+      -- one tool per query per aggregate
     #   - +RepositoryTools+ -- Find/All/Count per aggregate
     #
-    # This class handles the full lifecycle: building the domain gem into a temp
-    # directory, loading it, booting a runtime with memory adapters, and registering
-    # all tools on the MCP server.
+    # This class handles the full lifecycle: loading the domain into memory via
+    # InMemoryLoader (no disk I/O), booting a runtime with memory adapters, and
+    # registering all tools on the MCP server.
     #
     #   hecks domain mcp --domain NAME
     #
@@ -67,26 +66,19 @@ module Hecks
         register_repository_tools
       end
 
-      # Builds the domain gem into a temp directory (if not already loaded) and
-      # requires it. Sets +@mod+ to the generated domain module constant.
+      # Loads the domain into memory using InMemoryLoader (no disk I/O) and
+      # sets +@mod+ to the generated domain module constant.
       #
       # If the domain module is already defined in the Ruby runtime (e.g., from
-      # a prior load), it reuses it without rebuilding.
+      # a prior load), it reuses it without reloading.
       #
       # @return [void]
       def build_and_load
         mod_name = domain_module_name(@domain.name)
-        if Object.const_defined?(mod_name)
-          @mod = Object.const_get(mod_name)
-        else
-          @tmpdir = Dir.mktmpdir("hecks_mcp_domain")
-          gem_path = Hecks.build(@domain, output_dir: @tmpdir)
-          lib_path = File.join(gem_path, "lib")
-          $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
-          require @domain.gem_name
-          Dir[File.join(lib_path, "**/*.rb")].sort.each { |f| require f }
-          @mod = Object.const_get(mod_name)
-        end
+        return @mod = Object.const_get(mod_name) if Object.const_defined?(mod_name)
+
+        Hecks.load_domain(@domain, force: true)
+        @mod = Object.const_get(mod_name)
       end
 
       # Boots a Hecks::Runtime for the domain and binds repository methods

--- a/hecks_ai/lib/hecks_ai/play_tools.rb
+++ b/hecks_ai/lib/hecks_ai/play_tools.rb
@@ -51,6 +51,7 @@ module Hecks
           }
         ) do |args|
           ctx.ensure_session!
+          ctx.workshop.play! unless ctx.workshop.play?
           attrs = (args["attrs"] || {}).transform_keys(&:to_sym)
           ctx.capture_output { ctx.workshop.execute(args["command"], **attrs) }
         end

--- a/hecks_workshop/lib/hecks/extensions/ai/domain_server.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/domain_server.rb
@@ -1,5 +1,4 @@
 require "mcp"
-require "tmpdir"
 
 require_relative "domain_server/command_tools"
 require_relative "domain_server/query_tools"
@@ -19,9 +18,9 @@ module Hecks
     #   - +QueryTools+      -- one tool per query per aggregate
     #   - +RepositoryTools+ -- Find/All/Count per aggregate
     #
-    # This class handles the full lifecycle: building the domain gem into a temp
-    # directory, loading it, booting a runtime with memory adapters, and registering
-    # all tools on the MCP server.
+    # This class handles the full lifecycle: loading the domain into memory via
+    # InMemoryLoader (no disk I/O), booting a runtime with memory adapters, and
+    # registering all tools on the MCP server.
     #
     #   hecks domain mcp --domain NAME
     #
@@ -67,26 +66,19 @@ module Hecks
         register_repository_tools
       end
 
-      # Builds the domain gem into a temp directory (if not already loaded) and
-      # requires it. Sets +@mod+ to the generated domain module constant.
+      # Loads the domain into memory using InMemoryLoader (no disk I/O) and
+      # sets +@mod+ to the generated domain module constant.
       #
       # If the domain module is already defined in the Ruby runtime (e.g., from
-      # a prior load), it reuses it without rebuilding.
+      # a prior load), it reuses it without reloading.
       #
       # @return [void]
       def build_and_load
         mod_name = domain_module_name(@domain.name)
-        if Object.const_defined?(mod_name)
-          @mod = Object.const_get(mod_name)
-        else
-          @tmpdir = Dir.mktmpdir("hecks_mcp_domain")
-          gem_path = Hecks.build(@domain, output_dir: @tmpdir)
-          lib_path = File.join(gem_path, "lib")
-          $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
-          require @domain.gem_name
-          Dir[File.join(lib_path, "**/*.rb")].sort.each { |f| require f }
-          @mod = Object.const_get(mod_name)
-        end
+        return @mod = Object.const_get(mod_name) if Object.const_defined?(mod_name)
+
+        Hecks.load_domain(@domain, force: true)
+        @mod = Object.const_get(mod_name)
       end
 
       # Boots a Hecks::Runtime for the domain and binds repository methods

--- a/hecks_workshop/lib/hecks/extensions/ai/play_tools.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/play_tools.rb
@@ -51,6 +51,7 @@ module Hecks
           }
         ) do |args|
           ctx.ensure_session!
+          ctx.workshop.play! unless ctx.workshop.play?
           attrs = (args["attrs"] || {}).transform_keys(&:to_sym)
           ctx.capture_output { ctx.workshop.execute(args["command"], **attrs) }
         end

--- a/hecks_workshop/lib/hecks/workshop/play_mode.rb
+++ b/hecks_workshop/lib/hecks/workshop/play_mode.rb
@@ -78,6 +78,20 @@ module Hecks
         self
       end
 
+      # Execute a command by name against the live playground.
+      #
+      # Auto-enters play mode if not already in it. Delegates to
+      # Playground#execute which resolves the aggregate, translates the
+      # command name to a method call, and captures the emitted event.
+      #
+      # @param command_name [String] the command class name (e.g. "CreatePizza")
+      # @param attrs [Hash] keyword arguments for the command
+      # @return [Object] the result of the command execution
+      def execute(command_name, **attrs)
+        play! unless play?
+        @playground.execute(command_name, **attrs)
+      end
+
       # Return all events captured during play mode.
       #
       # @return [Array] list of event objects recorded by the playground

--- a/hecks_workshop/spec/runtime_from_ir_spec.rb
+++ b/hecks_workshop/spec/runtime_from_ir_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+# Hecks::Runtime — boot from IR without gem building
+#
+# Verifies that Hecks.load boots a domain from an in-memory IR object
+# (no Bluebook file, no disk writes) and that commands fire events.
+RSpec.describe "Hecks.load — boot from IR without gem building" do
+  before { allow($stdout).to receive(:puts) }
+
+  def build_domain
+    Hecks.domain "IrBootTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  describe "Hecks.load" do
+    it "returns a Runtime from a domain IR object" do
+      domain = build_domain
+      runtime = Hecks.load(domain)
+      expect(runtime).to be_a(Hecks::Runtime)
+    end
+
+    it "loads the domain module constant without writing to disk" do
+      domain = build_domain
+      Hecks.load(domain)
+      expect(Object.const_defined?("IrBootTestDomain")).to be true
+    end
+
+    it "accepts an event_bus: option" do
+      domain = build_domain
+      bus = Hecks::EventBus.new
+      runtime = Hecks.load(domain, event_bus: bus)
+      expect(runtime).to be_a(Hecks::Runtime)
+    end
+
+    it "executes a command and fires an event via the runtime" do
+      domain = build_domain
+      events = []
+      bus = Hecks::EventBus.new
+      original = bus.method(:publish)
+      bus.define_singleton_method(:publish) { |e| original.call(e); events << e }
+
+      Hecks.load(domain, event_bus: bus)
+      mod = Object.const_get("IrBootTestDomain")
+      mod::Widget.create(name: "Sprocket")
+
+      expect(events.size).to eq(1)
+      expect(events.first.name).to eq("Sprocket")
+    end
+  end
+
+  describe "Workshop#execute delegation" do
+    it "delegates execute to the playground" do
+      wb = Hecks::Workshop.new("WsExecTest")
+      pizza = wb.aggregate("Pizza")
+      pizza.attr :name, String
+      pizza.command("CreatePizza") { attribute :name, String }
+      wb.play!
+      result = wb.execute("CreatePizza", name: "Margherita")
+      expect(result.name).to eq("Margherita")
+    end
+
+    it "auto-enters play mode when not already in it" do
+      wb = Hecks::Workshop.new("AutoPlayTest")
+      widget = wb.aggregate("Widget")
+      widget.attr :name, String
+      widget.command("CreateWidget") { attribute :name, String }
+      expect(wb.play?).to be false
+      wb.execute("CreateWidget", name: "Bolt")
+      expect(wb.play?).to be true
+    end
+  end
+end

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -74,6 +74,16 @@ module Hecks
     @configuration
   end
 
+  # Load a domain from an IR object and return a booted Runtime. No filesystem
+  # required -- uses InMemoryLoader to generate and eval source in memory.
+  #
+  #   runtime = Hecks.load(domain)
+  #   runtime = Hecks.load(domain, event_bus: my_bus)
+  #
+  # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+  # @param force [Boolean] reload even if already cached (default false)
+  # @param opts [Hash] extra options forwarded to Runtime (e.g. event_bus:)
+  # @return [Hecks::Runtime] a fully wired runtime with memory adapters
   def self.load(domain, force: false, **opts, &config)
     load_domain(domain, force: force)
     Runtime.new(domain, **opts, &config)


### PR DESCRIPTION
## Summary

- `DomainServer#build_and_load` in both `hecks_workshop` and `hecks_ai` now uses `Hecks.load_domain` (InMemoryLoader) instead of `Hecks.build` — eliminates tmpdir, disk writes, and `$LOAD_PATH` mutation from MCP server startup
- `Workshop#execute` added to `PlayMode` — delegates to `@playground.execute` and auto-enters play mode when not already active
- `execute_command` MCP tool auto-enters play mode before running — removes one required round-trip for AI agents
- `Hecks.load` has a clear doc comment as the public API for IR-object boot (no Bluebook file needed)
- Both `hecks_workshop` and `hecks_ai` receive all fixes symmetrically

## Test plan

- [ ] New spec `hecks_workshop/spec/runtime_from_ir_spec.rb` — 6 examples: `Hecks.load` returns Runtime, loads constant, accepts event_bus, fires events; `Workshop#execute` delegates and auto-enters play mode
- [ ] Full suite: 1184 examples, 0 failures (run with `bundle exec rspec --order defined`)
- [ ] Smoke test: `ruby -Ilib examples/pizzas/app.rb` passes