### PR TITLE
HEC-240: Config page shows Mermaid domain wiring diagram

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -552,6 +552,7 @@
   - Resets server data before and after each run via `POST /_reset`
 - Form submission: accepts both JSON and form-urlencoded, redirects on success
 - Config page with roles, adapter, policies, aggregate counts, ports
+- Config page domain wiring diagrams: Mermaid structure, behavior, and flow diagrams generated at compile time
 - All DSL concepts generate Go code: lifecycle (state constants, predicates, transition validation, default on create, from-constraints on update), queries (prefixed to avoid collisions), specifications (with predicate translation), policies
 - Go aggregate `Validate()` enforces enum constraints from AggregateContract
 - Go commands set lifecycle default status on create, enforce from-constraints and set target on update

--- a/docs/usage/config_diagrams.md
+++ b/docs/usage/config_diagrams.md
@@ -1,0 +1,41 @@
+# Config Page Domain Wiring Diagrams
+
+The web explorer's `/config` page now renders Mermaid diagrams showing domain
+structure, behavior, and reactive flows.
+
+## What you see
+
+Three collapsible sections appear below the Aggregates table:
+
+- **Structure** -- classDiagram of aggregates, attributes, value objects, entities, and references
+- **Behavior** -- flowchart of commands, events, and policy chains
+- **Flows** -- sequenceDiagram of reactive chains (command -> event -> policy -> command)
+
+## How it works
+
+Diagrams are generated at **compile time** using `DomainVisualizer` and
+`FlowGenerator`, then embedded as string literals in the generated server code.
+The Mermaid CDN renders them client-side.
+
+```ruby
+# The generators call these internally:
+vis = Hecks::DomainVisualizer.new(domain)
+vis.generate_structure   # => classDiagram Mermaid string
+vis.generate_behavior    # => flowchart LR Mermaid string
+Hecks::FlowGenerator.new(domain).generate_mermaid  # => sequenceDiagram string
+```
+
+## Example
+
+Boot any domain app and visit `/config`:
+
+```bash
+cd examples/pizzas_static_ruby
+ruby -Ilib lib/pizzas_domain/server.rb
+# open http://localhost:8080/config
+```
+
+The Structure diagram shows Pizza and Order aggregates with their attributes,
+the Topping value object, and the Order -> Pizza reference arrow. The Behavior
+diagram shows command-to-event flows and policy links. The Flows diagram shows
+the reactive chain sequence.

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
@@ -91,6 +91,7 @@ module GoHecks
         dc = HecksTemplating::DisplayContract
         all_roles = dc.available_roles(@domain)
         policies = dc.policy_labels(@domain)
+        diagrams = generate_diagrams
 
         vc = HecksTemplating::ViewContract
         lines = []
@@ -119,10 +120,26 @@ module GoHecks
         lines << "\t\t\tBootedAt: \"running\","
         lines << "\t\t\tPolicies: []string{#{policies.map { |p| "\"#{p}\"" }.join(', ')}},"
         lines << "\t\t\tAggregates: aggs,"
+        lines << "\t\t\tStructureDiagram: #{go_html_literal(diagrams[:structure])},"
+        lines << "\t\t\tBehaviorDiagram: #{go_html_literal(diagrams[:behavior])},"
+        lines << "\t\t\tFlowsDiagram: #{go_html_literal(diagrams[:flows])},"
         lines << "\t\t})"
         lines << "\t})"
         lines << ""
         lines
+      end
+
+      def generate_diagrams
+        vis = Hecks::DomainVisualizer.new(@domain)
+        {
+          structure: vis.generate_structure,
+          behavior: vis.generate_behavior,
+          flows: Hecks::FlowGenerator.new(@domain).generate_mermaid
+        }
+      end
+
+      def go_html_literal(str)
+        "template.HTML(#{str.inspect})"
       end
     end
   end

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/config_routes.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/config_routes.rb
@@ -19,6 +19,7 @@ module HecksStatic
         end
 
         policies = dc.policy_labels(@domain)
+        diagrams = generate_diagrams
 
         [
           "        server.mount_proc \"/config\" do |req, res|",
@@ -29,11 +30,23 @@ module HecksStatic
           "            adapters: %w[memory filesystem sqlite], current_adapter: cfg[:adapter].to_s,",
           "            event_count: #{mod}.events.size, booted_at: (cfg[:booted_at] || \"unknown\").to_s,",
           "            policies: #{policies.inspect},",
-          "            aggregates: [#{agg_rows.join(', ')}])",
+          "            aggregates: [#{agg_rows.join(', ')}],",
+          "            structure_diagram: #{diagrams[:structure].inspect},",
+          "            behavior_diagram: #{diagrams[:behavior].inspect},",
+          "            flows_diagram: #{diagrams[:flows].inspect})",
           "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
           "        end",
           ""
         ]
+      end
+
+      def generate_diagrams
+        vis = Hecks::DomainVisualizer.new(@domain)
+        {
+          structure: vis.generate_structure,
+          behavior: vis.generate_behavior,
+          flows: Hecks::FlowGenerator.new(@domain).generate_mermaid
+        }
       end
 
       def reboot_route(mod)

