### PR TITLE
HEC-435: XSS — escape computed attribute output before rendering

### DIFF
--- a/hecks_workshop/explorer/lib/hecks_explorer/views/index.erb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/views/index.erb
@@ -26,7 +26,7 @@
       <tr>
         <td class="mono"><a href="<%= item[:show_href] %>"><%= item[:short_id] %></a></td>
         <% item[:cells].each do |cell| %>
-          <td><%= cell %></td>
+          <td><%= h(cell) %></td>
         <% end %>
         <% if row_actions.any? %>
           <td>

--- a/hecks_workshop/explorer/lib/hecks_explorer/views/show.erb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/views/show.erb
@@ -26,7 +26,7 @@
             </span>
           <% end %>
         <% else %>
-          <%= field[:value] %>
+          <%= h(field[:value]) %>
         <% end %>
       </dd>
     <% end %>

--- a/hecksties/lib/hecks/extensions/web_explorer/views/index.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/index.erb
@@ -26,7 +26,7 @@
       <tr>
         <td class="mono"><a href="<%= item[:show_href] %>"><%= item[:short_id] %></a></td>
         <% item[:cells].each do |cell| %>
-          <td><%= cell %></td>
+          <td><%= h(cell) %></td>
         <% end %>
         <% if row_actions.any? %>
           <td>

--- a/hecksties/lib/hecks/extensions/web_explorer/views/show.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/show.erb
@@ -26,7 +26,7 @@
             </span>
           <% end %>
         <% else %>
-          <%= field[:value] %>
+          <%= h(field[:value]) %>
         <% end %>
       </dd>
     <% end %>

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "hecks/extensions/web_explorer/ir_introspector"
 require "hecks/extensions/web_explorer/runtime_bridge"
+require "hecks/extensions/web_explorer/renderer"
 
 RSpec.describe "Web Explorer IR introspection" do
   let(:domain) { BootedDomains.pizzas }
@@ -91,6 +92,15 @@ RSpec.describe "Web Explorer IR introspection" do
       expect(data[:name]).to eq("Pizzas")
       expect(data[:command_names]).to include("Create Pizza")
       expect(data[:attributes]).to be_a(Integer)
+    end
+  end
+
+  describe Hecks::WebExplorer::Renderer do
+    let(:views_dir) { File.expand_path("../../lib/hecks/extensions/web_explorer/views", __dir__) }
+    let(:renderer) { Hecks::WebExplorer::Renderer.new(views_dir) }
+
+    it "escapes HTML special characters via h()" do
+      expect(renderer.h("<script>alert(1)</script>")).to eq("&lt;script&gt;alert(1)&lt;/script&gt;")
     end
   end
 


### PR DESCRIPTION
## Summary

- Applied `h()` (ERB::Util.html_escape) to bare `<%= %>` output for user-controlled values in both web explorer template sets
- **`index.erb` line 29**: `<%= cell %>` → `<%= h(cell) %>` — escapes computed attribute values in table cells on the list view
- **`show.erb` line 29**: `<%= field[:value] %>` → `<%= h(field[:value]) %>` — escapes computed attribute values in the detail field view
- Both changes applied in `hecksties/lib/hecks/extensions/web_explorer/views/` and mirrored in `hecks_workshop/explorer/lib/hecks_explorer/views/`
- Added `Renderer#h()` spec: verifies `<script>alert(1)</script>` escapes to `&lt;script&gt;alert(1)&lt;/script&gt;`

## What was escaped and where

| File | Expression | Before | After |
|------|-----------|--------|-------|
| `hecksties/.../views/index.erb:29` | table cell values | `<%= cell %>` | `<%= h(cell) %>` |
| `hecksties/.../views/show.erb:29` | detail field values | `<%= field[:value] %>` | `<%= h(field[:value]) %>` |
| `hecks_workshop/.../views/index.erb:29` | table cell values | `<%= cell %>` | `<%= h(cell) %>` |
| `hecks_workshop/.../views/show.erb:29` | detail field values | `<%= field[:value] %>` | `<%= h(field[:value]) %>` |

The `h()` helper delegates to `ERB::Util.html_escape` and was already present on both `Renderer` classes — these changes wire it into the templates where user-provided data is rendered.

## Test plan

- [x] `Renderer#h()` spec: `<script>alert(1)</script>` → `&lt;script&gt;alert(1)&lt;/script&gt;`
- [x] Full suite passes (1473 examples, 0 failures, 0.93s)