### PR TITLE
HEC-427: Auth extension default-secure — raise at boot when actors declared without auth

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -83,6 +83,8 @@
 
 ### Application Service Extensions
 - `hecks_auth` — actor-based authentication & authorization
+- Default-secure auth: raises `ConfigurationError` at boot when actor-protected commands exist but no `:auth` extension is registered
+- Explicit opt-out: `extend :auth, enforce: false` registers a no-op sentinel that satisfies the check
 - `hecks_tenancy` — multi-tenant isolation (`Hecks.tenant = "acme"`)
 - `hecks_audit` — audit trail of every command execution
 - `hecks_logging` — structured stdout logging with duration

--- a/docs/usage/auth_default_secure.md
+++ b/docs/usage/auth_default_secure.md
@@ -1,0 +1,64 @@
+# Auth Default-Secure
+
+When a domain declares `actor` requirements on commands, Hecks now
+raises `ConfigurationError` at boot if no `:auth` extension is
+registered. This prevents silent security gaps where access control
+is defined in the DSL but never enforced at runtime.
+
+## The problem
+
+```ruby
+Hecks.domain "Invoicing" do
+  aggregate "Invoice" do
+    attribute :total, Float
+    command "Approve" do
+      actor "Manager"       # declares who may approve
+      attribute :invoice_id, String
+    end
+  end
+end
+
+app = Hecks.boot(__dir__)   # no :auth extension loaded
+Invoice.approve(invoice_id: "123")  # silently succeeds — oops!
+```
+
+## The fix
+
+The boot process now checks for actor-protected commands after
+extensions are wired. If any exist and no `:auth` middleware is
+registered, it raises:
+
+```
+Hecks::ConfigurationError:
+  Domain 'Invoicing' declares actor requirements on 1 command
+  (Approve) but no auth middleware is registered. Add `extend :auth`
+  to your Hecks.boot or Hecks.configure block, or explicitly opt out
+  with `extend :auth, enforce: false`.
+```
+
+## Adding auth
+
+```ruby
+app = Hecks.boot(__dir__)
+app.extend(:auth)  # wires actor-based authorization middleware
+```
+
+## Opting out explicitly
+
+If you intentionally want to skip authorization (e.g., in a dev
+environment or a batch-processing service), use `enforce: false`:
+
+```ruby
+app = Hecks.boot(__dir__)
+app.extend(:auth, enforce: false)  # registers a no-op sentinel
+```
+
+This documents the intentional decision and satisfies the boot check
+without enforcing any access control.
+
+## When does the check run?
+
+- After `Hecks.boot` fires all extensions
+- After `Hecks.configure` boots domains (via `fire_extensions`)
+- Not after `Hecks.load` (test helper) — call `app.check_auth_coverage!`
+  manually if you want the check in tests

--- a/hecksties/lib/hecks/extensions/auth.rb
+++ b/hecksties/lib/hecks/extensions/auth.rb
@@ -27,7 +27,17 @@ Hecks.describe_extension(:auth,
   config: {},
   wires_to: :command_bus)
 
-Hecks.register_extension(:auth) do |domain_mod, domain, runtime|
+Hecks.register_extension(:auth) do |domain_mod, domain, runtime, **opts|
+  # When enforce: false, register a no-op sentinel middleware that satisfies
+  # the auth coverage check without actually enforcing access control.
+  # This documents an intentional decision to skip authorization.
+  if opts[:enforce] == false
+    runtime.use :auth do |_command, next_handler|
+      next_handler.call
+    end
+    next
+  end
+
   # Build a lookup of command class name → required actor roles.
   #
   # Iterates all aggregates and their commands, collecting any that have

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -8,6 +8,7 @@ require_relative "runtime/workflow_setup"
 require_relative "runtime/constant_hoisting"
 require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
+require_relative "runtime/auth_coverage_check"
 
 module Hecks
   # Hecks::Runtime
@@ -55,6 +56,7 @@ module Hecks
       include WorkflowSetup
       include ConstantHoisting
       include ConnectionSetup
+      include AuthCoverageCheck
 
       # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to
       attr_reader :domain
@@ -223,7 +225,7 @@ module Hecks
         if kwargs.any? && @mod.respond_to?(:connections)
           @mod.connections[:sends] << { name: name.to_sym, **kwargs }
         end
-        hook.call(@mod, @domain, self)
+        hook.call(@mod, @domain, self, **kwargs)
         puts "#{name} extension applied"
       end
 

--- a/hecksties/lib/hecks/runtime/auth_coverage_check.rb
+++ b/hecksties/lib/hecks/runtime/auth_coverage_check.rb
@@ -1,0 +1,57 @@
+# Hecks::Runtime::AuthCoverageCheck
+#
+# Validates that domains declaring actor requirements on commands have
+# auth middleware registered. Raises +ConfigurationError+ at boot when
+# actors are declared but no auth extension is wired, preventing silent
+# security gaps.
+#
+#   # Automatically called after extensions fire during Hecks.boot
+#   # To opt out explicitly:
+#   runtime.extend(:auth, enforce: false)
+#
+module Hecks
+  class Runtime
+    module AuthCoverageCheck
+      # Scans the domain IR for commands with actor declarations and
+      # verifies that auth middleware is registered on the command bus.
+      #
+      # Raises +Hecks::ConfigurationError+ if actor-protected commands
+      # exist but no +:auth+ middleware is registered.
+      #
+      # @return [void]
+      # @raise [Hecks::ConfigurationError] when actors declared without auth
+      def check_auth_coverage!
+        protected_commands = actor_protected_commands
+        return if protected_commands.empty?
+        return if auth_middleware_registered?
+
+        names = protected_commands.map(&:name).join(", ")
+        count = protected_commands.size
+        raise Hecks::ConfigurationError,
+          "Domain '#{@domain.name}' declares actor requirements on " \
+          "#{count} command#{'s' unless count == 1} (#{names}) but no " \
+          "auth middleware is registered. Add `extend :auth` to your " \
+          "Hecks.boot or Hecks.configure block, or explicitly opt out " \
+          "with `extend :auth, enforce: false`."
+      end
+
+      private
+
+      # Collects all commands across aggregates that declare actor requirements.
+      #
+      # @return [Array<Hecks::DomainModel::Structure::Command>] commands with actors
+      def actor_protected_commands
+        @domain.aggregates.flat_map do |agg|
+          agg.commands.select { |cmd| cmd.actors.any? }
+        end
+      end
+
+      # Checks whether auth middleware (real or sentinel) is on the command bus.
+      #
+      # @return [Boolean]
+      def auth_middleware_registered?
+        @command_bus.middleware.any? { |mw| mw[:name] == :auth }
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -99,6 +99,8 @@ module Hecks
         next if explicit && !config.extensions.key?(name)
         hook.call(mod, domain, runtime)
       end
