### PR TITLE
HEC-428: Go generator — CSRF middleware struct replaces inline validateCSRF

### DIFF
--- a/examples/pizzas_static_go/server/server.go
+++ b/examples/pizzas_static_go/server/server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 	"os"
 	"path/filepath"
 	"pizzas_domain/domain"
@@ -31,28 +34,34 @@ func NewApp() *App {
 func (app *App) Start(port int) error {
 	mux := http.NewServeMux()
 
-	exe, _ := os.Executable()
-	viewsDir := filepath.Join(filepath.Dir(exe), "..", "views")
-	if _, err := os.Stat(viewsDir); err != nil { viewsDir = "views" }
+	viewsDir := os.Getenv("VIEWS_DIR")
+	if viewsDir == "" {
+		exe, _ := os.Executable()
+		viewsDir = filepath.Join(filepath.Dir(exe), "..", "views")
+		if _, err := os.Stat(viewsDir); err != nil {
+			viewsDir = filepath.Join(filepath.Dir(exe), "views")
+		}
+		if _, err := os.Stat(viewsDir); err != nil { viewsDir = "views" }
+	}
 	nav := []NavItem{
 		{Label: "Pizzas", Href: "/pizzas", Group: ""},
 		{Label: "Orders", Href: "/orders", Group: ""},
 		{Label: "Config", Href: "/config", Group: "System"},
 	}
-	renderer := NewRenderer(viewsDir, "PizzasDomain", nav)
+	renderer := NewRenderer(viewsDir, "Pizzas", nav)
 
-	type HomeAgg struct { Href string; Name string; Commands int; Attributes int; Policies int }
+	type HomeAgg struct { Href string; Name string; CommandNames string; Attributes int; Policies int }
 	type HomeData struct { DomainName string; Aggregates []HomeAgg }
 	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
-		renderer.Render(w, "home", "PizzasDomain", HomeData{
-			DomainName: "PizzasDomain", Aggregates: []HomeAgg{{Name: "Pizzas", Href: "/pizzas", Commands: 2, Attributes: 3, Policies: 0}, {Name: "Orders", Href: "/orders", Commands: 2, Attributes: 3, Policies: 0}},
+		renderer.Render(w, "home", "Pizzas", HomeData{
+			DomainName: "Pizzas", Aggregates: []HomeAgg{{Name: "Pizzas", Href: "/pizzas", CommandNames: "Create Pizza, Add Topping", Attributes: 3, Policies: 0}, {Name: "Orders", Href: "/orders", CommandNames: "Place Order, Cancel Order", Attributes: 3, Policies: 0}},
 		})
 	})
 
 	type PizzaColumn struct { Label string }
 	type PizzaIndexItem struct { Id string; ShortId string; ShowHref string; Cells []string; RowActions []RowAction }
-	type PizzaButton struct { Label string; Href string; Allowed bool }
-	type PizzaIndexData struct { AggregateName string; Description string; Items []PizzaIndexItem; Columns []PizzaColumn; Buttons []PizzaButton; RowActions []RowAction }
+	type PizzaButton struct { Label string; Href string; Allowed bool; Direct bool; IdField string }
+	type PizzaIndexData struct { AggregateName string; Description string; CsrfToken string; Items []PizzaIndexItem; Columns []PizzaColumn; Buttons []PizzaButton; RowActions []RowAction }
 	mux.HandleFunc("GET /pizzas", func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Accept") == "application/json" || r.URL.Query().Get("format") == "json" {
 			items, _ := app.PizzaRepo.All(); jsonResponse(w, items); return
@@ -61,9 +70,12 @@ func (app *App) Start(port int) error {
 		var rows []PizzaIndexItem
 		for _, obj := range items {
 			sid := obj.ID; if len(sid)>8 { sid=sid[:8]+"..." }
-			rows = append(rows, PizzaIndexItem{Id: obj.ID, ShortId: sid, ShowHref: "/pizzas/show?id="+obj.ID, Cells: []string{fmt.Sprintf("%v", obj.Name), fmt.Sprintf("%v", obj.Description), fmt.Sprintf("%d items", len(obj.Toppings))}})
+			baseActions := []RowAction{{Label: "Add Topping", HrefPrefix: "/pizzas/add_topping/new?id=", Allowed: true}}
+			actions := make([]RowAction, len(baseActions))
+			for i, a := range baseActions { actions[i] = RowAction{Label: a.Label, HrefPrefix: a.HrefPrefix, Id: obj.ID, Allowed: a.Allowed, Direct: a.Direct, IdField: a.IdField} }
+			rows = append(rows, PizzaIndexItem{Id: obj.ID, ShortId: sid, ShowHref: "/pizzas/show?id="+obj.ID, Cells: []string{fmt.Sprintf("%v", obj.Name), fmt.Sprintf("%v", obj.Description), fmt.Sprintf("%d items", len(obj.Toppings))}, RowActions: actions})
 		}
-		renderer.Render(w, "index", "Pizzas", PizzaIndexData{AggregateName: "Pizza", Description: "", Items: rows, Columns: []PizzaColumn{{Label: "Name"}, {Label: "Description"}, {Label: "Toppings"}}, Buttons: []PizzaButton{{Label: "CreatePizza", Href: "/pizzas/create_pizza/new", Allowed: true}}})
+		renderer.Render(w, "index", "Pizzas", PizzaIndexData{AggregateName: "Pizza", Description: "", CsrfToken: csrfToken(w, r), Items: rows, Columns: []PizzaColumn{{Label: "Name"}, {Label: "Description"}, {Label: "Toppings"}}, Buttons: []PizzaButton{{Label: "Create Pizza", Href: "/pizzas/create_pizza/new", Allowed: true}}, RowActions: []RowAction{{Label: "Add Topping", HrefPrefix: "/pizzas/add_topping/new?id=", Allowed: true}}})
 	})
 
 	mux.HandleFunc("GET /pizzas/find", func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +84,7 @@ func (app *App) Start(port int) error {
 		jsonResponse(w, item)
 	})
 
-	mux.HandleFunc("POST /pizzas/create_pizza", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /pizzas/create_pizza/submit", func(w http.ResponseWriter, r *http.Request) {
 		var cmd domain.CreatePizza
 		if r.Header.Get("Content-Type") == "application/json" {
 			if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{"error":"invalid json"}`, 400); return }
@@ -85,20 +97,30 @@ func (app *App) Start(port int) error {
 		if event != nil { app.EventBus.Publish(event) }
 		if err != nil {
 			if r.Header.Get("Content-Type")=="application/json" { jsonError(w, err); return }
-			http.Error(w, err.Error(), 422); return
+			fields := []FormField{
+				{Type: "input", Name: "name", Label: "Name", InputType: "text", Required: true, Value: r.FormValue("name")},
+				{Type: "input", Name: "description", Label: "Description", InputType: "text", Required: true, Value: r.FormValue("description")},
+			}
+			w.WriteHeader(422)
+			renderer.Render(w, "form", "CreatePizza", FormData{
+				CommandName: "Create Pizza",
+				Action: "/pizzas/create_pizza",
+				ErrorMessage: err.Error(),
+				Fields: fields,
+				CsrfToken: csrfToken(w, r),
+			}); return
 		}
 		if r.Header.Get("Content-Type")=="application/json" { w.WriteHeader(201); jsonResponse(w, agg) } else {
 			http.Redirect(w, r, "/pizzas/show?id="+agg.ID, http.StatusSeeOther)
 		}
 	})
 
-	mux.HandleFunc("POST /pizzas/add_topping", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /pizzas/add_topping/submit", func(w http.ResponseWriter, r *http.Request) {
 		var cmd domain.AddTopping
 		if r.Header.Get("Content-Type") == "application/json" {
 			if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{"error":"invalid json"}`, 400); return }
 		} else {
 			r.ParseForm()
-			cmd.PizzaId = r.FormValue("pizza_id")
 			cmd.Name = r.FormValue("name")
 			if v := r.FormValue("amount"); v != "" { fmt.Sscanf(v, "%d", &cmd.Amount) }
 		}
@@ -106,7 +128,25 @@ func (app *App) Start(port int) error {
 		if event != nil { app.EventBus.Publish(event) }
 		if err != nil {
 			if r.Header.Get("Content-Type")=="application/json" { jsonError(w, err); return }
-			http.Error(w, err.Error(), 422); return
+			fields := []FormField{
+				{Type: "input", Name: "name", Label: "Name", InputType: "text", Required: true, Value: r.FormValue("name")},
+				{Type: "input", Name: "amount", Label: "Amount", InputType: "number", Required: true, Value: r.FormValue("amount")},
+				// Pizza dropdown built dynamically below
+			}
+			pizzas, _ := app.PizzaRepo.All()
+			var pizzaOpts []FormOption
+			for _, item := range pizzas {
+				pizzaOpts = append(pizzaOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.Name), Selected: item.ID == r.FormValue("pizza")})
+			}
+			fields = append(fields, FormField{Type: "select", Name: "pizza", Label: "Pizza", Required: true, Options: pizzaOpts})
+			w.WriteHeader(422)
+			renderer.Render(w, "form", "AddTopping", FormData{
+				CommandName: "Add Topping",
+				Action: "/pizzas/add_topping",
+				ErrorMessage: err.Error(),
+				Fields: fields,
+				CsrfToken: csrfToken(w, r),
+			}); return
 		}
 		if r.Header.Get("Content-Type")=="application/json" { w.WriteHeader(201); jsonResponse(w, agg) } else {
 			http.Redirect(w, r, "/pizzas/show?id="+agg.ID, http.StatusSeeOther)
@@ -115,8 +155,8 @@ func (app *App) Start(port int) error {
 
 	type OrderColumn struct { Label string }
 	type OrderIndexItem struct { Id string; ShortId string; ShowHref string; Cells []string; RowActions []RowAction }
-	type OrderButton struct { Label string; Href string; Allowed bool }
-	type OrderIndexData struct { AggregateName string; Description string; Items []OrderIndexItem; Columns []OrderColumn; Buttons []OrderButton; RowActions []RowAction }
+	type OrderButton struct { Label string; Href string; Allowed bool; Direct bool; IdField string }
+	type OrderIndexData struct { AggregateName string; Description string; CsrfToken string; Items []OrderIndexItem; Columns []OrderColumn; Buttons []OrderButton; RowActions []RowAction }
 	mux.HandleFunc("GET /orders", func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Accept") == "application/json" || r.URL.Query().Get("format") == "json" {
 			items, _ := app.OrderRepo.All(); jsonResponse(w, items); return
@@ -125,9 +165,12 @@ func (app *App) Start(port int) error {
 		var rows []OrderIndexItem
 		for _, obj := range items {
 			sid := obj.ID; if len(sid)>8 { sid=sid[:8]+"..." }
-			rows = append(rows, OrderIndexItem{Id: obj.ID, ShortId: sid, ShowHref: "/orders/show?id="+obj.ID, Cells: []string{fmt.Sprintf("%v", obj.CustomerName), fmt.Sprintf("%d items", len(obj.Items)), fmt.Sprintf("%v", obj.Status)}})
+			baseActions := []RowAction{{Label: "Cancel Order", HrefPrefix: "/orders/cancel_order", Allowed: true, Direct: true, IdField: "order"}}
+			actions := make([]RowAction, len(baseActions))
+			for i, a := range baseActions { actions[i] = RowAction{Label: a.Label, HrefPrefix: a.HrefPrefix, Id: obj.ID, Allowed: a.Allowed, Direct: a.Direct, IdField: a.IdField} }
+			rows = append(rows, OrderIndexItem{Id: obj.ID, ShortId: sid, ShowHref: "/orders/show?id="+obj.ID, Cells: []string{fmt.Sprintf("%v", obj.CustomerName), fmt.Sprintf("%d items", len(obj.Items)), fmt.Sprintf("%v", obj.Status)}, RowActions: actions})
 		}
-		renderer.Render(w, "index", "Orders", OrderIndexData{AggregateName: "Order", Description: "", Items: rows, Columns: []OrderColumn{{Label: "Customer Name"}, {Label: "Items"}, {Label: "Status"}}, Buttons: []OrderButton{{Label: "PlaceOrder", Href: "/orders/place_order/new", Allowed: true}}})
+		renderer.Render(w, "index", "Orders", OrderIndexData{AggregateName: "Order", Description: "", CsrfToken: csrfToken(w, r), Items: rows, Columns: []OrderColumn{{Label: "Customer Name"}, {Label: "Items"}, {Label: "Status"}}, Buttons: []OrderButton{{Label: "Place Order", Href: "/orders/place_order/new", Allowed: true}}, RowActions: []RowAction{{Label: "Cancel Order", HrefPrefix: "/orders/cancel_order", Allowed: true, Direct: true, IdField: "order"}}})
 	})
 
 	mux.HandleFunc("GET /orders/find", func(w http.ResponseWriter, r *http.Request) {
@@ -136,48 +179,80 @@ func (app *App) Start(port int) error {
 		jsonResponse(w, item)
 	})
 
-	mux.HandleFunc("POST /orders/place_order", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /orders/place_order/submit", func(w http.ResponseWriter, r *http.Request) {
 		var cmd domain.PlaceOrder
 		if r.Header.Get("Content-Type") == "application/json" {
 			if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{"error":"invalid json"}`, 400); return }
 		} else {
 			r.ParseForm()
 			cmd.CustomerName = r.FormValue("customer_name")
-			cmd.PizzaId = r.FormValue("pizza_id")
 			if v := r.FormValue("quantity"); v != "" { fmt.Sscanf(v, "%d", &cmd.Quantity) }
 		}
 		agg, event, err := cmd.Execute(app.OrderRepo)
 		if event != nil { app.EventBus.Publish(event) }
 		if err != nil {
 			if r.Header.Get("Content-Type")=="application/json" { jsonError(w, err); return }
-			http.Error(w, err.Error(), 422); return
+			fields := []FormField{
+				{Type: "input", Name: "customer_name", Label: "Customer Name", InputType: "text", Required: true, Value: r.FormValue("customer_name")},
+				{Type: "input", Name: "quantity", Label: "Quantity", InputType: "number", Required: true, Value: r.FormValue("quantity")},
+				// Pizza dropdown built dynamically below
+			}
+			pizzas, _ := app.PizzaRepo.All()
+			var pizzaOpts []FormOption
+			for _, item := range pizzas {
+				pizzaOpts = append(pizzaOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.Name), Selected: item.ID == r.FormValue("pizza")})
+			}
+			fields = append(fields, FormField{Type: "select", Name: "pizza", Label: "Pizza", Required: true, Options: pizzaOpts})
+			w.WriteHeader(422)
+			renderer.Render(w, "form", "PlaceOrder", FormData{
+				CommandName: "Place Order",
+				Action: "/orders/place_order",
+				ErrorMessage: err.Error(),
+				Fields: fields,
+				CsrfToken: csrfToken(w, r),
+			}); return
 		}
 		if r.Header.Get("Content-Type")=="application/json" { w.WriteHeader(201); jsonResponse(w, agg) } else {
 			http.Redirect(w, r, "/orders/show?id="+agg.ID, http.StatusSeeOther)
 		}
 	})
 
-	mux.HandleFunc("POST /orders/cancel_order", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /orders/cancel_order/submit", func(w http.ResponseWriter, r *http.Request) {
 		var cmd domain.CancelOrder
 		if r.Header.Get("Content-Type") == "application/json" {
 			if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{"error":"invalid json"}`, 400); return }
 		} else {
 			r.ParseForm()
-			cmd.OrderId = r.FormValue("order_id")
 		}
 		agg, event, err := cmd.Execute(app.OrderRepo)
 		if event != nil { app.EventBus.Publish(event) }
 		if err != nil {
 			if r.Header.Get("Content-Type")=="application/json" { jsonError(w, err); return }
-			http.Error(w, err.Error(), 422); return
+			fields := []FormField{
+				// Order dropdown built dynamically below
+			}
+			orders, _ := app.OrderRepo.All()
+			var orderOpts []FormOption
+			for _, item := range orders {
+				orderOpts = append(orderOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.ID), Selected: item.ID == r.FormValue("order")})
+			}
+			fields = append(fields, FormField{Type: "select", Name: "order", Label: "Order", Required: true, Options: orderOpts})
+			w.WriteHeader(422)
+			renderer.Render(w, "form", "CancelOrder", FormData{
+				CommandName: "Cancel Order",
+				Action: "/orders/cancel_order",
+				ErrorMessage: err.Error(),
+				Fields: fields,
+				CsrfToken: csrfToken(w, r),
+			}); return
 		}
 		if r.Header.Get("Content-Type")=="application/json" { w.WriteHeader(201); jsonResponse(w, agg) } else {
 			http.Redirect(w, r, "/orders/show?id="+agg.ID, http.StatusSeeOther)
 		}
 	})
 
