### PR TITLE
HEC-433: DispatchContract — runtime whitelist preventing arbitrary .send() dispatch

### DIFF
--- a/hecksties/lib/hecks/conventions.rb
+++ b/hecksties/lib/hecks/conventions.rb
@@ -51,4 +51,5 @@ module Hecks
   Contracts.register(:ui_labels,  Conventions::UILabelContract)
   Contracts.register(:commands,   Conventions::CommandContract)
   Contracts.register(:routes,     Conventions::RouteContract)
+  Contracts.register(:dispatch,   Conventions::DispatchContract)
 end

--- a/hecksties/lib/hecks/conventions/dispatch_contract.rb
+++ b/hecksties/lib/hecks/conventions/dispatch_contract.rb
@@ -1,0 +1,58 @@
+# = Hecks::Conventions::DispatchContract
+#
+# Runtime whitelist for .send() dispatch. Prevents arbitrary method
+# invocation by validating that the target method is declared in the
+# domain IR (commands, queries) or is a known CRUD builtin.
+#
+# Build the whitelist once at server boot, then validate every dispatch site.
+#
+#   whitelist = DispatchContract.build_whitelist(domain)
+#   DispatchContract.validate!(whitelist, "Pizza", :create)  # => passes
+#   DispatchContract.validate!(whitelist, "Pizza", :eval)    # => raises DispatchNotAllowed
+#
+module Hecks::Conventions
+  module DispatchContract
+    # Standard CRUD methods present on every generated aggregate class.
+    CRUD_BUILTINS = %i[all find delete count update create].freeze
+
+    # Raised when a dispatch target is not in the whitelist.
+    class DispatchNotAllowed < SecurityError
+      def initialize(agg_name, method_name)
+        super("Dispatch not allowed: #{agg_name}##{method_name} is not a declared command, query, or CRUD builtin")
+      end
+    end
+
+    # Build a whitelist from a domain IR.
+    #
+    # Keys are aggregate names (String), values are Sets of allowed method
+    # Symbols (derived commands + queries + CRUD builtins).
+    #
+    # @param domain [Hecks::Domain] the parsed domain definition
+    # @return [Hash{String => Set<Symbol>}] allowed methods per aggregate
+    def self.build_whitelist(domain)
+      domain.aggregates.each_with_object({}) do |agg, wl|
+        allowed = Set.new(CRUD_BUILTINS)
+        agg.commands.each do |cmd|
+          allowed << Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name)
+        end
+        agg.queries.each do |query|
+          allowed << Hecks::Conventions::Names.domain_snake_name(query.name).to_sym
+        end
+        wl[agg.name.to_s] = allowed
+      end
+    end
+
+    # Validate that a dispatch is allowed.
+    #
+    # @param whitelist [Hash{String => Set<Symbol>}] built by build_whitelist
+    # @param agg_name [String, Symbol] aggregate name
+    # @param method_name [Symbol, String] the method to be dispatched
+    # @raise [DispatchNotAllowed] if the method is not in the whitelist
+    # @return [void]
+    def self.validate!(whitelist, agg_name, method_name)
+      allowed = whitelist[agg_name.to_s]
+      raise DispatchNotAllowed.new(agg_name, method_name) unless allowed
+      raise DispatchNotAllowed.new(agg_name, method_name) unless allowed.include?(method_name.to_sym)
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -56,7 +56,8 @@ module Hecks
           slug = domain_slug(domain.name)
           mod = Object.const_get(domain_module_name(domain.name))
           ir = Hecks::WebExplorer::IRIntrospector.new(domain)
-          bridge = Hecks::WebExplorer::RuntimeBridge.new(mod)
+          whitelist = Hecks::Conventions::DispatchContract.build_whitelist(domain)
+          bridge = Hecks::WebExplorer::RuntimeBridge.new(mod, whitelist: whitelist)
           routes = RouteBuilder.new(domain, mod).build
           @entries << { ir: ir, bridge: bridge, runtime: runtime, slug: slug, routes: routes }
         end

--- a/hecksties/lib/hecks/extensions/serve/route_builder.rb
+++ b/hecksties/lib/hecks/extensions/serve/route_builder.rb
@@ -25,6 +25,7 @@ module Hecks
       def initialize(domain, mod)
         @domain = domain
         @mod = mod
+        @whitelist = Hecks::Conventions::DispatchContract.build_whitelist(domain)
       end
 
       # Build and return an array of route hashes for all aggregates.
@@ -72,6 +73,7 @@ module Hecks
         create_cmd = agg.commands.find { |c| c.name.start_with?("Create") }
         if create_cmd
           m = derive_method(create_cmd.name, agg.name)
+          Hecks::Conventions::DispatchContract.validate!(@whitelist, agg.name, m)
           routes << { method: "POST", path: "/#{slug}", handler: ->(req) {
             serialize(klass.send(m, **parse_body(req)))
           }}
@@ -104,6 +106,7 @@ module Hecks
       def query_routes(agg, klass, slug)
         agg.queries.map do |query|
           qn = domain_snake_name(query.name)
