### PR TITLE
HEC-91: Schema visualization in Workshop — wire Mermaid diagram output

### DIFF
--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -4,6 +4,7 @@ require_relative "workshop/play_mode"
 require_relative "workshop/presenter"
 require_relative "workshop/handles/aggregate_handle"
 require_relative "workshop/system_browser"
+require_relative "workshop/visualize_mode"
 require_relative "workshop/workshop_runner"
 require_relative "workshop/playground"
 require_relative "workshop/web_runner"
@@ -38,6 +39,7 @@ module Hecks
     include PlayMode
     include Presenter
     include SystemBrowser
+    include VisualizeMode
 
     attr_reader :name, :playground, :aggregate_builders
 

--- a/hecks_workshop/lib/hecks/workshop/visualize_mode.rb
+++ b/hecks_workshop/lib/hecks/workshop/visualize_mode.rb
@@ -1,0 +1,118 @@
+module Hecks
+  class Workshop
+    # Hecks::Workshop::VisualizeMode
+    #
+    # Mixin that adds Mermaid diagram visualization to the Workshop. Wires the
+    # existing DomainVisualizer, FlowGenerator, and SliceDiagram generators to
+    # produce output in three formats: printed to stdout, written to a Markdown
+    # file, or opened as a self-contained HTML page in the browser.
+    #
+    #   workshop.visualize                        # prints all diagrams
+    #   workshop.visualize(:browser)              # opens HTML in browser
+    #   workshop.visualize(:file, type: :flows)   # writes flows.md
+    #   workshop.visualize(:print, type: :structure)
+    #
+    module VisualizeMode
+      # Dispatch visualization to the requested output format.
+      #
+      # @param format [Symbol] :print (default), :browser, or :file
+      # @param type   [Symbol] :all (default), :structure, :behavior, :flows, :slices
+      # @return [void]
+      def visualize(format = :print, type: :all)
+        case format
+        when :print   then visualize_print(type)
+        when :browser then visualize_browser(type)
+        when :file    then visualize_file(type)
+        else
+          puts "Unknown format #{format.inspect}. Use :print, :browser, or :file."
+        end
+      end
+
+      private
+
+      # Print Mermaid markdown to stdout.
+      #
+      # @param type [Symbol] diagram type selector
+      # @return [nil]
+      def visualize_print(type)
+        puts mermaid_for(to_domain, type)
+        nil
+      end
+
+      # Write a self-contained HTML page and open it in the default browser.
+      #
+      # @param type [Symbol] diagram type selector
+      # @return [String] path to the written temp file
+      def visualize_browser(type)
+        content = mermaid_for(to_domain, type)
+        html = build_html(content)
+        require "tempfile"
+        tmp = Tempfile.new(["hecks_visualize", ".html"])
+        tmp.write(html)
+        tmp.close
+        path = tmp.path
+        system("open", path)
+        puts "Opened #{path}"
+        path
+      end
+
+      # Write raw Mermaid markdown to a .md file in the current directory.
+      #
+      # @param type [Symbol] diagram type selector
+      # @return [String] path to the written file
+      def visualize_file(type)
+        content = mermaid_for(to_domain, type)
+        filename = "#{type}_diagram.md"
+        File.write(filename, content)
+        puts "Wrote #{filename}"
+        filename
+      end
+
+      # Build Mermaid markdown for the given domain and diagram type.
+      #
+      # @param domain [DomainModel::Structure::Domain]
+      # @param type   [Symbol] :all, :structure, :behavior, :flows, :slices
+      # @return [String]
+      def mermaid_for(domain, type)
+        case type
+        when :structure
+          "```mermaid\n#{Hecks::DomainVisualizer.new(domain).send(:generate_structure)}\n```"
+        when :behavior
+          "```mermaid\n#{Hecks::DomainVisualizer.new(domain).send(:generate_behavior)}\n```"
+        when :flows
+          "```mermaid\n#{Hecks::FlowGenerator.new(domain).generate_mermaid}\n```"
+        when :slices
+          "```mermaid\n#{Hecks::Features::SliceDiagram.new(domain).generate}\n```"
+        else
+          Hecks::DomainVisualizer.new(domain).generate
+        end
+      end
+
+      # Build a self-contained HTML string with Mermaid CDN for browser rendering.
+      #
+      # @param mermaid_markdown [String] fenced mermaid blocks
+      # @return [String] complete HTML document
+      def build_html(mermaid_markdown)
+        # Strip fences and wrap each block in <pre class="mermaid">
+        blocks = mermaid_markdown.scan(/```mermaid\n(.*?)```/m).flatten
+        body = blocks.map { |b| "<pre class=\"mermaid\">#{b.strip}</pre>" }.join("\n")
+        <<~HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <title>Hecks Domain Visualization</title>
+          </head>
+          <body>
+            #{body}
+            <script type="module">
+              import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+              mermaid.initialize({ startOnLoad: true });
+            </script>
+          </body>
+          </html>
+        HTML
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -23,7 +23,7 @@ module Hecks
       aggregates remove add_verb active_hecks!
       validate preview describe build save to_dsl status browse
       play! sketch! serve! events events_of commands history reset!
