### PR TITLE
HEC-420: Named domain events — emits keyword

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,6 +25,8 @@
 ### Commands
 - Define commands with attributes, handlers, guards, read models, actors, and external system docs
 - Auto-infer domain events from commands (CreatePizza → CreatedPizza) with irregular verb support
+- Explicit event names with `emits` keyword: `emits "PizzaCreated"` overrides inferred conjugation
+- Multiple events per command: `emits "PizzaCreated", "MenuUpdated"` — all are emitted and reach subscribers
 - Events carry command attrs + all aggregate attrs by convention — policies can reference any field
 - Command `sets` declaration: `sets status: "approved"` — static field assignments
 - Define command `call` blocks in DSL for inline business logic (prototyping and play mode)

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -124,6 +124,10 @@ module Hecks
     def serialize_commands(commands)
       commands.flat_map do |cmd|
         lines = ["", "    command \"#{cmd.name}\" do"]
+        if cmd.emits
+          emits_names = Array(cmd.emits)
+          lines << "      emits #{emits_names.map { |n| "\"#{n}\"" }.join(", ")}"
+        end
         lines.concat(serialize_attributes(cmd.attributes, "      "))
         lines.concat(serialize_references(cmd.references, "      "))
         cmd.read_models.each { |rm| lines << "      read_model \"#{rm.name}\"" }

--- a/bluebook/lib/hecks/domain/flow_generator.rb
+++ b/bluebook/lib/hecks/domain/flow_generator.rb
@@ -71,7 +71,7 @@ module Hecks
         agg.commands.each do |cmd|
           key = cmd.name
           @command_to_aggregate[key] = agg.name
-          @command_to_event[key] = cmd.inferred_event_name
+          @command_to_event[key] = cmd.event_names.first
         end
 
         agg.policies.select(&:reactive?).each do |pol|

--- a/bluebook/lib/hecks/domain_model/behavior/command.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/command.rb
@@ -7,13 +7,18 @@ module Hecks
     # Intermediate representation of a domain command -- an intent to change state.
     # Each command carries attributes, optional read models, external systems,
     # and actors. Can infer a corresponding event name by converting the verb
-    # to past tense (CreatePizza -> CreatedPizza).
+    # to past tense (CreatePizza -> CreatedPizza), or can have explicit event
+    # name(s) declared via the +emits+ DSL keyword.
     #
     # Part of the DomainModel IR layer. Built by CommandBuilder or EventStorm
     # parser, consumed by CommandGenerator and event inference in AggregateBuilder.
     #
-    #   cmd = Command.new(name: "CreatePizza", attributes: [Attribute.new(name: :name, type: String)])
+    #   cmd = Command.new(name: "CreatePizza", attributes: [])
     #   cmd.inferred_event_name  # => "CreatedPizza"
+    #   cmd.event_names          # => ["CreatedPizza"]
+    #
+    #   cmd2 = Command.new(name: "CreatePizza", emits: ["PizzaCreated", "MenuUpdated"])
+    #   cmd2.event_names         # => ["PizzaCreated", "MenuUpdated"]
     #
     class Command
       # @return [String] PascalCase command name, e.g. "CreatePizza"
@@ -27,9 +32,10 @@ module Hecks
       # @return [Hash{Symbol => Object}] attribute defaults to set on the aggregate after execution
       # @return [Array<Condition>] preconditions checked before command execution
       # @return [Array<Condition>] postconditions checked after command execution
+      # @return [String, Array<String>, nil] explicit event name(s) declared via +emits+
       attr_reader :name, :attributes, :references, :handler, :guard_name, :read_models,
                   :external_systems, :actors, :call_body, :sets,
-                  :preconditions, :postconditions
+                  :preconditions, :postconditions, :emits
 
       # Creates a new Command IR node.
       #
@@ -44,10 +50,11 @@ module Hecks
       # @param sets [Hash{Symbol => Object}] attribute values to assign on the aggregate post-execution
       # @param preconditions [Array<Condition>] conditions that must hold before execution
       # @param postconditions [Array<Condition>] conditions that must hold after execution
