### PR TITLE
HEC-416: Row-level authorization — ownership/tenancy enforcement

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -84,6 +84,8 @@
 ### Application Service Extensions
 - `hecks_auth` — actor-based authentication & authorization
 - `hecks_tenancy` — multi-tenant isolation (`Hecks.tenant = "acme"`)
+- Row-level authorization — `owned_by :field` on gates restricts `find`/`all`/`delete` to the current user; `tenancy: :row` isolates by `Hecks.tenant`
+- `Hecks.current_user` / `Hecks.with_user(user) { }` — thread-local current user context for ownership enforcement
 - `hecks_audit` — audit trail of every command execution
 - `hecks_logging` — structured stdout logging with duration
 - `hecks_rate_limit` — sliding window rate limiting per actor

--- a/docs/usage/row_level_authorization.md
+++ b/docs/usage/row_level_authorization.md
@@ -1,0 +1,90 @@
+# Row-level Authorization
+
+Row-level authorization restricts data access to individual records based on ownership
+or tenancy. Hecks supports two modes:
+
+1. **`owned_by :field`** on a gate — records are scoped to `Hecks.current_user`
+2. **`tenancy: :row`** — records are scoped to `Hecks.tenant`
+
+## Gate-based ownership (`owned_by`)
+
+Declare `owned_by :owner_id` inside a gate block. `find` and `delete` raise
+`Hecks::GateAccessDenied` when the record belongs to a different user. `all` and
+`count` filter to only the current user's records.
+
+```ruby
+hecksagon = Hecks.hecksagon do
+  gate "Order", :customer do
+    allow :find, :all, :count, :create
+    owned_by :owner_id   # attribute on the Order aggregate
+  end
+end
+
+app = Hecks.load(domain, gate: :customer, hecksagon: hecksagon)
+
+Hecks.current_user = "alice"
+alice_order = Order.create(title: "My Order", owner_id: "alice")
+
+Hecks.current_user = "bob"
+Order.find(alice_order.id)  # => raises Hecks::GateAccessDenied
+Order.all                   # => []  (bob has no orders)
+```
+
+## Current user context
+
+Set the current user for the duration of a block:
+
+```ruby
+Hecks.with_user("alice") do
+  Order.all   # alice's orders only
+end
+```
+
+Or set it directly (thread-local):
+
+```ruby
+Hecks.current_user = "alice"
+# ... do work ...
+Hecks.current_user = nil
+```
+
+## Admin gate — full access
+
+A gate without `owned_by` sees all records:
+
+```ruby
+hecksagon = Hecks.hecksagon do
+  gate "Order", :admin do
+    allow :find, :all, :count, :create, :destroy
+  end
+end
+
+app = Hecks.load(domain, gate: :admin, hecksagon: hecksagon)
+
+Hecks.current_user = "bob"
+Order.find(alice_order.id)   # => works fine — admin has full access
+```
+
+## Row tenancy (`tenancy: :row`)
+
+When the tenancy strategy is `:row`, all repositories are wrapped with ownership
+scoping using `tenant_id` as the field and `Hecks.tenant` as the identity source:
+
+```ruby
+hecksagon = Hecks.hecksagon { tenancy :row }
+app = Hecks.load(domain, hecksagon: hecksagon)
+
+Hecks.tenant = "acme"
+Invoice.create(amount: 100, tenant_id: "acme")
+
+Hecks.tenant = "beta"
+Invoice.all   # => []  — beta has no invoices
+```
+
+## Admin bypass
+
+Load without a gate for unrestricted access:
+
+```ruby
+app = Hecks.load(domain)   # no gate: arg → full access
+```

--- a/hecksagon/lib/hecksagon/dsl/gate_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/gate_builder.rb
@@ -16,6 +16,7 @@ module Hecksagon
         @aggregate = aggregate
         @role = role
         @allowed_methods = []
+        @ownership_field = nil
       end
 
       # Declare one or more methods as allowed through this gate.
@@ -26,6 +27,19 @@ module Hecksagon
         @allowed_methods.concat(methods.map(&:to_sym))
       end
 
