### PR TITLE
HEC-193: `gems only:` / `gems except:` in configure block

### DIFF
--- a/hecks_on_rails/lib/active_hecks/generators/init_generator.rb
+++ b/hecks_on_rails/lib/active_hecks/generators/init_generator.rb
@@ -37,6 +37,9 @@ module ActiveHecks
 
       create_file "config/initializers/hecks.rb", <<~RUBY
         Hecks.configure do
+          # Optional: control which extension gems are required at boot.
+          # gems only: [:audit, :logging]   # require only these
+          # gems except: [:pii]             # skip from the default AUTO list
           domain "#{@gem_name}"
           adapter :memory
         end

--- a/hecksties/lib/hecks/runtime/configuration.rb
+++ b/hecksties/lib/hecks/runtime/configuration.rb
@@ -10,9 +10,11 @@ module Hecks
   #
   # Wires Hecks into an application. Supports single or multiple domains with
   # pluggable adapters (memory or SQL). Extensions can be auto-wired or
-  # explicitly declared.
+  # explicitly declared. Use the +gems+ DSL to control which extension gems
+  # are required at boot.
   #
   #   Hecks.configure do
+  #     gems only: [:audit, :logging]   # require only these
   #     domain "pizzas_domain"
   #     adapter :sqlite
   #     extension :http, port: 9292
@@ -35,6 +37,19 @@ module Hecks
       @ad_hoc_queries = false
       @extensions = {}
       @extensions_explicit = false
+      @gem_overrides = nil
+      @extensions_loaded = false
+    end
+
+    # Control which extension gems are required at boot.
+    #
+    # @param only [Array<Symbol>, nil] if provided, require only these gems
+    # @param except [Array<Symbol>] gems to skip from the AUTO list
+    #
+    #   gems only: [:audit, :logging]   # require only these
+    #   gems except: [:pii]             # skip pii from the AUTO list
+    def gems(only: nil, except: [])
+      @gem_overrides = { only: only&.map(&:to_sym), except: except.map(&:to_sym) }
     end
 
     # Register a domain gem to load at boot time.
@@ -73,11 +88,10 @@ module Hecks
     # @param only [Array<Symbol>, nil] if provided, only enable these
     def auto_wire(except: [], only: nil)
       @extensions_explicit = true
-      require_relative "load_extensions"
-      LoadExtensions.require_auto
+      require_extensions
 
       Hecks.extension_registry.each_key do |name|
-        next if Boot::PERSISTENCE_EXTENSIONS.include?(name)
+        next if Hecks.adapter?(name)
         next if except.map(&:to_sym).include?(name)
         next if only && !only.map(&:to_sym).include?(name)
         meta = Hecks.extension_meta[name]
@@ -105,6 +119,7 @@ module Hecks
 
     # Boot all registered domains, wire adapters and extensions.
     def boot!
+      require_extensions
       @shared_event_bus = EventBus.new
       @db = connect_database if @adapter_type == :sql
       @declarations = build_declarations
@@ -117,6 +132,22 @@ module Hecks
     def app = @apps.values.first
 
     private
+
+    # Require extension gems according to @gem_overrides, idempotently.
+    def require_extensions
+      return if @extensions_loaded
+
+      @extensions_loaded = true
+      require_relative "load_extensions"
+
+      if @gem_overrides.nil?
+        LoadExtensions.require_auto
+      elsif @gem_overrides[:only]
+        @gem_overrides[:only].each { |name| LoadExtensions.require_one(name) }
+      else
+        (LoadExtensions::AUTO - @gem_overrides[:except]).each { |name| LoadExtensions.require_one(name) }
+      end
+    end
 
     def build_declarations
       @domains.each_with_object({}) do |d, decl|

--- a/hecksties/spec/runtime/configuration_spec.rb
+++ b/hecksties/spec/runtime/configuration_spec.rb
@@ -59,4 +59,44 @@ RSpec.describe Hecks::Configuration do
       expect(custom_bus.events.size).to eq(1)
     end
   end
+
+  describe "gems DSL — extension gem loading" do
+    let(:config) { Hecks::Configuration.new }
+    let(:loaded) { [] }
+
+    before do
+      require "hecks/runtime/load_extensions"
+      allow(Hecks::LoadExtensions).to receive(:require_one) { |name| loaded << name }
+    end
+
+    it "gems only: loads exactly the specified gems" do
+      config.gems(only: [:audit, :logging])
+      config.send(:require_extensions)
+
+      expect(loaded).to contain_exactly(:audit, :logging)
+    end
+
+    it "gems except: skips excluded gems and loads the rest of AUTO" do
+      config.gems(except: [:pii])
+      config.send(:require_extensions)
+
+      expect(loaded).not_to include(:pii)
+      expect(loaded).to include(*Hecks::LoadExtensions::AUTO - [:pii])
+    end
+
+    it "default behavior loads the full AUTO list when no gems call is made" do
+      allow(Hecks::LoadExtensions).to receive(:require_auto)
+      config.send(:require_extensions)
+
+      expect(Hecks::LoadExtensions).to have_received(:require_auto).once
+    end
+
+    it "boot! is idempotent — calling require_extensions twice does not double-load" do
+      config.gems(only: [:audit])
+      config.send(:require_extensions)
+      config.send(:require_extensions)
+
+      expect(loaded).to eq([:audit])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a `gems` DSL method to `Hecks::Configuration` to control which extension gems are required at boot, supporting `only:` and `except:` modes
- Fixes a `NameError` bug in `auto_wire` where `Boot::PERSISTENCE_EXTENSIONS` was referenced (undefined constant) — replaced with `Hecks.adapter?(name)` which is the correct runtime check
- Extension loading is now idempotent via an `@extensions_loaded` flag, preventing double-requiring on repeated `boot!` calls
- Rails generator template (`config/initializers/hecks.rb`) updated with commented `gems` examples

## DSL usage

```ruby
# Require only specific extension gems:
Hecks.configure do
  gems only: [:audit, :logging]
  domain "my_domain"
  adapter :memory
end

# Skip specific gems from the default AUTO list:
Hecks.configure do
  gems except: [:pii]
  domain "my_domain"
  adapter :sqlite
end

# Default — no gems call — loads the full AUTO list (unchanged behaviour):
Hecks.configure do
  domain "my_domain"
  adapter :memory
end
```

## Test plan

- [ ] `bundle exec rspec hecksties/spec/runtime/configuration_spec.rb` — 4 new specs + existing 1472 pass
- [ ] Full suite under 1 second
- [ ] `gems only:` loads exactly the listed gems
- [ ] `gems except:` skips excluded gems, loads the rest of AUTO
- [ ] Default (no `gems` call) still calls `require_auto`
- [ ] Idempotency: `require_extensions` called twice only loads once