### PR TITLE
HEC-413: Unit specs for ActiveHecks — Railtie, DomainModelCompat, configure block

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -3,5 +3,5 @@
 -I hecksties
 -I hecksties/watchers/lib
 --require spec_helper
---pattern {hecksties,hecksties/watchers,bluebook,hecksagon,hecks_workshop,hecks_ai}/spec/**/*_spec.rb
+--pattern {hecksties,hecksties/watchers,bluebook,hecksagon,hecks_workshop,hecks_ai,hecks_on_rails}/spec/**/*_spec.rb
 --tag ~parity

--- a/hecks_on_rails/spec/active_hecks/configure_spec.rb
+++ b/hecks_on_rails/spec/active_hecks/configure_spec.rb
@@ -1,0 +1,50 @@
+# Specs for Hecks.configure with Rails defined
+#
+# Verifies the configure block returns a Configuration, does not auto-boot
+# when Rails is present, and that calling boot! activates DomainModelCompat.
+#
+require_relative "../spec_helper"
+
+RSpec.describe "Hecks.configure (Rails context)" do
+  after { Hecks.instance_variable_set(:@configuration, nil) }
+
+  it "returns a Configuration object" do
+    config = Hecks.configure { }
+    expect(config).to be_a(Hecks::Configuration)
+  end
+
+  it "does not call boot! automatically when Rails is defined" do
+    config = Hecks.configure { }
+    # boot! would populate @apps; without it, apps is empty
+    expect(config.apps).to be_empty
+  end
+
+  it "adapter :memory is the default" do
+    config = Hecks.configure { }
+    expect(config.instance_variable_get(:@adapter_type)).to eq(:memory)
+  end
+
+  it "domain method registers domain entries" do
+    config = Hecks.configure { domain "fake_gem" }
+    domains = config.instance_variable_get(:@domains)
+    expect(domains.map { |d| d[:gem_name] }).to include("fake_gem")
+  end
+
+  it "calling boot! activates DomainModelCompat on aggregate classes" do
+    domain = Hecks.domain "ConfigureSpecPizzas" do
+      aggregate "CSPizza" do
+        attribute :name, String
+        command "CreateCSPizza" do
+          attribute :name, String
+        end
+      end
+    end
+
+    Hecks.load(domain, force: true)
+    mod = Object.const_get("ConfigureSpecPizzasDomain")
+
+    ActiveHecks.activate(mod, domain: domain)
+
+    expect(ConfigureSpecPizzasDomain::CSPizza.ancestors).to include(ActiveHecks::DomainModelCompat)
+  end
+end

--- a/hecks_on_rails/spec/active_hecks/domain_model_compat_configure_spec.rb
+++ b/hecks_on_rails/spec/active_hecks/domain_model_compat_configure_spec.rb
@@ -1,0 +1,62 @@
+# Specs for ActiveHecks::DomainModelCompat edge cases
+#
+# Uses anonymous classes — no domain DSL required. Covers fallback attribute
+# introspection, timestamp inclusion, id deduplication, and serialization.
+#
+require_relative "../spec_helper"
+
+RSpec.describe "ActiveHecks::DomainModelCompat (edge cases)" do
+  let(:base_class) do
+    klass = Class.new do
+      def initialize(name:)
+        @name = name
+      end
+      attr_reader :name
+    end
+    klass.include(ActiveHecks::DomainModelCompat)
+    klass
+  end
+
+  it "attributes falls back to initialize parameters when hecks_attributes is absent" do
+    obj = base_class.new(name: "test")
+    expect(obj.attributes).to eq("name" => "test")
+  end
+
+  it "attributes includes timestamps when the object responds to them" do
+    klass = Class.new do
+      def initialize; end
+      def created_at = Time.now
+      def updated_at = Time.now
+    end
+    klass.include(ActiveHecks::DomainModelCompat)
+
+    obj = klass.new
+    attrs = obj.attributes
+    expect(attrs).to have_key("created_at")
+    expect(attrs).to have_key("updated_at")
+  end
+
+  it "attributes does not duplicate id when hecks_attributes lists id" do
+    klass = Class.new do
+      def initialize(id:)
+        @id = id
+      end
+      attr_reader :id
+
+      def self.hecks_attributes
+        [{ name: :id }]
+      end
+    end
+    klass.include(ActiveHecks::DomainModelCompat)
+
+    obj = klass.new(id: "abc-123")
+    attrs = obj.attributes
+    expect(attrs.keys.count("id")).to eq(1)
+    expect(attrs["id"]).to eq("abc-123")
+  end
+
+  it "#read_attribute_for_serialization delegates to the attribute reader" do
+    obj = base_class.new(name: "delegate-test")
+    expect(obj.read_attribute_for_serialization(:name)).to eq("delegate-test")
+  end
+end

