### PR TITLE
HEC-212: Flatten CLI — remove stale 'hecks domain' references

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -314,13 +314,13 @@
 
 ## CLI Commands
 - `hecks new NAME` — scaffold a complete project
-- `hecks domain build` — validate and generate versioned gem
-- `hecks domain serve [--rpc]` — start REST or JSON-RPC server
-- `hecks domain console [NAME]` — interactive REPL with domain loaded
-- `hecks domain validate` — check domain against DDD rules
-- `hecks domain mcp` — start MCP server
-- `hecks domain dump` — show glossary, visualizer, and DSL output
-- `hecks domain migrations` — schema migration management
+- `hecks build` — validate and generate versioned gem
+- `hecks serve [--rpc]` — start REST or JSON-RPC server
+- `hecks console [NAME]` — interactive REPL with domain loaded
+- `hecks validate` — check domain against DDD rules
+- `hecks mcp` — start MCP server
+- `hecks dump` — show glossary, visualizer, and DSL output
+- `hecks migrations` — schema migration management
 - `hecks docs update` — sync doc headers and READMEs
 - All commands accept `--domain` flag consistently
 
@@ -439,7 +439,7 @@
 ## Static Domain Generation (hecks_static)
 
 ### Zero-Dependency Output — Full DSL Parity
-- `hecks domain build --static` generates a complete Ruby project with no hecks runtime dependency
+- `hecks build --static` generates a complete Ruby project with no hecks runtime dependency
 - All DSL concepts generated: aggregates, value objects, entities, commands, events, ports, queries, validations, invariants, lifecycles, specifications, policies
 - Generated project includes inlined runtime (Model, Command, EventBus, QueryBuilder, Specification)
 - `bin/<domain> serve` starts an HTTP server with JSON API and HTML UI

--- a/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator.rb
@@ -12,7 +12,7 @@ module Hecks
     # events, policies, queries, ports, adapters, specs, and a gemspec. Delegates
     # to FileWriter (disk I/O) and SpecWriter
     # (RSpec scaffolds). Part of the Generators::Infrastructure layer, invoked by
-    # the CLI `hecks domain build` command and `Hecks.build`.
+    # the CLI `hecks build` command and `Hecks.build`.
     #
     #   gen = DomainGemGenerator.new(domain, output_dir: "./generated")
     #   gen.generate  # => path to generated gem root

--- a/docs/active_record.md
+++ b/docs/active_record.md
@@ -150,8 +150,8 @@ rake db:migrate
 
 Hecks (standalone):
 ```bash
-hecks domain generate:migrations
-hecks domain db:migrate --database my.db
+hecks generate:migrations
+hecks db:migrate --database my.db
 ```
 
 Hecks (in Rails):
@@ -196,7 +196,7 @@ Tests run against in-memory adapters. No database process, no migrations, no fix
 ## Switching from ActiveRecord
 
 1. Describe your models in a `hecks_domain.rb` file
-2. Run `hecks domain build` to generate the domain gem
+2. Run `hecks build` to generate the domain gem
 3. Add the gem to your Rails Gemfile
 4. Run `rails generate active_hecks:init` to create the initializer, or add
    `config/initializers/hecks.rb` manually:

--- a/examples/banking/build.rb
+++ b/examples/banking/build.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Build a banking domain live using the Hecks Session API.
-# This is exactly what you'd type in `hecks domain workshop`.
+# This is exactly what you'd type in `hecks console`.
 
 require_relative "../../lib/hecks"
 

--- a/hecks_ai/lib/hecks_ai/domain_server.rb
+++ b/hecks_ai/lib/hecks_ai/domain_server.rb
@@ -23,7 +23,7 @@ module Hecks
     # directory, loading it, booting a runtime with memory adapters, and registering
     # all tools on the MCP server.
     #
-    #   hecks domain mcp --domain NAME
+    #   hecks mcp --domain NAME
     #
     class DomainServer
       include HecksTemplating::NamingHelpers

--- a/hecks_ai/lib/hecks_ai/mcp_server.rb
+++ b/hecks_ai/lib/hecks_ai/mcp_server.rb
@@ -27,7 +27,7 @@ module Hecks
   #   - +resolve_type+ for converting type strings to Ruby types
   #   - +capture_output+ for capturing stdout during block execution
   #
-  #   hecks domain mcp    # starts the server on stdio
+  #   hecks mcp    # starts the server on stdio
   #
   class McpServer
     # The current Hecks::Workshop instance, set after +create_session+ or

--- a/hecks_on_rails/lib/active_hecks/generators/init_generator.rb
+++ b/hecks_on_rails/lib/active_hecks/generators/init_generator.rb
@@ -19,7 +19,7 @@ module ActiveHecks
       @gem_dir = Dir.glob(::Rails.root.join("*_domain")).first
       unless @gem_dir
         say "No domain gem found (looking for *_domain/ directory)", :red