+      # Declare which aggregate attribute identifies the record owner.
+      #
+      # When set, find/all/delete operations will be scoped to the current
+      # user (from +Hecks.current_user+). find and delete raise
+      # +Hecks::GateAccessDenied+ if the record is owned by someone else.
+      # +all+ filters to only owned records.
+      #
+      # @param field [Symbol] the attribute name holding the owner identity
+      # @return [void]
+      def owned_by(field)
+        @ownership_field = field.to_sym
+      end
+
       # Build and return the GateDefinition IR object.
       #
       # @return [Hecksagon::Structure::GateDefinition]
@@ -33,7 +47,8 @@ module Hecksagon
         Structure::GateDefinition.new(
           aggregate: @aggregate,
           role: @role,
-          allowed_methods: @allowed_methods
+          allowed_methods: @allowed_methods,
+          ownership_field: @ownership_field
         )
       end
     end

--- a/hecksagon/lib/hecksagon/structure/gate_definition.rb
+++ b/hecksagon/lib/hecksagon/structure/gate_definition.rb
@@ -21,10 +21,14 @@ module Hecksagon
       # @return [Array<Symbol>] methods this role is allowed to call
       attr_reader :allowed_methods
 
-      def initialize(aggregate:, role:, allowed_methods:)
+      # @return [Symbol, nil] the aggregate attribute used for ownership checks
+      attr_reader :ownership_field
+
+      def initialize(aggregate:, role:, allowed_methods:, ownership_field: nil)
         @aggregate = aggregate.to_s
         @role = role.to_sym
         @allowed_methods = allowed_methods.map(&:to_sym)
+        @ownership_field = ownership_field&.to_sym
       end
 
       # Returns true if the given method is allowed through this gate.

--- a/hecksties/lib/hecks/extensions/tenancy_support/ownership_scoped_repository.rb
+++ b/hecksties/lib/hecks/extensions/tenancy_support/ownership_scoped_repository.rb
@@ -1,0 +1,106 @@
+module HecksTenancy
+  # HecksTenancy::OwnershipScopedRepository
+  #
+  # Repository proxy that enforces row-level ownership. Wraps an inner
+  # repository instance and restricts find/all/delete to records whose
+  # ownership field matches the current identity (from +identity_source+).
+  #
+  # Used by the Hecks runtime when a gate declares +owned_by :field+.
+  # Also used for +:row+ tenancy strategy (identity_source reads +Hecks.tenant+).
+  #
+  #   repo = OwnershipScopedRepository.new(
+  #     inner_repo,
+  #     ownership_field: :owner_id,
+  #     identity_source: -> { Hecks.current_user }
+  #   )
+  #   Hecks.current_user = "alice"
+  #   repo.all           # => only alice's records
+  #   repo.find(other_id) # => raises Hecks::GateAccessDenied
+  #
+  class OwnershipScopedRepository
+    # @param inner_repo [Object] the underlying repository to wrap
+    # @param ownership_field [Symbol] attribute name identifying the owner
+    # @param identity_source [Proc] callable returning the current identity
+    def initialize(inner_repo, ownership_field:, identity_source: -> { Hecks.current_user })
+      @inner = inner_repo
+      @ownership_field = ownership_field.to_sym
+      @identity_source = identity_source
+    end
+
+    # Find a record by ID and verify ownership.
+    #
+    # @param id [String] aggregate ID to look up
+    # @return [Object] the found aggregate
+    # @raise [Hecks::GateAccessDenied] if the record is owned by someone else
+    def find(id)
+      record = @inner.find(id)
+      return nil if record.nil?
+      verify_ownership!(record)
+      record
+    end
+
+    # Return all records owned by the current identity.
+    #
+    # @return [Array<Object>] records whose ownership_field matches current identity
+    def all
+      identity = current_identity
+      @inner.all.select { |r| r.public_send(@ownership_field) == identity }
+    end
+
+    # Persist a record (delegates directly, ownership stamping is the caller's job).
+    #
+    # @param aggregate [Object] the aggregate to save
+    # @return [Object] saved aggregate
+    def save(aggregate)
+      @inner.save(aggregate)
+    end
+
+    # Delete a record by ID after verifying ownership.
+    #
+    # @param id [String] aggregate ID to delete
+    # @raise [Hecks::GateAccessDenied] if the record is owned by someone else
+    # @return [void]
+    def delete(id)
+      record = @inner.find(id)
+      verify_ownership!(record) if record
+      @inner.delete(id)
+    end
+
+    # Return count of records owned by the current identity.
+    #
+    # @return [Integer]
+    def count
+      all.size
+    end
+
+    # Remove all records owned by the current identity from the inner store.
+    #
+    # @return [void]
+    def clear
+      all.each { |r| @inner.delete(r.id) }
+    end
+
+    # Query records, filtering results to owned records.
+    #
+    # @param kwargs [Hash] passed through to the inner repository's +query+ method
+    # @return [Array<Object>] owned matching records
+    def query(**kwargs)
+      identity = current_identity
+      @inner.query(**kwargs).select { |r| r.public_send(@ownership_field) == identity }
+    end
+
+    private
+
+    def current_identity
+      @identity_source.call
+    end
+
+    def verify_ownership!(record)
+      identity = current_identity
+      owner = record.public_send(@ownership_field)
+      return if owner == identity
+      raise Hecks::GateAccessDenied,
+            "Access denied: record owned by #{owner.inspect}, current identity is #{identity.inspect}"
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/thread_context.rb
+++ b/hecksties/lib/hecks/registries/thread_context.rb
@@ -36,5 +36,21 @@ module Hecks
     ensure
       Thread.current[:hecks_actor] = old
     end
