### PR TITLE
HEC-419: Aggregate boundary advisor — DDD modeling warnings

### DIFF
--- a/bluebook/lib/hecks/validation_rules/structure.rb
+++ b/bluebook/lib/hecks/validation_rules/structure.rb
@@ -10,15 +10,19 @@ module Hecks
     # - +CommandsHaveAttributes+ -- every command must have at least one attribute
     # - +ValidPolicyEvents+ -- policies should listen for events that exist (advisory warnings)
     # - +ValidPolicyTriggers+ -- reactive policies must trigger commands that exist
+    # - +SingleAttributeAggregate+ -- warns when aggregate has only 1 attribute and no VOs/entities
+    # - +TooManyCommands+ -- warns when aggregate has 10+ commands (consider splitting)
     #
     # All rules are autoloaded and executed as part of +Hecks.validate+.
     #
     module Structure
-      autoload :AggregatesHaveCommands, "hecks/validation_rules/structure/aggregates_have_commands"
-      autoload :CommandsHaveAttributes, "hecks/validation_rules/structure/commands_have_attributes"
-      autoload :ValidPolicyEvents,      "hecks/validation_rules/structure/valid_policy_events"
-      autoload :ValidPolicyTriggers,    "hecks/validation_rules/structure/valid_policy_triggers"
-      autoload :NoPiiInIdentity,        "hecks/validation_rules/structure/no_pii_in_identity"
+      autoload :AggregatesHaveCommands,   "hecks/validation_rules/structure/aggregates_have_commands"
+      autoload :CommandsHaveAttributes,   "hecks/validation_rules/structure/commands_have_attributes"
+      autoload :ValidPolicyEvents,        "hecks/validation_rules/structure/valid_policy_events"
+      autoload :ValidPolicyTriggers,      "hecks/validation_rules/structure/valid_policy_triggers"
+      autoload :NoPiiInIdentity,          "hecks/validation_rules/structure/no_pii_in_identity"
+      autoload :SingleAttributeAggregate, "hecks/validation_rules/structure/single_attribute_aggregate"
+      autoload :TooManyCommands,          "hecks/validation_rules/structure/too_many_commands"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/structure/single_attribute_aggregate.rb
+++ b/bluebook/lib/hecks/validation_rules/structure/single_attribute_aggregate.rb
@@ -1,0 +1,48 @@
+module Hecks
+  module ValidationRules
+    module Structure
+
+    # Hecks::ValidationRules::Structure::SingleAttributeAggregate
+    #
+    # Advisory warning for aggregates that have exactly one attribute and no
+    # value objects or entities. A single-attribute aggregate with no composition
+    # is often better modeled as a value object inside another aggregate.
+    #
+    # Part of the ValidationRules::Structure group -- run by +Hecks.validate+.
+    #
+    # Example trigger:
+    #   aggregate "Color" do
+    #     attribute :hex, String
+    #     command "CreateColor" do attribute :hex, String end
+    #   end
+    #
+    # Would warn: "Color has only 1 attribute and no value objects or entities --
+    #   consider modeling as a value object"
+    class SingleAttributeAggregate < BaseRule
+      # Returns no errors. This rule only produces warnings.
+      #
+      # @return [Array<String>] always empty
+      def errors
+        []
+      end
+
+      # Returns a warning for each aggregate that has exactly one attribute and
+      # no value objects or entities.
+      #
+      # @return [Array<String>] warning messages
+      def warnings
+        result = []
+        @domain.aggregates.each do |agg|
+          vos = agg.respond_to?(:value_objects) ? agg.value_objects : []
+          entities = agg.respond_to?(:entities) ? agg.entities : []
+          if agg.attributes.size == 1 && vos.empty? && entities.empty?
+            result << "#{agg.name} has only 1 attribute and no value objects or entities -- consider modeling as a value object"
+          end
+        end
+        result
+      end
+    end
+    Hecks.register_validation_rule(SingleAttributeAggregate)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/structure/too_many_commands.rb
+++ b/bluebook/lib/hecks/validation_rules/structure/too_many_commands.rb
@@ -1,0 +1,48 @@
+module Hecks
+  module ValidationRules
+    module Structure
+
+    # Hecks::ValidationRules::Structure::TooManyCommands
+    #
+    # Advisory warning for aggregates that have an unusually large number of
+    # commands. A high command count often indicates that the aggregate has
+    # grown beyond a single bounded responsibility and should be split.
+    #
+    # Threshold is THRESHOLD = 10 commands.
+    #
+    # Part of the ValidationRules::Structure group -- run by +Hecks.validate+.
+    #
+    # Example trigger:
+    #   aggregate "Order" do
+    #     # ... 10 or more command definitions ...
+    #   end
+    #
+    # Would warn: "Order has 10 commands -- consider splitting into smaller aggregates"
+    class TooManyCommands < BaseRule
+      THRESHOLD = 10
+
+      # Returns no errors. This rule only produces warnings.
+      #
+      # @return [Array<String>] always empty
+      def errors
+        []
+      end
+
+      # Returns a warning for each aggregate whose command count meets or
+      # exceeds THRESHOLD.
+      #
+      # @return [Array<String>] warning messages
+      def warnings
+        result = []
+        @domain.aggregates.each do |agg|
+          if agg.commands.size >= THRESHOLD
+            result << "#{agg.name} has #{agg.commands.size} commands -- consider splitting into smaller aggregates"
+          end
+        end
+        result
+      end
+    end
+    Hecks.register_validation_rule(TooManyCommands)
+    end
+  end
+end

