### PR TITLE
HEC-430: Web Explorer — use Bluebook IR instead of runtime introspection

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -578,6 +578,12 @@
 - Renderer class with layout wrapping and HTML escaping
 - Registers with runtime, auto-wires when loaded
 
+### IR-Driven Structural Discovery (HEC-430)
+- All structural queries (aggregate names, attributes, columns, commands, policies, roles) come from the Bluebook IR via `IRIntrospector`
+- Runtime CRUD operations (find, all, create, delete) isolated behind `RuntimeBridge`
+- No `Object.const_get`, `respond_to?`, or `instance_variable_get` in the UI layer
+- Same IR structs consumed by Ruby, Go, and Rails generators now also drive the Web Explorer
+
 ## Implicit DSL (HEC-229)
 
 ### Infer Domain Concepts from Structure

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -3,6 +3,8 @@ require "json"
 require "tmpdir"
 require_relative "route_builder"
 require "hecks/extensions/web_explorer/renderer"
+require "hecks/extensions/web_explorer/ir_introspector"
+require "hecks/extensions/web_explorer/runtime_bridge"
 require_relative "multi_domain_ui_routes"
 
 module Hecks
@@ -10,10 +12,9 @@ module Hecks
     # Hecks::HTTP::MultiDomainServer
     #
     # WEBrick server that serves multiple Hecks domains in one process.
-    # Navigation is grouped by domain. Each domain's routes are prefixed
-    # with its slug (e.g. /blog/posts, /photos/photos).
-    #
-    # Uses the same ERB views as the static Ruby and Go generators.
+    # All structural discovery (aggregates, attributes, commands, policies)
+    # comes from the Bluebook IR via IRIntrospector. Runtime access for
+    # CRUD operations is isolated behind RuntimeBridge.
     #
     #   domains = [blog_domain, photos_domain]
     #   runtimes = [blog_runtime, photos_runtime]
@@ -34,7 +35,8 @@ module Hecks
       def run
         puts "Hecks serving #{@domains.size} domains on http://localhost:#{@port}"
         @entries.each do |e|
-          puts "  #{e[:domain].name}: /#{e[:slug]}/ (#{e[:domain].aggregates.size} aggregates)"
+          ir = e[:ir]
+          puts "  #{ir.domain.name}: /#{e[:slug]}/ (#{ir.aggregate_names.size} aggregates)"
         end
         puts ""
 
@@ -52,10 +54,11 @@ module Hecks
         @domains.each_with_index do |domain, i|
           runtime = @runtimes[i]
           slug = domain_slug(domain.name)
-          mod_name = domain_module_name(domain.name)
-          mod = Object.const_get(mod_name)
+          mod = Object.const_get(domain_module_name(domain.name))
+          ir = Hecks::WebExplorer::IRIntrospector.new(domain)
+          bridge = Hecks::WebExplorer::RuntimeBridge.new(mod)
           routes = RouteBuilder.new(domain, mod).build
-          @entries << { domain: domain, runtime: runtime, mod: mod, slug: slug, routes: routes }
+          @entries << { ir: ir, bridge: bridge, runtime: runtime, slug: slug, routes: routes }
         end
 
         require "hecks/extensions/web_explorer"
@@ -69,8 +72,9 @@ module Hecks
       def build_nav
         items = [{ label: "Home", href: "/" }]
         @entries.each do |e|
