### PR TITLE
HEC-31: Computed attributes — derived values from other attributes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -20,6 +20,7 @@
 - Cross-domain references: `reference_to "Billing::Invoice"`
 - References hold live objects in memory — IDs are purely a persistence concern
 - Enum constraints: `attribute :category, String, enum: %w[low medium high]` — validated at runtime, dropdown in UI
+- Computed attributes: `computed :lot_size do; area / 43560.0; end` — derived values not stored in the database, shown in UI with "(computed)" hint
 
 ### Commands
 - Define commands with attributes, handlers, guards, read models, actors, and external system docs

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -35,6 +35,7 @@ module Hecks
       lines.concat(serialize_validations(agg.validations))
       lines.concat(serialize_invariants(agg.invariants, "    "))
       lines.concat(serialize_scopes(agg.scopes))
+      lines.concat(serialize_computed_attributes(agg.computed_attributes))
       lines.concat(serialize_queries(agg.queries))
       lines.concat(serialize_specifications(agg.specifications))
       lines.concat(serialize_commands(agg.commands))
@@ -89,6 +90,14 @@ module Hecks
       queries.flat_map do |q|
         ["", "    query \"#{q.name}\" do",
          "      #{Hecks::Utils.block_source(q.block)}",
+         "    end"]
+      end
+    end
+
+    def serialize_computed_attributes(computed_attrs)
+      (computed_attrs || []).flat_map do |ca|
+        ["", "    computed :#{ca.name} do",
+         "      #{Hecks::Utils.block_source(ca.block)}",
          "    end"]
       end
     end

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -55,7 +55,8 @@ module Hecks
       autoload :Actor,          "hecks/domain_model/structure/actor"
       autoload :Lifecycle,        "hecks/domain_model/structure/lifecycle"
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
-      autoload :Reference,       "hecks/domain_model/structure/reference"
+      autoload :Reference,         "hecks/domain_model/structure/reference"
+      autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -72,6 +72,9 @@ module Hecks
       # @return [Array<Hash>] factory declarations for complex construction
       attr_reader :factories
 
+      # @return [Array<ComputedAttribute>] derived attributes computed from other attributes
+      attr_reader :computed_attributes
+
       # @return [Lifecycle, nil] optional state machine definition
       attr_reader :lifecycle
 
@@ -104,7 +107,8 @@ module Hecks
                      events: [], policies: [], validations: [], invariants: [],
                      scopes: [], queries: [], subscribers: [], indexes: [],
                      specifications: [], references: [],
-                     factories: [], lifecycle: nil, versioned: false,
+                     factories: [], computed_attributes: [],
+                     lifecycle: nil, versioned: false,
                      attachable: false, metadata: {}, origin_domain: nil,
                      identity_fields: nil)
         @name = Names.aggregate_name(name)
@@ -123,6 +127,7 @@ module Hecks
         @specifications = specifications
         @references = references
         @factories = factories
+        @computed_attributes = computed_attributes
         @lifecycle = lifecycle
         @versioned = versioned
         @attachable = attachable

--- a/bluebook/lib/hecks/domain_model/structure/computed_attribute.rb
+++ b/bluebook/lib/hecks/domain_model/structure/computed_attribute.rb
@@ -1,0 +1,29 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::ComputedAttribute
+    #
+    # A derived attribute computed from other attributes, not stored in the
+    # database. Holds a name and a block whose body becomes a method on the
+    # generated aggregate class.
+    #
+    #   ComputedAttribute.new(name: :lot_size, block: proc { area / 43560.0 })
+    #
+    class ComputedAttribute
+      # @return [Symbol] the name of this computed attribute
+      attr_reader :name
+
+      # @return [Proc] the block whose body computes the derived value
+      attr_reader :block
+
+      # @param name [Symbol] attribute name
+      # @param block [Proc] computation block referencing other attributes
+      def initialize(name:, block:)
+        @name = name
+        @block = block
+      end
+    end
+    end
+  end
+end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -78,6 +78,7 @@ module Hecks
         @references = []
         @explicit_events = []
         @factories = []
+        @computed_attributes = []
         @lifecycle = nil
         @versioned = false
         @attachable = false
@@ -96,6 +97,17 @@ module Hecks
 
       def attachable
         @attachable = true