+      # @param emits [String, Array<String>, nil] explicit event name(s); nil means infer from command name
       # @return [Command]
       def initialize(name:, attributes: [], references: [], handler: nil, guard_name: nil,
                      read_models: [], external_systems: [], actors: [],
-                     call_body: nil, sets: {}, preconditions: [], postconditions: [])
+                     call_body: nil, sets: {}, preconditions: [], postconditions: [], emits: nil)
         @name = Names.command_name(name)
         @attributes = attributes
         @references = references
@@ -60,6 +67,16 @@ module Hecks
         @sets = sets
         @preconditions = preconditions
         @postconditions = postconditions
+        @emits = emits
+      end
+
+      # Returns the event name(s) this command emits.
+      # When +emits+ is set explicitly, returns those names as an array.
+      # Otherwise returns an array containing the single inferred event name.
+      #
+      # @return [Array<String>] event names this command emits
+      def event_names
+        @emits ? Array(@emits) : [inferred_event_name]
       end
 
       # Lookup table of irregular English verb past tenses, keyed by PascalCase verb.

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -216,7 +216,7 @@ module Hecks
 
       def infer_events
         aggregate_id_attr = Structure::Attribute.new(name: :aggregate_id, type: String)
-        @commands.map do |command|
+        @commands.flat_map do |command|
           event_attrs = [aggregate_id_attr] + command.attributes.dup
           @attributes.each do |agg_attr|
             next if event_attrs.any? { |a| a.name == agg_attr.name }
@@ -227,11 +227,13 @@ module Hecks
             next if event_refs.any? { |r| r.name == agg_ref.name }
             event_refs << agg_ref
           end
-          Behavior::DomainEvent.new(
-            name: command.inferred_event_name,
-            attributes: event_attrs,
-            references: event_refs
-          )
+          command.event_names.map do |event_name|
+            Behavior::DomainEvent.new(
+              name: event_name,
+              attributes: event_attrs,
+              references: event_refs
+            )
+          end
         end
       end
     end

--- a/bluebook/lib/hecks/dsl/command_builder.rb
+++ b/bluebook/lib/hecks/dsl/command_builder.rb
@@ -55,6 +55,7 @@ module Hecks
         @sets = {}
         @preconditions = []
         @postconditions = []
+        @emits = nil
       end
 
       # Set the call body block executed when the command runs.
@@ -79,6 +80,22 @@ module Hecks
       # @return [void]
       def handler(&block)
         @handler = block
+      end
+
+      # Declare explicit event name(s) emitted when this command succeeds.
+      # Overrides the default inferred past-tense event name. Pass multiple
+      # names when a single command should emit more than one event.
+      #
+      # @param names [Array<String>] one or more PascalCase event names
+      # @return [void]
+      #
+      # @example Single explicit event
+      #   emits "PizzaCreated"
+      #
+      # @example Multiple events
+      #   emits "PizzaCreated", "MenuUpdated"
+      def emits(*names)
+        @emits = names.length == 1 ? names.first : names
       end
 
       # Reference a guard policy by name that must pass before execution.
@@ -208,7 +225,8 @@ module Hecks
           handler: @handler, guard_name: @guard_name,
           read_models: @read_models, external_systems: @external_systems, actors: @actors,
           call_body: @call_body, sets: @sets,
-          preconditions: @preconditions, postconditions: @postconditions
+          preconditions: @preconditions, postconditions: @postconditions,
+          emits: @emits
         )
       end
     end

--- a/bluebook/lib/hecks/generators/domain/command_generator.rb
+++ b/bluebook/lib/hecks/generators/domain/command_generator.rb
@@ -71,7 +71,15 @@ module Hecks
         lines << "    module Commands"
         lines << "      class #{@command.name}"
         lines << "        include #{@mixin_prefix}::#{@mixin_prefix == "Hecks" ? "Command" : "Runtime::Command"}"