-      promote
+      promote visualize
     ].each do |m|
       define_method(m) do |*args, **kwargs, &block|
         @workshop.send(m, *args, **kwargs, &block)
@@ -185,6 +185,9 @@ module Hecks
       puts "  play! / sketch!                  # switch modes"
       puts "  save / build"
       puts "  validate / describe / preview / browse"
+      puts "  visualize                        # print Mermaid diagrams"
+      puts "  visualize(:browser)              # open in browser"
+      puts "  visualize(:file, type: :flows)   # write .md file"
       puts ""
     end
   end

--- a/hecks_workshop/spec/visualize_mode_spec.rb
+++ b/hecks_workshop/spec/visualize_mode_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Hecks::Workshop::VisualizeMode do
+  subject(:workshop) do
+    wb = Hecks::Workshop.new("Pizzas")
+    wb.aggregate("Pizza") do
+      attribute :name, String
+      command "CreatePizza" do
+        attribute :name, String
+      end
+    end
+    wb
+  end
+
+  before { allow($stdout).to receive(:puts) }
+
+  describe "#visualize (default :print)" do
+    it "prints Mermaid markdown to stdout" do
+      expect { workshop.visualize }.to output(/mermaid/).to_stdout
+    end
+
+    it "includes classDiagram for :structure type" do
+      expect { workshop.visualize(:print, type: :structure) }
+        .to output(/classDiagram/).to_stdout
+    end
+
+    it "includes flowchart for :behavior type" do
+      expect { workshop.visualize(:print, type: :behavior) }
+        .to output(/flowchart/).to_stdout
+    end
+
+    it "includes sequenceDiagram for :flows type" do
+      expect { workshop.visualize(:print, type: :flows) }
+        .to output(/sequenceDiagram/).to_stdout
+    end
+  end
+
+  describe "#visualize(:file)" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    it "writes a .md file" do
+      workshop.visualize(:file)
+      expect(File.exist?("all_diagram.md")).to be true
+    end
+
+    it "file contains mermaid blocks" do
+      workshop.visualize(:file)
+      content = File.read("all_diagram.md")
+      expect(content).to include("```mermaid")
+    end
+
+    it "writes type-specific filename" do
+      workshop.visualize(:file, type: :structure)
+      expect(File.exist?("structure_diagram.md")).to be true
+    end
+  end
+
+  describe "#visualize(:browser)" do
+    it "creates an HTML tempfile and opens it" do
+      allow(workshop).to receive(:system)
+      path = workshop.visualize(:browser)
+      expect(File.exist?(path)).to be true
+      expect(File.read(path)).to include("<pre class=\"mermaid\">")
+    end
+
+    it "HTML includes Mermaid CDN script" do
+      allow(workshop).to receive(:system)
+      path = workshop.visualize(:browser)
+      expect(File.read(path)).to include("mermaid")
+    end
+  end
+
+  describe "#mermaid_for" do
+    let(:domain) { workshop.to_domain }
+
+    it "returns classDiagram for :structure" do
+      result = workshop.send(:mermaid_for, domain, :structure)
+      expect(result).to include("classDiagram")
+    end
+
+    it "returns flowchart for :behavior" do
+      result = workshop.send(:mermaid_for, domain, :behavior)
+      expect(result).to include("flowchart")
+    end
+
+    it "returns sequenceDiagram for :flows" do
+      result = workshop.send(:mermaid_for, domain, :flows)
+      expect(result).to include("sequenceDiagram")
+    end
+
+    it "returns full output for :all" do
+      result = workshop.send(:mermaid_for, domain, :all)
+      expect(result).to include("classDiagram")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `VisualizeMode` mixin to `Hecks::Workshop` with three output formats: `:print` (stdout), `:browser` (self-contained HTML tempfile opened via `open`), and `:file` (Markdown `.md` file)
- Delegates `visualize` through `WorkshopRunner` so it is available in the REPL alongside `describe`, `browse`, etc.
- Wires existing generators (`DomainVisualizer`, `FlowGenerator`, `SliceDiagram`) — no new Mermaid code

## Test plan

- [ ] `bundle exec rspec hecks_workshop/spec/visualize_mode_spec.rb` — all examples pass
- [ ] `workshop.visualize` prints classDiagram and flowchart blocks to stdout
- [ ] `workshop.visualize(:print, type: :structure)` outputs classDiagram only
- [ ] `workshop.visualize(:print, type: :behavior)` outputs flowchart only
- [ ] `workshop.visualize(:print, type: :flows)` outputs sequenceDiagram
- [ ] `workshop.visualize(:file)` writes `all_diagram.md` with fenced blocks
- [ ] `workshop.visualize(:browser)` creates HTML tempfile with Mermaid CDN
- [ ] Smoke test: `ruby -Ilib examples/pizzas/app.rb` passes