+          Hecks::Conventions::DispatchContract.validate!(@whitelist, agg.name, qn.to_sym)
           params = query.block.parameters
           { method: "GET", path: "/#{slug}/#{qn}", handler: ->(req) {
             results = params.empty? ? klass.send(qn.to_sym) : klass.send(qn.to_sym, *params.map { |_, n| req.params[n.to_s] })

--- a/hecksties/lib/hecks/extensions/serve/rpc_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/rpc_server.rb
@@ -37,6 +37,7 @@ module Hecks
         @port = port
         @methods = {}
         boot_domain
+        @whitelist = Hecks::Conventions::DispatchContract.build_whitelist(domain)
         register_methods
       end
 
@@ -150,6 +151,7 @@ module Hecks
       def register_commands(agg, klass)
         agg.commands.each do |cmd|
           method_name = domain_command_method(cmd.name, agg.name)
+          Hecks::Conventions::DispatchContract.validate!(@whitelist, agg.name, method_name)
           @methods[cmd.name] = ->(params) {
             serialize(klass.send(method_name, **params.transform_keys(&:to_sym)))
           }
@@ -168,6 +170,7 @@ module Hecks
       def register_queries(agg, klass)
         agg.queries.each do |query|
           qn = domain_snake_name(query.name)
+          Hecks::Conventions::DispatchContract.validate!(@whitelist, agg.name, qn.to_sym)
           params = query.block.parameters
           @methods["#{agg.name}.#{qn}"] = ->(p) {
             args = params.map { |_, name| p[name.to_s] }

--- a/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
@@ -16,8 +16,9 @@ module Hecks
     class RuntimeBridge
       include HecksTemplating::NamingHelpers
 
-      def initialize(mod)
+      def initialize(mod, whitelist: nil)
         @mod = mod
+        @whitelist = whitelist
       end
 
       def find_all(agg_name)
@@ -29,6 +30,9 @@ module Hecks
       end
 
       def execute_command(agg_name, method_name, attrs)
+        if @whitelist
+          Hecks::Conventions::DispatchContract.validate!(@whitelist, agg_name, method_name)
+        end
         result = klass_for(agg_name).send(method_name, **attrs)
         extract_id(result)
       end

--- a/hecksties/spec/conventions/dispatch_contract_spec.rb
+++ b/hecksties/spec/conventions/dispatch_contract_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::DispatchContract do
+  let(:domain) do
+    Hecks.domain "Widget" do
+      aggregate "Widget" do
+        attribute :name, String
+
+        command "CreateWidget" do
+          attribute :name, String
+        end
+
+        command "ArchiveWidget" do
+          reference_to "Widget"
+        end
+
+        query "ByName" do |name|
+          where(name: name)
+        end
+      end
+    end
+  end
+
+  let(:whitelist) { described_class.build_whitelist(domain) }
+
+  describe ".build_whitelist" do
+    it "includes command methods derived from the domain IR" do
+      expect(whitelist["Widget"]).to include(:create)
+    end
+
+    it "includes transition command methods derived from the domain IR" do
+      expect(whitelist["Widget"]).to include(:archive)
+    end
+
+    it "includes query methods derived from the domain IR" do
+      expect(whitelist["Widget"]).to include(:by_name)
+    end
+
+    it "includes all CRUD builtins" do
+      described_class::CRUD_BUILTINS.each do |m|
+        expect(whitelist["Widget"]).to include(m)
+      end
+    end
+
+    it "returns Sets (or objects responding to include?)" do
+      whitelist.each_value do |allowed|
+        expect(allowed).to respond_to(:include?)
+      end
+    end
+  end
+
+  describe ".validate!" do
+    it "passes for an allowed method" do
+      expect { described_class.validate!(whitelist, "Widget", :create) }.not_to raise_error
+    end
+
+    it "raises DispatchNotAllowed for :eval" do
+      expect {
+        described_class.validate!(whitelist, "Widget", :eval)
+      }.to raise_error(described_class::DispatchNotAllowed)
+    end
+
+    it "raises DispatchNotAllowed for :system" do
+      expect {
+        described_class.validate!(whitelist, "Widget", :system)
+      }.to raise_error(described_class::DispatchNotAllowed)
+    end
+
+    it "raises DispatchNotAllowed for :instance_eval" do
+      expect {
+        described_class.validate!(whitelist, "Widget", :instance_eval)
+      }.to raise_error(described_class::DispatchNotAllowed)
+    end
+
+    it "raises for an unknown aggregate name" do
+      expect {
+        described_class.validate!(whitelist, "UnknownAggregate", :create)
+      }.to raise_error(described_class::DispatchNotAllowed)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Added `Hecks::Conventions::DispatchContract` — a new contract module that builds a per-aggregate whitelist of allowed method names (commands + queries + CRUD builtins) from the domain IR
- Wired `validate!` at all 5 `.send()` dispatch sites in `RouteBuilder`, `RpcServer`, and `RuntimeBridge` so that only declared methods can be dispatched
- `MultiDomainServer` now builds the whitelist and passes it to `RuntimeBridge` via a new `whitelist:` kwarg

## DispatchNotAllowed in action

```ruby
domain = Hecks.domain "Pizzas" do
  aggregate "Pizza" do
    command "CreatePizza" do
      attribute :name, String
    end
  end
end

whitelist = Hecks::Conventions::DispatchContract.build_whitelist(domain)

# Allowed — declared in the domain
Hecks::Conventions::DispatchContract.validate!(whitelist, "Pizza", :create)   # => nil

# Blocked — not a declared command, query, or CRUD builtin
Hecks::Conventions::DispatchContract.validate!(whitelist, "Pizza", :eval)
# => raises Hecks::Conventions::DispatchContract::DispatchNotAllowed (SecurityError):
#      Dispatch not allowed: Pizza#eval is not a declared command, query, or CRUD builtin
```

## Test plan

- [x] `spec/conventions/dispatch_contract_spec.rb` — 10 examples covering whitelist build (commands, queries, CRUD builtins, Set#include?), `validate!` pass, and `validate!` raise for `:eval`, `:system`, `:instance_eval`, and unknown aggregate
- [x] Full suite: 1482 examples, 0 failures, under 1 second