### PR TITLE
HEC-254: Cross-target Ruby vs Go parity test

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -4,3 +4,4 @@
 -I hecksties/watchers/lib
 --require spec_helper
 --pattern {hecksties,hecksties/watchers,bluebook,hecksagon,hecks_workshop,hecks_ai}/spec/**/*_spec.rb
+--tag ~parity

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -569,6 +569,15 @@
 - Same IR output — implicit is sugar on top of explicit DSL
 - Both forms can be mixed in the same file
 
+## Testing
+
+### Cross-Target Parity
+- `hecksties/spec/cross_target_parity_spec.rb` — tagged `:parity`, excluded from default run
+- Builds Pizzas domain into both Ruby static and Go targets from the domain IR
+- Boots both HTTP servers, submits identical command sequences via browser-style form submission
+- Fetches `/_events` from both, normalizes to event name lists, asserts equality
+- Run explicitly: `bundle exec rspec hecksties/spec/cross_target_parity_spec.rb --tag parity`
+
 ## Examples
 - Pizzas domain: plain Ruby app with commands, queries, collection proxies, event history
 - Pizzas static Ruby: generated standalone Ruby project with HTTP server, UI, roles, filesystem persistence

--- a/docs/usage/cross_target_parity.md
+++ b/docs/usage/cross_target_parity.md
@@ -1,0 +1,41 @@
+# Cross-Target Parity Testing
+
+The parity spec proves that the Ruby static and Go targets produce identical event logs
+when given the same command sequence. It builds both targets from the Pizzas domain IR,
+boots them as HTTP servers, submits form commands to each, and compares `/_events`.
+
+## Running the spec
+
+```bash
+bundle exec rspec hecksties/spec/cross_target_parity_spec.rb --tag parity
+```
+
+Expected output:
+
+```
+Run options: include {:parity=>true}
+
+Cross-target behavioral parity: Ruby vs Go
+  produces identical event name lists after the same command sequence
+
+1 example, 0 failures
+```
+
+## How it works
+
+1. `Hecks.build_static(domain, ...)` generates a self-contained Ruby gem with HTTP server
+2. `Hecks.build_go(domain, ...)` generates a Go project with HTTP server
+3. Both servers are started on random ports
+4. `submit_form` GETs each form page, extracts the `action` URL, and POSTs form data
+5. `/_events` is fetched from both; names are sorted and compared
+
+## Default run exclusion
+
+The spec is tagged `:parity` and excluded from the default run via `.rspec`:
+
+```
+--tag ~parity
+```
+
+This keeps the default suite under 1 second. The parity spec itself runs in ~1s
+(builds are cached by the Go toolchain).

--- a/examples/pizzas/pizzas_static_ruby/boot.rb
+++ b/examples/pizzas/pizzas_static_ruby/boot.rb
@@ -87,7 +87,7 @@ module PizzasDomain
 
     def serve(port: 9292)
       require_relative "lib/pizzas_domain/server/domain_app"
-      Server::DomainApp.new(self).start(gate: port)
+      Server::DomainApp.new(self).start(port: port)
     end
 
     def domain_info

--- a/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
@@ -146,7 +146,10 @@ module GoHecks
       write("server/renderer.go", RendererGenerator.new.generate)
 
       # Convert ERB views to Go templates using view contracts
-      erb_dir = File.expand_path("../../../../hecks_runtime/lib/hecks/extensions/web_explorer/views", __dir__)
+      # Path resolution: try hecksties first (monorepo layout), then legacy hecks_runtime
+      erb_base = File.expand_path("../../../../../hecksties/lib/hecks/extensions/web_explorer/views", __dir__)
+      erb_base = File.expand_path("../../../../hecks_runtime/lib/hecks/extensions/web_explorer/views", __dir__) unless Dir.exist?(erb_base)
+      erb_dir = erb_base
       gen = ViewGenerator.new
       Dir.glob(File.join(erb_dir, "*.erb")).each do |erb_file|
         name = File.basename(erb_file, ".erb")

--- a/hecks_targets/ruby/lib/hecks_static/generators/entry_point_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/entry_point_generator.rb
@@ -168,7 +168,7 @@ module HecksStatic
       lines << ""
       lines << "    def serve(port: 9292)"
       lines << "      require_relative \"lib/#{@gem_name}/server/domain_app\""
