### PR TITLE
HEC-443: Reference authorizer fail-open — raise ConfigurationError at boot

### DIFF
--- a/examples/pizzas/PizzasBluebook
+++ b/examples/pizzas/PizzasBluebook
@@ -26,7 +26,7 @@ Hecks.domain "Pizzas" do
     end
 
     command "AddTopping" do
-      reference_to "Pizza"
+      reference_to "Pizza", validate: :exists
       attribute :name, String
       attribute :amount, Integer
     end
@@ -53,12 +53,12 @@ Hecks.domain "Pizzas" do
 
     command "PlaceOrder" do
       attribute :customer_name, String
-      reference_to "Pizza"
+      reference_to "Pizza", validate: :exists
       attribute :quantity, Integer
     end
 
     command "CancelOrder" do
-      reference_to "Order"
+      reference_to "Order", validate: :exists
     end
 
     query "Pending" do

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -12,6 +12,7 @@ require_relative "runtime/constant_hoisting"
 require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
 require_relative "runtime/auth_coverage_check"
+require_relative "runtime/reference_authorizer_check"
 
 module Hecks
   # Hecks::Runtime
@@ -60,6 +61,7 @@ module Hecks
       include ConstantHoisting
       include ConnectionSetup
       include AuthCoverageCheck
+      include ReferenceCoverageCheck
       include SagaSetup
 
       # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -101,6 +101,7 @@ module Hecks
       end
 
       runtime.check_auth_coverage!
+      runtime.check_reference_coverage!
     end
 
     def autoload_services(dir)

--- a/hecksties/lib/hecks/runtime/reference_authorizer_check.rb
+++ b/hecksties/lib/hecks/runtime/reference_authorizer_check.rb
@@ -1,0 +1,84 @@
+# Hecks::Runtime::ReferenceCoverageCheck
+#
+# Validates that domains declaring reference_to with validate: true (the default)
+# on commands have a reference_authorizer registered. Raises +ConfigurationError+
+# at boot when references need authorization checks but no authorizer is wired,
+# preventing silent IDOR vulnerabilities.
+#
+#   # Automatically called after extensions fire during Hecks.boot
+#   # To opt out, use validate: :exists or validate: false on the reference:
+#   reference_to "Pizza", validate: :exists
+#   reference_to "Pizza", validate: false
+#
+module Hecks
+  class Runtime
+    module ReferenceCoverageCheck
+      # Scans the domain IR for commands with reference_to declarations that
+      # require authorization (validate: true, the default) and verifies that
+      # reference_authorizer is set on the corresponding command class.
+      #
+      # Raises +Hecks::ConfigurationError+ if authorization-required references
+      # exist but no reference_authorizer is registered on the command class.
+      #
+      # @return [void]
+      # @raise [Hecks::ConfigurationError] when auth-required references have no authorizer
+      def check_reference_coverage!
+        unprotected = unprotected_reference_commands
+        return if unprotected.empty?
+
+        names = unprotected.map { |agg, cmd| "#{agg.name}##{cmd.name}" }.join(", ")
+        count = unprotected.size
+        raise Hecks::ConfigurationError,
+          "Domain '#{@domain.name}' declares reference_to with validate: true on " \
+          "#{count} command#{'s' unless count == 1} (#{names}) but no " \
+          "reference_authorizer is registered. Set reference_authorizer on the " \
+          "command class, or use validate: :exists or validate: false to opt out."
+      end
+
+      private
+
+      # Collects all [aggregate, command] pairs where a command has at least one
+      # reference_to with validate: true and no reference_authorizer set.
+      #
+      # @return [Array<[DomainModel::Structure::Aggregate, DomainModel::Behavior::Command]>]
+      def unprotected_reference_commands
+        @domain.aggregates.flat_map do |agg|
+          agg.commands.select do |cmd|
+            has_auth_required_reference?(cmd) && !authorizer_set?(agg, cmd)
+          end.map { |cmd| [agg, cmd] }
+        end
+      end
+
+      # Returns true if the command has at least one reference with validate: true.
+      #
+      # @param cmd [DomainModel::Behavior::Command]
+      # @return [Boolean]
+      def has_auth_required_reference?(cmd)
+        cmd.references.any? { |ref| ref.validate == true }
+      end
+
+      # Returns true if the resolved command class has a reference_authorizer set.
+      #
+      # @param agg [DomainModel::Structure::Aggregate]
+      # @param cmd [DomainModel::Behavior::Command]
+      # @return [Boolean]
+      def authorizer_set?(agg, cmd)
+        cmd_class = resolve_command_class(agg, cmd)
+        return false unless cmd_class
+        !cmd_class.reference_authorizer.nil?
+      end
+
+      # Resolves the Ruby command class from the domain module for a given
+      # aggregate/command pair.
+      #
+      # @param agg [DomainModel::Structure::Aggregate]
+      # @param cmd [DomainModel::Behavior::Command]
+      # @return [Class, nil]
+      def resolve_command_class(agg, cmd)
+        @mod.const_get("#{agg.name}::Commands::#{cmd.name}")
+      rescue NameError
+        nil
+      end
+    end
+  end
+end

