### PR TITLE
HEC-418: Go generator security — SafeIdentifierNames validator

### DIFF
--- a/bluebook/lib/hecks/validation_rules/naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming.rb
@@ -10,17 +10,20 @@ module Hecks
     # - +NameCollisions+ -- aggregate root names must not collide with value object/entity names
     # - +UniqueAggregateNames+ -- no duplicate aggregate names within a domain
     # - +ReservedNames+ -- rejects Ruby keywords as attribute names and invalid aggregate constants
+    # - +ComputedNameCollisions+ -- computed attribute names must not collide with regular attribute names
     # - +GlossaryTermViolations+ -- warns (or errors in strict mode) when names use banned glossary terms
+    # - +SafeIdentifierNames+ -- rejects dangerous characters that could cause injection in generated Go/Ruby code
     #
     # All rules are autoloaded and executed as part of +Hecks.validate+.
     #
     module Naming
-      autoload :CommandNaming,        "hecks/validation_rules/naming/command_naming"
-      autoload :NameCollisions,       "hecks/validation_rules/naming/name_collisions"
-      autoload :UniqueAggregateNames, "hecks/validation_rules/naming/unique_aggregate_names"
-      autoload :ReservedNames,            "hecks/validation_rules/naming/reserved_names"
-      autoload :ComputedNameCollisions,    "hecks/validation_rules/naming/computed_name_collisions"
-      autoload :GlossaryTermViolations,    "hecks/validation_rules/naming/glossary_term_violations"
+      autoload :CommandNaming,          "hecks/validation_rules/naming/command_naming"
+      autoload :NameCollisions,         "hecks/validation_rules/naming/name_collisions"
+      autoload :UniqueAggregateNames,   "hecks/validation_rules/naming/unique_aggregate_names"
+      autoload :ReservedNames,          "hecks/validation_rules/naming/reserved_names"
+      autoload :ComputedNameCollisions, "hecks/validation_rules/naming/computed_name_collisions"
+      autoload :GlossaryTermViolations, "hecks/validation_rules/naming/glossary_term_violations"
+      autoload :SafeIdentifierNames,    "hecks/validation_rules/naming/safe_identifier_names"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/naming/safe_identifier_names.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/safe_identifier_names.rb
@@ -1,0 +1,175 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::SafeIdentifierNames
+    #
+    # Validates that all names in the domain model contain only safe characters
+    # that can be interpolated into generated Go (and Ruby) code without risk of
+    # injection or syntax errors. Enforces strict character-set rules per category:
+    #
+    # - Type-level names (aggregates, VOs, entities, commands, events, queries,
+    #   policies): /\A[A-Z][a-zA-Z0-9]*\z/
+    # - Attribute names and lifecycle fields: /\A[a-z][a-z0-9_]*\z/
+    # - Lifecycle state values: /\A[a-z][a-z0-9_]*\z/
+    # - Domain names: /\A[A-Z][a-zA-Z0-9]*\z/
+    # - Enum values: /\A[a-zA-Z0-9_]+\z/
+    # - Invariant messages: no backticks, no unbalanced quotes
+    #
+    # Part of the ValidationRules::Naming group -- run by +Hecks.validate+.
+    #
+    #   rule = SafeIdentifierNames.new(domain)
+    #   rule.errors  # => ["Unsafe aggregate name 'Pizza`Danger': ..."]
+    #
+    class SafeIdentifierNames < BaseRule
+      TYPE_NAME_RE   = /\A[A-Z][a-zA-Z0-9]*\z/
+      ATTR_NAME_RE   = /\A[a-z][a-z0-9_]*\z/
+      DOMAIN_NAME_RE = /\A[A-Z][a-zA-Z0-9]*\z/
+      ENUM_VALUE_RE  = /\A[a-zA-Z0-9_]+\z/
+
+      # Validates all names in the domain model.
+      #
+      # @return [Array<String>] error messages for each unsafe name found
+      def errors
+        errs = []
+        errs.concat(check_domain_name)
+        @domain.aggregates.each do |agg|
+          errs.concat(check_type_name(agg.name, "aggregate"))
+          errs.concat(check_aggregate_members(agg))
+        end
+        errs
+      end
+
+      private
+
+      # Validates the domain name.
+      #
+      # @return [Array<String>] error messages (empty if valid)
+      def check_domain_name
+        return [] if @domain.name =~ DOMAIN_NAME_RE
+        ["Unsafe domain name '#{@domain.name}': must start with an uppercase letter and contain only alphanumeric characters"]
+      end
+
+      # Validates all members of an aggregate: attributes, value objects,
+      # entities, commands, events, queries, policies, lifecycle, and invariants.
+      #
+      # @param agg [Hecks::DomainModel::Structure::Aggregate] the aggregate to check
+      # @return [Array<String>] error messages (empty if all valid)
+      def check_aggregate_members(agg)
+        errs = []
+        agg.attributes.each do |attr|
+          errs.concat(check_attr_name(attr.name.to_s, agg.name))
+          errs.concat(check_enum_values(attr, agg.name))
+        end
+        agg.value_objects.each do |vo|
+          errs.concat(check_type_name(vo.name, "value object"))
+          vo.attributes.each do |attr|
+            errs.concat(check_attr_name(attr.name.to_s, "#{agg.name}::#{vo.name}"))
+            errs.concat(check_enum_values(attr, "#{agg.name}::#{vo.name}"))
+          end
+        end
+        agg.entities.each do |ent|
+          errs.concat(check_type_name(ent.name, "entity"))
+          ent.attributes.each do |attr|
+            errs.concat(check_attr_name(attr.name.to_s, "#{agg.name}::#{ent.name}"))
+          end
+        end
+        agg.commands.each do |cmd|
+          errs.concat(check_type_name(cmd.name, "command"))
+          cmd.attributes.each do |attr|
+            errs.concat(check_attr_name(attr.name.to_s, "#{agg.name}::#{cmd.name}"))
+          end
+        end
+        agg.events.each  { |evt| errs.concat(check_type_name(evt.name, "event")) }
+        agg.queries.each { |q|   errs.concat(check_type_name(q.name, "query")) }
+        agg.policies.each { |pol| errs.concat(check_type_name(pol.name, "policy")) }
+        errs.concat(check_lifecycle(agg))
+        agg.invariants.each { |inv| errs.concat(check_invariant_message(inv.message, agg.name)) }
+        errs
+      end
+
+      # Validates a PascalCase type-level name.
+      #
+      # @param name [String] the name to validate
+      # @param kind [String] the label for the error message (e.g., "aggregate")
+      # @return [Array<String>] error messages (empty if valid)
+      def check_type_name(name, kind)
+        return [] if name =~ TYPE_NAME_RE
+        ["Unsafe #{kind} name '#{name}': must start with an uppercase letter and contain only alphanumeric characters"]
+      end
+
+      # Validates an attribute or lifecycle field name (snake_case).
+      #
+      # @param name [String] the attribute name to validate
+      # @param context [String] the context label for the error message
+      # @return [Array<String>] error messages (empty if valid)
+      def check_attr_name(name, context)
+        return [] if name =~ ATTR_NAME_RE
+        ["Unsafe attribute name '#{name}' in #{context}: must start with a lowercase letter and contain only lowercase letters, digits, and underscores"]
+      end
+
+      # Validates enum values on an attribute.
+      #
+      # @param attr [Hecks::DomainModel::Structure::Attribute] the attribute to check
+      # @param context [String] the context label for the error message
+      # @return [Array<String>] error messages (empty if all enum values are valid)
+      def check_enum_values(attr, context)
+        return [] unless attr.enum
+        attr.enum.flat_map do |val|
+          next [] if val.to_s =~ ENUM_VALUE_RE
+          ["Unsafe enum value '#{val}' on attribute '#{attr.name}' in #{context}: must contain only alphanumeric characters and underscores"]
+        end
+      end
+
+      # Validates lifecycle field, default state, and all transition states.
+      #
+      # @param agg [Hecks::DomainModel::Structure::Aggregate] the aggregate to check
+      # @return [Array<String>] error messages (empty if no lifecycle or all valid)
+      def check_lifecycle(agg)
+        lc = agg.lifecycle
+        return [] unless lc
+        errs = []
+        errs.concat(check_attr_name(lc.field.to_s, "#{agg.name} lifecycle field"))
+        errs.concat(check_state_value(lc.default.to_s, agg.name, "default"))
+        lc.transitions.each do |cmd_name, transition|
+          target = transition.respond_to?(:target) ? transition.target : transition.to_s
+          errs.concat(check_state_value(target, agg.name, "transition target for #{cmd_name}"))
+          if transition.respond_to?(:from) && transition.from
+            errs.concat(check_state_value(transition.from.to_s, agg.name, "transition from-state for #{cmd_name}"))
+          end
+        end
+        errs
+      end
+
+      # Validates a lifecycle state value (must be snake_case).
+      #
+      # @param value [String] the state value to validate
+      # @param agg_name [String] aggregate name for context
+      # @param label [String] label describing where this state value appears
+      # @return [Array<String>] error messages (empty if valid)
+      def check_state_value(value, agg_name, label)
+        return [] if value =~ ATTR_NAME_RE
+        ["Unsafe lifecycle state '#{value}' (#{label}) in #{agg_name}: must start with a lowercase letter and contain only lowercase letters, digits, and underscores"]
+      end
+
+      # Validates an invariant message for dangerous characters.
+      # Backticks are rejected outright (they break Go raw string literals and
+      # Ruby heredocs). Unbalanced double quotes are also flagged since they can
+      # break out of interpolated string contexts in generated code. Single
+      # quotes (apostrophes) are not checked because contractions in natural
+      # English messages are common and safe.
+      #
+      # @param message [String] the invariant message to validate
+      # @param agg_name [String] aggregate name for context
+      # @return [Array<String>] error messages (empty if safe)
+      def check_invariant_message(message, agg_name)
+        errs = []
+        errs << "Unsafe invariant message in #{agg_name}: backtick not allowed in '#{message}'" if message.include?("`")
+        errs << "Unsafe invariant message in #{agg_name}: unbalanced double quotes in '#{message}'" if message.count('"').odd?
+        errs
+      end
+    end
+    Hecks.register_validation_rule(SafeIdentifierNames)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/naming/safe_identifier_names_spec.rb
+++ b/bluebook/spec/validation_rules/naming/safe_identifier_names_spec.rb
@@ -1,0 +1,251 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
+  def validate(domain)
+    v = Hecks::Validator.new(domain)
+    [v.valid?, v.errors]
+  end
+
+  describe "aggregate names" do
+    it "rejects a name containing a backtick" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza`Danger",
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizzaDanger",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("Pizza`Danger") }).to be true
+    end
+
+    it "rejects a name containing a double quote" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: 'Pizza"Bad',
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizzaBad",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?('Pizza"Bad') }).to be true
+    end
+
+    it "rejects a lowercase aggregate name" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "pizza",
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("pizza") && e.include?("aggregate") }).to be true
+    end
+  end
+
+  describe "attribute names" do
+    it "rejects an attribute name containing a semicolon" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            attributes: [
+              Hecks::DomainModel::Structure::Attribute.new(name: :"bad;name", type: String)
+            ],
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("bad;name") }).to be true
+    end
+
+    it "rejects an attribute name starting with uppercase" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            attributes: [
+              Hecks::DomainModel::Structure::Attribute.new(name: :BadName, type: String)
+            ],
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("BadName") }).to be true
+    end
+  end
+
+  describe "domain names" do
+    it "rejects a domain name containing a slash" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Bad/Domain",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("Bad/Domain") }).to be true
+    end
+
+    it "rejects a lowercase domain name" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("pizzas") && e.include?("domain") }).to be true
+    end
+  end
+
+  describe "enum values" do
+    it "rejects an enum value containing a space" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            attributes: [
+              Hecks::DomainModel::Structure::Attribute.new(
+                name: :status,
+                type: String,
+                enum: ["active", "bad value!"]
+              )
+            ],
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("bad value!") }).to be true
+    end
+  end
+
+  describe "invariant messages" do
+    it "rejects a message containing a backtick" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            invariants: [
+              Hecks::DomainModel::Structure::Invariant.new(message: "name must not be `empty`")
+            ],
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("backtick") && e.include?("Pizza") }).to be true
+    end
+
+    it "rejects a message with unbalanced double quotes" do
+      domain = Hecks::DomainModel::Structure::Domain.new(
+        name: "Pizzas",
+        aggregates: [
+          Hecks::DomainModel::Structure::Aggregate.new(
+            name: "Pizza",
+            invariants: [
+              Hecks::DomainModel::Structure::Invariant.new(message: 'name must not be "empty')
+            ],
+            commands: [
+              Hecks::DomainModel::Behavior::Command.new(
+                name: "CreatePizza",
+                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
+              )
+            ]
+          )
+        ]
+      )
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("unbalanced double quotes") }).to be true
+    end
+  end
+
+  describe "valid domain" do
+    it "passes all checks for a well-formed domain" do
+      domain = Hecks.domain("Pizzas") do
+        aggregate("Pizza") do
+          attribute :name, String
+          attribute :status, String, enum: ["active", "archived"]
+          command("CreatePizza") { attribute :name, String }
+        end
+      end
+      valid, errors = validate(domain)
+      expect(valid).to be(true), "Expected valid domain but got: #{errors}"
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/naming/safe_identifier_names_spec.rb
+++ b/bluebook/spec/validation_rules/naming/safe_identifier_names_spec.rb
@@ -1,6 +1,19 @@
 require "spec_helper"
 
 RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