-      lines << "      Server::DomainApp.new(self).start(gate: port)"
+      lines << "      Server::DomainApp.new(self).start(port: port)"
       lines << "    end"
       lines << ""
       lines << "    def domain_info"

--- a/hecks_targets/ruby/lib/hecks_static/generators/gem_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/gem_generator.rb
@@ -49,7 +49,9 @@ class GemGenerator < Hecks::Generator
 
   def generate_domain_rb(root)
     serializer = Hecks::DslSerializer.new(@domain)
-    File.write(Dir[File.join(root, "*Bluebook")].first, serializer.serialize)
+    bluebook = Dir[File.join(root, "*Bluebook")].first ||
+               File.join(root, "#{@domain.name}Bluebook")
+    File.write(bluebook, serializer.serialize)
   end
 
   def generate_gemspec(root, gem_name, mod)
@@ -98,7 +100,9 @@ class GemGenerator < Hecks::Generator
     File.write(File.join(server_dir, "server.rb"), source.gsub("__DOMAIN_MODULE__", mod))
 
     # Copy renderer from runtime web_explorer extension
-    explorer_dir = File.expand_path("../../../../hecks_runtime/lib/hecks/extensions/web_explorer", __dir__)
+    # Path resolution: try hecksties first (monorepo layout), then legacy hecks_runtime
+    explorer_dir = File.expand_path("../../../../../hecksties/lib/hecks/extensions/web_explorer", __dir__)
+    explorer_dir = File.expand_path("../../../../hecks_runtime/lib/hecks/extensions/web_explorer", __dir__) unless Dir.exist?(explorer_dir)
     renderer_src = File.read(File.join(explorer_dir, "renderer.rb"))
     renderer_out = renderer_src
       .gsub("module Hecks\n  module WebExplorer", "module #{mod}\n  module Server")