--- a/hecksties/spec/runtime/boot_sql_spec.rb
+++ b/hecksties/spec/runtime/boot_sql_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Hecks.boot with SQL adapter" do
           reference_to "Owner"
           attribute :price, Float
           command "CreateProduct" do
-            reference_to "Owner"
+            reference_to "Owner", validate: :exists
             attribute :price, Float
           end
         end

--- a/hecksties/spec/runtime/reference_authorizer_check_spec.rb
+++ b/hecksties/spec/runtime/reference_authorizer_check_spec.rb
@@ -1,0 +1,144 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Runtime::ReferenceCoverageCheck do
+  after { Hecks::Utils.cleanup_constants! }
+
+  context "reference_to with default validate:true and no authorizer" do
+    let(:domain) do
+      Hecks.domain "RefCovNone" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+
+        aggregate "Order" do
+          attribute :quantity, Integer
+
+          command "PlaceOrder" do
+            reference_to "Pizza"
+            attribute :quantity, Integer
+          end
+        end
+      end
+    end
+
+    it "raises ConfigurationError naming the unprotected command" do
+      app = Hecks.load(domain)
+      expect { app.check_reference_coverage! }.to raise_error(
+        Hecks::ConfigurationError,
+        /Domain 'RefCovNone' declares reference_to with validate: true on 1 command \(Order#PlaceOrder\)/
+      )
+    end
+  end
+
+  context "reference_to with authorizer registered" do
+    let(:domain) do
+      Hecks.domain "RefCovWith" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+
+        aggregate "Order" do
+          attribute :quantity, Integer
+
+          command "PlaceOrder" do
+            reference_to "Pizza"
+            attribute :quantity, Integer
+          end
+        end
+      end
+    end
+
+    it "boots normally when reference_authorizer is set" do
+      app = Hecks.load(domain)
+      cmd_class = RefCovWithDomain::Order::Commands::PlaceOrder
+      cmd_class.reference_authorizer = ->(_ref, _record, _cmd) { true }
+
+      expect { app.check_reference_coverage! }.not_to raise_error
+
+      cmd_class.reference_authorizer = nil
+    end
+  end
+
+  context "reference_to with validate: :exists and no authorizer" do
+    let(:domain) do
+      Hecks.domain "RefCovExists" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+
+        aggregate "Order" do
+          attribute :quantity, Integer
+
+          command "VerifyStock" do
+            reference_to "Pizza", validate: :exists
+            attribute :quantity, Integer
+          end
+        end
+      end
+    end
+
+    it "boots normally — existence-only check needs no authorizer" do
+      app = Hecks.load(domain)
+      expect { app.check_reference_coverage! }.not_to raise_error
+    end
+  end
+
+  context "reference_to with validate: false and no authorizer" do
+    let(:domain) do
+      Hecks.domain "RefCovFalse" do
+        aggregate "Pizza" do
+          attribute :name, String
+
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+
+        aggregate "Order" do
+          attribute :quantity, Integer
+
+          command "DispatchOrder" do
+            reference_to "Pizza", validate: false
+            attribute :quantity, Integer
+          end
+        end
+      end
+    end
+
+    it "boots normally — validation disabled, no authorizer required" do
+      app = Hecks.load(domain)
+      expect { app.check_reference_coverage! }.not_to raise_error
+    end
+  end
+
+  context "no references at all" do
+    let(:domain) do
+      Hecks.domain "RefCovClean" do
+        aggregate "Widget" do
+          attribute :name, String
+
+          command "Create" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "boots normally" do
+      app = Hecks.load(domain)
+      expect { app.check_reference_coverage! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `ReferenceCoverageCheck` module to `Hecks::Runtime` that scans the domain IR at boot for commands with `reference_to(validate: true)` (the default) and raises `Hecks::ConfigurationError` if no `reference_authorizer` is registered
- Wires the check into `fire_extensions` in `Boot`, running immediately after `check_auth_coverage!`
- Adds 5-case spec covering: missing authorizer, authorizer present, `validate: :exists`, `validate: false`, and no references at all
- Fixes `boot_sql_spec` to use `validate: :exists` on a persistence-focused test that was silently skipping authorization

## Before (silent IDOR gap)

```ruby
Hecks.domain "Pizzas" do
  aggregate "Order" do
    command "PlaceOrder" do
      reference_to "Pizza"   # validate: true by default
      attribute :quantity, Integer
    end
  end
end

Hecks.boot(__dir__)   # boots fine — IDOR check silently skipped
```

## After (fail-open at boot)

```ruby
Hecks.boot(__dir__)
# => Hecks::ConfigurationError:
#      Domain 'Pizzas' declares reference_to with validate: true on 1 command
#      (Order#PlaceOrder) but no reference_authorizer is registered.
#      Set reference_authorizer on the command class, or use validate: :exists
#      or validate: false to opt out.
```

**To opt out explicitly:**

```ruby
reference_to "Pizza", validate: :exists   # existence check only, no authz needed
reference_to "Pizza", validate: false     # skip all validation (eventual consistency)
```