-	type PizzaShowField struct { Label string; Value string; Type string; Items []string }
-	type PizzaShowData struct { AggregateName string; Id string; BackHref string; Fields []PizzaShowField; Buttons []PizzaButton }
+	type PizzaShowField struct { Label string; Value string; Type string; Items []string; Transitions []string }
+	type PizzaShowData struct { AggregateName string; Id string; BackHref string; CsrfToken string; Fields []PizzaShowField; Buttons []PizzaButton }
 	mux.HandleFunc("GET /pizzas/show", func(w http.ResponseWriter, r *http.Request) {
 		obj, _ := app.PizzaRepo.Find(r.URL.Query().Get("id"))
 		if obj == nil { http.Error(w, "Not found", 404); return }
@@ -186,20 +261,23 @@ func (app *App) Start(port int) error {
 			{Label: "Description", Value: fmt.Sprintf("%v", obj.Description)},
 			{Label: "Toppings", Type: "list", Items: func() []string { var s []string; for _, v := range obj.Toppings { s = append(s, fmt.Sprintf("%v", v)) }; return s }()},
 		}
-		renderer.Render(w, "show", "Pizza", PizzaShowData{AggregateName: "Pizza", BackHref: "/pizzas", Id: obj.ID, Fields: fields})
+		buttons := []PizzaButton{PizzaButton{Label: "Add Topping", Href: "/pizzas/add_topping/new?id=" + obj.ID, Allowed: true}}
+		buttons = append(buttons, PizzaButton{Label: "Place Order", Href: "/orders/place_order/new?id=" + obj.ID, Allowed: true})
+		renderer.Render(w, "show", "Pizza", PizzaShowData{AggregateName: "Pizza", BackHref: "/pizzas", Id: obj.ID, CsrfToken: csrfToken(w, r), Fields: fields, Buttons: buttons})
 	})
 
