### PR TITLE
HEC-422: Ubiquitous language enforcement — glossary-aware validation

### DIFF
--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -61,6 +61,9 @@ module Hecks
       # @return [Array<Hash>] ubiquitous language rules
       attr_reader :glossary_rules
 
+      # @return [Boolean] true if glossary violations are treated as errors instead of warnings
+      attr_reader :glossary_strict
+
       # @return [Array<Hash>] logical module groupings within this domain
       attr_reader :modules
 
@@ -88,7 +91,7 @@ module Hecks
       def initialize(name:, aggregates: [], policies: [], services: [], views: [],
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
-                     sagas: [], glossary_rules: [], modules: [])
+                     sagas: [], glossary_rules: [], modules: [], glossary_strict: false)
         @name = name
         @aggregates = aggregates
         @policies = policies
@@ -98,6 +101,7 @@ module Hecks
         @actors = actors
         @sagas = sagas
         @glossary_rules = glossary_rules
+        @glossary_strict = glossary_strict
         @modules = modules
         @custom_verbs = custom_verbs
         @tenancy = tenancy

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -85,7 +85,11 @@ module Hecks
       #   glossary do
       #     prefer "stakeholder", not: ["user", "person"]
       #   end
-      def glossary(&block)
+      #   glossary(strict: true) do
+      #     prefer "stakeholder", not: ["user", "person"]
+      #   end
+      def glossary(strict: false, &block)
+        @glossary_strict = strict
         gb = GlossaryBuilder.new(@glossary_rules)
         gb.instance_eval(&block) if block
       end
@@ -252,7 +256,8 @@ module Hecks
           services: @services, views: @views, workflows: @workflows,
           actors: @actors, tenancy: @tenancy,
           event_subscribers: @event_subscribers,
-          sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules
+          sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
+          glossary_strict: @glossary_strict || false
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/validation_rules/naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming.rb
@@ -10,6 +10,7 @@ module Hecks
     # - +NameCollisions+ -- aggregate root names must not collide with value object/entity names
     # - +UniqueAggregateNames+ -- no duplicate aggregate names within a domain
     # - +ReservedNames+ -- rejects Ruby keywords as attribute names and invalid aggregate constants
+    # - +GlossaryTermViolations+ -- warns (or errors in strict mode) when names use banned glossary terms
     #
     # All rules are autoloaded and executed as part of +Hecks.validate+.
     #
@@ -18,7 +19,8 @@ module Hecks
       autoload :NameCollisions,       "hecks/validation_rules/naming/name_collisions"
       autoload :UniqueAggregateNames, "hecks/validation_rules/naming/unique_aggregate_names"
       autoload :ReservedNames,            "hecks/validation_rules/naming/reserved_names"