+
+    def current_user
+      Thread.current[:hecks_current_user]
+    end
+
+    def current_user=(user)
+      Thread.current[:hecks_current_user] = user
+    end
+
+    def with_user(user)
+      old = Thread.current[:hecks_current_user]
+      Thread.current[:hecks_current_user] = user
+      yield
+    ensure
+      Thread.current[:hecks_current_user] = old
+    end
   end
 end

--- a/hecksties/lib/hecks/runtime/port_setup.rb
+++ b/hecksties/lib/hecks/runtime/port_setup.rb
@@ -54,7 +54,7 @@ module Hecks
       # @return [void]
       def wire_aggregate(agg)
         agg_class = @mod.const_get(domain_constant_name(agg.name))
-        repo = @repositories[agg.name]
+        repo = ownership_scoped_repo(agg, @repositories[agg.name])
         defaults = build_defaults(agg)
 
         Persistence.bind(agg_class, agg, repo)
@@ -65,6 +65,33 @@ module Hecks
         AttachmentMethods.bind(agg_class) if agg.attachable?
         wire_query_objects(agg, agg_class)
         GateEnforcer.new(gate_name: @gate_name, hecksagon: @hecksagon).enforce!(agg, agg_class)
+      end
+
+      # Wraps the repository with an OwnershipScopedRepository when the active
+      # gate declares +owned_by+ or when tenancy is +:row+.
+      #
+      # @param agg [Hecks::DomainModel::Aggregate] the aggregate definition
+      # @param repo [Object] the inner repository instance
+      # @return [Object] the repo, possibly wrapped with ownership scoping
+      def ownership_scoped_repo(agg, repo)
+        gate_def = @hecksagon&.gate_for(agg.name, @gate_name) if @gate_name && @hecksagon
+        if gate_def&.ownership_field
+          require "hecks/extensions/tenancy_support/ownership_scoped_repository"
+          HecksTenancy::OwnershipScopedRepository.new(
+            repo,
+            ownership_field: gate_def.ownership_field,
+            identity_source: -> { Hecks.current_user }
+          )
+        elsif @hecksagon&.tenancy == :row
+          require "hecks/extensions/tenancy_support/ownership_scoped_repository"
+          HecksTenancy::OwnershipScopedRepository.new(
+            repo,
+            ownership_field: :tenant_id,
+            identity_source: -> { Hecks.tenant }
+          )
+        else
+          repo
+        end
       end
 
       # Builds a default values hash for the aggregate's attributes.