-          group = HecksTemplating::UILabelContract.label(e[:domain].name)
-          e[:domain].aggregates.each do |agg|
+          ir = e[:ir]
+          group = HecksTemplating::UILabelContract.label(ir.domain.name)
+          ir.domain.aggregates.each do |agg|
             items << {
               label: HecksTemplating::UILabelContract.plural_label(agg.name),
               href: "/#{e[:slug]}/#{plural(agg)}",
@@ -111,8 +115,9 @@ module Hecks
 
       def serve_home(res)
         agg_data = @entries.flat_map do |e|
-          e[:domain].aggregates.map do |agg|
-            d = HecksTemplating::DisplayContract.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
+          ir = e[:ir]
+          ir.domain.aggregates.map do |agg|
+            d = ir.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
             { name: d[:name], href: d[:href], command_names: d[:command_names],
               attributes: d[:attributes], policies: d[:policies] }
           end
@@ -126,13 +131,14 @@ module Hecks
 
       def serve_config(res)
         summaries = @entries.flat_map do |e|
-          e[:domain].aggregates.map do |agg|
-            s = HecksTemplating::DisplayContract.aggregate_summary(agg)
+          ir = e[:ir]
+          ir.domain.aggregates.map do |agg|
+            s = ir.aggregate_summary(agg)
             { name: agg.name, commands: s[:commands], ports: s[:ports] }
           end
         end
-        policies = @entries.flat_map { |e| HecksTemplating::DisplayContract.policy_labels(e[:domain]) }
-        roles = @entries.flat_map { |e| HecksTemplating::DisplayContract.available_roles(e[:domain]) }.uniq
+        policies = @entries.flat_map { |e| e[:ir].policy_labels }
+        roles = @entries.flat_map { |e| e[:ir].available_roles }.uniq
         html = @renderer.render(:config,
           title: "Config — #{@brand}", brand: @brand, nav_items: @nav,
           aggregates: summaries, policies: policies, roles: roles,
@@ -155,10 +161,6 @@ module Hecks
 
       def plural(agg)
         domain_aggregate_slug(agg.name)
-      end
-
-      def humanize(name)
-        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(name))
       end
 
       def match?(pattern, path)

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
@@ -4,8 +4,9 @@ module Hecks
     class MultiDomainServer
       # Hecks::HTTP::MultiDomainServer::UIRoutes
       #
-      # UI route handlers for the multi-domain web explorer. Renders ERB
-      # views for index, show, form, and submit routes, scoped by domain.
+      # UI route handlers for the multi-domain web explorer. Structural
+      # discovery (columns, fields, buttons) comes from IRIntrospector.
+      # Runtime data access (find, all, execute) goes through RuntimeBridge.
       # Extracted from MultiDomainServer to stay under the 200-line limit.
       #
       module UIRoutes
@@ -13,61 +14,55 @@ module Hecks
         private
 
         def serve_ui_route(req, res, entry, sub_path)
-          domain = entry[:domain]
-          mod = entry[:mod]
+          ir = entry[:ir]
+          bridge = entry[:bridge]
           slug = entry[:slug]
 
-          agg = domain.aggregates.find { |a| sub_path.start_with?("/#{plural(a)}") }
+          agg = ir.domain.aggregates.find { |a| sub_path.start_with?("/#{plural(a)}") }
           unless agg
             res.status = 404; res.body = "Not found"; return
           end
 
           safe = domain_constant_name(agg.name)
-          klass = mod.const_get(safe)
           p = plural(agg)
           prefix = "/#{slug}"
           remaining = sub_path.sub("/#{p}", "")
 
           if remaining == "" || remaining == "/"
-            serve_index(res, agg, klass, safe, p, prefix, domain)
+            serve_index(res, ir, bridge, agg, safe, p, prefix)
           elsif remaining == "/show"
-            serve_show(req, res, agg, klass, safe, p, prefix, domain)
+            serve_show(req, res, ir, bridge, agg, safe, p, prefix)
           elsif remaining =~ /\/(\w+)\/new$/
-            serve_form(req, res, agg, klass, safe, p, prefix, $1)
+            serve_form(req, res, ir, agg, safe, p, prefix, $1)
           elsif remaining =~ /\/(\w+)\/submit$/
-            serve_submit(req, res, agg, klass, safe, p, prefix, $1)
+            serve_submit(req, res, ir, bridge, agg, safe, p, prefix, $1)
           else
             res.status = 404; res.body = "Not found"
           end
         end
 
-        def serve_index(res, agg, klass, safe, p, prefix, domain)
-          dc = HecksTemplating::DisplayContract
-          user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
-          items = klass.all.map do |obj|
+        def serve_index(res, ir, bridge, agg, safe, p, prefix)
+          user_attrs = ir.user_attributes(agg)
+          items = bridge.find_all(agg.name).map do |obj|
             cells = user_attrs.map { |a|
-              if dc.reference_attr?(a)
-                ref_agg = dc.find_referenced_aggregate(a, domain)
-                resolve_reference(obj, a, ref_agg, klass)
+              if ir.reference_attr?(a)
+                ref_agg = ir.find_referenced_aggregate(a)
+                bridge.resolve_reference_display(obj, a, ref_agg&.name)
               else
-                obj.send(a.name).to_s
+                bridge.read_attribute(obj, a.name)
               end
             }
-            { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
+            id = bridge.read_id(obj)
+            { id: id, short_id: id[0..7], show_href: "#{prefix}/#{p}/show?id=#{id}", cells: cells }
           end
-          computed = agg.computed_attributes || []
-          computed.each do |ca|
+          ir.computed_attributes(agg).each do |ca|
             items.each do |item|
-              obj = klass.find(item[:id])
-              item[:cells] << obj.instance_eval(&ca.block).to_s if obj
+              obj = bridge.find_by_id(agg.name, item[:id])
+              item[:cells] << bridge.evaluate_computed(obj, ca.block) if obj
             end
           end
-          columns = user_attrs.map { |a|
-            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
-            { label: lbl }
-          }
-          computed.each { |ca| columns << { label: "#{humanize(ca.name)} (computed)" } }
-          create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
+          columns = ir.columns_for(agg)
+          create_cmds = ir.create_commands(agg)
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
             { label: HecksTemplating::UILabelContract.label(c.name), href: "#{prefix}/#{p}/#{cm}/new", allowed: true }
@@ -80,43 +75,40 @@ module Hecks
           res.body = html
         end
 
-        def serve_show(req, res, agg, klass, safe, p, prefix, domain)
-          dc = HecksTemplating::DisplayContract
-          obj = klass.find(req.query["id"])
+        def serve_show(req, res, ir, bridge, agg, safe, p, prefix)
+          obj = bridge.find_by_id(agg.name, req.query["id"])
           unless obj
             res.status = 404; res.body = "Not found"; return
           end
-          user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+          user_attrs = ir.user_attributes(agg)
           fields = user_attrs.map { |a|
-            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
-            val = if dc.reference_attr?(a)
-              ref_agg = dc.find_referenced_aggregate(a, domain)
-              resolve_reference(obj, a, ref_agg, klass)
+            lbl = ir.field_label(a)
+            val = if ir.reference_attr?(a)
+              ref_agg = ir.find_referenced_aggregate(a)
+              bridge.resolve_reference_display(obj, a, ref_agg&.name)
             else
-              obj.send(a.name).to_s
+              bridge.read_attribute(obj, a.name)
             end
             { label: lbl, value: val }
           }
-          (agg.computed_attributes || []).each do |ca|
-            fields << { label: "#{humanize(ca.name)} (computed)", value: obj.instance_eval(&ca.block).to_s }
+          ir.computed_attributes(agg).each do |ca|
+            fields << { label: "#{Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(ca.name))} (computed)",
+                        value: bridge.evaluate_computed(obj, ca.block) }
           end
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",
-            id: obj.id, fields: fields, buttons: [])
+            id: bridge.read_id(obj), fields: fields, buttons: [])
           res["Content-Type"] = "text/html"
           res.body = html
         end
 