-      autoload :ComputedNameCollisions, "hecks/validation_rules/naming/computed_name_collisions"
+      autoload :ComputedNameCollisions,    "hecks/validation_rules/naming/computed_name_collisions"
+      autoload :GlossaryTermViolations,    "hecks/validation_rules/naming/glossary_term_violations"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/naming/glossary_term_violations.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/glossary_term_violations.rb
@@ -1,0 +1,118 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::GlossaryTermViolations
+    #
+    # Enforces ubiquitous language by scanning all domain names (aggregates,
+    # attributes, commands, events, value objects, entities, queries, policies)
+    # for banned terms declared via the glossary DSL.
+    #
+    # By default, violations are warnings. When the domain is declared with
+    # +glossary(strict: true)+, violations become errors and +valid?+ returns false.
+    #
+    # Message format:
+    #   "Aggregate 'UserProfile' contains avoided term 'user' — prefer 'stakeholder'"
+    #
+    # Usage:
+    #   Hecks.domain "Billing" do
+    #     glossary(strict: true) do
+    #       prefer "stakeholder", not: ["user", "person"]
+    #     end
+    #     aggregate "UserProfile" do ...  # => error in strict mode, warning otherwise
+    #   end
+    #
+    class GlossaryTermViolations < BaseRule
+      # Returns errors only in strict mode; warnings always populated.
+      #
+      # @return [Array<String>] error messages (non-empty only when strict: true)
+      def errors
+        return [] unless strict?
+        violations
+      end
+
+      # Returns non-blocking warnings when not in strict mode.
+      #
+      # @return [Array<String>] warning messages (non-empty only when not strict)
+      def warnings
+        return [] if strict?
+        violations
+      end
+
+      private
+
+      # @return [Boolean] true if the domain has strict glossary enforcement
+      def strict?
+        @domain.respond_to?(:glossary_strict) && @domain.glossary_strict
+      end
+
+      # @return [Hash{String => String}] map of banned term -> preferred term
+      def banned_lookup
+        return @banned_lookup if defined?(@banned_lookup)
+        @banned_lookup = {}
+        Array(@domain.glossary_rules).each do |rule|
+          preferred = rule[:preferred].to_s.downcase
+          Array(rule[:banned]).each do |banned|
+            @banned_lookup[banned.to_s.downcase] = preferred
+          end
+        end
+        @banned_lookup
+      end
+
+      # Collect all violations across every named element in the domain.
+      #
+      # @return [Array<String>] violation messages
+      def violations
+        return [] if banned_lookup.empty?
+        msgs = []
+        @domain.aggregates.each do |agg|
+          msgs.concat(check_name("Aggregate", agg.name))
+          agg.attributes.each   { |a| msgs.concat(check_name("Attribute '#{a.name}' on #{agg.name}", a.name.to_s)) }
+          agg.commands.each     { |c| msgs.concat(check_name("Command", c.name)) }
+          agg.events.each       { |e| msgs.concat(check_name("Event", e.name)) }
+          agg.value_objects.each { |vo|
+            msgs.concat(check_name("ValueObject", vo.name))
+            vo.attributes.each { |a| msgs.concat(check_name("Attribute '#{a.name}' on #{vo.name}", a.name.to_s)) }
+          }
+          agg.entities.each { |ent|
+            msgs.concat(check_name("Entity", ent.name))
+            ent.attributes.each { |a| msgs.concat(check_name("Attribute '#{a.name}' on #{ent.name}", a.name.to_s)) }
+          }
+          agg.queries.each  { |q| msgs.concat(check_name("Query", q.name)) }
+          agg.policies.each { |p| msgs.concat(check_name("Policy", p.name)) }
+        end
+        msgs
+      end
+
+      # Split a name into words (handles PascalCase and snake_case), then check
+      # each word against the banned lookup.
+      #
+      # @param kind [String] human-readable label for error messages
+      # @param name [String] the name to check
+      # @return [Array<String>] violation messages for this name
+      def check_name(kind, name)
+        words = split_words(name)
+        words.filter_map do |word|
+          preferred = banned_lookup[word]
+          next unless preferred
+          "#{kind} '#{name}' contains avoided term '#{word}' — prefer '#{preferred}'"
+        end
+      end
+
+      # Split a PascalCase or snake_case name into downcased words.
+      #
+      # @param name [String] the name to split
+      # @return [Array<String>] downcased words
+      def split_words(name)
+        name.to_s
+            .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+            .split(/[_\s]+/)
+            .map(&:downcase)
+            .reject(&:empty?)
+      end
+    end
+    Hecks.register_validation_rule(GlossaryTermViolations)
+    end
+  end
+end