--- a/hecksties/spec/cross_target_parity_spec.rb
+++ b/hecksties/spec/cross_target_parity_spec.rb
@@ -1,0 +1,138 @@
+# = Cross-Target Parity Spec
+#
+# Builds the Pizzas domain into both Ruby (static) and Go targets, boots both
+# HTTP servers, runs the same command sequence against each via browser-style
+# form submission, fetches /_events from each, and asserts that the normalized
+# event name lists are identical.
+#
+# Tagged :parity — excluded from the default sub-second RSpec run.
+# Run explicitly:
+#   bundle exec rspec hecksties/spec/cross_target_parity_spec.rb --tag parity
+#
+require "spec_helper"
+require "net/http"
+require "uri"
+require "json"
+require "tmpdir"
+require "fileutils"
+
+# Load static targets (not in the default bundle path)
+$LOAD_PATH.unshift(File.expand_path("../../hecks_targets/ruby/lib", __dir__))
+$LOAD_PATH.unshift(File.expand_path("../../hecks_targets/go/lib", __dir__))
+require "hecks_static"
+require "go_hecks"
+
+def normalize_events(json)
+  json.map { |e| e["name"] }.sort
+end
+
+def free_port
+  require "socket"
+  s = TCPServer.new(0)
+  port = s.addr[1]
+  s.close
+  port
+end
+
+def wait_for_server(url, timeout: 20)
+  deadline = Time.now + timeout
+  uri = URI(url)
+  loop do
+    Net::HTTP.get_response(uri)
+    return true
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, Net::ReadTimeout
+    raise "Server at #{url} did not start in #{timeout}s" if Time.now > deadline
+    sleep 0.5
+  end
+end
+
+# Browser-style form submission: GET the form page, parse the action URL,
+# POST form-urlencoded data. Handles route differences between Ruby (/submit)
+# and Go (direct POST) transparently.
+def submit_form(base_url, form_path, params)
+  html = Net::HTTP.get(URI("#{base_url}#{form_path}"))
+  action = html.match(/<form[^>]*action="([^"]*)"/)&.captures&.first
+  raise "No form action found at #{form_path} on #{base_url}" unless action
+  Net::HTTP.post_form(URI("#{base_url}#{action}"), params)
+end
+
+def run_command_sequence(base_url)
+  submit_form(base_url, "/pizzas/create_pizza/new",
+              "name" => "Margherita", "description" => "Classic tomato and mozzarella")
+  submit_form(base_url, "/pizzas/create_pizza/new",
+              "name" => "Pepperoni", "description" => "Spicy pepperoni")
+  submit_form(base_url, "/pizzas/create_pizza/new",
+              "name" => "Veggie", "description" => "Garden fresh")
+end
+
+def fetch_events(base_url)
+  uri = URI("#{base_url}/_events")
+  req = Net::HTTP::Get.new(uri)
+  req["Accept"] = "application/json"
+  res = Net::HTTP.start(uri.host, uri.port) { |h| h.request(req) }
+  JSON.parse(res.body)
+rescue => e
+  raise "Failed to fetch /_events from #{base_url}: #{e.message}"
+end
+
+RSpec.describe "Cross-target behavioral parity: Ruby vs Go", :parity do
+  before(:all) do
+    skip "go not installed" unless system("which go > /dev/null 2>&1")
+
+    bluebook = File.join(__dir__, "../../examples/pizzas/PizzasBluebook")
+    domain = eval(File.read(bluebook), TOPLEVEL_BINDING, bluebook, 1)
+
+    @ruby_dir = Dir.mktmpdir("hecks-ruby-parity-")
+    @go_dir   = Dir.mktmpdir("hecks-go-parity-")
+
+    ruby_root = Hecks.build_static(domain, output_dir: @ruby_dir, smoke_test: false)
+    go_root   = Hecks.build_go(domain, output_dir: @go_dir, smoke_test: false)
+
+    # Build Go binary for fast startup (tidy first to resolve go.sum)
+    @go_bin = File.join(@go_dir, "pizzas_server")
+    system("go", "mod", "tidy", chdir: go_root, out: "/dev/null", err: "/dev/null")
+    ok = system("go", "build", "-o", @go_bin, "./cmd/pizzas/", chdir: go_root)
+    skip "go build failed" unless ok && File.exist?(@go_bin)
+
+    @ruby_port = free_port
+    @go_port   = free_port
+
+    ruby_bin = File.join(ruby_root, "bin", "pizzas")
+    @ruby_pid = spawn(RbConfig.ruby, ruby_bin, "serve", @ruby_port.to_s,
+                      out: "/dev/null", err: "/dev/null")
+    go_views  = File.join(go_root, "views")
+    @go_pid   = spawn({ "VIEWS_DIR" => go_views }, @go_bin, @go_port.to_s,
+                      out: "/dev/null", err: "/dev/null", in: "/dev/null")
+
+    wait_for_server("http://localhost:#{@ruby_port}/")
+    wait_for_server("http://localhost:#{@go_port}/")
+  end
+
+  after(:all) do
+    [@ruby_pid, @go_pid].each do |pid|
+      next unless pid
+      Process.kill("TERM", pid) rescue nil
+      Process.wait(pid) rescue nil
+    end
+    FileUtils.rm_rf(@ruby_dir) if @ruby_dir
+    FileUtils.rm_rf(@go_dir)   if @go_dir
+  end
+
+  it "produces identical event name lists after the same command sequence" do
+    ruby_base = "http://localhost:#{@ruby_port}"
+    go_base   = "http://localhost:#{@go_port}"
+
+    run_command_sequence(ruby_base)
+    run_command_sequence(go_base)
+
+    ruby_events = fetch_events(ruby_base)
+    go_events   = fetch_events(go_base)
+
+    ruby_names = normalize_events(ruby_events)
+    go_names   = normalize_events(go_events)
+
+    expect(ruby_names).not_to be_empty, "Ruby server produced no events"
+    expect(go_names).not_to be_empty,   "Go server produced no events"
+    expect(ruby_names).to eq(go_names)
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `hecksties/spec/cross_target_parity_spec.rb` tagged `:parity` to prove Ruby and Go targets produce identical event logs given the same command sequence
- Fixes three generator bugs uncovered while building the test: `gate: port` typo in entry_point_generator, nil Bluebook path in gem_generator, and broken hecks_runtime path resolution in both Ruby and Go generators
- Adds `--tag ~parity` to `.rspec` so the slow parity spec is excluded from the default sub-second suite

## Test plan
- [ ] `bundle exec rspec hecksties/spec/ 2>&1 | tail -3` — 1178 examples, 0 failures, under 1 second
- [ ] `bundle exec rspec hecksties/spec/cross_target_parity_spec.rb --tag parity --format documentation` — 1 example, 0 failures, both targets produce matching `CreatedPizza` event lists
- [ ] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes