### PR TITLE
HEC-102: Natural language to domain — AI generates Bluebook DSL from description

### DIFF
--- a/hecks_ai/lib/hecks_ai.rb
+++ b/hecks_ai/lib/hecks_ai.rb
@@ -2,6 +2,7 @@
 #
 # MCP server and AI tools for Hecks. Provides aggregate building,
 # domain inspection, play mode, and build tools via MCP protocol.
+# Also includes LLM-driven domain generation (HEC-102).
 #
 module Hecks
   module AI
@@ -14,5 +15,13 @@ module Hecks
     autoload :DomainSerializer, "hecks_ai/domain_serializer"
     autoload :DomainServer,     "hecks_ai/domain_server"
     autoload :Connection,       "hecks_ai/connection"
+    autoload :TypeResolver,     "hecks_ai/type_resolver"
+    autoload :LlmClient,        "hecks_ai/llm_client"
+    autoload :DomainBuilder,    "hecks_ai/domain_builder"
+
+    module Prompts
+      autoload :DomainGeneration, "hecks_ai/prompts/domain_generation"
+      autoload :DomainToolSchema, "hecks_ai/prompts/domain_tool_schema"
+    end
   end
 end

--- a/hecks_ai/lib/hecks_ai/commands/generate.rb
+++ b/hecks_ai/lib/hecks_ai/commands/generate.rb
@@ -1,0 +1,55 @@
+# Hecks::AI::Commands::Generate
+#
+# CLI command: generate a Bluebook DSL file from a natural language description.
+# Reads ANTHROPIC_API_KEY from ENV, calls the LLM, builds via Workshop, saves DSL.
+#
+#   hecks generate "banking system with accounts, loans, and transfers"
+#   hecks generate "e-commerce platform" --output MyShopBluebook --dry-run
+#
+Hecks::CLI.register_command(:generate, "Generate Bluebook DSL from a natural language description",
+  args: ["DESCRIPTION"],
+  options: {
+    model:   { type: :string,  desc: "Anthropic model (default: claude-opus-4-5)" },
+    output:  { type: :string,  desc: "Output file path (default: <DomainName>Bluebook)" },
+    dry_run: { type: :boolean, desc: "Print DSL without writing to disk", aliases: ["--dry-run"] }
+  }
+) do |description|
+  require "hecks_ai"
+  require_relative "../type_resolver"
+  require_relative "../llm_client"
+  require_relative "../domain_builder"
+  require_relative "../prompts/domain_generation"
+
+  unless description && !description.strip.empty?
+    say "Usage: hecks generate \"describe your domain here\"", :red
+    next
+  end
+
+  api_key = ENV["ANTHROPIC_API_KEY"]
+  unless api_key && !api_key.strip.empty?
+    say "Error: ANTHROPIC_API_KEY environment variable is not set", :red
+    next
+  end
+
+  say "Generating domain from: #{description}"
+
+  client_opts = { api_key: api_key }
+  client_opts[:model] = options[:model] if options[:model]
+
+  domain_json = Hecks::AI::LlmClient.new(**client_opts).generate_domain(description)
+  workshop    = Hecks::AI::DomainBuilder.new(domain_json).build
+  dsl         = workshop.to_dsl
+
+  if options[:dry_run]
+    say "\n#{dsl}", :cyan
+    say "\nDry run — no file written", :yellow
+  else
+    domain_name = domain_json[:domain_name] || domain_json["domain_name"]
+    output_path = options[:output] || "#{domain_name}Bluebook"
+    File.write(output_path, dsl)
+    say "Wrote #{output_path}", :green
+    say "\n#{dsl}"
+  end
+rescue => e
+  say "Error: #{e.message}", :red
+end