-        lines << "        emits \"#{@event.name}\"" if @event
+        if @event
+          event_names = Array(@command.emits).any? ? Array(@command.emits) : [@event.name]
+          if event_names.length == 1
+            lines << "        emits \"#{event_names.first}\""
+          else
+            names_str = event_names.map { |n| "\"#{n}\"" }.join(", ")
+            lines << "        emits #{names_str}"
+          end
+        end
         lines.concat(condition_declarations)
         lines << ""
         attr_syms = @command.attributes.map { |a| ":#{a.name}" } +

--- a/bluebook/spec/domain_model/command_spec.rb
+++ b/bluebook/spec/domain_model/command_spec.rb
@@ -21,4 +21,44 @@ RSpec.describe Hecks::DomainModel::Behavior::Command do
       expect(cmd.inferred_event_name).to eq("PlacedOrder")
     end
   end
+
+  describe "#event_names" do
+    context "when emits is nil (default)" do
+      it "returns array with inferred event name" do
+        cmd = described_class.new(name: "CreatePizza", attributes: [])
+        expect(cmd.event_names).to eq(["CreatedPizza"])
+      end
+    end
+
+    context "when emits is a single string" do
+      it "returns array with that name" do
+        cmd = described_class.new(name: "CreatePizza", attributes: [], emits: "PizzaCreated")
+        expect(cmd.event_names).to eq(["PizzaCreated"])
+      end
+    end
+
+    context "when emits is an array of names" do
+      it "returns all names" do
+        cmd = described_class.new(name: "CreatePizza", attributes: [], emits: ["PizzaCreated", "MenuUpdated"])
+        expect(cmd.event_names).to eq(["PizzaCreated", "MenuUpdated"])
+      end
+    end
+  end
+
+  describe "#emits" do
+    it "is nil by default" do
+      cmd = described_class.new(name: "CreatePizza", attributes: [])
+      expect(cmd.emits).to be_nil
+    end
+
+    it "stores a single name string" do
+      cmd = described_class.new(name: "CreatePizza", attributes: [], emits: "PizzaCreated")
+      expect(cmd.emits).to eq("PizzaCreated")
+    end
+
+    it "stores an array for multiple names" do
+      cmd = described_class.new(name: "CreatePizza", attributes: [], emits: ["PizzaCreated", "MenuUpdated"])
+      expect(cmd.emits).to eq(["PizzaCreated", "MenuUpdated"])
+    end
+  end
 end

--- a/bluebook/spec/dsl/domain_builder_spec.rb
+++ b/bluebook/spec/dsl/domain_builder_spec.rb
@@ -31,6 +31,53 @@ RSpec.describe Hecks::DSL::DomainBuilder do
       event = domain.aggregates.first.events.first
       expect(event.attributes.map(&:name)).to eq([:aggregate_id, :title, :price, :name])
     end
+
+    describe "emits keyword" do
+      it "overrides the inferred event name with a single explicit name" do
+        domain = Hecks.domain("Pizzeria") do
+          aggregate("Pizza") do
+            attribute :name, String
+            command("CreatePizza") do
+              attribute :name, String
+              emits "PizzaCreated"
+            end
+          end
+        end
+        agg = domain.aggregates.first
+        cmd = agg.commands.first
+        expect(cmd.emits).to eq("PizzaCreated")
+        expect(cmd.event_names).to eq(["PizzaCreated"])
+        expect(agg.events.map(&:name)).to include("PizzaCreated")
+        expect(agg.events.map(&:name)).not_to include("CreatedPizza")
+      end
+
+      it "produces multiple events for a command with multiple emits" do
+        domain = Hecks.domain("Pizzeria") do
+          aggregate("Pizza") do
+            attribute :name, String
+            command("CreatePizza") do
+              attribute :name, String
+              emits "PizzaCreated", "MenuUpdated"
+            end
+          end
+        end
+        agg = domain.aggregates.first
+        cmd = agg.commands.first
+        expect(cmd.event_names).to eq(["PizzaCreated", "MenuUpdated"])
+        expect(agg.events.map(&:name)).to include("PizzaCreated", "MenuUpdated")
+      end
+
+      it "falls back to inferred event name when emits is not set" do
+        domain = Hecks.domain("Pizzeria") do
+          aggregate("Pizza") do
+            attribute :name, String
+            command("CreatePizza") { attribute :name, String }
+          end
+        end
+        cmd = domain.aggregates.first.commands.first
+        expect(cmd.event_names).to eq(["CreatedPizza"])
+      end
+    end
   end
 
   describe "queries" do