-	type OrderShowField struct { Label string; Value string; Type string; Items []string }
-	type OrderShowData struct { AggregateName string; Id string; BackHref string; Fields []OrderShowField; Buttons []OrderButton }
+	type OrderShowField struct { Label string; Value string; Type string; Items []string; Transitions []string }
+	type OrderShowData struct { AggregateName string; Id string; BackHref string; CsrfToken string; Fields []OrderShowField; Buttons []OrderButton }
 	mux.HandleFunc("GET /orders/show", func(w http.ResponseWriter, r *http.Request) {
 		obj, _ := app.OrderRepo.Find(r.URL.Query().Get("id"))
 		if obj == nil { http.Error(w, "Not found", 404); return }
 		fields := []OrderShowField{
 			{Label: "Customer Name", Value: fmt.Sprintf("%v", obj.CustomerName)},
 			{Label: "Items", Type: "list", Items: func() []string { var s []string; for _, v := range obj.Items { s = append(s, fmt.Sprintf("%v", v)) }; return s }()},
-			{Label: "Status", Value: fmt.Sprintf("%v", obj.Status)},
+			{Label: "Status", Type: "lifecycle", Value: fmt.Sprintf("%v", obj.Status), Transitions: []string{"Cancel Order → cancelled"}},
 		}
-		renderer.Render(w, "show", "Order", OrderShowData{AggregateName: "Order", BackHref: "/orders", Id: obj.ID, Fields: fields})
+		buttons := []OrderButton{OrderButton{Label: "Cancel Order", Href: "/orders/cancel_order", Allowed: true, Direct: true, IdField: "order"}}
+		renderer.Render(w, "show", "Order", OrderShowData{AggregateName: "Order", BackHref: "/orders", Id: obj.ID, CsrfToken: csrfToken(w, r), Fields: fields, Buttons: buttons})
 	})
 
 	// Form routes (types in renderer.go)