--- a/hecks_ai/lib/hecks_ai/domain_builder.rb
+++ b/hecks_ai/lib/hecks_ai/domain_builder.rb
@@ -1,0 +1,170 @@
+# Hecks::AI::DomainBuilder
+#
+# Walks the structured JSON returned by LlmClient and replays it through the
+# Workshop API to build a valid domain. Delegates type resolution to TypeResolver.
+# After building, calls workshop.validate to confirm the domain is well-formed.
+#
+# Handles: aggregates, attributes, references, value_objects, entities,
+#          validations, policies, lifecycle states, and lifecycle transitions.
+#
+#   json = { domain_name: "Banking", aggregates: [...] }
+#   builder = Hecks::AI::DomainBuilder.new(json)
+#   workshop = builder.build   # => Hecks::Workshop
+#   dsl = workshop.to_dsl      # => "Hecks.domain \"Banking\" do ..."
+#
+module Hecks
+  module AI
+    class DomainBuilder
+      # Initializes with the structured JSON hash from LlmClient.
+      #
+      # @param domain_json [Hash] structured domain definition with :domain_name and :aggregates
+      def initialize(domain_json)
+        @domain_json = domain_json
+      end
+
+      # Builds and returns a validated Workshop from the domain JSON.
+      #
+      # @return [Hecks::Workshop] the populated workshop
+      # @raise [RuntimeError] if the domain fails validation
+      def build
+        domain_name = @domain_json[:domain_name] || @domain_json["domain_name"]
+        raise "domain_name is required in domain JSON" unless domain_name
+
+        @workshop = Hecks.workshop(domain_name)
+
+        aggregates = @domain_json[:aggregates] || @domain_json["aggregates"] || []
+        aggregates.each { |agg_json| build_aggregate(agg_json) }
+
+        validate!
+        @workshop
+      end
+
+      private
+
+      def build_aggregate(agg_json)
+        name = agg_json[:name] || agg_json["name"]
+        return unless name
+
+        handle = @workshop.aggregate(name)
+
+        attrs      = agg_json[:attributes]      || agg_json["attributes"]      || []
+        refs       = agg_json[:references]      || agg_json["references"]      || []
+        vos        = agg_json[:value_objects]   || agg_json["value_objects"]   || []
+        entities   = agg_json[:entities]        || agg_json["entities"]        || []
+        validations = agg_json[:validations]    || agg_json["validations"]     || []
+        policies   = agg_json[:policies]        || agg_json["policies"]        || []
+        commands   = agg_json[:commands]        || agg_json["commands"]        || []
+        lifecycle  = agg_json[:lifecycle]       || agg_json["lifecycle"]
+
+        attrs.each     { |a| apply_attribute(handle, a) }
+        refs.each      { |r| apply_reference(handle, r) }
+        vos.each       { |v| apply_value_object(handle, v) }
+        entities.each  { |e| apply_entity(handle, e) }
+        validations.each { |v| apply_validation(handle, v) }
+        policies.each  { |p| apply_policy(handle, p) }
+        commands.each  { |c| apply_command(handle, c) }
+        apply_lifecycle(handle, lifecycle) if lifecycle
+      end
+
+      def apply_attribute(handle, attr)
+        name     = sym(attr[:name] || attr["name"])
+        type_str = attr[:type] || attr["type"] || "String"
+        return unless name
+
+        if TypeResolver.reference_type?(type_str)
+          handle.reference_to(TypeResolver.reference_target(type_str))
+        else
+          handle.attr(name, TypeResolver.resolve(type_str))
+        end
+      end
+
+      def apply_reference(handle, ref)
+        target = ref[:target] || ref["target"] || ref[:name] || ref["name"]
+        handle.reference_to(target) if target
+      end
+
+      def apply_value_object(handle, vo)
+        name  = vo[:name] || vo["name"]
+        attrs = vo[:attributes] || vo["attributes"] || []
+        return unless name
+
+        resolved = attrs.map { |a| [sym(a[:name] || a["name"]), TypeResolver.resolve(a[:type] || a["type"])] }
+        handle.value_object(name) do
+          resolved.each { |n, t| attribute n, t }
+        end
+      end
+
+      def apply_entity(handle, entity)
+        name  = entity[:name] || entity["name"]
+        attrs = entity[:attributes] || entity["attributes"] || []
+        return unless name
+
+        resolved = attrs.map { |a| [sym(a[:name] || a["name"]), TypeResolver.resolve(a[:type] || a["type"])] }
+        handle.entity(name) do
+          resolved.each { |n, t| attribute n, t }
+        end
+      end
+
+      def apply_validation(handle, v)
+        field    = sym(v[:field] || v["field"])
+        presence = v[:presence] || v["presence"]
+        return unless field
+
+        rules = {}
+        rules[:presence] = true if presence
+        handle.validation(field, rules) unless rules.empty?
+      end
+
+      def apply_policy(handle, pol)
+        name     = pol[:name]     || pol["name"]
+        on_event = pol[:on_event] || pol["on_event"]
+        trigger  = pol[:trigger]  || pol["trigger"]
+        return unless name && on_event && trigger
+
+        evt, trig = on_event, trigger
+        handle.policy(name) { on evt; trigger trig }
+      end
+
+      def apply_command(handle, cmd)
+        name  = cmd[:name] || cmd["name"]
+        attrs = cmd[:attributes] || cmd["attributes"] || []
+        return unless name
+
+        plain_attrs = attrs.reject { |a| TypeResolver.reference_type?(a[:type] || a["type"]) }
+        ref_attrs   = attrs.select { |a| TypeResolver.reference_type?(a[:type] || a["type"]) }
+
+        resolved    = plain_attrs.map { |a| [sym(a[:name] || a["name"]), TypeResolver.resolve(a[:type] || a["type"])] }
+        ref_targets = ref_attrs.map   { |a| TypeResolver.reference_target(a[:type] || a["type"]) }
+
+        handle.command(name) do
+          resolved.each    { |n, t| attribute n, t }
+          ref_targets.each { |t|   reference_to t }
+        end
+      end
+
+      def apply_lifecycle(handle, lc)
+        field     = lc[:field]    || lc["field"]
+        default   = lc[:default]  || lc["default"]
+        transitions = lc[:transitions] || lc["transitions"] || []
+        return unless field && default
+
+        handle.lifecycle(sym(field), default: default)
+        transitions.each do |tr|
+          cmd    = tr[:command]  || tr["command"]
+          target = tr[:target]   || tr["target"]
+          handle.transition(cmd => target) if cmd && target
+        end
+      end
+
+      def validate!
+        domain = @workshop.to_domain
+        valid, errors = Hecks.validate(domain)
+        raise "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}" unless valid
+      end
+
+      def sym(val)
+        val&.to_sym
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/llm_client.rb
+++ b/hecks_ai/lib/hecks_ai/llm_client.rb
@@ -1,0 +1,92 @@
+# Hecks::AI::LlmClient
+#
+# Minimal net/http client for the Anthropic Messages API.
+# Uses tool_use to force structured JSON output matching a domain schema —
+# no free-form text generation, no parsing failures.
+#
+# Zero new gem dependencies: uses only net/http, json, and uri from stdlib.
+#
+#   client = Hecks::AI::LlmClient.new(api_key: ENV["ANTHROPIC_API_KEY"])
+#   result = client.generate_domain("banking system with accounts and loans")
+#   result[:domain_name]   # => "Banking"
+#   result[:aggregates]    # => [{ name: "Account", attributes: [...], commands: [...] }, ...]
+#
+module Hecks
+  module AI
+    class LlmClient
+      require "net/http"
+      require "uri"
+      require "json"
+
+      API_URL  = "https://api.anthropic.com/v1/messages"
+      MODEL    = "claude-opus-4-5"
+      MAX_TOKENS = 4096
+
+      # Initializes the client with an Anthropic API key.
+      #
+      # @param api_key [String] Anthropic API key
+      # @param model [String] model ID override (default: claude-opus-4-5)
+      def initialize(api_key:, model: MODEL)
+        @api_key = api_key
+        @model   = model
+      end
+
+      # Send a domain description to the LLM and return structured domain JSON.
+      #
+      # Uses tool_use to force the model to return structured JSON matching the
+      # Hecks domain schema. Returns the parsed tool input hash on success.
+      #
+      # @param description [String] natural language domain description
+      # @return [Hash] structured domain definition with :domain_name and :aggregates
+      # @raise [RuntimeError] on HTTP errors or unexpected API responses
+      def generate_domain(description)
+        body = build_request(description)
+        response = post(body)
+        extract_tool_result(response)
+      end
+
+      private
+
+      def build_request(description)
+        {
+          model: @model,
+          max_tokens: MAX_TOKENS,
+          system: Hecks::AI::Prompts::DomainGeneration::SYSTEM_PROMPT,
+          tools: [Hecks::AI::Prompts::DomainGeneration::TOOL_SCHEMA],
+          tool_choice: { type: "tool", name: "define_domain" },
+          messages: [
+            { role: "user", content: description }
+          ]
+        }
+      end
+
+      def post(body)
+        uri  = URI.parse(API_URL)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Post.new(uri.path)
+        request["x-api-key"]         = @api_key
+        request["anthropic-version"]  = "2023-06-01"
+        request["content-type"]       = "application/json"
+        request.body = JSON.generate(body)
+
+        response = http.request(request)
+        raise "Anthropic API error #{response.code}: #{response.body}" unless response.code == "200"
+
+        JSON.parse(response.body, symbolize_names: true)
+      end
+
+      def extract_tool_result(response)
+        content = response[:content] || []
+        tool_use = content.find { |block| block[:type] == "tool_use" }
+        raise "No tool_use block in response. Full response: #{response.inspect}" unless tool_use
+
+        input = tool_use[:input]
+        raise "Empty tool input in response" unless input
+
+        input
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/mcp_server.rb
+++ b/hecks_ai/lib/hecks_ai/mcp_server.rb
@@ -1,4 +1,5 @@
 require "mcp"