-        say "Build one first with `hecks domain build` and add it to your Gemfile."
+        say "Build one first with `hecks build` and add it to your Gemfile."
         raise SystemExit
       end
 
@@ -69,8 +69,8 @@ module ActiveHecks
         The domain is defined in a standalone Hecks project. To modify it:
 
         1. Go to the Hecks project where `domain.rb` lives
-        2. Run `hecks domain workshop` to edit interactively
-        3. Run `hecks domain build` to generate a new version of the gem
+        2. Run `hecks console` to edit interactively
+        3. Run `hecks build` to generate a new version of the gem
         4. Update the gem version in this app's Gemfile
         5. `bundle update #{@gem_name}`
         6. Generate and run migrations:

--- a/hecks_targets/ruby/lib/hecks_static.rb
+++ b/hecks_targets/ruby/lib/hecks_static.rb
@@ -11,7 +11,7 @@
 #   HecksStatic::GemGenerator.new(domain).generate
 #
 #   # Or via CLI:
-#   hecks domain build --standalone
+#   hecks build --standalone
 #
 require_relative "hecks_static/generators/runtime_writer"
 require_relative "hecks_static/generators/entry_point_generator"

--- a/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
@@ -18,8 +18,8 @@ module Hecks
     # When +--live+ is enabled, a WebSocket server runs alongside HTTP on a
     # separate port.
     #
-    #   hecks domain serve pizzas_domain
-    #   hecks domain serve pizzas_domain --live
+    #   hecks serve pizzas_domain
+    #   hecks serve pizzas_domain --live
     #
     class DomainServer
       include HecksTemplating::NamingHelpers

--- a/hecks_workshop/explorer/lib/hecks_explorer/rpc_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/rpc_server.rb
@@ -16,7 +16,7 @@ module Hecks
     # - Queries: use "AggregateName.query_name" (e.g. "Pizza.by_topping")
     # - CRUD: use "AggregateName.find", ".all", ".count", ".delete"
     #
-    #   hecks domain serve pizzas_domain --rpc
+    #   hecks serve pizzas_domain --rpc
     #
     #   # JSON-RPC request:
     #   # POST / {"jsonrpc":"2.0","method":"CreatePizza","params":{"name":"Margherita"},"id":1}

--- a/hecks_workshop/lib/hecks/extensions/ai/domain_server.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/domain_server.rb
@@ -23,7 +23,7 @@ module Hecks
     # directory, loading it, booting a runtime with memory adapters, and registering
     # all tools on the MCP server.
     #
-    #   hecks domain mcp --domain NAME
+    #   hecks mcp --domain NAME
     #
     class DomainServer
       include HecksTemplating::NamingHelpers

--- a/hecks_workshop/lib/hecks/extensions/ai/mcp_server.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/mcp_server.rb
@@ -27,7 +27,7 @@ module Hecks
   #   - +resolve_type+ for converting type strings to Ruby types
   #   - +capture_output+ for capturing stdout during block execution
   #
-  #   hecks domain mcp    # starts the server on stdio
+  #   hecks mcp    # starts the server on stdio
   #
   class McpServer
     # The current Hecks::Workshop instance, set after +create_session+ or

