### PR TITLE
HEC-442: Generator file writer — path sanitization against traversal

### DIFF
--- a/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator/file_writer.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator/file_writer.rb
@@ -260,7 +260,7 @@ module Hecks
           #   checked for +call_body+ to decide preservation behavior
           # @return [void]
           def write_command_file(root, relative_path, new_content, command)
-            full_path = File.join(root, relative_path)
+            full_path = Hecks::Utils.safe_path!(root, relative_path)
             if !command.call_body && File.exist?(full_path)
               existing_source = File.read(full_path)
               existing_call = Hecks::Utils.extract_call_method(existing_source)
@@ -279,7 +279,7 @@ module Hecks
           # @param content [String] the file content to write
           # @return [void]
           def write_file(root, relative_path, content)
-            path = File.join(root, relative_path)
+            path = Hecks::Utils.safe_path!(root, relative_path)
             FileUtils.mkdir_p(File.dirname(path))
             File.write(path, content)
           end

--- a/bluebook/lib/hecks/generators/rails_generator.rb
+++ b/bluebook/lib/hecks/generators/rails_generator.rb
@@ -149,7 +149,7 @@ module Hecks
       end
 
       def write(path, content)
-        full = File.join(@root, path)
+        full = Hecks::Utils.safe_path!(@root, path)
         FileUtils.mkdir_p(File.dirname(full))
         File.write(full, content)
       end

--- a/bluebook/spec/generators/path_traversal_spec.rb
+++ b/bluebook/spec/generators/path_traversal_spec.rb
@@ -1,0 +1,80 @@
+# bluebook/spec/generators/path_traversal_spec.rb
+#
+# Specs for Hecks::Utils.safe_path! — path traversal prevention for generator
+# file writers. Covers the attack vectors that could escape the output directory.
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe "Generator path traversal protection" do
+  let(:root) { Dir.mktmpdir }
+
+  after { FileUtils.rm_rf(root) }
+
+  describe "Hecks::Utils.safe_path!" do
+    context "when the relative path contains ../" do
+      it "raises PathTraversalDetected" do
+        expect {
+          Hecks::Utils.safe_path!(root, "../etc/passwd")
+        }.to raise_error(Hecks::PathTraversalDetected, /outside/)
+      end
+    end
+
+    context "when the relative path is absolute" do
+      it "raises PathTraversalDetected" do
+        expect {
+          Hecks::Utils.safe_path!(root, "/etc/passwd")
+        }.to raise_error(Hecks::PathTraversalDetected, /outside/)
+      end
+    end
+
+    context "when the relative path contains a null byte" do
+      it "raises PathTraversalDetected" do
+        expect {
+          Hecks::Utils.safe_path!(root, "safe\0../evil")
+        }.to raise_error(Hecks::PathTraversalDetected, /outside/)
+      end
+    end
+
+    context "when the relative path is a safe nested path" do
+      it "returns the absolute resolved path" do
+        result = Hecks::Utils.safe_path!(root, "lib/pizza/pizza.rb")
+        expect(result).to eq(File.join(root, "lib/pizza/pizza.rb"))
+      end
+    end
+
+    context "when a domain name contains ../ traversal" do
+      it "raises PathTraversalDetected" do
+        malicious_relative = "lib/../../etc/passwd"
+        expect {
+          Hecks::Utils.safe_path!(root, malicious_relative)
+        }.to raise_error(Hecks::PathTraversalDetected)
+      end
+    end
+
+    context "when an aggregate name contains traversal segments" do
+      it "raises PathTraversalDetected" do
+        malicious_relative = "lib/my_domain/../../../shadow"
+        expect {
+          Hecks::Utils.safe_path!(root, malicious_relative)
+        }.to raise_error(Hecks::PathTraversalDetected)
+      end
+    end
+  end
+
+  describe "Hecks::PathTraversalDetected" do
+    it "exposes attempted_path and output_dir" do
+      error = Hecks::PathTraversalDetected.new(
+        attempted_path: "../evil",
+        output_dir: "/tmp/safe"
+      )
+      expect(error.attempted_path).to eq("../evil")
+      expect(error.output_dir).to eq("/tmp/safe")
+      expect(error.message).to include("../evil")
+      expect(error.message).to include("/tmp/safe")
+    end
+
+    it "is a subclass of Hecks::Error" do
+      expect(Hecks::PathTraversalDetected.ancestors).to include(Hecks::Error)
+    end
+  end
+end