@@ -209,70 +287,119 @@ func (app *App) Start(port int) error {
 			{Type: "input", Name: "description", Label: "Description", InputType: "text", Required: true},
 		}
 		renderer.Render(w, "form", "CreatePizza", FormData{
-			CommandName: "CreatePizza",
-			Action: "/pizzas/create_pizza",
+			CommandName: "Create Pizza",
+			Action: "/pizzas/create_pizza/submit",
 			Fields: fields,
+			CsrfToken: csrfToken(w, r),
 		})
 	})
 
 	mux.HandleFunc("GET /pizzas/add_topping/new", func(w http.ResponseWriter, r *http.Request) {
 		fields := []FormField{
-			{Type: "hidden", Name: "pizza_id", Value: r.URL.Query().Get("id")},
 			{Type: "input", Name: "name", Label: "Name", InputType: "text", Required: true},
 			{Type: "input", Name: "amount", Label: "Amount", InputType: "number", Required: true},
-		}
-		renderer.Render(w, "form", "AddTopping", FormData{
-			CommandName: "AddTopping",
-			Action: "/pizzas/add_topping",
-			Fields: fields,
-		})
-	})
-
-	mux.HandleFunc("GET /orders/place_order/new", func(w http.ResponseWriter, r *http.Request) {
-		fields := []FormField{
-			{Type: "input", Name: "customer_name", Label: "Customer Name", InputType: "text", Required: true},
 			// Pizza dropdown built dynamically below
-			{Type: "input", Name: "quantity", Label: "Quantity", InputType: "number", Required: true},
 		}
 		pizzas, _ := app.PizzaRepo.All()
 		var pizzaOpts []FormOption
 		for _, item := range pizzas {
 			pizzaOpts = append(pizzaOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.Name), Selected: item.ID == r.URL.Query().Get("id")})
 		}