+      end
+
+      # Declare a computed (derived) attribute. The block body becomes a
+      # method on the generated aggregate class. Not stored in the database.
+      #
+      #   computed :lot_size do
+      #     area / 43560.0
+      #   end
+      #
+      def computed(name, &block)
+        @computed_attributes << Structure::ComputedAttribute.new(name: name.to_sym, block: block)
       end
 
       # Declare a natural key composed from attributes.
@@ -186,8 +198,8 @@ module Hecks
           validations: @validations, invariants: @invariants,
           scopes: @scopes, queries: @queries,
           subscribers: @subscribers, indexes: @indexes,
-          specifications: @specifications, lifecycle: @lifecycle,
-          versioned: @versioned, attachable: @attachable,
+          specifications: @specifications, computed_attributes: @computed_attributes,
+          lifecycle: @lifecycle, versioned: @versioned, attachable: @attachable,
           metadata: @metadata, references: @references,
           factories: @factories, identity_fields: @identity_fields
         )

--- a/bluebook/lib/hecks/generators/domain/aggregate_generator.rb
+++ b/bluebook/lib/hecks/generators/domain/aggregate_generator.rb
@@ -75,6 +75,15 @@ module Hecks
         (@aggregate.references || []).each do |ref|
           lines << "    attribute :#{ref.name}"
         end
+        unless (@aggregate.computed_attributes || []).empty?
+          lines << ""
+          lines << "    # Computed attributes — derived values, not stored"
+          @aggregate.computed_attributes.each do |ca|
+            lines << "    def #{ca.name}"
+            lines << "      #{Hecks::Utils.block_source(ca.block)}"
+            lines << "    end"
+          end
+        end
         if @aggregate.lifecycle
           lines << ""
           lines << "    # State predicates — see lifecycle.rb for full state machine"

--- a/bluebook/lib/hecks/validation_rules/naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming.rb
@@ -17,7 +17,8 @@ module Hecks
       autoload :CommandNaming,        "hecks/validation_rules/naming/command_naming"
       autoload :NameCollisions,       "hecks/validation_rules/naming/name_collisions"
       autoload :UniqueAggregateNames, "hecks/validation_rules/naming/unique_aggregate_names"
-      autoload :ReservedNames,        "hecks/validation_rules/naming/reserved_names"
+      autoload :ReservedNames,            "hecks/validation_rules/naming/reserved_names"
+      autoload :ComputedNameCollisions, "hecks/validation_rules/naming/computed_name_collisions"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/naming/computed_name_collisions.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/computed_name_collisions.rb
@@ -1,0 +1,36 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::ComputedNameCollisions
+    #
+    # Validates that computed attribute names do not collide with regular
+    # attribute names on the same aggregate. Such collisions would generate
+    # a method that shadows the stored attribute accessor.
+    #
+    # Part of the ValidationRules::Naming group -- run by +Hecks.validate+.
+    #
+    #   rule = ComputedNameCollisions.new(domain)
+    #   rule.errors  # => ["Parcel: computed attribute 'area' collides with a regular attribute"]
+    #
+    class ComputedNameCollisions < BaseRule
+      # Checks all aggregates for name collisions between computed and regular attributes.
+      #
+      # @return [Array<String>] error messages for each collision found
+      def errors
+        result = []
+        @domain.aggregates.each do |agg|
+          attr_names = agg.attributes.map(&:name).map(&:to_sym)
+          (agg.computed_attributes || []).each do |ca|
+            if attr_names.include?(ca.name.to_sym)
+              result << "#{agg.name}: computed attribute '#{ca.name}' collides with a regular attribute"
+            end
+          end
+        end
+        result
+      end
+    end
+    Hecks.register_validation_rule(ComputedNameCollisions)
+    end
+  end
+end

