### PR TITLE
HEC-414: Rails app smoke test — boot real server, tag :slow

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -5,3 +5,4 @@
 --require spec_helper
 --pattern {hecksties,hecksties/watchers,bluebook,hecksagon,hecks_workshop,hecks_ai}/spec/**/*_spec.rb
 --tag ~parity
+--tag ~slow

--- a/hecksties/spec/cross_target_parity_spec.rb
+++ b/hecksties/spec/cross_target_parity_spec.rb
@@ -15,6 +15,7 @@ require "uri"
 require "json"
 require "tmpdir"
 require "fileutils"
+require_relative "support/server_helpers"
 
 # Load static targets (not in the default bundle path)
 $LOAD_PATH.unshift(File.expand_path("../../hecks_targets/ruby/lib", __dir__))
@@ -24,36 +25,6 @@ require "go_hecks"
 
 def normalize_events(json)
   json.map { |e| e["name"] }.sort
-end
-
-def free_port
-  require "socket"
-  s = TCPServer.new(0)
-  port = s.addr[1]
-  s.close
-  port
-end
-
-def wait_for_server(url, timeout: 20)
-  deadline = Time.now + timeout
-  uri = URI(url)
-  loop do
-    Net::HTTP.get_response(uri)
-    return true
-  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, Net::ReadTimeout
-    raise "Server at #{url} did not start in #{timeout}s" if Time.now > deadline
-    sleep 0.5
-  end
-end
-
-# Browser-style form submission: GET the form page, parse the action URL,
-# POST form-urlencoded data. Handles route differences between Ruby (/submit)
-# and Go (direct POST) transparently.
-def submit_form(base_url, form_path, params)
-  html = Net::HTTP.get(URI("#{base_url}#{form_path}"))
-  action = html.match(/<form[^>]*action="([^"]*)"/)&.captures&.first
-  raise "No form action found at #{form_path} on #{base_url}" unless action
-  Net::HTTP.post_form(URI("#{base_url}#{action}"), params)
 end
 
 def run_command_sequence(base_url)

--- a/hecksties/spec/rails_smoke_spec.rb
+++ b/hecksties/spec/rails_smoke_spec.rb
@@ -1,0 +1,100 @@
+# = Rails Smoke Spec
+#
+# Boots the pizzas_rails example app as a real subprocess and runs HTTP
+# smoke tests against it. Verifies the app starts cleanly and responds
+# to basic requests without 5xx errors.
+#
+# Tagged :slow — excluded from the default sub-second RSpec run.
+# Run explicitly:
+#   bundle exec rspec hecksties/spec/rails_smoke_spec.rb --tag slow
+
+require "spec_helper"
+require "net/http"
+require "uri"
+require_relative "support/server_helpers"
+
+RAILS_APP_ROOT = File.expand_path("../../examples/pizzas_rails", __dir__)
+
+RSpec.describe "Rails example app smoke test", :slow do
+  before(:all) do
+    skip "pizzas_rails not found" unless Dir.exist?(RAILS_APP_ROOT)
+    @port = free_port
+    env = { "PORT" => @port.to_s, "RAILS_ENV" => "test" }
+    @pid = spawn(env, "bundle", "exec", "bin/rails", "server",
+                 chdir: RAILS_APP_ROOT, out: "/dev/null", err: "/dev/null")
+    wait_for_server("http://localhost:#{@port}/up")
+    @base = "http://localhost:#{@port}"
+  end
+
+  after(:all) do
+    Process.kill("TERM", @pid) rescue nil
+    Process.wait(@pid) rescue nil if @pid
+  end
+
+  it "boots and responds to health check" do
+    res = Net::HTTP.get_response(URI("#{@base}/up"))
+    expect(res.code.to_i).to eq(200)
+  end
+
+  it "serves root without a 5xx crash" do
+    res = Net::HTTP.get_response(URI("#{@base}/"))
+    expect(res.code.to_i).to be < 500
+  end
+
+  # Tier 2 — pending until scaffold routes land
+
+  it "GET /pizzas returns 200" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.get_response(URI("#{@base}/pizzas"))
+    expect(res.code.to_i).to eq(200)
+  end
+
+  it "GET /pizzas/new returns 200" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.get_response(URI("#{@base}/pizzas/new"))
+    expect(res.code.to_i).to eq(200)
+  end
+
+  it "POST /pizzas with valid params redirects" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.post_form(URI("#{@base}/pizzas"),
+                              "pizza[name]" => "Margherita",
+                              "pizza[description]" => "Classic tomato and mozzarella")
+    expect(res.code.to_i).to be_between(200, 399)
+  end
+
+  it "POST /pizzas with invalid params returns 422" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.post_form(URI("#{@base}/pizzas"), {})
+    expect(res.code.to_i).to eq(422)
+  end
+
+  it "GET /pizzas/:id returns 200" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.get_response(URI("#{@base}/pizzas/1"))
+    expect(res.code.to_i).to eq(200)
+  end
+
+  it "GET /pizzas/:id/edit returns 200" do
+    pending "scaffold routes not yet wired"
+    res = Net::HTTP.get_response(URI("#{@base}/pizzas/1/edit"))
+    expect(res.code.to_i).to eq(200)
+  end
+
+  it "PATCH /pizzas/:id updates a pizza" do
+    pending "scaffold routes not yet wired"
+    uri = URI("#{@base}/pizzas/1")
+    req = Net::HTTP::Patch.new(uri)
+    req.set_form_data("pizza[name]" => "Updated Pizza")
+    res = Net::HTTP.start(uri.host, uri.port) { |h| h.request(req) }
+    expect(res.code.to_i).to be_between(200, 399)
+  end
+
+  it "DELETE /pizzas/:id removes a pizza" do
+    pending "scaffold routes not yet wired"
+    uri = URI("#{@base}/pizzas/1")
+    req = Net::HTTP::Delete.new(uri)
+    res = Net::HTTP.start(uri.host, uri.port) { |h| h.request(req) }
+    expect(res.code.to_i).to be_between(200, 399)
+  end
+end