-		fields = append(fields, FormField{Type: "select", Name: "pizza_id", Label: "Pizza", Required: true, Options: pizzaOpts})
-		renderer.Render(w, "form", "PlaceOrder", FormData{
-			CommandName: "PlaceOrder",
-			Action: "/orders/place_order",
+		fields = append(fields, FormField{Type: "select", Name: "pizza", Label: "Pizza", Required: true, Options: pizzaOpts})
+		renderer.Render(w, "form", "AddTopping", FormData{
+			CommandName: "Add Topping",
+			Action: "/pizzas/add_topping/submit",
 			Fields: fields,
+			CsrfToken: csrfToken(w, r),
+		})
+	})
+
+	mux.HandleFunc("GET /orders/place_order/new", func(w http.ResponseWriter, r *http.Request) {
+		fields := []FormField{
+			{Type: "input", Name: "customer_name", Label: "Customer Name", InputType: "text", Required: true},
+			{Type: "input", Name: "quantity", Label: "Quantity", InputType: "number", Required: true},
+			// Pizza dropdown built dynamically below
+		}
+		pizzas, _ := app.PizzaRepo.All()
+		var pizzaOpts []FormOption
+		for _, item := range pizzas {
+			pizzaOpts = append(pizzaOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.Name), Selected: item.ID == r.URL.Query().Get("id")})
+		}
+		fields = append(fields, FormField{Type: "select", Name: "pizza", Label: "Pizza", Required: true, Options: pizzaOpts})
+		renderer.Render(w, "form", "PlaceOrder", FormData{
+			CommandName: "Place Order",
+			Action: "/orders/place_order/submit",
+			Fields: fields,
+			CsrfToken: csrfToken(w, r),
 		})
 	})
 
 	mux.HandleFunc("GET /orders/cancel_order/new", func(w http.ResponseWriter, r *http.Request) {
 		fields := []FormField{
-			{Type: "hidden", Name: "order_id", Value: r.URL.Query().Get("id")},
+			// Order dropdown built dynamically below
 		}
+		orders, _ := app.OrderRepo.All()
+		var orderOpts []FormOption
+		for _, item := range orders {
+			orderOpts = append(orderOpts, FormOption{Value: item.ID, Label: fmt.Sprintf("%v", item.ID), Selected: item.ID == r.URL.Query().Get("id")})
+		}
+		fields = append(fields, FormField{Type: "select", Name: "order", Label: "Order", Required: true, Options: orderOpts})
 		renderer.Render(w, "form", "CancelOrder", FormData{
-			CommandName: "CancelOrder",
-			Action: "/orders/cancel_order",
+			CommandName: "Cancel Order",
+			Action: "/orders/cancel_order/submit",
 			Fields: fields,
+			CsrfToken: csrfToken(w, r),
 		})
+	})
+
+	mux.HandleFunc("POST /_reset", func(w http.ResponseWriter, r *http.Request) {
+		app.PizzaRepo = memory.NewPizzaMemoryRepository()
+		app.OrderRepo = memory.NewOrderMemoryRepository()
+		app.EventBus.Clear()
+		http.Redirect(w, r, "/config", http.StatusSeeOther)
+	})
+
+	mux.HandleFunc("GET /_events", func(w http.ResponseWriter, r *http.Request) {
+		events := app.EventBus.Events()
+		type eventEntry struct {
+			Name string `json:"name"`
+			OccurredAt string `json:"occurred_at"`
+		}
+		var result []eventEntry
+		for _, e := range events {
+			result = append(result, eventEntry{
+				Name: e.EventName(),
+				OccurredAt: e.GetOccurredAt().Format(time.RFC3339),
+			})
+		}
+		jsonResponse(w, result)
+	})
+
+	mux.HandleFunc("GET /pizzas/queries/by_description", func(w http.ResponseWriter, r *http.Request) {
+		results, _ := domain.PizzaByDescription(app.PizzaRepo, r.URL.Query().Get("desc"))
+		jsonResponse(w, results)
+	})
+
+	mux.HandleFunc("GET /orders/queries/pending", func(w http.ResponseWriter, r *http.Request) {
+		results, _ := domain.OrderPending(app.OrderRepo)
+		jsonResponse(w, results)
 	})
 
 	// Config
 	type ConfigAgg struct { Name string; Href string; Count int; Commands string; Ports string }