--- a/bluebook/spec/dsl/computed_attribute_spec.rb
+++ b/bluebook/spec/dsl/computed_attribute_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+RSpec.describe "computed attributes" do
+  describe "DSL parsing" do
+    it "parses computed keyword and builds IR" do
+      domain = Hecks.domain("RealEstate") do
+        aggregate("Parcel") do
+          attribute :area, Float
+          attribute :density, Float
+          computed :lot_size do
+            area / 43560.0
+          end
+          command("CreateParcel") { attribute :area, Float; attribute :density, Float }
+        end
+      end
+
+      agg = domain.aggregates.first
+      expect(agg.computed_attributes.size).to eq(1)
+
+      ca = agg.computed_attributes.first
+      expect(ca.name).to eq(:lot_size)
+      expect(ca.block).to be_a(Proc)
+    end
+
+    it "supports multiple computed attributes" do
+      domain = Hecks.domain("RealEstate") do
+        aggregate("Parcel") do
+          attribute :area, Float
+          attribute :density, Float
+          computed(:lot_size) { area / 43560.0 }
+          computed(:total) { area * density }
+          command("CreateParcel") { attribute :area, Float }
+        end
+      end
+
+      expect(domain.aggregates.first.computed_attributes.size).to eq(2)
+    end
+  end
+
+  describe "Ruby code generation" do
+    it "generates computed method on aggregate class" do
+      domain = Hecks.domain("RealEstate") do
+        aggregate("Parcel") do
+          attribute :area, Float
+          computed :lot_size do
+            area / 43560.0
+          end
+          command("CreateParcel") { attribute :area, Float }
+        end
+      end
+
+      gen = Hecks::Generators::Domain::AggregateGenerator.new(
+        domain.aggregates.first, domain_module: "RealEstateDomain"
+      )
+      code = gen.generate
+
+      expect(code).to include("def lot_size")
+      expect(code).to include("area / 43560.0")
+      expect(code).to include("# Computed attributes")
+    end
+  end
+
+  describe "validation" do
+    it "detects name collision between computed and regular attributes" do
+      domain = Hecks.domain("RealEstate") do
+        aggregate("Parcel") do
+          attribute :area, Float
+          computed(:area) { 42 }
+          command("CreateParcel") { attribute :area, Float }
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      expect(validator.errors).to include(
+        "Parcel: computed attribute 'area' collides with a regular attribute"
+      )
+    end
+  end
+
+  describe "defaults" do
+    it "defaults computed_attributes to empty array" do
+      domain = Hecks.domain("Simple") do
+        aggregate("Thing") do
+          attribute :name, String
+          command("CreateThing") { attribute :name, String }
+        end
+      end
+
+      expect(domain.aggregates.first.computed_attributes).to eq([])
+    end
+  end
+end

--- a/docs/usage/computed_attributes.md
+++ b/docs/usage/computed_attributes.md
@@ -1,0 +1,83 @@
+# Computed Attributes
+
+Computed attributes are derived values calculated from other attributes on an
+aggregate. They are not stored in the database -- they exist only as methods on
+the generated Ruby class.
+
+## DSL
+
+```ruby
+Hecks.domain "RealEstate" do
+  aggregate "Parcel" do
+    attribute :area, Float
+    attribute :density, Float
+
+    computed :lot_size do
+      area / 43560.0
+    end
+
+    computed :total_units do
+      (area * density).ceil
+    end
+
+    command "CreateParcel" do
+      attribute :area, Float
+      attribute :density, Float
+    end
+  end
+end
+```
+
+## Generated Ruby
+
+The `computed` block body becomes a method on the aggregate class:
+
+```ruby
+class Parcel
+  include Hecks::Model
+
+  attribute :area
+  attribute :density
+
+  # Computed attributes -- derived values, not stored
+  def lot_size
+    area / 43560.0
+  end
+
+  def total_units
+    (area * density).ceil
+  end
+end
+```
+
+## Usage at Runtime
+
+```ruby
+parcel = Parcel.create(area: 87120.0, density: 0.5)
+parcel.lot_size    # => 2.0
+parcel.total_units # => 43561
+```
+
+## Web Explorer
+
+Computed attributes appear on index and show pages with a "(computed)" label.
+They are not shown on command forms since they are derived, not user-entered.
+
+## Go Target
+
+Go aggregates get placeholder receiver methods with a TODO comment:
+
+```go
+// LotSize -- computed attribute (TODO: implement)
+func (a *Parcel) LotSize() interface{} {
+    // TODO: translate computed logic from Ruby DSL
+    return nil
+}
+```
+
+## Validation
+
+Computed attribute names must not collide with regular attribute names. The
+validator will report an error like:
+
+    Parcel: computed attribute 'area' collides with a regular attribute

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -219,6 +219,11 @@ aggregate "Pizza" do
     attribute :reason, String
   end
 
+  # Computed attributes (derived, not stored)
+  computed :lot_size do
+    area / 43560.0
+  end
+
   # Versioning and attachments
   versioned
   attachable