+require_relative "type_resolver"
 require_relative "session_tools"
 require_relative "aggregate_tools"
 require_relative "inspect_tools"
@@ -69,36 +70,22 @@ module Hecks
     end
 
     # Converts a type string from MCP tool input into a Ruby type or type
-    # descriptor hash. Used by AggregateTools when adding attributes.
-    #
-    # Supported formats:
-    #   - +"String"+              -> String
-    #   - +"Integer"+             -> Integer
-    #   - +"Float"+               -> Float
-    #   - +"reference_to(Order)"+ -> { reference: "Order" }
-    #   - +"list_of(Topping)"+    -> { list: "Topping" }
-    #   - anything else           -> String (default)
+    # descriptor hash. Delegates to Hecks::AI::TypeResolver.
     #
     # @param type_str [String] the type string to resolve
     # @return [Class, Hash] the resolved Ruby type or descriptor hash
     def resolve_type(type_str)
-      case type_str
-      when "String" then String
-      when "Integer" then Integer
-      when "Float" then Float
-      when /^list_of\((.+)\)$/ then { list: $1.delete('"') }
-      else String
-      end
+      Hecks::AI::TypeResolver.resolve(type_str)
     end
 
     # Returns true if the type string is a reference_to declaration.
     def reference_type?(type_str)