--- a/docs/usage/emits.md
+++ b/docs/usage/emits.md
@@ -1,0 +1,99 @@
+# emits — Named Domain Events
+
+The `emits` keyword lets commands declare explicit event names instead of
+relying on automatic past-tense conjugation. It also supports multiple events
+per command.
+
+## Without emits (default)
+
+Event names are inferred by converting the leading verb to past tense:
+
+```ruby
+command "CreatePizza" do
+  attribute :name, String
+end
+# emits CreatedPizza automatically
+```
+
+## Single explicit event name
+
+Override the inferred name with any PascalCase string:
+
+```ruby
+command "CreatePizza" do
+  attribute :name, String
+  emits "PizzaCreated"
+end
+# emits PizzaCreated instead of CreatedPizza
+```
+
+This is useful when your team prefers noun-first event names or when the
+inferred conjugation is wrong for a domain-specific verb.
+
+## Multiple events per command
+
+A single command can emit more than one event:
+
+```ruby
+command "CreatePizza" do
+  attribute :name, String
+  emits "PizzaCreated", "MenuUpdated"
+end
+# emits both PizzaCreated and MenuUpdated
+```
+
+All events are published to the event bus, so policies and subscribers can
+react to any of them independently.
+
+## Runtime access
+
+```ruby
+cmd = PizzasDomain::Pizza.create(name: "Margherita")
+
+cmd.event    # => first emitted event (backward compat)
+cmd.events   # => [PizzaCreated, MenuUpdated] — all events
+```
+
+## Policies reacting to named events
+
+Policies work the same way — just reference the explicit name:
+
+```ruby
+policy "AutoReady" do
+  on "PizzaCreated"
+  trigger "MarkReady"
+end
+```
+
+## Serializer round-trip
+
+The DSL serializer preserves `emits` declarations:
+
+```ruby
+Hecks::DslSerializer.new(domain).serialize
+# => includes:  emits "PizzaCreated", "MenuUpdated"
+```
+
+## Running examples
+
+```ruby
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+
+    command "CreatePizza" do
+      attribute :name, String
+      emits "PizzaCreated", "MenuUpdated"
+    end
+  end
+end
+
+app = Hecks.load(domain)
+cmd = PizzasDomain::Pizza.create(name: "Margherita")
+
+puts cmd.events.map { |e| e.class.name.split("::").last }.inspect
+# => ["PizzaCreated", "MenuUpdated"]
+
+puts app.events.size
+# => 2
+```

--- a/hecksties/lib/hecks/mixins/command.rb
+++ b/hecksties/lib/hecks/mixins/command.rb
@@ -42,14 +42,17 @@ module Hecks
   #
   module Command
     # Hook called when a class includes +Hecks::Command+. Extends the class
-    # with +ClassMethods+ and defines +aggregate+ and +event+ readers on
-    # instances so callers can inspect command results.
+    # with +ClassMethods+ and defines +aggregate+, +event+, and +events+ readers
+    # on instances so callers can inspect command results.
+    #
+    # +event+ returns the first (or only) emitted event for backward compatibility.
+    # +events+ returns all emitted events as an array.
     #
     # @param base [Class] the class including this module
     # @return [void]
     def self.included(base)
       base.extend(ClassMethods)
-      base.attr_reader :aggregate, :event
+      base.attr_reader :aggregate, :event, :events
     end
 
     # Class-level DSL and execution entry point for command classes.
@@ -61,20 +64,28 @@ module Hecks
       attr_accessor :repository, :event_bus, :handler, :guarded_by,
                     :event_recorder, :aggregate_type, :command_bus
 