+
+      runtime.check_auth_coverage!
     end
 
     def autoload_services(dir)

--- a/hecksties/spec/runtime/auth_coverage_check_spec.rb
+++ b/hecksties/spec/runtime/auth_coverage_check_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+require "hecks/extensions/auth"
+
+RSpec.describe Hecks::Runtime::AuthCoverageCheck do
+  after { Hecks.actor = nil }
+
+  context "domain with actor-protected commands and no :auth" do
+    let(:domain) do
+      Hecks.domain "AuthCovNone" do
+        aggregate "Invoice" do
+          attribute :total, Float
+
+          command "Create" do
+            actor "Admin"
+            attribute :total, Float
+          end
+
+          command "Approve" do
+            actor "Manager"
+            attribute :invoice_id, String
+          end
+        end
+      end
+    end
+
+    it "raises ConfigurationError naming the affected commands" do
+      app = Hecks.load(domain)
+      expect { app.check_auth_coverage! }.to raise_error(
+        Hecks::ConfigurationError,
+        /Domain 'AuthCovNone' declares actor requirements on 2 commands \(Create, Approve\)/
+      )
+    end
+  end
+
+  context "domain with actor-protected commands and extend :auth" do
+    let(:domain) do
+      Hecks.domain "AuthCovWith" do
+        aggregate "Invoice" do
+          attribute :total, Float
+
+          command "Create" do
+            actor "Admin"
+            attribute :total, Float
+          end
+        end
+      end
+    end
+
+    it "boots cleanly" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:auth].call(
+        Object.const_get("AuthCovWithDomain"), domain, app
+      )
+      expect { app.check_auth_coverage! }.not_to raise_error
+    end
+  end
+
+  context "domain with actor-protected commands and extend :auth, enforce: false" do
+    let(:domain) do
+      Hecks.domain "AuthCovOptOut" do
+        aggregate "Invoice" do
+          attribute :total, Float
+
+          command "Create" do
+            actor "Admin"
+            attribute :total, Float
+          end
+        end
+      end
+    end
+
+    it "boots cleanly with no-op sentinel" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:auth].call(
+        Object.const_get("AuthCovOptOutDomain"), domain, app, enforce: false
+      )
+      expect { app.check_auth_coverage! }.not_to raise_error
+    end
+
+    it "does not enforce authorization" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:auth].call(
+        Object.const_get("AuthCovOptOutDomain"), domain, app, enforce: false
+      )
+      # No actor set, but should not raise
+      expect { Invoice.create(total: 100.0) }.not_to raise_error
+    end
+  end
+
+  context "domain with no actor requirements and no :auth" do
+    let(:domain) do
+      Hecks.domain "AuthCovClean" do
+        aggregate "Widget" do
+          attribute :name, String
+
+          command "Create" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "boots cleanly (backward compat)" do
+      app = Hecks.load(domain)
+      expect { app.check_auth_coverage! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What this solves

Domains that declare actor requirements on commands could be deployed without \`extend :auth\`, silently shipping an unauthenticated app. The runtime now raises at boot time if actor-protected commands exist but no auth middleware is registered — making the secure path the default and the insecure path an explicit opt-out.

## Example

**Before** — silent footgun: no auth, no error, all commands callable by anyone:
```ruby
Hecks.configure do
  domain InvoicingDomain
  # forgot extend :auth — deploys unprotected
end
```

**After** — raises at boot with a clear fix message:
```
Hecks::ConfigurationError: Domain 'Invoicing' declares actor requirements on
3 commands (CreateInvoice, ApproveInvoice, VoidInvoice) but no auth
middleware is registered. Add `extend :auth` to your Hecks.configure block,
or explicitly opt out with `extend :auth, enforce: false`.
```

**With auth (normal path):**
```ruby
Hecks.configure do
  domain InvoicingDomain
  extend :auth         # boots cleanly, auth enforced
end
```

**Explicit opt-out (documents the decision):**
```ruby
Hecks.configure do
  domain InvoicingDomain
  extend :auth, enforce: false  # boots cleanly, no enforcement
end
```

**Public domain (no actor declarations) — unaffected:**
```ruby
Hecks.configure do
  domain PublicCatalog  # no actors declared → no check, boots cleanly
end
```

## Test plan
- [ ] Domain with actor-protected commands + no `:auth` → `ConfigurationError` at boot
- [ ] Domain with actor-protected commands + `extend :auth` → boots cleanly
- [ ] Domain with actor-protected commands + `extend :auth, enforce: false` → boots cleanly
- [ ] Domain with no actor requirements → boots cleanly (backward compat)