--- a/hecks_on_rails/spec/active_hecks/railtie_spec.rb
+++ b/hecks_on_rails/spec/active_hecks/railtie_spec.rb
@@ -1,0 +1,45 @@
+# Specs for ActiveHecks::Railtie
+#
+# Verifies that the railtie registers itself correctly and that the
+# active_hecks.setup initializer boots the configuration when present.
+#
+require_relative "../spec_helper"
+require "active_hecks/railtie"
+
+RSpec.describe "ActiveHecks::Railtie" do
+  it "exists as a subclass of the stubbed Rails::Railtie" do
+    expect(ActiveHecks::Railtie.ancestors).to include(Rails::Railtie)
+  end
+
+  describe "initializer active_hecks.setup" do
+    let(:initializer_entry) do
+      ActiveHecks::Railtie._initializers.find { |i| i[:name] == "active_hecks.setup" }
+    end
+
+    it "is registered" do
+      expect(initializer_entry).not_to be_nil
+    end
+
+    it "calls boot! when configuration is present" do
+      config = instance_double(Hecks::Configuration, boot!: nil)
+      allow(Hecks).to receive(:configuration).and_return(config)
+
+      expect(config).to receive(:boot!).once
+      initializer_entry[:block].call
+    end
+
+    it "is a no-op when configuration is nil" do
+      allow(Hecks).to receive(:configuration).and_return(nil)
+
+      expect { initializer_entry[:block].call }.not_to raise_error
+    end
+
+    it "calls boot! exactly once" do
+      config = instance_double(Hecks::Configuration, boot!: nil)
+      allow(Hecks).to receive(:configuration).and_return(config)
+
+      expect(config).to receive(:boot!).exactly(1).times
+      initializer_entry[:block].call
+    end
+  end
+end

--- a/hecks_on_rails/spec/spec_helper.rb
+++ b/hecks_on_rails/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+# spec_helper for hecks_on_rails
+#
+# Stubs Rails::Railtie before requiring active_hecks so tests never
+# need the railties gem. Captures registered initializer blocks so
+# railtie_spec can replay them.
+#
+module Rails
+  class Railtie
+    def self.generators(&block); end
+
+    def self.initializer(name, **opts, &block)
+      (@_initializers ||= []) << { name: name, opts: opts, block: block }
+    end
+
+    def self.rake_tasks(&block); end
+    def self._initializers; @_initializers ||= []; end
+  end
+end
+
+require "hecks"
+require "active_hecks"


### PR DESCRIPTION
## Summary
- Adds `hecks_on_rails/spec/spec_helper.rb` that stubs `Rails::Railtie` before requiring `active_hecks`, capturing registered initializer blocks for replay in tests
- Adds `railtie_spec.rb` verifying `ActiveHecks::Railtie` subclasses the stub, and that `active_hecks.setup` calls `boot!` when configuration is present, is a no-op when nil, and fires exactly once
- Adds `configure_spec.rb` covering the configure block return type, no auto-boot in Rails context, default `:memory` adapter, domain registration, and `boot!` activating `DomainModelCompat` on aggregate classes
- Adds `domain_model_compat_configure_spec.rb` with edge cases using anonymous classes: initialize-parameter fallback, timestamp inclusion, no-duplicate id, and `read_attribute_for_serialization`
- Updates root `.rspec` `--pattern` to include `hecks_on_rails`

## Test plan
- [ ] `bundle exec rspec hecks_on_rails/spec/` — all pass (1299 examples, 0 failures, under 1s)
- [ ] `bundle exec ruby examples/pizzas/app.rb` — smoke test passes