-	type ConfigData struct { Roles []string; CurrentRole string; Adapters []string; CurrentAdapter string; EventCount int; BootedAt string; Policies []string; Aggregates []ConfigAgg }
+	type ConfigData struct { Roles []string; CurrentRole string; Adapters []string; CurrentAdapter string; EventCount int; BootedAt string; Policies []string; Aggregates []ConfigAgg; StructureDiagram template.HTML; BehaviorDiagram template.HTML; FlowsDiagram template.HTML }
 	currentRole := "admin"
 	mux.HandleFunc("GET /config", func(w http.ResponseWriter, r *http.Request) {
 		aggs := []ConfigAgg{
-			{Name: "Pizza", Href: "/pizzas", Commands: "CreatePizza, AddTopping", Ports: "admin: find, all, create_pizza, add_topping | customer: find, all"},
-			{Name: "Order", Href: "/orders", Commands: "PlaceOrder, CancelOrder", Ports: "admin: find, all, place_order, cancel_order | customer: find, all, place_order"},
+			{Name: "Pizza", Href: "/pizzas", Commands: "CreatePizza, AddTopping", Ports: "(none)"},
+			{Name: "Order", Href: "/orders", Commands: "PlaceOrder, CancelOrder", Ports: "(none)"},
 		}
 		pizzaCount, _ := app.PizzaRepo.Count()
 		aggs[0].Count = pizzaCount
 		orderCount, _ := app.OrderRepo.Count()
 		aggs[1].Count = orderCount
 		renderer.Render(w, "config", "Config", ConfigData{
-			Roles: []string{"admin", "customer"},
+			Roles: []string{"admin"},
 			CurrentRole: currentRole,
 			Adapters: []string{"memory", "filesystem"},
 			CurrentAdapter: "memory",
@@ -280,12 +407,15 @@ func (app *App) Start(port int) error {
 			BootedAt: "running",
 			Policies: []string{},
 			Aggregates: aggs,
+			StructureDiagram: template.HTML("classDiagram\n    class Pizza {\n        +String name\n        +String description\n        +Topping[] toppings\n    }\n    class Topping {\n        +String name\n        +Integer amount\n    }\n    Pizza *-- Topping\n    class Order {\n        +String customer_name\n        +OrderItem[] items\n        +String status\n    }\n    class OrderItem {\n        +Integer quantity\n    }\n    Order *-- OrderItem\n    Order --> Pizza : pizza"),
+			BehaviorDiagram: template.HTML("flowchart LR\n    subgraph Pizza\n        Pizza_CreatePizza[CreatePizza]\n        Pizza_CreatedPizza([CreatedPizza])\n        Pizza_CreatePizza --> Pizza_CreatedPizza\n        Pizza_AddTopping[AddTopping]\n        Pizza_AddedTopping([AddedTopping])\n        Pizza_AddTopping --> Pizza_AddedTopping\n    end\n    subgraph Order\n        Order_PlaceOrder[PlaceOrder]\n        Order_PlacedOrder([PlacedOrder])\n        Order_PlaceOrder --> Order_PlacedOrder\n        Order_CancelOrder[CancelOrder]\n        Order_CanceledOrder([CanceledOrder])\n        Order_CancelOrder --> Order_CanceledOrder\n    end"),
+			FlowsDiagram: template.HTML("sequenceDiagram\n  Note over Domain: No reactive flows"),
 		})
 	})
 
 	addr := fmt.Sprintf(":%d", port)
 	fmt.Printf("PizzasDomain on http://localhost%s\n", addr)
-	return http.ListenAndServe(addr, mux)
+	return http.ListenAndServe(addr, NewCSRFMiddleware(mux))
 }
 
 func jsonResponse(w http.ResponseWriter, data interface{}) {
@@ -297,4 +427,33 @@ func jsonError(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(422)
 	json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+}
+
+func csrfToken(w http.ResponseWriter, r *http.Request) string {
+	const cookieName = "_csrf_token"
+	if c, err := r.Cookie(cookieName); err == nil && c.Value != "" {
+		return c.Value
+	}
+	b := make([]byte, 32)
+	rand.Read(b)
+	token := hex.EncodeToString(b)
+	http.SetCookie(w, &http.Cookie{Name: cookieName, Value: token, SameSite: http.SameSiteStrictMode, HttpOnly: true})
+	return token
+}
+
+type CSRFMiddleware struct{ next http.Handler }
+
+func NewCSRFMiddleware(next http.Handler) *CSRFMiddleware {
+	return &CSRFMiddleware{next: next}
+}
+
+func (m *CSRFMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "POST" && r.Header.Get("Content-Type") != "application/json" {
+		cookie, err := r.Cookie("_csrf_token")
+		if err != nil || r.FormValue("_csrf_token") != cookie.Value {
+			http.Error(w, "CSRF validation failed", http.StatusForbidden)
+			return
+		}
+	}
+	m.next.ServeHTTP(w, r)
 }

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
@@ -104,7 +104,7 @@ module GoHecks
       lines.concat(config_route)
       lines << "\taddr := fmt.Sprintf(\":%d\", port)"
       lines << "\tfmt.Printf(\"#{@domain.name}Domain on http://localhost%s\\n\", addr)"
-      lines << "\treturn http.ListenAndServe(addr, mux)"
+      lines << "\treturn http.ListenAndServe(addr, NewCSRFMiddleware(mux))"
       lines << "}"
       lines << ""
       lines
@@ -155,13 +155,21 @@ module GoHecks
         "\treturn token",
         "}",
         "",
-        "func validateCSRF(w http.ResponseWriter, r *http.Request) bool {",
-        "\tc, err := r.Cookie(\"_csrf_token\")",
-        "\tif err != nil || c.Value == \"\" || c.Value != r.FormValue(\"_csrf_token\") {",
-        "\t\thttp.Error(w, \"Forbidden: CSRF token mismatch\", http.StatusForbidden)",
-        "\t\treturn false",
+        "type CSRFMiddleware struct{ next http.Handler }",
+        "",
+        "func NewCSRFMiddleware(next http.Handler) *CSRFMiddleware {",
+        "\treturn &CSRFMiddleware{next: next}",
+        "}",
+        "",
+        "func (m *CSRFMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {",
+        "\tif r.Method == \"POST\" && r.Header.Get(\"Content-Type\") != \"application/json\" {",
+        "\t\tcookie, err := r.Cookie(\"_csrf_token\")",
+        "\t\tif err != nil || r.FormValue(\"_csrf_token\") != cookie.Value {",
+        "\t\t\thttp.Error(w, \"CSRF validation failed\", http.StatusForbidden)",
+        "\t\t\treturn",
+        "\t\t}",
         "\t}",
-        "\treturn true",
+        "\tm.next.ServeHTTP(w, r)",
         "}",
       ]
     end

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -121,7 +121,6 @@ module GoHecks
         lines << "\t\t\tif err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{\"error\":\"invalid json\"}`, 400); return }"
         lines << "\t\t} else {"
         lines << "\t\t\tr.ParseForm()"