+  Attr  = Hecks::DomainModel::Structure::Attribute
+  Agg   = Hecks::DomainModel::Structure::Aggregate
+  Cmd   = Hecks::DomainModel::Behavior::Command
+  Dom   = Hecks::DomainModel::Structure::Domain
+  Inv   = Hecks::DomainModel::Structure::Invariant
+
+  def str_attr(name) = Attr.new(name: name, type: String)
+  def create_cmd     = Cmd.new(name: "CreatePizza", attributes: [str_attr(:name)])
+
+  def domain_with_agg(agg_name, **opts)
+    Dom.new(name: "Pizzas", aggregates: [Agg.new(name: agg_name, commands: [create_cmd], **opts)])
+  end
+
   def validate(domain)
     v = Hecks::Validator.new(domain)
     [v.valid?, v.errors]
@@ -8,61 +21,19 @@ RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
 
   describe "aggregate names" do
     it "rejects a name containing a backtick" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza`Danger",
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizzaDanger",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      valid, errors = validate(domain_with_agg("Pizza`Danger"))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("Pizza`Danger") }).to be true
     end
 
     it "rejects a name containing a double quote" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: 'Pizza"Bad',
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizzaBad",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      valid, errors = validate(domain_with_agg('Pizza"Bad'))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?('Pizza"Bad') }).to be true
     end
 
     it "rejects a lowercase aggregate name" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "pizza",
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      valid, errors = validate(domain_with_agg("pizza"))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("pizza") && e.include?("aggregate") }).to be true
     end
@@ -70,47 +41,13 @@ RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
 
   describe "attribute names" do
     it "rejects an attribute name containing a semicolon" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            attributes: [
-              Hecks::DomainModel::Structure::Attribute.new(name: :"bad;name", type: String)
-            ],
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      valid, errors = validate(domain_with_agg("Pizza", attributes: [str_attr(:"bad;name")]))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("bad;name") }).to be true
     end
 
     it "rejects an attribute name starting with uppercase" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            attributes: [
-              Hecks::DomainModel::Structure::Attribute.new(name: :BadName, type: String)
-            ],
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      valid, errors = validate(domain_with_agg("Pizza", attributes: [str_attr(:BadName)]))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("BadName") }).to be true
     end
@@ -118,40 +55,14 @@ RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
 
   describe "domain names" do
     it "rejects a domain name containing a slash" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Bad/Domain",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
+      domain = Dom.new(name: "Bad/Domain", aggregates: [Agg.new(name: "Pizza", commands: [create_cmd])])
       valid, errors = validate(domain)
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("Bad/Domain") }).to be true
     end
 
     it "rejects a lowercase domain name" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
+      domain = Dom.new(name: "pizzas", aggregates: [Agg.new(name: "Pizza", commands: [create_cmd])])
       valid, errors = validate(domain)
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("pizzas") && e.include?("domain") }).to be true
@@ -159,29 +70,9 @@ RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
   end
 
   describe "enum values" do
-    it "rejects an enum value containing a space" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            attributes: [
-              Hecks::DomainModel::Structure::Attribute.new(
-                name: :status,
-                type: String,
-                enum: ["active", "bad value!"]
-              )
-            ],
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+    it "rejects an enum value containing special characters" do
+      enum_attr = Attr.new(name: :status, type: String, enum: ["active", "bad value!"])
+      valid, errors = validate(domain_with_agg("Pizza", attributes: [enum_attr]))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("bad value!") }).to be true
     end
@@ -189,47 +80,15 @@ RSpec.describe Hecks::ValidationRules::Naming::SafeIdentifierNames do
 
   describe "invariant messages" do
     it "rejects a message containing a backtick" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            invariants: [
-              Hecks::DomainModel::Structure::Invariant.new(message: "name must not be `empty`")
-            ],
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      inv = Inv.new(message: "name must not be `empty`")
+      valid, errors = validate(domain_with_agg("Pizza", invariants: [inv]))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("backtick") && e.include?("Pizza") }).to be true
     end
 
     it "rejects a message with unbalanced double quotes" do
-      domain = Hecks::DomainModel::Structure::Domain.new(
-        name: "Pizzas",
-        aggregates: [
-          Hecks::DomainModel::Structure::Aggregate.new(
-            name: "Pizza",
-            invariants: [
-              Hecks::DomainModel::Structure::Invariant.new(message: 'name must not be "empty')
-            ],
-            commands: [
-              Hecks::DomainModel::Behavior::Command.new(
-                name: "CreatePizza",
-                attributes: [Hecks::DomainModel::Structure::Attribute.new(name: :name, type: String)]
-              )
-            ]
-          )
-        ]
-      )
-      valid, errors = validate(domain)
+      inv = Inv.new(message: 'name must not be "empty')
+      valid, errors = validate(domain_with_agg("Pizza", invariants: [inv]))
       expect(valid).to be false
       expect(errors.any? { |e| e.include?("unbalanced double quotes") }).to be true
     end


### PR DESCRIPTION
## Summary

- Adds `Hecks::ValidationRules::Naming::SafeIdentifierNames`, a parse-time validation rule that prevents injection-unsafe characters from entering the domain model IR
- Enforces strict character-set patterns per name category: PascalCase for type names, snake_case for attributes/lifecycle fields, alphanumeric+underscore for enum values, no backticks or unbalanced double quotes in invariant messages
- Registered in `ValidationRules::Naming` and triggered on every `Hecks.validate` call — provides defense-in-depth before names reach Go or Ruby code generation

## Test plan

- [ ] `bundle exec rspec bluebook/spec/validation_rules/naming/safe_identifier_names_spec.rb` — all 10 examples pass
- [ ] Full suite: `bundle exec rspec bluebook/spec` — 1332 examples, 0 failures
- [ ] Aggregate name with backtick → rejected
- [ ] Aggregate name with double quote → rejected
- [ ] Attribute name with semicolon → rejected
- [ ] Domain name with slash → rejected
- [ ] Enum value with special characters → rejected
- [ ] Invariant message with backtick → rejected
- [ ] Invariant message with unbalanced double quotes → rejected
- [ ] Well-formed domain with contractions in invariant messages → passes