@@ -421,6 +426,37 @@ end
 # TeamCycle.find(uuid)                                    # always works
 # TeamCycle.find_by_identity(team: "Alpha", start_date: Date.today)  # natural key
 ```
+
+---
+
+## Computed Attributes
+
+Computed attributes are derived values calculated from other attributes. They generate methods on the aggregate class but are not stored in the database. The block body becomes the method body.
+
+```ruby
+aggregate "Parcel" do
+  attribute :area, Float
+  attribute :density, Float
+
+  computed :lot_size do
+    area / 43560.0
+  end
+
+  computed :total_units do
+    (area * density).ceil
+  end
+end
+```
+
+At runtime:
+
+```ruby
+parcel = Parcel.create(area: 87120.0, density: 0.5)
+parcel.lot_size    # => 2.0
+parcel.total_units # => 43561
+```
+
+Computed attribute names must not collide with regular attribute names (the validator will catch this). They appear in the web explorer with a "(computed)" label but are not shown on command forms.
 
 ---
 

--- a/hecks_targets/go/lib/go_hecks/generators/aggregate_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/aggregate_generator.rb
@@ -107,6 +107,22 @@ module GoHecks
 
       lines << "\treturn nil"
       lines << "}"
+      lines.concat(computed_methods)
+      lines
+    end
+
+    def computed_methods
+      cas = @agg.computed_attributes || []
+      return [] if cas.empty?
+      lines = []
+      cas.each do |ca|
+        lines << ""
+        lines << "// #{GoUtils.pascal_case(ca.name)} — computed attribute (TODO: implement)"
+        lines << "func (a *#{@agg.name}) #{GoUtils.pascal_case(ca.name)}() interface{} {"
+        lines << "\t// TODO: translate computed logic from Ruby DSL"
+        lines << "\treturn nil"
+        lines << "}"
+      end
       lines
     end
   end

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
@@ -47,7 +47,15 @@ module Hecks
             cells = user_attrs.map { |a| obj.send(a.name).to_s }
             { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
           end
+          computed = agg.computed_attributes || []
+          computed.each do |ca|
+            items.each do |item|
+              obj = klass.find(item[:id])
+              item[:cells] << obj.instance_eval(&ca.block).to_s if obj
+            end
+          end
           columns = user_attrs.map { |a| { label: humanize(a.name) } }
+          computed.each { |ca| columns << { label: "#{humanize(ca.name)} (computed)" } }
           create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
@@ -68,6 +76,9 @@ module Hecks
           end
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
           fields = user_attrs.map { |a| { label: humanize(a.name), value: obj.send(a.name).to_s } }
+          (agg.computed_attributes || []).each do |ca|
+            fields << { label: "#{humanize(ca.name)} (computed)", value: obj.instance_eval(&ca.block).to_s }
+          end
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
@@ -47,7 +47,15 @@ module Hecks
             cells = user_attrs.map { |a| obj.send(a.name).to_s }
             { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
           end
+          computed = agg.computed_attributes || []
+          computed.each do |ca|
+            items.each do |item|
+              obj = klass.find(item[:id])
+              item[:cells] << obj.instance_eval(&ca.block).to_s if obj
+            end
+          end
           columns = user_attrs.map { |a| { label: humanize(a.name) } }
+          computed.each { |ca| columns << { label: "#{humanize(ca.name)} (computed)" } }
           create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
@@ -68,6 +76,9 @@ module Hecks
           end
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
           fields = user_attrs.map { |a| { label: humanize(a.name), value: obj.send(a.name).to_s } }
+          (agg.computed_attributes || []).each do |ca|
+            fields << { label: "#{humanize(ca.name)} (computed)", value: obj.instance_eval(&ca.block).to_s }
+          end
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",


### PR DESCRIPTION
## Summary
- Add `computed` keyword to the Bluebook DSL for derived attributes not stored in the database
- New IR class `ComputedAttribute` with name and block, wired into `Aggregate` structure
- Ruby generator emits computed methods on aggregate classes; Go generator emits placeholder receiver methods with TODO
- Validation rule detects name collisions between computed and regular attributes
- Web explorer (both serve and workshop) shows computed values on index/show pages with "(computed)" label
- DSL serializer round-trips computed attributes via `block_source`

## Test plan
- [x] `computed` keyword parses and builds IR (single and multiple)
- [x] Generated Ruby class includes the computed method with correct body
- [x] Validator detects name collision between computed and regular attribute
- [x] Defaults to empty array when no computed attributes declared
- [x] Full suite: 1304 specs pass in <1s
- [x] Smoke test: `ruby -Ilib examples/pizzas/app.rb` passes