-        lines << "\t\t\tif !validateCSRF(w, r) { return }"
         cmd.attributes.each do |a|
           field = GoUtils.pascal_case(a.name)
           go_type = GoUtils.go_type(a)

--- a/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
+++ b/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
@@ -112,12 +112,18 @@ RSpec.describe GoHecks::ServerGenerator do
       expect(output).to include("func csrfToken(w http.ResponseWriter, r *http.Request) string {")
     end
 
-    it "generates validateCSRF helper function" do
-      expect(output).to include("func validateCSRF(w http.ResponseWriter, r *http.Request) bool {")
+    it "generates CSRFMiddleware struct and constructor" do
+      expect(output).to include("type CSRFMiddleware struct{ next http.Handler }")
+      expect(output).to include("func NewCSRFMiddleware(next http.Handler) *CSRFMiddleware {")
     end
 
-    it "calls validateCSRF in form POST handler" do
-      expect(output).to include("if !validateCSRF(w, r) { return }")
+    it "wraps mux with CSRFMiddleware in ListenAndServe" do
+      expect(output).to include("NewCSRFMiddleware(mux)")
+    end
+
+    it "does not emit inline validateCSRF function or calls" do
+      expect(output).not_to include("func validateCSRF(")
+      expect(output).not_to include("if !validateCSRF(w, r)")
     end
 
     it "passes CsrfToken to index render" do


