### PR TITLE
HEC-242: Web explorer home page cards list command names

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
@@ -110,7 +110,7 @@ module GoHecks
       agg_data = @domain.aggregates.map do |agg|
         plural = GoUtils.snake_case(agg.name) + "s"
         d = HecksTemplating::DisplayContract.home_aggregate_data(agg, plural)
-        "{Name: \"#{d[:name]}\", Href: \"#{d[:href]}\", Commands: #{d[:commands]}, Attributes: #{d[:attributes]}, Policies: #{d[:policies]}}"
+        "{Name: \"#{d[:name]}\", Href: \"#{d[:href]}\", CommandNames: \"#{d[:command_names]}\", Attributes: #{d[:attributes]}, Policies: #{d[:policies]}}"
       end
       lines = []
       vc = HecksTemplating::ViewContract

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -95,7 +95,7 @@ class UIGenerator < Hecks::Generator
   def root_route(mod)
     agg_data = @domain.aggregates.map do |agg|
       d = HecksTemplating::DisplayContract.home_aggregate_data(agg, plural(agg))
-      "{ name: \"#{d[:name]}\", href: \"#{d[:href]}\", commands: #{d[:commands]}, attributes: #{d[:attributes]}, policies: #{d[:policies]} }"
+      "{ name: \"#{d[:name]}\", href: \"#{d[:href]}\", command_names: \"#{d[:command_names]}\", attributes: #{d[:attributes]}, policies: #{d[:policies]} }"
     end
     [
       "        server.mount_proc \"/\" do |req, res|",

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -113,7 +113,7 @@ module Hecks
         agg_data = @entries.flat_map do |e|
           e[:domain].aggregates.map do |agg|
             d = HecksTemplating::DisplayContract.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
-            { name: d[:name], href: d[:href], commands: d[:commands],
+            { name: d[:name], href: d[:href], command_names: d[:command_names],
               attributes: d[:attributes], policies: d[:policies] }
           end
         end

--- a/hecks_workshop/explorer/lib/hecks_explorer/views/home.erb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/views/home.erb
@@ -3,7 +3,7 @@
   <% aggregates.each do |agg| %>
     <a href="<%= agg[:href] %>" class="card">
       <h2><%= agg[:name] %></h2>
-      <p class="mono"><%= agg[:commands] %> commands &middot; <%= agg[:attributes] %> attributes<% if agg[:policies] && agg[:policies] > 0 %> &middot; <%= agg[:policies] %> policies<% end %></p>
+      <p class="mono"><%= agg[:command_names] %> &middot; <%= agg[:attributes] %> attributes<% if agg[:policies] && agg[:policies] > 0 %> &middot; <%= agg[:policies] %> policies<% end %></p>
     </a>
   <% end %>
 </div>

--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -105,7 +105,7 @@ module Hecks::Conventions
     #
     # @param agg [Aggregate] the aggregate IR
     # @param plural [String] the plural URL segment
-    # @return [Hash] { name:, href:, commands:, attributes:, policies: }
+    # @return [Hash] { name:, href:, command_names:, attributes:, policies: }
     def self.home_aggregate_data(agg, plural)
       user_attrs = agg.attributes.reject { |a|
         Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s)
@@ -113,7 +113,7 @@ module Hecks::Conventions
       {
         name: UILabelContract.plural_label(agg.name),
         href: "/#{plural}",
-        commands: agg.commands.size,
+        command_names: agg.commands.map { |c| UILabelContract.label(c.name) }.join(", "),
         attributes: user_attrs.size,
         policies: agg.policies.size,
       }

--- a/hecksties/lib/hecks/conventions/view_contract.rb
+++ b/hecksties/lib/hecks/conventions/view_contract.rb
@@ -96,7 +96,7 @@ module Hecks::Conventions
         home_agg: [
           { name: :href, type: :string },
           { name: :name, type: :string },
-          { name: :commands, type: :int },
+          { name: :command_names, type: :string },
           { name: :attributes, type: :int },
           { name: :policies, type: :int },
         ],

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -113,7 +113,7 @@ module Hecks
         agg_data = @entries.flat_map do |e|
           e[:domain].aggregates.map do |agg|
             d = HecksTemplating::DisplayContract.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
-            { name: d[:name], href: d[:href], commands: d[:commands],
+            { name: d[:name], href: d[:href], command_names: d[:command_names],
               attributes: d[:attributes], policies: d[:policies] }
           end
         end

--- a/hecksties/lib/hecks/extensions/web_explorer/views/home.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/home.erb
@@ -3,7 +3,7 @@
   <% aggregates.each do |agg| %>
     <a href="<%= agg[:href] %>" class="card">
       <h2><%= agg[:name] %></h2>
-      <p class="mono"><%= agg[:commands] %> commands &middot; <%= agg[:attributes] %> attributes<% if agg[:policies] && agg[:policies] > 0 %> &middot; <%= agg[:policies] %> policies<% end %></p>
+      <p class="mono"><%= agg[:command_names] %> &middot; <%= agg[:attributes] %> attributes<% if agg[:policies] && agg[:policies] > 0 %> &middot; <%= agg[:policies] %> policies<% end %></p>
     </a>
   <% end %>
 </div>

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::DisplayContract do
+  let(:domain) { BootedDomains.pizzas }
+
+  describe ".home_aggregate_data" do
+    it "returns command_names as a humanized comma-separated string" do
+      pizza = domain.aggregates.find { |a| a.name == "Pizza" }
+      data = described_class.home_aggregate_data(pizza, "pizzas")
+      expect(data[:command_names]).to eq("Create Pizza, Add Topping")
+    end
+
+    it "returns an empty string when there are no commands" do
+      agg = double("agg",
+        name: "Empty",
+        commands: [],
+        attributes: [],
+        policies: [])
+      data = described_class.home_aggregate_data(agg, "empties")
+      expect(data[:command_names]).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Home page aggregate cards now show humanized command names (e.g. "Create Pizza, Add Topping") instead of a count (e.g. "2 commands")
- Updated ViewContract, DisplayContract, ERB templates, Ruby/Go static generators, and both multi-domain servers
- Added display_contract_spec covering `home_aggregate_data` with commands and zero-command edge case

## Test plan
- [x] `bundle exec rspec` -- 1301 examples, 0 failures (0.87s)
- [x] `ruby -Ilib examples/pizzas/app.rb` -- smoke test passes
- [ ] Boot web explorer and verify home page cards show command names instead of counts