--- a/hecksties/lib/hecks/conventions/view_contract.rb
+++ b/hecksties/lib/hecks/conventions/view_contract.rb
@@ -212,6 +212,9 @@ module Hecks::Conventions
         { name: :booted_at, type: :string },
         { name: :policies, type: :string_list },
         { name: :aggregates, type: :list, item_type: :config_agg },
+        { name: :structure_diagram, type: :html },
+        { name: :behavior_diagram, type: :html },
+        { name: :flows_diagram, type: :html },
       ],
       structs: {
         config_agg: [

--- a/hecksties/lib/hecks/extensions/web_explorer/views/config.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/config.erb
@@ -63,3 +63,15 @@
     <% end %>
   </tbody>
 </table>
+<% if defined?(structure_diagram) && structure_diagram && !structure_diagram.empty? %>
+<h2>Domain Wiring</h2>
+<details open><summary>Structure</summary>
+  <pre class="mermaid"><%= structure_diagram %></pre>
+</details>
+<details><summary>Behavior</summary>
+  <pre class="mermaid"><%= behavior_diagram %></pre>
+</details>
+<details><summary>Flows</summary>
+  <pre class="mermaid"><%= flows_diagram %></pre>
+</details>
+<% end %>

--- a/hecksties/lib/hecks/extensions/web_explorer/views/layout.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/layout.erb
@@ -107,5 +107,6 @@
       }
     });
   </script>
+  <script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'; mermaid.initialize({startOnLoad: true});</script>
 </body>
 </html>

--- a/hecksties/spec/conventions/view_contract_config_diagrams_spec.rb
+++ b/hecksties/spec/conventions/view_contract_config_diagrams_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "hecks/extensions/web_explorer/renderer"
+
+RSpec.describe Hecks::Conventions::ViewContract do
+  describe "CONFIG contract" do
+    let(:fields) { described_class::CONFIG[:fields] }
+
+    it "includes structure_diagram as html" do
+      field = fields.find { |f| f[:name] == :structure_diagram }
+      expect(field).to eq(name: :structure_diagram, type: :html)
+    end
+
+    it "includes behavior_diagram as html" do
+      field = fields.find { |f| f[:name] == :behavior_diagram }
+      expect(field).to eq(name: :behavior_diagram, type: :html)
+    end
+
+    it "includes flows_diagram as html" do
+      field = fields.find { |f| f[:name] == :flows_diagram }
+      expect(field).to eq(name: :flows_diagram, type: :html)
+    end
+
+    it "maps html type to template.HTML in Go" do
+      expect(described_class::GO_TYPES[:html]).to eq("template.HTML")
+    end
+  end
+
+  describe "config template renders diagrams" do
+    let(:views_dir) do
+      File.expand_path("../../lib/hecks/extensions/web_explorer/views", __dir__)
+    end
+
+    let(:renderer) { Hecks::WebExplorer::Renderer.new(views_dir) }
+
+    let(:html) do
+      renderer.render(:config,
+        skip_layout: true,
+        title: "Config", brand: "Test", nav_items: [],
+        roles: ["admin"], current_role: "admin",
+        adapters: ["memory"], current_adapter: "memory",
+        event_count: 0, booted_at: "now",
+        policies: [], aggregates: [],
+        structure_diagram: "classDiagram\n    class Pizza",
+        behavior_diagram: "flowchart LR\n    subgraph Pizza",
+        flows_diagram: "sequenceDiagram\n  participant Pizza")
+    end
+
+    it "renders mermaid pre tags for structure" do
+      expect(html).to include('<pre class="mermaid">classDiagram')
+    end
+
+    it "renders mermaid pre tags for behavior" do
+      expect(html).to include('<pre class="mermaid">flowchart LR')
+    end
+
+    it "renders mermaid pre tags for flows" do
+      expect(html).to include('<pre class="mermaid">sequenceDiagram')
+    end
+
+    it "shows Domain Wiring heading" do
+      expect(html).to include("<h2>Domain Wiring</h2>")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add Mermaid structure, behavior, and flow diagrams to the web explorer `/config` page
- Diagrams generated at compile time from `DomainVisualizer` and `FlowGenerator`, embedded as string literals in both Ruby and Go targets
- ViewContract updated with `structure_diagram`, `behavior_diagram`, `flows_diagram` fields (type `:html` / `template.HTML`)

## Changes
- `view_contract.rb` -- 3 new html fields in CONFIG contract
- `layout.erb` -- Mermaid CDN script tag
- `config.erb` -- collapsible diagram sections (Structure, Behavior, Flows)
- `config_routes.rb` (Ruby) -- generate and pass diagram data to renderer
- `ui_routes.rb` (Go) -- generate and pass diagram data to renderer
- New spec: `view_contract_config_diagrams_spec.rb`
- Usage doc: `docs/usage/config_diagrams.md`

## Test plan
- [x] ViewContract CONFIG includes diagram fields with correct types
- [x] Config template renders `<pre class="mermaid">` tags when diagram data is present
- [x] All 1307 specs pass in under 1 second
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)