### PR DESCRIPTION
## Summary

- Replaced inline `validateCSRF` free function with idiomatic Go `CSRFMiddleware` struct that wraps the mux
- Removed per-handler `if !validateCSRF(w, r) { return }` calls from command routes — middleware handles it at the transport layer
- Regenerated `examples/pizzas_static_go/server/server.go` with the new pattern

## Before (per-handler inline check)

```go
func validateCSRF(w http.ResponseWriter, r *http.Request) bool {
    c, err := r.Cookie("_csrf_token")
    if err != nil || c.Value == "" || c.Value != r.FormValue("_csrf_token") {
        http.Error(w, "Forbidden: CSRF token mismatch", http.StatusForbidden)
        return false
    }
    return true
}

// In every command handler:
} else {
    r.ParseForm()
    if !validateCSRF(w, r) { return }
    // ...parse fields...
}

http.ListenAndServe(addr, mux)
```

## After (middleware struct)

```go
type CSRFMiddleware struct{ next http.Handler }

func NewCSRFMiddleware(next http.Handler) *CSRFMiddleware {
    return &CSRFMiddleware{next: next}
}

func (m *CSRFMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
    if r.Method == "POST" && r.Header.Get("Content-Type") != "application/json" {
        cookie, err := r.Cookie("_csrf_token")
        if err != nil || r.FormValue("_csrf_token") != cookie.Value {
            http.Error(w, "CSRF validation failed", http.StatusForbidden)
            return
        }
    }
    m.next.ServeHTTP(w, r)
}

// Command handlers no longer need CSRF checks
} else {
    r.ParseForm()
    // ...parse fields directly...
}

http.ListenAndServe(addr, NewCSRFMiddleware(mux))
```

## Why middleware is better

- **Single point of enforcement** — CSRF validation happens once at the transport layer, not duplicated in every POST handler
- **Idiomatic Go** — `http.Handler` wrapper is the standard Go middleware pattern
- **JSON exemption preserved** — `Content-Type: application/json` requests skip validation, matching the previous inline behavior
- **Easier to extend** — adding new POST routes automatically gets CSRF protection

## Test plan

- [x] Specs assert `CSRFMiddleware` struct and `NewCSRFMiddleware` appear in generated output
- [x] Specs assert `validateCSRF` free function and inline calls are absent
- [x] Full suite passes (1472 examples, 0 failures, under 1 second)
- [x] Smoke test passes
- [x] Regenerated pizzas example has correct output