-      type_str.to_s =~ /^reference_to\(/
+      Hecks::AI::TypeResolver.reference_type?(type_str)
     end
 
     # Extracts the target type from a reference_to string.
     def reference_target(type_str)
-      type_str.to_s[/^reference_to\(["']?(.+?)["']?\)$/, 1]
+      Hecks::AI::TypeResolver.reference_target(type_str)
     end
 
     # Captures stdout during the execution of the given block and returns

--- a/hecks_ai/lib/hecks_ai/prompts/domain_generation.rb
+++ b/hecks_ai/lib/hecks_ai/prompts/domain_generation.rb
@@ -1,0 +1,133 @@
+# Hecks::AI::Prompts::DomainGeneration
+#
+# System prompt with few-shot examples for LLM domain generation.
+# TOOL_SCHEMA delegates to DomainToolSchema to keep each file under 200 lines.
+#
+# Used by LlmClient to build the Anthropic Messages API request body.
+#
+#   Hecks::AI::Prompts::DomainGeneration::SYSTEM_PROMPT  # => String
+#   Hecks::AI::Prompts::DomainGeneration::TOOL_SCHEMA    # => Hash
+#
+require_relative "domain_tool_schema"
+
+module Hecks
+  module AI
+    module Prompts
+      module DomainGeneration
+        SYSTEM_PROMPT = <<~PROMPT
+          You are an expert Domain-Driven Design architect. Given a natural language
+          description, you extract a domain model expressed as structured JSON.
+
+          Rules:
+          - Each aggregate is an independent consistency boundary (a "thing" in the domain)
+          - Commands are always PascalCase: Verb + Noun (e.g. CreateAccount, PlaceOrder)
+          - Attribute types must be: String, Integer, Float, list_of(Name), reference_to(Name)
+          - Include a CreateX command for every aggregate X
+          - Transition commands reference their own aggregate (e.g. CancelOrder references Order)
+          - Validations should cover required fields on the primary create command
+          - Keep it clean: 2-5 aggregates, 2-5 commands each, relevant attributes only
+
+          Attribute type examples:
+            String, Integer, Float
+            list_of(OrderItem)        — aggregate holds a list of this type
+            reference_to(Customer)    — aggregate references another aggregate
+
+          Few-shot example — Pizzas domain:
+          {
+            "domain_name": "Pizzas",
+            "aggregates": [
+              {
+                "name": "Pizza",
+                "attributes": [
+                  { "name": "name",        "type": "String" },
+                  { "name": "description", "type": "String" },
+                  { "name": "toppings",    "type": "list_of(Topping)" }
+                ],
+                "value_objects": [
+                  { "name": "Topping", "attributes": [
+                    { "name": "name",   "type": "String" },
+                    { "name": "amount", "type": "Integer" }
+                  ]}
+                ],
+                "validations": [
+                  { "field": "name",        "presence": true },
+                  { "field": "description", "presence": true }
+                ],
+                "commands": [
+                  { "name": "CreatePizza",
+                    "attributes": [
+                      { "name": "name",        "type": "String" },
+                      { "name": "description", "type": "String" }
+                    ]
+                  },
+                  { "name": "AddTopping",
+                    "attributes": [
+                      { "name": "pizza_id", "type": "reference_to(Pizza)" },
+                      { "name": "name",     "type": "String" },
+                      { "name": "amount",   "type": "Integer" }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Order",
+                "attributes": [
+                  { "name": "customer_name", "type": "String" },
+                  { "name": "status",        "type": "String" }
+                ],
+                "references": [{ "target": "Pizza" }],
+                "validations": [{ "field": "customer_name", "presence": true }],
+                "commands": [
+                  { "name": "PlaceOrder",
+                    "attributes": [
+                      { "name": "customer_name", "type": "String" },
+                      { "name": "pizza_id",      "type": "reference_to(Pizza)" },
+                      { "name": "quantity",      "type": "Integer" }
+                    ]
+                  },
+                  { "name": "CancelOrder",
+                    "attributes": [{ "name": "order_id", "type": "reference_to(Order)" }]
+                  }
+                ]
+              }
+            ]
+          }
+
+          Few-shot example — Banking domain:
+          {
+            "domain_name": "Banking",
+            "aggregates": [
+              {
+                "name": "Account",
+                "attributes": [
+                  { "name": "balance",      "type": "Float" },
+                  { "name": "account_type", "type": "String" },
+                  { "name": "status",       "type": "String" }
+                ],
+                "references": [{ "target": "Customer" }],
+                "validations": [{ "field": "account_type", "presence": true }],
+                "commands": [
+                  { "name": "OpenAccount",
+                    "attributes": [
+                      { "name": "customer_id",  "type": "reference_to(Customer)" },
+                      { "name": "account_type", "type": "String" }
+                    ]
+                  },
+                  { "name": "Deposit",
+                    "attributes": [
+                      { "name": "account_id", "type": "reference_to(Account)" },
+                      { "name": "amount",     "type": "Float" }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        PROMPT
+
+        # Tool schema delegated to DomainToolSchema to keep file size manageable.
+        TOOL_SCHEMA = Hecks::AI::Prompts::DomainToolSchema::SCHEMA
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/prompts/domain_tool_schema.rb
+++ b/hecks_ai/lib/hecks_ai/prompts/domain_tool_schema.rb
@@ -1,0 +1,107 @@
+# Hecks::AI::Prompts::DomainToolSchema
+#
+# Anthropic tool_use schema for the define_domain tool. Defines the JSON
+# structure the LLM must return when generating a domain model.
+#
+# Separated from DomainGeneration to keep file sizes within limits.
+#
+#   Hecks::AI::Prompts::DomainToolSchema::SCHEMA  # => Hash
+#
+module Hecks
+  module AI
+    module Prompts
+      module DomainToolSchema
+        ATTR_ITEM = {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            type: { type: "string" }
+          }
+        }.freeze
+
+        NAMED_ATTRS_ITEM = {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            attributes: { type: "array", items: ATTR_ITEM }
+          }
+        }.freeze
+
+        SCHEMA = {
+          name: "define_domain",
+          description: "Define a domain model as structured JSON for the Hecks compiler",
+          input_schema: {
+            type: "object",
+            required: ["domain_name", "aggregates"],
+            properties: {
+              domain_name: { type: "string", description: "PascalCase domain name (e.g. Banking)" },
+              aggregates: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "commands"],
+                  properties: {
+                    name:         { type: "string" },
+                    attributes:   { type: "array", items: ATTR_ITEM },
+                    references:   { type: "array", items: { type: "object", properties: { target: { type: "string" } } } },
+                    value_objects: { type: "array", items: NAMED_ATTRS_ITEM },
+                    entities:     { type: "array", items: NAMED_ATTRS_ITEM },
+                    validations:  {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          field:    { type: "string" },
+                          presence: { type: "boolean" }
+                        }
+                      }
+                    },
+                    policies: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          name:     { type: "string" },
+                          on_event: { type: "string" },
+                          trigger:  { type: "string" }
+                        }
+                      }
+                    },
+                    commands: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        required: ["name"],
+                        properties: {
+                          name:       { type: "string" },
+                          attributes: { type: "array", items: ATTR_ITEM }
+                        }
+                      }
+                    },
+                    lifecycle: {
+                      type: "object",
+                      properties: {
+                        field:   { type: "string" },
+                        default: { type: "string" },
+                        transitions: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              command: { type: "string" },
+                              target:  { type: "string" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/type_resolver.rb
+++ b/hecks_ai/lib/hecks_ai/type_resolver.rb
@@ -1,0 +1,52 @@
+# Hecks::AI::TypeResolver
+#
+# Shared module for converting type strings to Ruby types or descriptor hashes.
+# Extracted from McpServer so it can be reused by DomainBuilder and other
+# components that need to interpret typed attribute declarations.
+#
+# Supported formats:
+#   "String"               -> String
+#   "Integer"              -> Integer
+#   "Float"                -> Float
+#   "list_of(Topping)"     -> { list: "Topping" }
+#   "reference_to(Order)"  -> treated as reference (see reference_type?)
+#   anything else          -> String (default)
+#
+#   Hecks::AI::TypeResolver.resolve("Float")          # => Float
+#   Hecks::AI::TypeResolver.resolve("list_of(Item)")  # => { list: "Item" }
+#
+module Hecks
+  module AI
+    module TypeResolver
+      # Converts a type string into a Ruby type or descriptor hash.
+      #
+      # @param type_str [String, nil] the type string to resolve
+      # @return [Class, Hash] the resolved type
+      def self.resolve(type_str)
+        case type_str.to_s
+        when "String"  then String
+        when "Integer" then Integer
+        when "Float"   then Float
+        when /^list_of\((.+)\)$/ then { list: $1.delete('"') }
+        else String
+        end
+      end
+
+      # Returns true when the type string is a reference_to declaration.
+      #
+      # @param type_str [String, nil] the type string to check
+      # @return [Boolean]
+      def self.reference_type?(type_str)
+        type_str.to_s =~ /^reference_to\(/
+      end
+
+      # Extracts the target aggregate name from a reference_to string.
+      #
+      # @param type_str [String] e.g. "reference_to(Order)" or "reference_to('Order')"
+      # @return [String, nil] the target name, or nil if not a reference
+      def self.reference_target(type_str)
+        type_str.to_s[/^reference_to\(["']?(.+?)["']?\)$/, 1]
+      end
+    end
+  end
+end

--- a/hecks_ai/spec/domain_builder_spec.rb
+++ b/hecks_ai/spec/domain_builder_spec.rb
@@ -1,0 +1,148 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::DomainBuilder do
+  def build(json)
+    described_class.new(json).build
+  end
+
+  describe "#build" do
+    context "with a minimal domain" do
+      let(:domain_json) do
+        {
+          domain_name: "Library",
+          aggregates: [
+            {
+              name: "Book",
+              attributes: [
+                { name: "title",  type: "String" },
+                { name: "pages",  type: "Integer" }
+              ],
+              validations: [{ field: "title", presence: true }],
+              commands: [
+                { name: "AddBook",
+                  attributes: [
+                    { name: "title", type: "String" },
+                    { name: "pages", type: "Integer" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns a valid Workshop" do
+        workshop = build(domain_json)
+        expect(workshop).to be_a(Hecks::Workshop)
+        expect(workshop.aggregates).to include("Book")
+      end
+
+      it "builds the domain with the correct name" do
+        workshop = build(domain_json)
+        expect(workshop.to_domain.name).to eq("Library")
+      end
+    end
+
+    context "with references" do
+      let(:domain_json) do
+        {
+          domain_name: "Shop",
+          aggregates: [
+            {
+              name: "Product",
+              attributes: [{ name: "name", type: "String" }],
+              commands: [{ name: "CreateProduct", attributes: [{ name: "name", type: "String" }] }]
+            },
+            {
+              name: "Order",
+              attributes: [{ name: "quantity", type: "Integer" }],
+              references: [{ target: "Product" }],
+              commands: [
+                { name: "PlaceOrder",
+                  attributes: [
+                    { name: "product_id", type: "reference_to(Product)" },
+                    { name: "quantity",   type: "Integer" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "includes both aggregates" do
+        workshop = build(domain_json)
+        expect(workshop.aggregates).to include("Product", "Order")
+      end
+    end
+
+    context "with value objects and entities" do
+      let(:domain_json) do
+        {
+          domain_name: "Catalog",
+          aggregates: [
+            {
+              name: "Item",
+              attributes: [{ name: "name", type: "String" }],
+              value_objects: [
+                { name: "Dimension",
+                  attributes: [
+                    { name: "width",  type: "Float" },
+                    { name: "height", type: "Float" }
+                  ]
+                }
+              ],
+              entities: [
+                { name: "Variant",
+                  attributes: [{ name: "sku", type: "String" }]
+                }
+              ],
+              commands: [{ name: "CreateItem", attributes: [{ name: "name", type: "String" }] }]
+            }
+          ]
+        }
+      end
+
+      it "builds without errors" do
+        expect { build(domain_json) }.not_to raise_error
+      end
+    end
+
+    context "when domain_name is missing" do
+      it "raises a descriptive error" do
+        expect { build({ aggregates: [] }) }
+          .to raise_error(RuntimeError, /domain_name is required/)
+      end
+    end
+
+    context "with lifecycle" do
+      let(:domain_json) do
+        {
+          domain_name: "Tasks",
+          aggregates: [
+            {
+              name: "Task",
+              attributes: [
+                { name: "title",  type: "String" },
+                { name: "status", type: "String" }
+              ],
+              commands: [
+                { name: "CreateTask", attributes: [{ name: "title", type: "String" }] },
+                { name: "CompleteTask", attributes: [{ name: "task_id", type: "reference_to(Task)" }] }
+              ],
+              lifecycle: {
+                field: "status",
+                default: "open",
+                transitions: [{ command: "CompleteTask", target: "done" }]
+              }
+            }
+          ]
+        }
+      end
+
+      it "builds without errors" do
+        expect { build(domain_json) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/hecks_ai/spec/llm_client_spec.rb
+++ b/hecks_ai/spec/llm_client_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::LlmClient do
+  let(:api_key) { "test-key" }
+  subject(:client) { described_class.new(api_key: api_key) }
+
+  describe "#generate_domain" do
+    let(:tool_input) do
+      {
+        domain_name: "Bakery",
+        aggregates: [
+          {
+            name: "Cake",
+            attributes: [{ name: "name", type: "String" }],
+            commands: [{ name: "CreateCake", attributes: [{ name: "name", type: "String" }] }],
+            validations: [{ field: "name", presence: true }]
+          }
+        ]
+      }
+    end
+
+    let(:api_response_body) do
+      {
+        id: "msg_01",
+        type: "message",
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "toolu_01", name: "define_domain", input: tool_input }
+        ],
+        model: "claude-opus-4-5",
+        stop_reason: "tool_use"
+      }.to_json
+    end
+
+    before do
+      stub_http_response(200, api_response_body)
+    end
+
+    it "returns the tool input hash from the API response" do
+      result = client.generate_domain("a bakery domain with cakes")
+      expect(result[:domain_name]).to eq("Bakery")
+      expect(result[:aggregates].first[:name]).to eq("Cake")
+    end
+
+    context "when the API returns a non-200 status" do
+      before { stub_http_response(401, '{"error": "unauthorized"}') }
+
+      it "raises a descriptive error" do
+        expect { client.generate_domain("test") }
+          .to raise_error(RuntimeError, /Anthropic API error 401/)
+      end
+    end
+
+    context "when the response contains no tool_use block" do
+      let(:no_tool_body) do
+        { content: [{ type: "text", text: "here is your domain" }] }.to_json
+      end
+
+      before { stub_http_response(200, no_tool_body) }
+
+      it "raises a descriptive error" do
+        expect { client.generate_domain("test") }
+          .to raise_error(RuntimeError, /No tool_use block/)
+      end
+    end
+
+    def stub_http_response(code, body)
+      response = instance_double(Net::HTTPResponse, code: code.to_s, body: body)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+    end
+  end
+end

--- a/hecks_ai/spec/prompts/domain_generation_spec.rb
+++ b/hecks_ai/spec/prompts/domain_generation_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::Prompts::DomainGeneration do
+  describe "SYSTEM_PROMPT" do
+    it "contains DDD role definition" do
+      expect(described_class::SYSTEM_PROMPT).to include("Domain-Driven Design")
+    end
+
+    it "includes Pizzas few-shot example" do
+      expect(described_class::SYSTEM_PROMPT).to include("Pizzas")
+    end
+
+    it "includes Banking few-shot example" do
+      expect(described_class::SYSTEM_PROMPT).to include("Banking")
+    end
+
+    it "mentions reference_to type" do
+      expect(described_class::SYSTEM_PROMPT).to include("reference_to")
+    end
+  end
+
+  describe "TOOL_SCHEMA" do
+    subject(:schema) { described_class::TOOL_SCHEMA }
+
+    it "is named define_domain" do
+      expect(schema[:name]).to eq("define_domain")
+    end
+
+    it "requires domain_name and aggregates" do
+      required = schema[:input_schema][:required]
+      expect(required).to include("domain_name", "aggregates")
+    end
+  end
+end

--- a/hecks_ai/spec/type_resolver_spec.rb
+++ b/hecks_ai/spec/type_resolver_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::TypeResolver do
+  describe ".resolve" do
+    it "resolves String"  do expect(described_class.resolve("String")).to eq(String) end
+    it "resolves Integer" do expect(described_class.resolve("Integer")).to eq(Integer) end
+    it "resolves Float"   do expect(described_class.resolve("Float")).to eq(Float) end
+
+    it "resolves list_of to a hash" do
+      expect(described_class.resolve("list_of(Item)")).to eq({ list: "Item" })
+    end
+
+    it "defaults unknown types to String" do
+      expect(described_class.resolve("Bogus")).to eq(String)
+    end
+
+    it "defaults nil to String" do
+      expect(described_class.resolve(nil)).to eq(String)
+    end
+  end
+
+  describe ".reference_type?" do
+    it "returns truthy for reference_to(...)" do
+      expect(described_class.reference_type?("reference_to(Order)")).to be_truthy
+    end
+
+    it "returns falsy for plain types" do
+      expect(described_class.reference_type?("String")).to be_falsy
+    end
+  end
+
+  describe ".reference_target" do
+    it "extracts the target name" do
+      expect(described_class.reference_target("reference_to(Order)")).to eq("Order")
+    end
+
+    it "handles quoted targets" do
+      expect(described_class.reference_target("reference_to('Order')")).to eq("Order")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `hecks generate "description"` CLI command — natural language in, Bluebook DSL out
- LLM generates structured JSON via Anthropic `tool_use` (no free-form text); `DomainBuilder` replays it through the Workshop API; `DslSerializer` writes the file
- Extracts `TypeResolver` from `McpServer` as a shared module used by both MCP tools and AI generation
- Zero new gem dependencies — uses only `net/http`, `json`, `uri` from stdlib

## Architecture

```
hecks generate "banking system" 
  → LlmClient (net/http → Anthropic tool_use)
  → DomainBuilder (Workshop API replay)
  → workshop.validate
  → workshop.to_dsl → file
```

## New files

- `hecks_ai/lib/hecks_ai/commands/generate.rb` — CLI entry point with `--model`, `--output`, `--dry-run`
- `hecks_ai/lib/hecks_ai/llm_client.rb` — minimal Anthropic Messages API client
- `hecks_ai/lib/hecks_ai/domain_builder.rb` — JSON → Workshop API replay
- `hecks_ai/lib/hecks_ai/prompts/domain_generation.rb` — system prompt + few-shot examples (Pizzas, Banking)
- `hecks_ai/lib/hecks_ai/prompts/domain_tool_schema.rb` — Anthropic tool schema (split for 200-line limit)
- `hecks_ai/lib/hecks_ai/type_resolver.rb` — extracted from McpServer, shared

## Test plan

- [ ] `bundle exec rspec hecks_ai/spec/` — 1230 examples, 0 failures (< 1s)
- [ ] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes
- [ ] `ANTHROPIC_API_KEY=... hecks generate "e-commerce with products and orders"` — generates a Bluebook
- [ ] `hecks generate "task tracker" --dry-run` — prints DSL, no file written