--- a/hecksagon/lib/hecks_persist/commands/migrations.rb
+++ b/hecksagon/lib/hecks_persist/commands/migrations.rb
@@ -67,7 +67,7 @@ Hecks::CLI.register_command(:generate_sql, "Generate SQL schema and adapters",
       say "Generated #{path}", :green
     end
   else
-    say "Domain gem not found at #{gem_dir}/. Run 'hecks domain build' first.", :yellow
+    say "Domain gem not found at #{gem_dir}/. Run 'hecks build' first.", :yellow
   end
 end
 

--- a/hecksagon/lib/hecks_persist/sql_migration_generator.rb
+++ b/hecksagon/lib/hecks_persist/sql_migration_generator.rb
@@ -6,7 +6,7 @@ module Hecks
     #
     # Generates CREATE TABLE SQL statements from a domain model. Produces one
     # table per aggregate plus join tables for list-type value objects. Part of
-    # Generators::SQL, invoked by the CLI `hecks domain build` command to produce
+    # Generators::SQL, invoked by the CLI `hecks build` command to produce
     # db/schema.sql.
     #
     #   gen = SqlMigrationGenerator.new(domain)

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -18,8 +18,8 @@ module Hecks
     # When +--live+ is enabled, a WebSocket server runs alongside HTTP on a
     # separate port.
     #
-    #   hecks domain serve pizzas_domain
-    #   hecks domain serve pizzas_domain --live
+    #   hecks serve pizzas_domain
+    #   hecks serve pizzas_domain --live
     #
     class DomainServer
       include HecksTemplating::NamingHelpers

--- a/hecksties/lib/hecks/extensions/serve/rpc_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/rpc_server.rb
@@ -16,7 +16,7 @@ module Hecks
     # - Queries: use "AggregateName.query_name" (e.g. "Pizza.by_topping")
     # - CRUD: use "AggregateName.find", ".all", ".count", ".delete"
     #
-    #   hecks domain serve pizzas_domain --rpc
+    #   hecks serve pizzas_domain --rpc
     #
     #   # JSON-RPC request:
     #   # POST / {"jsonrpc":"2.0","method":"CreatePizza","params":{"name":"Margherita"},"id":1}

--- a/hecksties/lib/hecks_cli/commands/init.rb
+++ b/hecksties/lib/hecks_cli/commands/init.rb
@@ -13,6 +13,6 @@ Hecks::CLI.register_command(:init, "Initialize a Hecks domain in the current dir
   say "  verbs.txt   — add custom action verbs (optional)"
   say ""
   say "Next steps:"
-  say "  hecks domain workshop   # edit interactively"
-  say "  hecks domain build     # generate the domain gem"
+  say "  hecks console           # edit interactively"
+  say "  hecks build             # generate the domain gem"
 end

--- a/hecksties/lib/hecks_cli/conflict_handler.rb
+++ b/hecksties/lib/hecks_cli/conflict_handler.rb
@@ -7,7 +7,7 @@ module Hecks
     # --force to overwrite without prompting. Uses system `diff -u` for real
     # unified diffs with proper insertion/deletion handling.
     #
-    #   class Domain < Thor
+    #   class MyCommand < Thor
     #     include ConflictHandler
     #
     #     def some_generator

--- a/hecksties/spec/cli/commands/build_spec.rb
+++ b/hecksties/spec/cli/commands/build_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks_cli"
 
-RSpec.describe "hecks domain build" do
+RSpec.describe "hecks build" do
   before { allow($stdout).to receive(:puts) }
 
   it "builds a domain gem from Bluebook" do

--- a/hecksties/spec/cli/commands/diff_spec.rb
+++ b/hecksties/spec/cli/commands/diff_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks_cli"
 
-RSpec.describe "hecks domain diff" do
+RSpec.describe "hecks diff" do
   before { allow($stdout).to receive(:puts) }
 
   it "detects added aggregates as non-breaking" do

--- a/hecksties/spec/cli/commands/promote_spec.rb
+++ b/hecksties/spec/cli/commands/promote_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks_cli"
 
-RSpec.describe "hecks domain promote" do
+RSpec.describe "hecks promote" do
   before { allow($stdout).to receive(:puts) }
 
   it "extracts an aggregate into a standalone domain file" do

--- a/hecksties/spec/cli/commands/validate_spec.rb
+++ b/hecksties/spec/cli/commands/validate_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks_cli"
 
-RSpec.describe "hecks domain validate" do
+RSpec.describe "hecks validate" do
   let(:cli) { Hecks::CLI.new }
 
   before { allow($stdout).to receive(:puts) }

--- a/hecksties/spec/cli/commands_spec.rb
+++ b/hecksties/spec/cli/commands_spec.rb
@@ -4,7 +4,7 @@ require "fileutils"
 
 # Hecks CLI Command Integration Tests
 #
-# Tests each `hecks domain` subcommand by invoking Hecks::CLI.start
+# Tests each `hecks` command by invoking Hecks::CLI.start
 # with captured stdout. Uses a temp directory with a minimal domain.
 RSpec.describe "CLI commands" do
   let(:tmpdir) { Dir.mktmpdir("hecks-cli-") }


### PR DESCRIPTION
## Summary

- Replace all `hecks domain <cmd>` references with the flat `hecks <cmd>` form across 23 files
- Covers user-facing output strings (highest priority), doc comments (~12 files), spec descriptions (~5 files), FEATURES.md, and other docs
- No behavioral changes — the structural CLI flattening was already done

## Files changed

- **User-facing output**: `init.rb`, `migrations.rb`
- **Doc comments**: `domain_server.rb`, `rpc_server.rb`, `mcp_server.rb`, `conflict_handler.rb`, `domain_gem_generator.rb`, `sql_migration_generator.rb` (across hecksties, hecks_ai, hecks_workshop, hecksagon, bluebook)
- **Spec descriptions**: `build_spec.rb`, `diff_spec.rb`, `validate_spec.rb`, `promote_spec.rb`, `commands_spec.rb`
- **Docs**: `FEATURES.md`, `docs/active_record.md`, `hecks_static.rb`, `init_generator.rb`, `examples/banking/build.rb`

## Test plan

- [x] `bundle exec rspec hecksties/spec/cli/` — 1205 examples, 0 failures (0.95s)
- [x] Smoke test `ruby -Ilib examples/pizzas/app.rb` — passes
- [x] Pre-commit hook confirmed: tests 0.80s, smoke 12 examples 0 failures
- [x] `grep -r "hecks domain"` — zero matches remaining