### PR TITLE
HEC-436: DSL — visible: false option to suppress aggregate attributes from web explorer

### DIFF
--- a/bluebook/lib/hecks/domain_model/structure/attribute.rb
+++ b/bluebook/lib/hecks/domain_model/structure/attribute.rb
@@ -42,15 +42,19 @@ module Hecks
       #   and should be handled according to PII policies (encryption, masking, etc.).
       # @param enum [Array<String>, nil] optional list of allowed string values. When present,
       #   generated code will validate that the attribute value is one of these.
+      # @param visible [Boolean] if false, this attribute is hidden from the web explorer
+      #   and generated UI (index tables, show pages, home cards). Useful for internal fields
+      #   like passwords, tokens, or raw foreign keys that should not be displayed to users.
       #
       # @return [Attribute] a new Attribute instance
-      def initialize(name:, type:, default: nil, list: false, pii: false, enum: nil)
+      def initialize(name:, type:, default: nil, list: false, pii: false, enum: nil, visible: true)
         @name = name.to_sym
         @type = type
         @default = default
         @list = list
         @pii = pii
         @enum = enum
+        @visible = visible
       end
 
       # Returns true if this attribute holds a collection of values.
@@ -69,6 +73,18 @@ module Hecks
       # @return [Boolean] true if this attribute holds PII data
       def pii?
         @pii
+      end
+
+      # Returns true if this attribute should appear in the web explorer
+      # and generated UI (index tables, show pages, home cards).
+      # Defaults to true. Set +visible: false+ in the DSL to suppress an attribute
+      # from all UI surfaces while retaining it in the domain model.
+      #
+      #   attribute :password_digest, String, visible: false
+      #
+      # @return [Boolean] true if this attribute is visible in the UI
+      def visible?
+        @visible
       end
 
       # Returns true if this attribute stores a JSON blob.

--- a/bluebook/spec/domain_model/attribute_spec.rb
+++ b/bluebook/spec/domain_model/attribute_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe Hecks::DomainModel::Structure::Attribute do
       expect(attr).to be_list
     end
   end
+
+  describe "visibility" do
+    it "is visible by default" do
+      attr = described_class.new(name: :name, type: String)
+      expect(attr.visible?).to be true
+    end
+
+    it "is hidden when visible: false" do
+      attr = described_class.new(name: :password_digest, type: String, visible: false)
+      expect(attr.visible?).to be false
+    end
+  end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -14,7 +14,9 @@ module GoHecks
         @domain.aggregates.each do |agg|
           safe = agg.name
           plural = GoUtils.snake_case(safe) + "s"
-          attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+          attrs = agg.attributes.reject { |a|
+            Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) || !a.visible?
+          }
           agg_snake = GoUtils.snake_case(safe)
 
           lines.concat(index_route(agg, safe, plural, attrs, agg_snake))

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/html_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/html_routes.rb
@@ -19,7 +19,9 @@ module GoHecks
           safe = agg.name
           plural = GoUtils.snake_case(safe) + "s"
           agg_snake = GoUtils.snake_case(safe)
-          attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+          attrs = agg.attributes.reject { |a|
+            Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) || !a.visible?
+          }
 
           ref_attrs = attrs.select { |a| dc.reference_attr?(a) }
           show_ref_lookups = ref_attrs.map { |a| [a, dc.find_referenced_aggregate(a, @domain)] }.select { |_, ra| ra }

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -63,7 +63,9 @@ class UIGenerator < Hecks::Generator
   end
 
   def user_attrs(agg)
-    agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+    agg.attributes.reject { |a|
+      Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) || !a.visible?
+    }
   end
 
   def self_ref?(cmd, agg_snake)

--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -155,7 +155,7 @@ module Hecks::Conventions
     # @return [Hash] { name:, href:, command_names:, attributes:, policies: }
     def self.home_aggregate_data(agg, plural)
       user_attrs = agg.attributes.reject { |a|
-        Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s)
+        Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) || !a.visible?
       }
       {
         name: UILabelContract.plural_label(agg.name),

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -35,7 +35,9 @@ module Hecks
       end
 
       def user_attributes(agg)
-        agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+        agg.attributes.reject { |a|
+          Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) || !a.visible?
+        }
       end
 
       def computed_attributes(agg)

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Hecks::Conventions::DisplayContract do
       data = described_class.home_aggregate_data(agg, "empties")
       expect(data[:command_names]).to eq("")
     end
+
+    it "does not count hidden attributes in the attribute count" do
+      visible_attr = attr_class.new(name: :name, type: String)
+      hidden_attr  = attr_class.new(name: :password_digest, type: String, visible: false)
+      agg = double("agg",
+        name: "Account",
+        commands: [],
+        attributes: [visible_attr, hidden_attr],
+        policies: [])
+      data = described_class.home_aggregate_data(agg, "accounts")
+      expect(data[:attributes]).to eq(1)
+    end
   end
 
   describe ".reference_attr?" do

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe "Web Explorer IR introspection" do
       expect(ref.name).to eq("Pizza")
     end
 
+    it "excludes hidden attributes from user_attributes" do
+      attr_class = Hecks::DomainModel::Structure::Attribute
+      hidden = attr_class.new(name: :secret, type: String, visible: false)
+      visible = attr_class.new(name: :label, type: String)
+      agg = double("agg", attributes: [hidden, visible])
+      result = ir.user_attributes(agg)
+      expect(result.map(&:name)).to eq([:label])
+      expect(result.map(&:name)).not_to include(:secret)
+    end
+
+    it "excludes hidden attributes from columns_for" do
+      attr_class = Hecks::DomainModel::Structure::Attribute
+      hidden = attr_class.new(name: :token, type: String, visible: false)
+      visible = attr_class.new(name: :title, type: String)
+      agg = double("agg", attributes: [hidden, visible], computed_attributes: [])
+      cols = ir.columns_for(agg)
+      labels = cols.map { |c| c[:label] }
+      expect(labels).to include("Title")
+      expect(labels).not_to include("Token")
+    end
+
     it "returns policy labels from the IR" do
       labels = ir.policy_labels
       expect(labels).to include("PlacedOrder \u2192 ReserveIngredients")


### PR DESCRIPTION
## Summary

- Adds `visible: false` DSL option to `attribute` declarations, allowing any aggregate attribute to be hidden from all UI surfaces
- Hidden attributes remain fully present in the domain model, repository, and serializers — only the display layer is affected
- Filtering is applied upstream of all templates; no ERB changes required

## DSL usage

```ruby
aggregate "Account" do
  attribute :email, String
  attribute :password_digest, String, visible: false  # suppressed from web explorer
end
```

## What is filtered when `visible: false`

| Surface | Filtered? |
|---|---|
| Web Explorer index columns (`columns_for`) | Yes |
| Web Explorer show fields (`user_attributes`) | Yes |
| Home card attribute count (`home_aggregate_data`) | Yes |
| Ruby static UI generator index + show | Yes |
| Go server generator index + show routes | Yes |
| `StateSerializer` | No — developer tool, all attrs visible |

## Test plan

- [ ] `bluebook/spec/domain_model/attribute_spec.rb` — `visible?` defaults `true`; `visible: false` returns `false`
- [ ] `hecksties/spec/extensions/web_explorer_ir_spec.rb` — hidden attr excluded from `user_attributes` and `columns_for`
- [ ] `hecksties/spec/conventions/display_contract_spec.rb` — home card does not count hidden attrs
- [ ] All 1477 examples pass, suite runs under 1 second