--- a/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
@@ -37,7 +37,7 @@ module GoHecks
     private
 
     def write(path, content)
-      full = File.join(@root, path)
+      full = Hecks::Utils.safe_path!(@root, path)
       FileUtils.mkdir_p(File.dirname(full))
       File.write(full, content)
     end

--- a/hecks_targets/ruby/lib/hecks_static/generators/gem_generator/domain_writer.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/gem_generator/domain_writer.rb
@@ -14,9 +14,20 @@ module HecksStatic
 
       private
 
+      # Resolves a path relative to root through +Hecks::Utils.safe_path!+,
+      # raising +PathTraversalDetected+ if the path escapes root.
+      #
+      # @param root [String] the output root directory
+      # @param *parts [Array<String>] path segments to join before resolving
+      # @return [String] the safe absolute path
+      def safe_join(root, *parts)
+        relative = File.join(*parts)
+        Hecks::Utils.safe_path!(root, relative)
+      end
+
       def generate_aggregates(root, gem_name, mod)
         @domain.aggregates.each do |agg|
-          agg_dir = File.join(root, "lib", gem_name, domain_snake_name(agg.name))
+          agg_dir = safe_join(root, "lib", gem_name, domain_snake_name(agg.name))
           FileUtils.mkdir_p(agg_dir)
 
           gen = DomainGen::AggregateGenerator.new(agg, domain_module: mod, mixin_prefix: mod)
@@ -39,7 +50,7 @@ module HecksStatic
       def generate_queries(root, gem_name, mod)
         @domain.aggregates.each do |agg|
           next if agg.queries.empty?