--- a/hecksties/spec/runtime/ownership_spec.rb
+++ b/hecksties/spec/runtime/ownership_spec.rb
@@ -1,0 +1,257 @@
+require "spec_helper"
+require "hecks/extensions/tenancy_support/ownership_scoped_repository"
+
+RSpec.describe "Row-level authorization" do
+  let(:domain) do
+    Hecks.domain "OwnershipTest" do
+      aggregate "Order" do
+        attribute :title, String
+        attribute :owner_id, String
+
+        command "CreateOrder" do
+          attribute :title, String
+          attribute :owner_id, String
+        end
+      end
+    end
+  end
+
+  let(:hecksagon_with_ownership) do
+    Hecks.hecksagon do
+      gate "Order", :customer do
+        allow :find, :all, :count, :create
+        owned_by :owner_id
+      end
+    end
+  end
+
+  let(:hecksagon_admin) do
+    Hecks.hecksagon do
+      gate "Order", :admin do
+        allow :find, :all, :count, :create
+      end
+    end
+  end
+
+  after do
+    Hecks.current_user = nil
+    Hecks.tenant = nil
+    Hecks.last_hecksagon = nil
+  end
+
+  describe "GateBuilder#owned_by" do
+    it "stores ownership_field on the gate definition" do
+      gate = hecksagon_with_ownership.gate_for("Order", :customer)
+      expect(gate.ownership_field).to eq(:owner_id)
+    end
+
+    it "is nil when not declared" do
+      gate = hecksagon_admin.gate_for("Order", :admin)
+      expect(gate.ownership_field).to be_nil
+    end
+  end
+
+  describe "OwnershipScopedRepository (unit)" do
+    let(:inner) do
+      obj = Object.new
+      store = {}
+      obj.define_singleton_method(:save) { |r| store[r.id] = r; r }
+      obj.define_singleton_method(:find) { |id| store[id] }
+      obj.define_singleton_method(:all) { store.values }
+      obj.define_singleton_method(:delete) { |id| store.delete(id) }
+      obj.define_singleton_method(:count) { store.size }
+      obj.define_singleton_method(:clear) { store.clear }
+      obj.define_singleton_method(:query) { |**_| store.values }
+      obj
+    end
+
+    let(:record_alice) do
+      r = Object.new
+      r.define_singleton_method(:id) { "r1" }
+      r.define_singleton_method(:owner_id) { "alice" }
+      r
+    end
+
+    let(:record_bob) do
+      r = Object.new
+      r.define_singleton_method(:id) { "r2" }
+      r.define_singleton_method(:owner_id) { "bob" }
+      r
+    end
+
+    subject(:repo) do
+      HecksTenancy::OwnershipScopedRepository.new(
+        inner,
+        ownership_field: :owner_id,
+        identity_source: -> { Hecks.current_user }
+      )
+    end
+
+    before do
+      inner.save(record_alice)
+      inner.save(record_bob)
+    end
+
+    describe "#all" do
+      it "returns only the current user's records" do
+        Hecks.current_user = "alice"
+        expect(repo.all).to eq([record_alice])
+      end
+
+      it "returns an empty array when user has no records" do
+        Hecks.current_user = "charlie"
+        expect(repo.all).to be_empty
+      end
+    end
+
+    describe "#find" do
+      it "returns the record when the user owns it" do
+        Hecks.current_user = "alice"
+        expect(repo.find("r1")).to eq(record_alice)
+      end
+
+      it "raises GateAccessDenied when accessing another user's record" do
+        Hecks.current_user = "bob"
+        expect { repo.find("r1") }.to raise_error(Hecks::GateAccessDenied)
+      end
+
+      it "returns nil for missing records" do
+        Hecks.current_user = "alice"
+        expect(repo.find("missing")).to be_nil
+      end
+    end
+
+    describe "#delete" do
+      it "deletes owned records" do
+        Hecks.current_user = "alice"
+        repo.delete("r1")
+        expect(inner.find("r1")).to be_nil
+      end
+
+      it "raises GateAccessDenied when deleting another user's record" do
+        Hecks.current_user = "bob"
+        expect { repo.delete("r1") }.to raise_error(Hecks::GateAccessDenied)
+        expect(inner.find("r1")).not_to be_nil
+      end
+    end
+
+    describe "#count" do
+      it "counts only owned records" do
+        Hecks.current_user = "alice"
+        expect(repo.count).to eq(1)
+      end
+    end
+
+    describe "#save" do
+      it "delegates directly without ownership check" do
+        Hecks.current_user = "charlie"
+        new_record = Object.new
+        new_record.define_singleton_method(:id) { "r3" }
+        new_record.define_singleton_method(:owner_id) { "charlie" }
+        repo.save(new_record)
+        expect(inner.find("r3")).to eq(new_record)
+      end
+    end
+  end
+
+  describe "Runtime integration — customer gate with owned_by" do
+    before do
+      @app = Hecks.load(domain, gate: :customer, hecksagon: hecksagon_with_ownership)
+    end
+
+    it "user A cannot find user B's records" do
+      Hecks.current_user = "alice"
+      alice_order = OwnershipTestDomain::Order.create(title: "Alice's Order", owner_id: "alice")
+
+      Hecks.current_user = "bob"
+      expect { OwnershipTestDomain::Order.find(alice_order.id) }.to raise_error(Hecks::GateAccessDenied)
+    end
+
+    it ".all only returns the current user's records" do
+      Hecks.current_user = "alice"
+      OwnershipTestDomain::Order.create(title: "Alice's Order", owner_id: "alice")
+
+      Hecks.current_user = "bob"
+      OwnershipTestDomain::Order.create(title: "Bob's Order", owner_id: "bob")
+
+      Hecks.current_user = "alice"
+      expect(OwnershipTestDomain::Order.all.map(&:title)).to eq(["Alice's Order"])
+    end
+  end
+
+  describe "Runtime integration — admin gate without owned_by" do
+    before do
+      @app = Hecks.load(domain, gate: :admin, hecksagon: hecksagon_admin)
+    end
+
+    it "has full access to all records regardless of owner" do
+      Hecks.current_user = "alice"
+      alice_order = OwnershipTestDomain::Order.create(title: "Alice's Order", owner_id: "alice")
+
+      Hecks.current_user = "bob"
+      expect(OwnershipTestDomain::Order.find(alice_order.id)).not_to be_nil
+      expect(OwnershipTestDomain::Order.all.size).to eq(1)
+    end
+  end
+
+  describe "Runtime integration — no gate (full access)" do
+    before do
+      @app = Hecks.load(domain)
+    end
+
+    it "allows all operations without any ownership filtering" do
+      OwnershipTestDomain::Order.create(title: "Public Order", owner_id: "anyone")
+      expect(OwnershipTestDomain::Order.all.size).to eq(1)
+    end
+  end
+
+  describe "tenancy: :row enforcement" do
+    let(:hecksagon_row_tenancy) do
+      Hecks.hecksagon { tenancy :row }
+    end
+
+    let(:row_domain) do
+      Hecks.domain "RowTenancyTest" do
+        aggregate "Invoice" do
+          attribute :amount, Integer
+          attribute :tenant_id, String
+
+          command "CreateInvoice" do
+            attribute :amount, Integer
+            attribute :tenant_id, String
+          end
+        end
+      end
+    end
+
+    before do
+      @app = Hecks.load(row_domain, hecksagon: hecksagon_row_tenancy)
+    end
+
+    after do
+      Hecks.tenant = nil
+      Hecks.last_hecksagon = nil
+    end
+
+    it "isolates records by tenant" do
+      Hecks.tenant = "acme"
+      RowTenancyTestDomain::Invoice.create(amount: 100, tenant_id: "acme")
+
+      Hecks.tenant = "beta"
+      expect(RowTenancyTestDomain::Invoice.all).to be_empty
+    end
+
+    it "each tenant sees only their own invoices" do
+      Hecks.tenant = "acme"
+      RowTenancyTestDomain::Invoice.create(amount: 100, tenant_id: "acme")
+
+      Hecks.tenant = "beta"
+      RowTenancyTestDomain::Invoice.create(amount: 200, tenant_id: "beta")
+
+      Hecks.tenant = "acme"
+      results = RowTenancyTestDomain::Invoice.all
+      expect(results.size).to eq(1)
+      expect(results.first.amount).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `owned_by :field` to the Hecksagon gate DSL; `GateDefinition` gains `ownership_field`
- New `OwnershipScopedRepository` proxy: `find`/`delete` raise `GateAccessDenied` when the record belongs to a different identity; `all`/`count` filter to owned records only
- `PortSetup` wraps repositories with `OwnershipScopedRepository` before port binding when a gate declares `owned_by`, or when `tenancy: :row` is set
- `Hecks.current_user` / `Hecks.current_user=` / `Hecks.with_user { }` thread-local helpers added to `ThreadContextMethods`
- `tenancy: :row` uses `Hecks.tenant` as identity source and `:tenant_id` as the ownership field

## Test plan

- [ ] Customer gate with `owned_by`: user A cannot `.find` user B's records
- [ ] `.all` only returns the current user's records
- [ ] Admin gate without `owned_by`: full unrestricted access
- [ ] No gate: full unrestricted access
- [ ] `tenancy: :row`: records isolated by `Hecks.tenant`
- [ ] Unit tests for `OwnershipScopedRepository` (#find, #all, #delete, #count, #save)
- [ ] All 1338 specs pass in under 1 second