--- a/hecksties/spec/support/server_helpers.rb
+++ b/hecksties/spec/support/server_helpers.rb
@@ -1,0 +1,44 @@
+# = ServerHelpers
+#
+# Shared helpers for specs that boot real HTTP servers as subprocesses.
+# Provides port allocation, server readiness polling, and browser-style
+# form submission.
+#
+# Usage:
+#   require_relative "support/server_helpers"
+#   port = free_port
+#   wait_for_server("http://localhost:#{port}/up")
+#   submit_form("http://localhost:#{port}", "/some/form/new", "field" => "value")
+
+require "net/http"
+require "uri"
+require "socket"
+
+def free_port
+  s = TCPServer.new(0)
+  port = s.addr[1]
+  s.close
+  port
+end
+
+def wait_for_server(url, timeout: 20)
+  deadline = Time.now + timeout
+  uri = URI(url)
+  loop do
+    Net::HTTP.get_response(uri)
+    return true
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, Net::ReadTimeout
+    raise "Server at #{url} did not start in #{timeout}s" if Time.now > deadline
+    sleep 0.5
+  end
+end
+
+# Browser-style form submission: GET the form page, parse the action URL,
+# POST form-urlencoded data. Handles route differences between Ruby (/submit)
+# and Go (direct POST) transparently.
+def submit_form(base_url, form_path, params)
+  html = Net::HTTP.get(URI("#{base_url}#{form_path}"))
+  action = html.match(/<form[^>]*action="([^"]*)"/)&.captures&.first
+  raise "No form action found at #{form_path} on #{base_url}" unless action
+  Net::HTTP.post_form(URI("#{base_url}#{action}"), params)
+end


### PR DESCRIPTION
## Summary

- Extracts `free_port`, `wait_for_server`, and `submit_form` from `cross_target_parity_spec.rb` into a new shared file `hecksties/spec/support/server_helpers.rb`
- Adds `hecksties/spec/rails_smoke_spec.rb` tagged `:slow` that spawns the `pizzas_rails` example app as a subprocess and runs HTTP assertions against it
- Adds `--tag ~slow` to `.rspec` so the default suite stays under 1 second

## Test plan

- [ ] Default suite still passes under 1s: `bundle exec rspec`
- [ ] Smoke test passes: `ruby -Ilib examples/pizzas/app.rb`
- [ ] Rails smoke spec can be run manually with `bundle exec rspec hecksties/spec/rails_smoke_spec.rb --tag slow` (requires `pizzas_rails` to exist and have a valid `bundle`)
- [ ] Tier 2 CRUD examples are all `pending` until scaffold routes land