-          q_dir = File.join(root, "lib", gem_name, domain_snake_name(agg.name), "queries")
+          q_dir = safe_join(root, "lib", gem_name, domain_snake_name(agg.name), "queries")
           FileUtils.mkdir_p(q_dir)
           agg.queries.each do |query|
             gen = DomainGen::QueryGenerator.new(query,
@@ -50,7 +61,7 @@ module HecksStatic
       end
 
       def generate_ports(root, gem_name, mod)
-        port_dir = File.join(root, "lib", gem_name, "ports")
+        port_dir = safe_join(root, "lib", gem_name, "ports")
         FileUtils.mkdir_p(port_dir)
         @domain.aggregates.each do |agg|
           gen = InfraGen::PortGenerator.new(agg, domain_module: mod)
@@ -59,7 +70,7 @@ module HecksStatic
       end
 
       def generate_adapters(root, gem_name, mod)
-        adapter_dir = File.join(root, "lib", gem_name, "adapters")
+        adapter_dir = safe_join(root, "lib", gem_name, "adapters")
         FileUtils.mkdir_p(adapter_dir)
         @domain.aggregates.each do |agg|
           gen = InfraGen::MemoryAdapterGenerator.new(agg,
@@ -73,7 +84,7 @@ module HecksStatic
 
       def generate_services(root, gem_name, mod)
         return if @domain.services.empty?
-        svc_dir = File.join(root, "lib", gem_name, "services")
+        svc_dir = safe_join(root, "lib", gem_name, "services")
         FileUtils.mkdir_p(svc_dir)
         @domain.services.each do |svc|
           gen = DomainGen::ServiceGenerator.new(svc, domain_module: mod)

--- a/hecksties/lib/hecks/errors.rb
+++ b/hecksties/lib/hecks/errors.rb
@@ -200,6 +200,31 @@ module Hecks
   # Raised when a rate limit is exceeded for a command or query operation.
   class RateLimitExceeded < Error; end
 
+  # Raised when a generator attempts to write a file outside the designated
+  # output directory. Prevents path traversal attacks where user-controlled
+  # domain names or aggregate names contain +../+ segments, absolute paths,
+  # or null bytes that would escape the intended root directory.
+  #
+  #   raise Hecks::PathTraversalDetected.new(
+  #     attempted_path: "../etc/passwd",
+  #     output_dir: "/tmp/my_domain"
+  #   )
+  class PathTraversalDetected < Hecks::Error
+    # @return [String] the path that was attempted
+    attr_reader :attempted_path
+
+    # @return [String] the output directory that was being written to
+    attr_reader :output_dir
+
+    # @param attempted_path [String] the relative or absolute path that was rejected
+    # @param output_dir [String] the root directory the write was constrained to
+    def initialize(attempted_path:, output_dir:)
+      @attempted_path = attempted_path
+      @output_dir = output_dir
+      super("Path traversal detected: #{attempted_path} is outside #{output_dir}")
+    end
+  end
+
   # Raised when a command references an aggregate ID that does not exist in the
   # repository. Prevents executing commands with dangling foreign keys.
   #

--- a/hecksties/lib/hecks/utils.rb
+++ b/hecksties/lib/hecks/utils.rb
@@ -274,6 +274,32 @@ module Hecks
       end
     end
 
+    # Resolves a relative path under a root directory, raising
+    # +Hecks::PathTraversalDetected+ if the resolved path escapes the root.
+    # Guards against +../+ traversal, absolute paths, and null bytes.
+    #
+    # @param root [String] the directory the write must stay within
+    # @param relative_path [String] the path to resolve (relative to root)
+    # @return [String] the absolute resolved path when safe
+    # @raise [Hecks::PathTraversalDetected] if the path escapes root or contains
+    #   a null byte
+    #
+    # @example
+    #   Hecks::Utils.safe_path!("/tmp/out", "lib/pizza.rb")
+    #   # => "/tmp/out/lib/pizza.rb"
+    #
+    #   Hecks::Utils.safe_path!("/tmp/out", "../etc/passwd")
+    #   # raises Hecks::PathTraversalDetected
+    def safe_path!(root, relative_path)
+      raise PathTraversalDetected.new(attempted_path: relative_path, output_dir: root) if relative_path.include?("\0")
+      expanded_root = File.expand_path(root)
+      full = File.expand_path(relative_path, expanded_root)
+      unless full.start_with?(expanded_root + File::SEPARATOR) || full == expanded_root
+        raise PathTraversalDetected.new(attempted_path: relative_path, output_dir: root)
+      end
+      full
+    end
+
     # Remove a constant from a module if it exists.
     #
     #   Hecks::Utils.remove_constant(:PizzasDomain)


### PR DESCRIPTION
## Summary

- Add `Hecks::PathTraversalDetected` error with `attempted_path` and `output_dir` attributes
- Add `Hecks::Utils.safe_path!(root, relative_path)` — validates that any resolved path stays within root, blocking `../` traversal, absolute paths, and null bytes
- Route all generator `write` methods through `safe_path!`: `DomainGemGenerator::FileWriter`, `RailsGenerator`, Go `ProjectGenerator`, and Ruby static `DomainWriter`
- 8 new specs in `bluebook/spec/generators/path_traversal_spec.rb` covering all attack vectors

## Attack vector prevented

A malicious or malformed domain definition with `../` in an aggregate name, command name, or domain name could cause the generator to write files outside the intended output directory (e.g., overwriting system files or application source). This change ensures every generator write is constrained to its designated root before any disk I/O occurs.

## Files protected

| File | Generator |
|------|-----------|
| `bluebook/lib/hecks/generators/infrastructure/domain_gem_generator/file_writer.rb` | Ruby domain gem |
| `bluebook/lib/hecks/generators/rails_generator.rb` | Rails app scaffolding |
| `hecks_targets/go/lib/go_hecks/generators/project_generator.rb` | Go static target |
| `hecks_targets/ruby/lib/hecks_static/generators/gem_generator/domain_writer.rb` | Ruby static target |

## Test plan

- [ ] `bundle exec rspec bluebook/spec/generators/path_traversal_spec.rb` — all 8 cases pass
- [ ] `bundle exec rspec` from repo root — all 1480 examples pass, under 1 second