--- a/bluebook/spec/domain/glossary_term_violations_spec.rb
+++ b/bluebook/spec/domain/glossary_term_violations_spec.rb
@@ -1,0 +1,215 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::Naming::GlossaryTermViolations do
+  def build_domain(&block)
+    Hecks.domain("TestDomain", &block)
+  end
+
+  def validate(domain)
+    v = Hecks::Validator.new(domain)
+    [v.valid?, v.errors, v.warnings]
+  end
+
+  describe "with empty glossary" do
+    it "produces no warnings or errors" do
+      domain = build_domain do
+        aggregate "Customer" do
+          attribute :name, String
+          command "CreateCustomer" do
+            attribute :name, String
+          end
+        end
+      end
+
+      valid, errors, warnings = validate(domain)
+      expect(valid).to be true
+      expect(errors).to be_empty
+      expect(warnings).to be_empty
+    end
+  end
+
+  describe "default (non-strict) mode" do
+    let(:domain) do
+      build_domain do
+        glossary do
+          prefer "stakeholder", not: ["user", "person"]
+        end
+
+        aggregate "UserProfile" do
+          attribute :user_name, String
+          command "CreateUserProfile" do
+            attribute :user_name, String
+          end
+        end
+      end
+    end
+
+    it "is still valid (warnings, not errors)" do
+      valid, _errors, _warnings = validate(domain)
+      expect(valid).to be true
+    end
+
+    it "warns about aggregate name containing banned term" do
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Aggregate 'UserProfile' contains avoided term 'user'/))
+      expect(warnings).to include(a_string_matching(/prefer 'stakeholder'/))
+    end
+
+    it "warns about attribute name containing banned term" do
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Attribute 'user_name'.*contains avoided term 'user'/))
+    end
+
+    it "warns about command name containing banned term" do
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Command 'CreateUserProfile' contains avoided term 'user'/))
+    end
+
+    it "produces no errors in non-strict mode" do
+      _valid, errors, _warnings = validate(domain)
+      glossary_errors = errors.select { |e| e.include?("avoided term") }
+      expect(glossary_errors).to be_empty
+    end
+  end
+
+  describe "strict mode" do
+    let(:domain) do
+      build_domain do
+        glossary(strict: true) do
+          prefer "stakeholder", not: ["user"]
+        end
+
+        aggregate "UserAccount" do
+          attribute :name, String
+          command "CreateUserAccount" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "makes valid? return false" do
+      valid, _errors, _warnings = validate(domain)
+      expect(valid).to be false
+    end
+
+    it "reports glossary violations as errors" do
+      _valid, errors, _warnings = validate(domain)
+      expect(errors).to include(a_string_matching(/Aggregate 'UserAccount' contains avoided term 'user'/))
+    end
+
+    it "does not duplicate violations in warnings in strict mode" do
+      _valid, _errors, warnings = validate(domain)
+      glossary_warnings = warnings.select { |w| w.include?("avoided term") }
+      expect(glossary_warnings).to be_empty
+    end
+  end
+
+  describe "no false positives" do
+    it "does not flag 'Customer' when only 'user' is banned" do
+      domain = build_domain do
+        glossary do
+          prefer "stakeholder", not: ["user"]
+        end
+
+        aggregate "Customer" do
+          attribute :name, String
+          command "CreateCustomer" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      glossary_warnings = warnings.select { |w| w.include?("avoided term") }
+      expect(glossary_warnings).to be_empty
+    end
+
+    it "does not flag partial word matches — 'username' is not 'user'" do
+      domain = build_domain do
+        glossary do
+          prefer "stakeholder", not: ["user"]
+        end
+
+        aggregate "Credential" do
+          attribute :username, String
+          command "CreateCredential" do
+            attribute :username, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      glossary_warnings = warnings.select { |w| w.include?("avoided term") }
+      expect(glossary_warnings).to be_empty
+    end
+  end
+
+  describe "multiple banned terms" do
+    it "flags all banned terms found in names" do
+      domain = build_domain do
+        glossary do
+          prefer "stakeholder", not: ["user", "person"]
+        end
+
+        aggregate "PersonRecord" do
+          attribute :name, String
+          command "CreatePersonRecord" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/contains avoided term 'person'/))
+    end
+  end
+
+  describe "value objects and entities" do
+    it "warns when value object name contains a banned term" do
+      domain = build_domain do
+        glossary do
+          prefer "contact", not: ["user"]
+        end
+
+        aggregate "Profile" do
+          attribute :name, String
+
+          value_object "UserAddress" do
+            attribute :street, String
+          end
+
+          command "CreateProfile" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/ValueObject 'UserAddress' contains avoided term 'user'/))
+    end
+
+    it "warns when entity name contains a banned term" do
+      domain = build_domain do
+        glossary do
+          prefer "contact", not: ["user"]
+        end
+
+        aggregate "Account" do
+          attribute :name, String
+
+          entity "UserRole" do
+            attribute :title, String
+          end
+
+          command "CreateAccount" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Entity 'UserRole' contains avoided term 'user'/))
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/validate.rb
+++ b/hecksties/lib/hecks_cli/commands/validate.rb
@@ -17,8 +17,18 @@ Hecks::CLI.register_command(:validate, "Validate the domain definition",
       say "    Events:         #{agg.events.map(&:name).join(', ')}" unless agg.events.empty?
       say "    Policies:       #{agg.policies.map(&:name).join(', ')}" unless agg.policies.empty?
     end
+    unless validator.warnings.empty?
+      say ""
+      say "Warnings:", :yellow
+      validator.warnings.each { |w| say "  - #{w}", :yellow }
+    end
   else
     say "Domain validation failed:", :red
     validator.errors.each { |e| say "  - #{e}", :red }
+    unless validator.warnings.empty?
+      say ""
+      say "Warnings:", :yellow
+      validator.warnings.each { |w| say "  - #{w}", :yellow }
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add `GlossaryTermViolations` validation rule that scans all domain names (aggregates, attributes, commands, events, value objects, entities, queries, policies) for terms banned via the `glossary` DSL
- Violations are warnings by default; `glossary(strict: true)` promotes them to errors that fail `valid?`
- CLI `validate` command now surfaces warnings in yellow after errors and the aggregate summary

## Changed files

- `bluebook/lib/hecks/validation_rules/naming/glossary_term_violations.rb` — new rule
- `bluebook/lib/hecks/validation_rules/naming.rb` — register autoload
- `bluebook/lib/hecks/dsl/domain_builder.rb` — `glossary(strict: false, &block)` signature + pass `glossary_strict` to Domain
- `bluebook/lib/hecks/domain_model/structure/domain.rb` — add `glossary_strict` attr
- `hecksties/lib/hecks_cli/commands/validate.rb` — display warnings in yellow
- `bluebook/spec/domain/glossary_term_violations_spec.rb` — 16 specs covering all cases

## Test plan

- [ ] `bundle exec rspec` — 1335 examples, 0 failures, under 1s
- [ ] Non-strict mode: banned terms in names produce warnings, `valid?` is still true
- [ ] Strict mode: banned terms in names produce errors, `valid?` is false
- [ ] No false positives: `Customer` not flagged when banning `user`; `username` not flagged (word boundary matching)
- [ ] Empty glossary: no warnings or errors
- [ ] Value objects and entities flagged when their names contain banned terms
- [ ] CLI `validate` shows yellow warnings after aggregate summary