### PR TITLE
HEC-258: Go show page renders cross-aggregate command buttons

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -176,6 +176,22 @@ module GoHecks
             lines << "\t\tvar buttons []#{safe}Button"
           end
 
+          # Cross-aggregate command buttons
+          @domain.aggregates.each do |other|
+            next if other.name == agg.name
+            other_snake = GoUtils.snake_case(other.name)
+            other_plural = other_snake + "s"
+            other.commands.each do |cmd|
+              snake = GoUtils.snake_case(agg.name)
+              has_ref = (cmd.references || []).any? { |r| Hecks::Utils.underscore(r.type) == snake }
+              has_attr = cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
+              next unless has_ref || has_attr
+              cm = GoUtils.snake_case(cmd.name)
+              label = HecksTemplating::UILabelContract.label(cmd.name)
+              lines << "\t\tbuttons = append(buttons, #{safe}Button{Label: \"#{label}\", Href: \"/#{other_plural}/#{cm}/new?id=\" + obj.ID, Allowed: true})"
+            end
+          end
+
           lines << "\t\trenderer.Render(w, \"show\", \"#{safe}\", #{safe}ShowData{AggregateName: \"#{safe}\", BackHref: \"/#{plural}\", Id: obj.ID, Fields: fields, Buttons: buttons})"
           lines << "\t})"
           lines << ""

--- a/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
+++ b/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
@@ -71,6 +71,32 @@ RSpec.describe GoHecks::ServerGenerator do
     end
   end
 
+  describe "cross-aggregate command buttons on show page" do
+    let(:domain) do
+      Hecks.domain("Store") do
+        aggregate("Product") do
+          attribute :name, String
+          command("CreateProduct") { attribute :name, String }
+        end
+        aggregate("Review") do
+          attribute :body, String
+          command("CreateReview") { attribute :product_id, String; attribute :body, String }
+        end
+      end
+    end
+
+    let(:server) { GoHecks::ServerGenerator.new(domain, module_path: "store_domain") }
+    let(:output) { server.generate }
+
+    it "renders cross-aggregate Create Review button on Product show page" do
+      expect(output).to include('Label: "Create Review"')
+    end
+
+    it "links cross-aggregate button to the other aggregate's form with id param" do
+      expect(output).to include('/reviews/create_review/new?id=')
+    end
+  end
+
   describe "nav items" do
     it "does not include duplicate Home entry" do
       expect(output.scan('"Home"').size).to eq(0)


### PR DESCRIPTION
## Summary
- Go show pages now render command buttons from OTHER aggregates that reference the current one (matching Ruby target parity)
- Detection checks both `cmd.attributes` for `<agg>_id` naming and `cmd.references` for type match
- Buttons link to the other aggregate's form with `?id=` pre-filled

## Test plan
- [x] New specs: Product show page includes "Create Review" button when Review has `product_id` attribute
- [x] New specs: Button href points to `/reviews/create_review/new?id=`
- [x] Full suite passes (1299 examples, 0 failures, 0.83s)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)