-        def serve_form(req, res, agg, klass, safe, p, prefix, cmd_snake)
-          cmd = agg.commands.find { |c| domain_snake_name(c.name) == cmd_snake }
+        def serve_form(req, res, ir, agg, safe, p, prefix, cmd_snake)
+          cmd = ir.find_command(agg, cmd_snake)
           unless cmd
             res.status = 404; res.body = "Command not found"; return
           end
-          fields = cmd.attributes.map do |a|
-            { type: :input, name: a.name.to_s, label: humanize(a.name),
-              input_type: "text", step: false, required: false, value: req.query[a.name.to_s] || "" }
-          end
+          fields = ir.command_fields(cmd, req.query)
           html = @renderer.render(:form,
             title: "#{cmd.name} — #{@brand}", brand: @brand, nav_items: @nav,
             command_name: HecksTemplating::UILabelContract.label(cmd.name),
@@ -126,23 +118,18 @@ module Hecks
           res.body = html
         end
 
-        def serve_submit(req, res, agg, klass, safe, p, prefix, cmd_snake)
-          cmd = agg.commands.find { |c| domain_snake_name(c.name) == cmd_snake }
+        def serve_submit(req, res, ir, bridge, agg, safe, p, prefix, cmd_snake)
+          cmd = ir.find_command(agg, cmd_snake)
           unless cmd
             res.status = 404; res.body = "Command not found"; return
           end
-          mod = klass
           params = req.query
           method_name = domain_command_method(cmd.name, agg.name)
           attrs = cmd.attributes.each_with_object({}) { |a, h| h[a.name] = params[a.name.to_s] || "" }
-          result = klass.send(method_name, **attrs)
-          id = result.respond_to?(:aggregate) ? result.aggregate.id : result.id
+          id = bridge.execute_command(agg.name, method_name, attrs)
           res.set_redirect(WEBrick::HTTPStatus::SeeOther, "#{prefix}/#{p}/show?id=#{id}")
         rescue => e
-          fields = cmd.attributes.map do |a|
-            { type: :input, name: a.name.to_s, label: humanize(a.name),
-              input_type: "text", step: false, required: false, value: params[a.name.to_s] || "" }
-          end
+          fields = ir.command_fields(cmd, params || {})
           html = @renderer.render(:form,
             title: "#{cmd.name} — #{@brand}", brand: @brand, nav_items: @nav,
             command_name: HecksTemplating::UILabelContract.label(cmd.name),
@@ -150,16 +137,6 @@ module Hecks
             error_message: e.message, fields: fields)
           res["Content-Type"] = "text/html"
           res.body = html
-        end
-        def resolve_reference(obj, attr, ref_agg, klass)
-          raw = obj.send(attr.name).to_s
-          return raw[0..7] + "..." unless ref_agg
-          ref_const = domain_constant_name(ref_agg.name)
-          mod = klass.is_a?(Module) ? klass.to_s.split("::")[0..-2].join("::") : nil
-          ref_klass = mod ? Object.const_get("#{mod}::#{ref_const}") : Object.const_get(ref_const) rescue nil
-          return raw[0..7] + "..." unless ref_klass
-          found = ref_klass.all.find { |x| x.id == raw }
-          found&.respond_to?(:name) ? found.name.to_s : raw[0..7] + "..."
         end
       end
     end

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -3,6 +3,8 @@ require "json"
 require "tmpdir"
 require_relative "route_builder"
 require "hecks/extensions/web_explorer/renderer"
+require "hecks/extensions/web_explorer/ir_introspector"
+require "hecks/extensions/web_explorer/runtime_bridge"
 require_relative "multi_domain_ui_routes"
 
 module Hecks
@@ -10,10 +12,9 @@ module Hecks
     # Hecks::HTTP::MultiDomainServer
     #
     # WEBrick server that serves multiple Hecks domains in one process.
-    # Navigation is grouped by domain. Each domain's routes are prefixed
-    # with its slug (e.g. /blog/posts, /photos/photos).
-    #
-    # Uses the same ERB views as the static Ruby and Go generators.
+    # All structural discovery (aggregates, attributes, commands, policies)
+    # comes from the Bluebook IR via IRIntrospector. Runtime access for
+    # CRUD operations is isolated behind RuntimeBridge.
     #
     #   domains = [blog_domain, photos_domain]
     #   runtimes = [blog_runtime, photos_runtime]
@@ -34,7 +35,8 @@ module Hecks
       def run
         puts "Hecks serving #{@domains.size} domains on http://localhost:#{@port}"
         @entries.each do |e|
-          puts "  #{e[:domain].name}: /#{e[:slug]}/ (#{e[:domain].aggregates.size} aggregates)"
+          ir = e[:ir]
+          puts "  #{ir.domain.name}: /#{e[:slug]}/ (#{ir.aggregate_names.size} aggregates)"
         end
         puts ""
 
@@ -52,10 +54,11 @@ module Hecks
         @domains.each_with_index do |domain, i|
           runtime = @runtimes[i]
           slug = domain_slug(domain.name)
-          mod_name = domain_module_name(domain.name)
-          mod = Object.const_get(mod_name)
+          mod = Object.const_get(domain_module_name(domain.name))
+          ir = Hecks::WebExplorer::IRIntrospector.new(domain)
+          bridge = Hecks::WebExplorer::RuntimeBridge.new(mod)
           routes = RouteBuilder.new(domain, mod).build
-          @entries << { domain: domain, runtime: runtime, mod: mod, slug: slug, routes: routes }
+          @entries << { ir: ir, bridge: bridge, runtime: runtime, slug: slug, routes: routes }
         end
 
         require "hecks/extensions/web_explorer"
@@ -69,8 +72,9 @@ module Hecks
       def build_nav
         items = [{ label: "Home", href: "/" }]
         @entries.each do |e|
-          group = HecksTemplating::UILabelContract.label(e[:domain].name)
-          e[:domain].aggregates.each do |agg|
+          ir = e[:ir]
+          group = HecksTemplating::UILabelContract.label(ir.domain.name)
+          ir.domain.aggregates.each do |agg|
             items << {
               label: HecksTemplating::UILabelContract.plural_label(agg.name),
               href: "/#{e[:slug]}/#{plural(agg)}",
@@ -111,8 +115,9 @@ module Hecks
 
       def serve_home(res)
         agg_data = @entries.flat_map do |e|
-          e[:domain].aggregates.map do |agg|
-            d = HecksTemplating::DisplayContract.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
+          ir = e[:ir]
+          ir.domain.aggregates.map do |agg|
+            d = ir.home_aggregate_data(agg, "#{e[:slug]}/#{plural(agg)}")
             { name: d[:name], href: d[:href], command_names: d[:command_names],
               attributes: d[:attributes], policies: d[:policies] }
           end
@@ -126,13 +131,14 @@ module Hecks
 
       def serve_config(res)
         summaries = @entries.flat_map do |e|
-          e[:domain].aggregates.map do |agg|
-            s = HecksTemplating::DisplayContract.aggregate_summary(agg)
+          ir = e[:ir]
+          ir.domain.aggregates.map do |agg|
+            s = ir.aggregate_summary(agg)
             { name: agg.name, commands: s[:commands], ports: s[:ports] }
           end
         end
-        policies = @entries.flat_map { |e| HecksTemplating::DisplayContract.policy_labels(e[:domain]) }
-        roles = @entries.flat_map { |e| HecksTemplating::DisplayContract.available_roles(e[:domain]) }.uniq
+        policies = @entries.flat_map { |e| e[:ir].policy_labels }
+        roles = @entries.flat_map { |e| e[:ir].available_roles }.uniq
         html = @renderer.render(:config,
           title: "Config — #{@brand}", brand: @brand, nav_items: @nav,
           aggregates: summaries, policies: policies, roles: roles,
@@ -155,10 +161,6 @@ module Hecks
 
       def plural(agg)
         domain_aggregate_slug(agg.name)
-      end
-
-      def humanize(name)
-        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(name))
       end
 
       def match?(pattern, path)

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
@@ -4,8 +4,9 @@ module Hecks
     class MultiDomainServer
       # Hecks::HTTP::MultiDomainServer::UIRoutes
       #
-      # UI route handlers for the multi-domain web explorer. Renders ERB
-      # views for index, show, form, and submit routes, scoped by domain.
+      # UI route handlers for the multi-domain web explorer. Structural
+      # discovery (columns, fields, buttons) comes from IRIntrospector.
+      # Runtime data access (find, all, execute) goes through RuntimeBridge.
       # Extracted from MultiDomainServer to stay under the 200-line limit.
       #
       module UIRoutes
@@ -13,62 +14,56 @@ module Hecks
         private
 
         def serve_ui_route(req, res, entry, sub_path)
-          domain = entry[:domain]
-          mod = entry[:mod]
+          ir = entry[:ir]
+          bridge = entry[:bridge]
           slug = entry[:slug]
 
-          agg = domain.aggregates.find { |a| sub_path.start_with?("/#{plural(a)}") }
+          agg = ir.domain.aggregates.find { |a| sub_path.start_with?("/#{plural(a)}") }
           unless agg
             res.status = 404; res.body = "Not found"; return
           end
 
           safe = domain_constant_name(agg.name)
-          klass = mod.const_get(safe)
           p = plural(agg)
           prefix = "/#{slug}"
           remaining = sub_path.sub("/#{p}", "")
 
           if remaining == "" || remaining == "/"
-            serve_index(req, res, agg, klass, safe, p, prefix, domain)
+            serve_index(req, res, ir, bridge, agg, safe, p, prefix)
           elsif remaining == "/show"
-            serve_show(req, res, agg, klass, safe, p, prefix, domain)
+            serve_show(req, res, ir, bridge, agg, safe, p, prefix)
           elsif remaining =~ /\/(\w+)\/new$/
-            serve_form(req, res, agg, klass, safe, p, prefix, $1)
+            serve_form(req, res, ir, agg, safe, p, prefix, $1)
           elsif remaining =~ /\/(\w+)\/submit$/
-            serve_submit(req, res, agg, klass, safe, p, prefix, $1)
+            serve_submit(req, res, ir, bridge, agg, safe, p, prefix, $1)
           else
             res.status = 404; res.body = "Not found"
           end
         end
 
-        def serve_index(req, res, agg, klass, safe, p, prefix, domain)
+        def serve_index(req, res, ir, bridge, agg, safe, p, prefix)
           token = ensure_csrf_cookie(req, res)
-          dc = HecksTemplating::DisplayContract
-          user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
-          items = klass.all.map do |obj|
+          user_attrs = ir.user_attributes(agg)
+          items = bridge.find_all(agg.name).map do |obj|
             cells = user_attrs.map { |a|
-              if dc.reference_attr?(a)
-                ref_agg = dc.find_referenced_aggregate(a, domain)
-                resolve_reference(obj, a, ref_agg, klass)
+              if ir.reference_attr?(a)
+                ref_agg = ir.find_referenced_aggregate(a)
+                bridge.resolve_reference_display(obj, a, ref_agg&.name)
               else
-                obj.send(a.name).to_s
+                bridge.read_attribute(obj, a.name)
               end
             }
-            { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
+            id = bridge.read_id(obj)
+            { id: id, short_id: id[0..7], show_href: "#{prefix}/#{p}/show?id=#{id}", cells: cells }
           end
-          computed = agg.computed_attributes || []
-          computed.each do |ca|
+          ir.computed_attributes(agg).each do |ca|
             items.each do |item|
-              obj = klass.find(item[:id])
-              item[:cells] << obj.instance_eval(&ca.block).to_s if obj
+              obj = bridge.find_by_id(agg.name, item[:id])
+              item[:cells] << bridge.evaluate_computed(obj, ca.block) if obj
             end
           end
-          columns = user_attrs.map { |a|
-            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
-            { label: lbl }
-          }
-          computed.each { |ca| columns << { label: "#{humanize(ca.name)} (computed)" } }
-          create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
+          columns = ir.columns_for(agg)
+          create_cmds = ir.create_commands(agg)
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
             { label: HecksTemplating::UILabelContract.label(c.name), href: "#{prefix}/#{p}/#{cm}/new", allowed: true }
@@ -81,45 +76,42 @@ module Hecks
           res.body = html
         end
 
-        def serve_show(req, res, agg, klass, safe, p, prefix, domain)
+        def serve_show(req, res, ir, bridge, agg, safe, p, prefix)
           token = ensure_csrf_cookie(req, res)
-          dc = HecksTemplating::DisplayContract
-          obj = klass.find(req.query["id"])
+          obj = bridge.find_by_id(agg.name, req.query["id"])
           unless obj
             res.status = 404; res.body = "Not found"; return
           end
-          user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+          user_attrs = ir.user_attributes(agg)
           fields = user_attrs.map { |a|
-            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
-            val = if dc.reference_attr?(a)
-              ref_agg = dc.find_referenced_aggregate(a, domain)
-              resolve_reference(obj, a, ref_agg, klass)
+            lbl = ir.field_label(a)
+            val = if ir.reference_attr?(a)
+              ref_agg = ir.find_referenced_aggregate(a)
+              bridge.resolve_reference_display(obj, a, ref_agg&.name)
             else
-              obj.send(a.name).to_s
+              bridge.read_attribute(obj, a.name)
             end
             { label: lbl, value: val }
           }
-          (agg.computed_attributes || []).each do |ca|
-            fields << { label: "#{humanize(ca.name)} (computed)", value: obj.instance_eval(&ca.block).to_s }
+          ir.computed_attributes(agg).each do |ca|
+            fields << { label: "#{Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(ca.name))} (computed)",
+                        value: bridge.evaluate_computed(obj, ca.block) }
           end
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",
-            id: obj.id, fields: fields, buttons: [], csrf_token: token)
+            id: bridge.read_id(obj), fields: fields, buttons: [], csrf_token: token)
           res["Content-Type"] = "text/html"
           res.body = html
         end
 
-        def serve_form(req, res, agg, klass, safe, p, prefix, cmd_snake)
+        def serve_form(req, res, ir, agg, safe, p, prefix, cmd_snake)
           token = ensure_csrf_cookie(req, res)
-          cmd = agg.commands.find { |c| domain_snake_name(c.name) == cmd_snake }
+          cmd = ir.find_command(agg, cmd_snake)
           unless cmd
             res.status = 404; res.body = "Command not found"; return
           end
-          fields = cmd.attributes.map do |a|
-            { type: :input, name: a.name.to_s, label: humanize(a.name),
-              input_type: "text", step: false, required: false, value: req.query[a.name.to_s] || "" }
-          end
+          fields = ir.command_fields(cmd, req.query)
           html = @renderer.render(:form,
             title: "#{cmd.name} — #{@brand}", brand: @brand, nav_items: @nav,
             command_name: HecksTemplating::UILabelContract.label(cmd.name),
@@ -129,26 +121,22 @@ module Hecks
           res.body = html
         end
 
-        def serve_submit(req, res, agg, klass, safe, p, prefix, cmd_snake)
+        def serve_submit(req, res, ir, bridge, agg, safe, p, prefix, cmd_snake)
           unless valid_csrf?(req)
             res.status = 403; res.body = "Forbidden: CSRF token mismatch"; return
           end
-          cmd = agg.commands.find { |c| domain_snake_name(c.name) == cmd_snake }
+          cmd = ir.find_command(agg, cmd_snake)
           unless cmd
             res.status = 404; res.body = "Command not found"; return
           end
           params = req.query
           method_name = domain_command_method(cmd.name, agg.name)
           attrs = cmd.attributes.each_with_object({}) { |a, h| h[a.name] = params[a.name.to_s] || "" }
-          result = klass.send(method_name, **attrs)
-          id = result.respond_to?(:aggregate) ? result.aggregate.id : result.id
+          id = bridge.execute_command(agg.name, method_name, attrs)
           res.set_redirect(WEBrick::HTTPStatus::SeeOther, "#{prefix}/#{p}/show?id=#{id}")
         rescue => e
           token = read_csrf_cookie(req)
-          fields = cmd.attributes.map do |a|
-            { type: :input, name: a.name.to_s, label: humanize(a.name),
-              input_type: "text", step: false, required: false, value: params[a.name.to_s] || "" }
-          end
+          fields = ir.command_fields(cmd, params || {})
           html = @renderer.render(:form,
             title: "#{cmd.name} — #{@brand}", brand: @brand, nav_items: @nav,
             command_name: HecksTemplating::UILabelContract.label(cmd.name),
@@ -177,17 +165,6 @@ module Hecks
           cookie_val = read_csrf_cookie(req)
           form_val = req.query[Hecks::Conventions::CsrfContract::FIELD_NAME]
           Hecks::Conventions::CsrfContract.valid?(cookie_val, form_val)
-        end
-
-        def resolve_reference(obj, attr, ref_agg, klass)
-          raw = obj.send(attr.name).to_s
-          return raw[0..7] + "..." unless ref_agg
-          ref_const = domain_constant_name(ref_agg.name)
-          mod = klass.is_a?(Module) ? klass.to_s.split("::")[0..-2].join("::") : nil
-          ref_klass = mod ? Object.const_get("#{mod}::#{ref_const}") : Object.const_get(ref_const) rescue nil
-          return raw[0..7] + "..." unless ref_klass
-          found = ref_klass.all.find { |x| x.id == raw }
-          found&.respond_to?(:name) ? found.name.to_s : raw[0..7] + "..."
         end
       end
     end

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -1,0 +1,110 @@
+# Hecks::WebExplorer::IRIntrospector
+#
+# Provides structural queries from the Bluebook IR for the Web Explorer.
+# All aggregate names, attribute definitions, command fields, lifecycle
+# states, policies, and reference targets come from the IR -- not from
+# runtime object inspection.
+#
+#   ir = IRIntrospector.new(domain)
+#   ir.aggregate_names          # => ["Pizza", "Order"]
+#   ir.user_attributes("Pizza") # => [<Attribute name: ...>, ...]
+#   ir.columns_for("Pizza")     # => [{ label: "Name" }, ...]
+#   ir.command_fields(cmd)      # => [{ name: "name", label: "Name", ... }]
+#
+module Hecks
+  module WebExplorer
+    class IRIntrospector
+      include HecksTemplating::NamingHelpers
+
+      attr_reader :domain
+
+      def initialize(domain)
+        @domain = domain
+      end
+
+      def aggregate_names
+        @domain.aggregates.map(&:name)
+      end
+
+      def find_aggregate(name)
+        @domain.aggregates.find { |a| a.name == name }
+      end
+
+      def find_aggregate_by_slug(slug)
+        @domain.aggregates.find { |a| domain_aggregate_slug(a.name) == slug }
+      end
+
+      def user_attributes(agg)
+        agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+      end
+
+      def computed_attributes(agg)
+        agg.computed_attributes || []
+      end
+
+      def columns_for(agg)
+        dc = HecksTemplating::DisplayContract
+        cols = user_attributes(agg).map { |a|
+          lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+          { label: lbl }
+        }
+        computed_attributes(agg).each { |ca| cols << { label: "#{humanize(ca.name)} (computed)" } }
+        cols
+      end
+
+      def create_commands(agg)
+        agg.commands.select { |c| c.name.start_with?("Create") }
+      end
+
+      def find_command(agg, cmd_snake)
+        agg.commands.find { |c| domain_snake_name(c.name) == cmd_snake }
+      end
+
+      def command_fields(cmd, params = {})
+        cmd.attributes.map do |a|
+          { type: :input, name: a.name.to_s, label: humanize(a.name),
+            input_type: "text", step: false, required: false,
+            value: params[a.name.to_s] || "" }
+        end
+      end
+
+      def reference_attr?(attr)
+        HecksTemplating::DisplayContract.reference_attr?(attr)
+      end
+
+      def find_referenced_aggregate(attr)
+        HecksTemplating::DisplayContract.find_referenced_aggregate(attr, @domain)
+      end
+
+      def field_label(attr)
+        if reference_attr?(attr)
+          HecksTemplating::DisplayContract.reference_column_label(attr)
+        else
+          humanize(attr.name)
+        end
+      end
+
+      def home_aggregate_data(agg, plural_slug)
+        HecksTemplating::DisplayContract.home_aggregate_data(agg, plural_slug)
+      end
+
+      def aggregate_summary(agg)
+        HecksTemplating::DisplayContract.aggregate_summary(agg)
+      end
+
+      def policy_labels
+        HecksTemplating::DisplayContract.policy_labels(@domain)
+      end
+
+      def available_roles
+        HecksTemplating::DisplayContract.available_roles(@domain)
+      end
+
+      private
+
+      def humanize(name)
+        Hecks::Utils.humanize(Hecks::Utils.sanitize_constant(name))
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
@@ -1,0 +1,78 @@
+# Hecks::WebExplorer::RuntimeBridge
+#
+# Isolates all runtime CRUD access behind a clean interface. The Web
+# Explorer uses this bridge for data operations (find, all, create)
+# while getting all structural information from the IRIntrospector.
+# This eliminates Object.const_get, respond_to?, and dynamic dispatch
+# from the UI layer.
+#
+#   bridge = RuntimeBridge.new(mod)
+#   bridge.find_all("Pizza")            # => [obj, ...]
+#   bridge.find_by_id("Pizza", id)      # => obj or nil
+#   bridge.execute_command("Pizza", :create, name: "Margherita")
+#
+module Hecks
+  module WebExplorer
+    class RuntimeBridge
+      include HecksTemplating::NamingHelpers
+
+      def initialize(mod)
+        @mod = mod
+      end
+
+      def find_all(agg_name)
+        klass_for(agg_name).all
+      end
+
+      def find_by_id(agg_name, id)
+        klass_for(agg_name).find(id)
+      end
+
+      def execute_command(agg_name, method_name, attrs)
+        result = klass_for(agg_name).send(method_name, **attrs)
+        extract_id(result)
+      end
+
+      def read_attribute(obj, attr_name)
+        obj.send(attr_name).to_s
+      end
+
+      def read_id(obj)
+        obj.id
+      end
+
+      def evaluate_computed(obj, block)
+        obj.instance_eval(&block).to_s
+      end
+
+      def resolve_reference_display(obj, attr, ref_agg_name)
+        raw = obj.send(attr.name).to_s
+        return truncate_id(raw) unless ref_agg_name
+        ref_klass = klass_for(ref_agg_name)
+        found = ref_klass.all.find { |x| x.id == raw }
+        found&.respond_to?(:name) ? found.name.to_s : truncate_id(raw)
+      rescue NameError
+        truncate_id(raw)
+      end
+
+      private
+
+      def klass_for(agg_name)
+        safe = domain_constant_name(agg_name)
+        @mod.const_get(safe)
+      end
+
+      def extract_id(result)
+        if result.respond_to?(:aggregate)
+          result.aggregate.id
+        else
+          result.id
+        end
+      end
+
+      def truncate_id(raw)
+        raw[0..7] + "..."
+      end
+    end
+  end
+end

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -1,0 +1,138 @@
+require "spec_helper"
+require "hecks/extensions/web_explorer/ir_introspector"
+require "hecks/extensions/web_explorer/runtime_bridge"
+
+RSpec.describe "Web Explorer IR introspection" do
+  let(:domain) { BootedDomains.pizzas }
+  let(:ir) { Hecks::WebExplorer::IRIntrospector.new(domain) }
+
+  describe Hecks::WebExplorer::IRIntrospector do
+    it "returns aggregate names from the IR" do
+      expect(ir.aggregate_names).to eq(["Pizza", "Order"])
+    end
+
+    it "finds an aggregate by name" do
+      agg = ir.find_aggregate("Pizza")
+      expect(agg).not_to be_nil
+      expect(agg.name).to eq("Pizza")
+    end
+
+    it "returns user attributes (excludes reserved)" do
+      agg = ir.find_aggregate("Pizza")
+      names = ir.user_attributes(agg).map(&:name)
+      expect(names).to include(:name, :style)
+      expect(names).not_to include(:id, :created_at, :updated_at)
+    end
+
+    it "returns columns from IR attribute definitions" do
+      agg = ir.find_aggregate("Pizza")
+      columns = ir.columns_for(agg)
+      labels = columns.map { |c| c[:label] }
+      expect(labels).to include("Name", "Style", "Description")
+    end
+
+    it "returns create commands from the IR" do
+      agg = ir.find_aggregate("Pizza")
+      cmds = ir.create_commands(agg)
+      expect(cmds.map(&:name)).to eq(["CreatePizza"])
+    end
+
+    it "finds a command by snake name" do
+      agg = ir.find_aggregate("Pizza")
+      cmd = ir.find_command(agg, "create_pizza")
+      expect(cmd).not_to be_nil
+      expect(cmd.name).to eq("CreatePizza")
+    end
+
+    it "builds command form fields from IR command attributes" do
+      agg = ir.find_aggregate("Pizza")
+      cmd = ir.find_command(agg, "create_pizza")
+      fields = ir.command_fields(cmd)
+      names = fields.map { |f| f[:name] }
+      expect(names).to include("name", "style", "description", "price")
+    end
+
+    it "pre-fills command fields from params" do
+      agg = ir.find_aggregate("Pizza")
+      cmd = ir.find_command(agg, "create_pizza")
+      fields = ir.command_fields(cmd, { "name" => "Margherita" })
+      name_field = fields.find { |f| f[:name] == "name" }
+      expect(name_field[:value]).to eq("Margherita")
+    end
+
+    it "detects reference attributes via IR" do
+      attr_class = Hecks::DomainModel::Structure::Attribute
+      ref_attr = attr_class.new(name: :pizza_id, type: String)
+      expect(ir.reference_attr?(ref_attr)).to be true
+    end
+
+    it "finds referenced aggregate by IR lookup" do
+      attr_class = Hecks::DomainModel::Structure::Attribute
+      ref_attr = attr_class.new(name: :pizza_id, type: String)
+      ref = ir.find_referenced_aggregate(ref_attr)
+      expect(ref).not_to be_nil
+      expect(ref.name).to eq("Pizza")
+    end
+
+    it "returns policy labels from the IR" do
+      labels = ir.policy_labels
+      expect(labels).to include("PlacedOrder \u2192 ReserveIngredients")
+    end
+
+    it "returns available roles from the IR" do
+      roles = ir.available_roles
+      expect(roles).to be_an(Array)
+      expect(roles).not_to be_empty
+    end
+
+    it "builds home aggregate data from the IR" do
+      agg = ir.find_aggregate("Pizza")
+      data = ir.home_aggregate_data(agg, "pizzas")
+      expect(data[:name]).to eq("Pizzas")
+      expect(data[:command_names]).to include("Create Pizza")
+      expect(data[:attributes]).to be_a(Integer)
+    end
+  end
+
+  describe Hecks::WebExplorer::RuntimeBridge do
+    let(:bridge_domain) do
+      Hecks.domain "BridgeTest" do
+        aggregate "Widget" do
+          attribute :label, String
+          command "CreateWidget" do
+            attribute :label, String
+          end
+        end
+      end
+    end
+    let(:bridge_mod) { Hecks.load(bridge_domain); BridgeTestDomain }
+    let(:bridge) { Hecks::WebExplorer::RuntimeBridge.new(bridge_mod) }
+
+    it "finds all records via the bridge" do
+      bridge.execute_command("Widget", :create, { label: "A" })
+      all = bridge.find_all("Widget")
+      expect(all).not_to be_empty
+    end
+
+    it "finds a record by id via the bridge" do
+      id = bridge.execute_command("Widget", :create, { label: "Lookup" })
+      obj = bridge.find_by_id("Widget", id)
+      expect(obj).not_to be_nil
+      expect(bridge.read_attribute(obj, :label)).to eq("Lookup")
+    end
+
+    it "executes commands and returns the id" do
+      id = bridge.execute_command("Widget", :create, { label: "Exec" })
+      expect(id).to be_a(String)
+      expect(id).not_to be_empty
+    end
+
+    it "does not expose Object.const_get to the UI layer" do
+      # RuntimeBridge encapsulates const_get internally -- the UI never
+      # resolves module constants directly
+      expect(bridge).to respond_to(:find_all)
+      expect(bridge).to respond_to(:find_by_id)
+      expect(bridge).not_to respond_to(:klass_for)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces `IRIntrospector` for all structural queries (aggregate names, attributes, columns, commands, policies, roles) from the Bluebook IR
- Introduces `RuntimeBridge` to isolate CRUD data operations (find, all, execute) behind a clean interface
- Refactors both `hecksties` and `hecks_workshop` multi-domain server and UI routes to use IR + bridge instead of `Object.const_get`, `respond_to?`, and `klass.to_s.split("::").join`

## Problem

The Web Explorer reached directly into runtime/domain objects for structural discovery — resolving module constants via `Object.const_get`, inspecting class hierarchies with `klass.to_s.split("::")`, and using `respond_to?` for type checking. This was a "hexagonal impurity": the same structural information was already available in the Bluebook IR that all generators consume.

## Before/After

**Before** — UI routes resolved runtime classes and used them for structural queries:
```ruby
# multi_domain_ui_routes.rb (before)
klass = mod.const_get(safe)
user_attrs = agg.attributes.reject { ... }
items = klass.all.map { |obj| obj.send(a.name).to_s }
columns = user_attrs.map { |a| dc.reference_attr?(a) ? ... : humanize(a.name) }
```

**After** — structural queries go through IRIntrospector, data operations through RuntimeBridge:
```ruby
# multi_domain_ui_routes.rb (after)
user_attrs = ir.user_attributes(agg)
columns = ir.columns_for(agg)
items = bridge.find_all(agg.name).map { |obj| bridge.read_attribute(obj, a.name) }
```

**Before** — reference resolution introspected module hierarchy:
```ruby
# resolve_reference (before)
mod = klass.is_a?(Module) ? klass.to_s.split("::")[0..-2].join("::") : nil
ref_klass = Object.const_get("#{mod}::#{ref_const}") rescue nil
```

**After** — RuntimeBridge encapsulates all const resolution:
```ruby
# RuntimeBridge#resolve_reference_display
ref_klass = klass_for(ref_agg_name)  # internal, not exposed to UI
```

## Test plan

- [x] IRIntrospector returns aggregate names from the IR
- [x] IRIntrospector returns user attributes (excludes reserved)
- [x] IRIntrospector returns columns from IR attribute definitions
- [x] IRIntrospector returns create commands from the IR
- [x] IRIntrospector builds command form fields from IR command attributes
- [x] IRIntrospector detects reference attributes via IR
- [x] IRIntrospector finds referenced aggregate by IR lookup
- [x] IRIntrospector returns policy labels from the IR
- [x] RuntimeBridge finds all records via the bridge
- [x] RuntimeBridge finds a record by id via the bridge
- [x] RuntimeBridge executes commands and returns the id
- [x] RuntimeBridge does not expose Object.const_get to the UI layer
- [x] Full suite passes (1395 examples, 0 failures)
- [x] Smoke test passes