-      # Declares the event name emitted when this command succeeds.
-      # The event class is resolved at runtime from the aggregate's Events module.
+      # Declares the event name(s) emitted when this command succeeds.
+      # The event class(es) are resolved at runtime from the aggregate's Events module.
+      # Pass multiple names to emit more than one event per command execution.
       #
-      # @param event_name [String] PascalCase event name (e.g. "CreatedPizza")
+      # @param event_names [Array<String>] one or more PascalCase event names
       # @return [void]
-      def emits(event_name)
-        @event_name = event_name
+      def emits(*event_names)
+        @event_names = event_names
       end
 
-      # Returns the declared event name for this command.
+      # Returns the first declared event name for this command (backward compat).
       #
-      # @return [String, nil] the event name set via +emits+, or nil if none declared
+      # @return [String, nil] the first event name set via +emits+, or nil if none declared
       def event_name
-        @event_name
+        @event_names&.first
+      end
+
+      # Returns all declared event names for this command.
+      #
+      # @return [Array<String>] all event names set via +emits+, or empty array if none declared
+      def event_names
+        @event_names || []
       end
 
       # Returns the list of registered precondition checks.
@@ -119,7 +130,7 @@ module Hecks
         postconditions << DomainModel::Behavior::Condition.new(message: message, block: block)
       end
 
-      # Resolves the event class constant from the declared event name.
+      # Resolves the event class constant from the declared event name (first event).
       # Navigates up from the command's namespace to the aggregate module,
       # then looks up +Events::<event_name>+.
       #
@@ -127,7 +138,16 @@ module Hecks
       # @raise [NameError] if the event class cannot be found
       def event_class
         agg_module = name.split("::")[0..-3].join("::")
-        Object.const_get("#{agg_module}::Events::#{@event_name}")
+        Object.const_get("#{agg_module}::Events::#{event_name}")
+      end
+
+      # Resolves all event class constants from the declared event names.
+      #
+      # @return [Array<Class>] all event classes
+      # @raise [NameError] if any event class cannot be found
+      def event_classes
+        agg_module = name.split("::")[0..-3].join("::")
+        event_names.map { |en| Object.const_get("#{agg_module}::Events::#{en}") }
       end
 
       # Executes the full command lifecycle: guard, handler, preconditions,
@@ -153,14 +173,16 @@ module Hecks
 
       # Runs the command through validation steps (guard, precondition, call,
       # postcondition) without persisting, emitting, or recording. Builds the
-      # event that would have been emitted and attaches it to the command.
+      # event(s) that would have been emitted and attaches them to the command.
       #
       # @param attrs [Hash] command attributes
-      # @return [self] the command instance with +#aggregate+ and +#event+ populated
+      # @return [self] the command instance with +#aggregate+, +#event+, and +#events+ populated
       def dry_call(**attrs)
         cmd = new(**attrs)
         Command::LifecycleSteps::DRY_RUN_PIPELINE.each { |step| step.call(cmd) }
-        cmd.instance_variable_set(:@event, cmd.send(:build_event))
+        built = cmd.send(:build_events)
+        cmd.instance_variable_set(:@events, built)
+        cmd.instance_variable_set(:@event, built.first)
         cmd
       end
     end
@@ -325,13 +347,13 @@ module Hecks
       repository.save(aggregate)
     end
 
-    # Constructs the event declared via +emits+ without publishing it.
+    # Constructs a single event instance from the given event class.
     # Introspects the event class constructor to map command and aggregate
     # attributes into event parameters.
     #
+    # @param event_class [Class] the event class to instantiate
     # @return [Object] the constructed event instance
-    def build_event
-      event_class = self.class.event_class
+    def build_event_for(event_class)
       event_params = event_class.instance_method(:initialize).parameters.map { |_, n| n }
       attrs = {}
       event_params.each do |param|
@@ -346,13 +368,31 @@ module Hecks
       event_class.new(**attrs)
     end
 
-    # Builds and publishes the event on the event bus.
+    # Constructs all events declared via +emits+ without publishing them.
+    #
+    # @return [Array<Object>] all constructed event instances
+    def build_events
+      self.class.event_classes.map { |klass| build_event_for(klass) }
+    end
+
+    # Constructs the first event declared via +emits+ without publishing it.
+    # Preserved for backward compatibility.
     #
     # @return [Object] the constructed event instance