--- a/bluebook/spec/domain/boundary_advisor_spec.rb
+++ b/bluebook/spec/domain/boundary_advisor_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+RSpec.describe "Boundary advisor warnings" do
+  def warnings_for(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  def valid?(domain)
+    Hecks::Validator.new(domain).valid?
+  end
+
+  describe "SingleAttributeAggregate" do
+    it "warns when aggregate has 1 attribute and no VOs or entities" do
+      domain = Hecks.domain "Test" do
+        aggregate "Color" do
+          attribute :hex, String
+          command "CreateColor" do
+            attribute :hex, String
+          end
+        end
+      end
+
+      warns = warnings_for(domain)
+      expect(warns).to include(/Color has only 1 attribute and no value objects or entities/)
+    end
+
+    it "does not warn when aggregate has 1 attribute but has value objects" do
+      domain = Hecks.domain "Test" do
+        aggregate "Color" do
+          attribute :hex, String
+
+          value_object "Shade" do
+            attribute :name, String
+          end
+
+          command "CreateColor" do
+            attribute :hex, String
+          end
+        end
+      end
+
+      warns = warnings_for(domain)
+      expect(warns).not_to include(/Color has only 1 attribute/)
+    end
+
+    it "does not warn when aggregate has 2 or more attributes" do
+      domain = Hecks.domain "Test" do
+        aggregate "Color" do
+          attribute :hex, String
+          attribute :name, String
+          command "CreateColor" do
+            attribute :hex, String
+          end
+        end
+      end
+
+      warns = warnings_for(domain)
+      expect(warns).not_to include(/Color has only 1 attribute/)
+    end
+
+    it "does not affect valid? result" do
+      domain = Hecks.domain "Test" do
+        aggregate "Color" do
+          attribute :hex, String
+          command "CreateColor" do
+            attribute :hex, String
+          end
+        end
+      end
+
+      expect(valid?(domain)).to be true
+    end
+  end
+
+  describe "TooManyCommands" do
+    def domain_with_commands(count)
+      Hecks.domain "Test" do
+        aggregate "Order" do
+          attribute :name, String
+          count.times do |i|
+            command "DoThing#{i}" do
+              attribute :name, String
+            end
+          end
+        end
+      end
+    end
+
+    it "does not warn for 9 commands" do
+      warns = warnings_for(domain_with_commands(9))
+      expect(warns).not_to include(/Order has \d+ commands/)
+    end
+
+    it "warns for exactly 10 commands" do
+      warns = warnings_for(domain_with_commands(10))
+      expect(warns).to include(/Order has 10 commands -- consider splitting/)
+    end
+
+    it "warns for more than 10 commands" do
+      warns = warnings_for(domain_with_commands(12))
+      expect(warns).to include(/Order has 12 commands -- consider splitting/)
+    end
+
+    it "does not affect valid? result" do
+      expect(valid?(domain_with_commands(10))).to be true
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/info.rb
+++ b/hecksties/lib/hecks_cli/commands/info.rb
@@ -98,6 +98,25 @@ Hecks::CLI.register_command(:info, "Show auto-wiring details for this project") 
     end
   end
 
+  say_boundary_advisories = lambda do |domains|
+    all_warnings = []
+    domains.each do |d|
+      validator = Hecks::Validator.new(d)
+      validator.valid?
+      validator.warnings.each { |w| all_warnings << "#{d.name}: #{w}" }
+    end
+    if defined?(Hecks::MultiDomain::Validator)
+      Hecks::MultiDomain::Validator.ambiguous_name_warnings(domains).each do |w|
+        all_warnings << w
+      end
+    end
+    if all_warnings.any?
+      say ""
+      say "Boundary advisories:", :yellow
+      all_warnings.each { |w| say "  - #{w}", :yellow }
+    end
+  end
+
   domains = load_all_domains_local.call
   next if domains.empty?
 
@@ -105,4 +124,5 @@ Hecks::CLI.register_command(:info, "Show auto-wiring details for this project") 
   say_extensions.call
   say_services.call
   say_cross_domain_policies.call(domains)
+  say_boundary_advisories.call(domains)
 end

--- a/hecksties/lib/hecks_cli/commands/validate.rb
+++ b/hecksties/lib/hecks_cli/commands/validate.rb
@@ -21,4 +21,9 @@ Hecks::CLI.register_command(:validate, "Validate the domain definition",
     say "Domain validation failed:", :red
     validator.errors.each { |e| say "  - #{e}", :red }
   end
+  unless validator.warnings.empty?
+    say ""
+    say "Warnings:", :yellow
+    validator.warnings.each { |w| say "  - #{w}", :yellow }
+  end
 end

--- a/hecksties/lib/hecks_multidomain/validator.rb
+++ b/hecksties/lib/hecks_multidomain/validator.rb
@@ -11,6 +11,26 @@ module Hecks
       extend HecksTemplating::NamingHelpers
       module_function
 
+      # Returns warnings for aggregate names that appear in more than one bounded
+      # context. Shared names across contexts suggest ambiguous ubiquitous language
+      # that should be clarified with a context-specific prefix or rename.
+      #
+      # @param domains [Array<Hecks::DomainModel::Structure::Domain>]
+      # @return [Array<String>] warning messages
+      def ambiguous_name_warnings(domains)
+        name_to_contexts = Hash.new { |h, k| h[k] = [] }
+        domains.each do |domain|
+          domain.aggregates.each do |agg|
+            name_to_contexts[agg.name] << domain.name
+          end
+        end
+        name_to_contexts.each_with_object([]) do |(name, contexts), warnings|
+          if contexts.size > 1
+            warnings << "Aggregate name '#{name}' appears in multiple bounded contexts (#{contexts.join(', ')}) -- consider a context-specific name to clarify ubiquitous language"
+          end
+        end
+      end
+
       def validate_no_cross_domain_references(domains)
         errors = []
         domains.each do |domain|

--- a/hecksties/spec/ambiguous_names_spec.rb
+++ b/hecksties/spec/ambiguous_names_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe "AmbiguousNames multi-domain warning" do
+  def build_domain(name, aggregate_names)
+    Hecks.domain name do
+      aggregate_names.each do |agg_name|
+        aggregate agg_name do
+          attribute :name, String
+          command "Create#{agg_name}" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+  end
+
+  it "warns when the same aggregate name appears in two bounded contexts" do
+    d1 = build_domain("Billing", ["Invoice", "Order"])
+    d2 = build_domain("Shipping", ["Shipment", "Order"])
+
+    warnings = Hecks::MultiDomain::Validator.ambiguous_name_warnings([d1, d2])
+    expect(warnings).to include(/'Order' appears in multiple bounded contexts/)
+  end
+
+  it "does not warn when aggregate names are unique across contexts" do
+    d1 = build_domain("Billing", ["Invoice"])
+    d2 = build_domain("Shipping", ["Shipment"])
+
+    warnings = Hecks::MultiDomain::Validator.ambiguous_name_warnings([d1, d2])
+    expect(warnings).to be_empty
+  end
+
+  it "includes all context names in the warning message" do
+    d1 = build_domain("Sales", ["Product"])
+    d2 = build_domain("Inventory", ["Product"])
+
+    warnings = Hecks::MultiDomain::Validator.ambiguous_name_warnings([d1, d2])
+    expect(warnings.first).to include("Sales")
+    expect(warnings.first).to include("Inventory")
+  end
+end


### PR DESCRIPTION
## Summary

- Add `SingleAttributeAggregate` warning rule: warns when an aggregate has exactly 1 attribute and no value objects or entities (consider modeling as a value object)
- Add `TooManyCommands` warning rule: warns when an aggregate has 10+ commands (threshold configurable via `THRESHOLD` constant; consider splitting)
- Add `Hecks::MultiDomain::Validator.ambiguous_name_warnings`: warns when the same aggregate name appears in multiple bounded contexts
- Update `hecks validate` CLI to display warnings in yellow after errors or the valid message
- Update `hecks info` CLI to collect and display boundary advisories across all domains

## Test plan

- [ ] 1-attribute aggregate with no VOs warns
- [ ] 1-attribute aggregate with VOs does not warn
- [ ] 2+ attributes does not warn
- [ ] 9 commands does not warn
- [ ] 10+ commands warns
- [ ] Cross-domain same aggregate name warns
- [ ] Warnings do not affect `valid?`
- [ ] Full suite: `bundle exec rspec` — 1330 examples, 0 failures, under 1s