+    def build_event
+      build_event_for(self.class.event_class)
+    end
+
+    # Builds and publishes all events declared via +emits+ on the event bus.
+    # Sets +@event+ to the first event for backward compatibility,
+    # and +@events+ to the full array.
+    #
+    # @return [Array<Object>] all constructed and published event instances
     def emit_event
-      @event = build_event
-      self.class.event_bus&.publish(@event)
-      @event
+      @events = build_events
+      @event = @events.first
+      @events.each { |evt| self.class.event_bus&.publish(evt) }
+      @events
     end
 
     # Records the emitted event in the event recorder for the aggregate,

--- a/hecksties/spec/emits_keyword_spec.rb
+++ b/hecksties/spec/emits_keyword_spec.rb
@@ -1,0 +1,205 @@
+# emits_keyword_spec.rb — HEC-420
+#
+# Specs for the `emits` DSL keyword on commands. Covers:
+# - Single explicit event name overriding inferred conjugation
+# - Multiple events emitted per command
+# - Backward compatibility when `emits` is not declared
+# - Runtime: cmd.event, cmd.events after execution
+# - Serializer round-trip
+#
+require "spec_helper"
+
+RSpec.describe "emits keyword" do
+  describe "single explicit event name" do
+    let(:domain) do
+      Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+            emits "PizzaCreated"
+          end
+        end
+      end
+    end
+
+    let!(:app) { Hecks.load(domain) }
+
+    it "wires the named event instead of the inferred one" do
+      expect(domain.aggregates.first.events.map(&:name)).to include("PizzaCreated")
+      expect(domain.aggregates.first.events.map(&:name)).not_to include("CreatedPizza")
+    end
+
+    it "emits the named event at runtime" do
+      PizzasDomain::Pizza.create(name: "Margherita")
+      expect(app.events.size).to eq(1)
+      expect(app.events.first.class.name).to match(/PizzaCreated/)
+    end
+
+    it "sets cmd.event to the emitted event" do
+      cmd = PizzasDomain::Pizza.create(name: "Quattro")
+      expect(cmd.event).not_to be_nil
+      expect(cmd.event.class.name).to match(/PizzaCreated/)
+    end
+
+    it "sets cmd.events to an array with one event" do
+      cmd = PizzasDomain::Pizza.create(name: "Quattro")
+      expect(cmd.events).to be_an(Array)
+      expect(cmd.events.size).to eq(1)
+      expect(cmd.events.first).to eq(cmd.event)
+    end
+  end
+
+  describe "multiple explicit event names" do
+    let(:domain) do
+      Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+            emits "PizzaCreated", "MenuUpdated"
+          end
+        end
+      end
+    end
+
+    let!(:app) { Hecks.load(domain) }
+
+    it "generates both event classes" do
+      event_names = domain.aggregates.first.events.map(&:name)
+      expect(event_names).to include("PizzaCreated", "MenuUpdated")
+    end
+
+    it "emits all events at runtime" do
+      PizzasDomain::Pizza.create(name: "Margherita")
+      expect(app.events.size).to eq(2)
+      event_class_names = app.events.map { |e| e.class.name }
+      expect(event_class_names).to include(match(/PizzaCreated/), match(/MenuUpdated/))
+    end
+
+    it "sets cmd.event to the first event" do
+      cmd = PizzasDomain::Pizza.create(name: "Napolitana")
+      expect(cmd.event.class.name).to match(/PizzaCreated/)
+    end
+
+    it "sets cmd.events to all events" do
+      cmd = PizzasDomain::Pizza.create(name: "Napolitana")
+      expect(cmd.events.size).to eq(2)
+      class_names = cmd.events.map { |e| e.class.name }
+      expect(class_names).to include(match(/PizzaCreated/), match(/MenuUpdated/))
+    end
+
+    it "fires subscribers for each event" do
+      received = []
+      app.event_bus.subscribe("PizzaCreated") { |e| received << e.class.name.split("::").last }
+      app.event_bus.subscribe("MenuUpdated") { |e| received << e.class.name.split("::").last }
+      PizzasDomain::Pizza.create(name: "Romana")
+      expect(received).to include("PizzaCreated", "MenuUpdated")
+    end
+  end
+
+  describe "backward compatibility (no emits declared)" do
+    let(:domain) do
+      Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    let!(:app) { Hecks.load(domain) }
+
+    it "still emits the inferred event" do
+      PizzasDomain::Pizza.create(name: "Margherita")
+      expect(app.events.size).to eq(1)
+      expect(app.events.first.class.name).to match(/CreatedPizza/)
+    end
+
+    it "cmd.events has one entry equal to cmd.event" do
+      cmd = PizzasDomain::Pizza.create(name: "Margherita")
+      expect(cmd.events).to eq([cmd.event])
+    end
+  end
+
+  describe "DSL serializer round-trip" do
+    it "outputs emits line for single explicit name" do
+      domain = Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+            emits "PizzaCreated"
+          end
+        end
+      end
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).to include('emits "PizzaCreated"')
+    end
+
+    it "outputs emits line with multiple names" do
+      domain = Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+            emits "PizzaCreated", "MenuUpdated"
+          end
+        end
+      end
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).to include('emits "PizzaCreated", "MenuUpdated"')
+    end
+
+    it "omits emits line when not declared" do
+      domain = Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+      end
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).not_to include("emits")
+    end
+  end
+
+  describe "policy reacts to named event" do
+    let(:domain) do
+      Hecks.domain "Pizzas" do
+        aggregate "Pizza" do
+          attribute :name, String
+          attribute :status, String
+
+          command "CreatePizza" do
+            attribute :name, String
+            emits "PizzaCreated"
+          end
+
+          command "MarkReady" do
+            attribute :pizza_id, String
+          end
+
+          policy "AutoReady" do
+            on "PizzaCreated"
+            trigger "MarkReady"
+          end
+        end
+      end
+    end
+
+    let!(:app) { Hecks.load(domain) }
+
+    it "triggers the policy when the named event fires" do
+      PizzasDomain::Pizza.create(name: "Margherita")
+      expect(app.events.size).to be >= 2
+      event_class_names = app.events.map { |e| e.class.name }
+      expect(event_class_names).to include(match(/PizzaCreated/), match(/MarkedReady/))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `emits` keyword to the Hecks DSL so commands can declare explicit event names instead of relying on automatic past-tense conjugation (e.g. `emits "PizzaCreated"` instead of the inferred `CreatedPizza`)
- Supports multiple events per command: `emits "PizzaCreated", "MenuUpdated"` — all are published to the event bus and reach subscribers independently
- Fully backward compatible: when `emits` is not declared, behavior is identical to today

## Changes

- **IR** (`Command`): adds `emits` kwarg + `#event_names` that returns explicit names or falls back to `[inferred_event_name]`
- **DSL** (`CommandBuilder`): adds `emits(*names)` method
- **DSL** (`AggregateBuilder`): `infer_events` uses `flat_map` + `command.event_names` to generate one event IR per declared name
- **Generator** (`CommandGenerator`): outputs `emits "Name"` or `emits "A", "B"` in generated code
- **Runtime** (`Hecks::Command` mixin): `emits` accepts variadic args; `emit_event` publishes all events; `cmd.event` (first, backward compat) and `cmd.events` (array) on instances
- **Serializer** (`DslSerializer`): outputs `emits` line when set
- **FlowGenerator**: uses `event_names.first` for reactive chain tracing

## Test plan

- [ ] `bundle exec rspec` — 1345 examples, 0 failures
- [ ] Single explicit name: `emits "PizzaCreated"` wires named event, not inferred
- [ ] Multiple events: both published, both reach subscribers, `cmd.events` has both
- [ ] Policy fires on named event
- [ ] Backward compat: no `emits` → single inferred event, `cmd.events == [cmd.event]`
- [ ] Serializer round-trips single and multi-name `emits` declarations
- [ ] `cmd.event` still works (first event, backward compat)