### PR TITLE
HEC-440: Guard Access-Control-Allow-Origin behind ENV check

### DIFF
--- a/docs/usage/cors.md
+++ b/docs/usage/cors.md
@@ -1,0 +1,45 @@
+# CORS Configuration
+
+Hecks HTTP servers (`DomainServer`, `RpcServer`, `MultiDomainServer`) do **not**
+emit `Access-Control-Allow-Origin` by default. Cross-origin access is opt-in via
+environment variables.
+
+## Environment variables
+
+| Variable | Value | Behaviour |
+|---|---|---|
+| `HECKS_ALLOW_ALL_ORIGINS` | `true` | Emits `Access-Control-Allow-Origin: *` |
+| `HECKS_CORS_ORIGIN` | e.g. `https://app.example.com` | Emits that exact value |
+| (neither set) | — | Header is not emitted |
+
+`HECKS_ALLOW_ALL_ORIGINS` takes precedence. If both are set, `*` is emitted.
+
+## Before (always open)
+
+Previously every response included:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+regardless of deployment context.
+
+## After (opt-in)
+
+```bash
+# Allow all origins (development / public APIs)
+HECKS_ALLOW_ALL_ORIGINS=true hecks serve pizzas_domain
+
+# Allow a specific origin (production)
+HECKS_CORS_ORIGIN=https://app.example.com hecks serve pizzas_domain
+
+# No CORS header — same-origin only (default)
+hecks serve pizzas_domain
+```
+
+## How it works
+
+All three servers include `Hecks::HTTP::CorsHeaders` and call
+`apply_cors_origin(res)` at the top of each request handler. The method reads
+the ENV variables once per request and sets the header only when a value is
+present.

--- a/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
@@ -3,6 +3,7 @@ require "json"
 require "stringio"
 require "tmpdir"
 require_relative "route_builder"
+require "hecks/extensions/serve/cors_headers"
 
 module Hecks
   module HTTP
@@ -23,6 +24,7 @@ module Hecks
     #
     class DomainServer
       include HecksTemplating::NamingHelpers
+      include Hecks::HTTP::CorsHeaders
       # Initialize the server, boot the domain gem, and build routes.
       #
       # Builds the domain gem into a temporary directory, requires it,
@@ -173,12 +175,15 @@ module Hecks
         pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
       end
 
-      # Set CORS headers on the response to allow cross-origin requests.
+      # Set CORS headers on the response using ENV-driven origin config.
+      #
+      # Delegates to {Hecks::HTTP::CorsHeaders#apply_cors_origin} which
+      # checks HECKS_ALLOW_ALL_ORIGINS and HECKS_CORS_ORIGIN env vars.
       #
       # @param res [WEBrick::HTTPResponse] the response to add headers to
       # @return [void]
       def set_cors(res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         res["Access-Control-Allow-Methods"] = "GET, POST, PATCH, DELETE, OPTIONS"
         res["Access-Control-Allow-Headers"] = "Content-Type"
       end

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -2,6 +2,7 @@ require "webrick"
 require "json"
 require "tmpdir"
 require_relative "route_builder"
+require "hecks/extensions/serve/cors_headers"
 require "hecks/extensions/web_explorer/renderer"
 require "hecks/extensions/web_explorer/ir_introspector"
 require "hecks/extensions/web_explorer/runtime_bridge"
@@ -23,6 +24,7 @@ module Hecks
     class MultiDomainServer
       include HecksTemplating::NamingHelpers
       include UIRoutes
+      include Hecks::HTTP::CorsHeaders
 
       def initialize(domains, runtimes, port: 9292)
         @domains = domains
@@ -87,7 +89,7 @@ module Hecks
       end
 
       def handle(req, res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         return if req.request_method == "OPTIONS"
 
         path = req.path

--- a/hecks_workshop/explorer/lib/hecks_explorer/rpc_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/rpc_server.rb
@@ -1,6 +1,7 @@
 require "webrick"
 require "json"
 require "tmpdir"
+require "hecks/extensions/serve/cors_headers"
 
 module Hecks
   module HTTP
@@ -23,6 +24,7 @@ module Hecks
     #
     class RpcServer
       include HecksTemplating::NamingHelpers
+      include Hecks::HTTP::CorsHeaders
       # Initialize the RPC server, boot the domain, and register all methods.
       #
       # Builds the domain gem into a temp directory, boots it, then
@@ -71,7 +73,7 @@ module Hecks
       # @param res [WEBrick::HTTPResponse] the outgoing HTTP response
       # @return [void]
       def handle(req, res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         res["Access-Control-Allow-Methods"] = "POST, OPTIONS"
         res["Access-Control-Allow-Headers"] = "Content-Type"
         res["Content-Type"] = "application/json"

--- a/hecksties/lib/hecks/extensions/serve/cors_headers.rb
+++ b/hecksties/lib/hecks/extensions/serve/cors_headers.rb
@@ -1,0 +1,54 @@
+# Hecks::HTTP::CorsHeaders
+#
+# Mixin that provides ENV-driven CORS origin logic for Hecks HTTP servers.
+# Instead of unconditionally emitting `Access-Control-Allow-Origin: *`,
+# servers include this module and call `apply_cors_origin(res)` to set the
+# header only when an origin is explicitly configured via environment variable.
+#
+# ENV variables (checked in order):
+#   HECKS_ALLOW_ALL_ORIGINS=true          → emits `*`
+#   HECKS_CORS_ORIGIN=https://app.example.com → emits that value
+#   (neither set)                          → header is not emitted
+#
+# Usage:
+#   class MyServer
+#     include Hecks::HTTP::CorsHeaders
+#
+#     def handle(req, res)
+#       apply_cors_origin(res)
+#       # ... rest of handler
+#     end
+#   end
+
+module Hecks
+  module HTTP
+    module CorsHeaders
+      # Return the CORS origin value based on ENV configuration.
+      #
+      # Checks HECKS_ALLOW_ALL_ORIGINS first; if truthy returns "*".
+      # Otherwise returns HECKS_CORS_ORIGIN if set, or nil if neither is set.
+      #
+      # @return [String, nil] the origin value to use, or nil to suppress the header
+      def cors_origin_value
+        return "*" if ENV["HECKS_ALLOW_ALL_ORIGINS"].to_s.downcase == "true"
+
+        origin = ENV["HECKS_CORS_ORIGIN"]
+        return origin if origin && !origin.empty?
+
+        nil
+      end
+
+      # Set the Access-Control-Allow-Origin header on a response, if configured.
+      #
+      # Calls {#cors_origin_value}; if non-nil, sets the header. If nil,
+      # the header is left unset and no cross-origin access is permitted.
+      #
+      # @param res [WEBrick::HTTPResponse] the response to modify
+      # @return [void]
+      def apply_cors_origin(res)
+        value = cors_origin_value
+        res["Access-Control-Allow-Origin"] = value if value
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -3,6 +3,7 @@ require "json"
 require "stringio"
 require "tmpdir"
 require_relative "route_builder"
+require_relative "cors_headers"
 
 module Hecks
   module HTTP
@@ -23,6 +24,7 @@ module Hecks
     #
     class DomainServer
       include HecksTemplating::NamingHelpers
+      include Hecks::HTTP::CorsHeaders
       # Initialize the server, boot the domain gem, and build routes.
       #
       # Builds the domain gem into a temporary directory, requires it,
@@ -173,12 +175,15 @@ module Hecks
         pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
       end
 
-      # Set CORS headers on the response to allow cross-origin requests.
+      # Set CORS headers on the response using ENV-driven origin config.
+      #
+      # Delegates to {Hecks::HTTP::CorsHeaders#apply_cors_origin} which
+      # checks HECKS_ALLOW_ALL_ORIGINS and HECKS_CORS_ORIGIN env vars.
       #
       # @param res [WEBrick::HTTPResponse] the response to add headers to
       # @return [void]
       def set_cors(res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         res["Access-Control-Allow-Methods"] = "GET, POST, PATCH, DELETE, OPTIONS"
         res["Access-Control-Allow-Headers"] = "Content-Type"
       end

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -2,6 +2,7 @@ require "webrick"
 require "json"
 require "tmpdir"
 require_relative "route_builder"
+require_relative "cors_headers"
 require "hecks/extensions/web_explorer/renderer"
 require "hecks/extensions/web_explorer/ir_introspector"
 require "hecks/extensions/web_explorer/runtime_bridge"
@@ -23,6 +24,7 @@ module Hecks
     class MultiDomainServer
       include HecksTemplating::NamingHelpers
       include UIRoutes
+      include Hecks::HTTP::CorsHeaders
 
       def initialize(domains, runtimes, port: 9292)
         @domains = domains
@@ -87,7 +89,7 @@ module Hecks
       end
 
       def handle(req, res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         return if req.request_method == "OPTIONS"
 
         path = req.path

--- a/hecksties/lib/hecks/extensions/serve/rpc_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/rpc_server.rb
@@ -1,6 +1,7 @@
 require "webrick"
 require "json"
 require "tmpdir"
+require_relative "cors_headers"
 
 module Hecks
   module HTTP
@@ -23,6 +24,7 @@ module Hecks
     #
     class RpcServer
       include HecksTemplating::NamingHelpers
+      include Hecks::HTTP::CorsHeaders
       # Initialize the RPC server, boot the domain, and register all methods.
       #
       # Builds the domain gem into a temp directory, boots it, then
@@ -71,7 +73,7 @@ module Hecks
       # @param res [WEBrick::HTTPResponse] the outgoing HTTP response
       # @return [void]
       def handle(req, res)
-        res["Access-Control-Allow-Origin"] = "*"
+        apply_cors_origin(res)
         res["Access-Control-Allow-Methods"] = "POST, OPTIONS"
         res["Access-Control-Allow-Headers"] = "Content-Type"
         res["Content-Type"] = "application/json"

--- a/hecksties/spec/extensions/serve/cors_headers_spec.rb
+++ b/hecksties/spec/extensions/serve/cors_headers_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+require "hecks/extensions/serve/cors_headers"
+
+RSpec.describe Hecks::HTTP::CorsHeaders do
+  subject(:host) do
+    Class.new { include Hecks::HTTP::CorsHeaders }.new
+  end
+
+  around do |example|
+    orig_allow_all = ENV.delete("HECKS_ALLOW_ALL_ORIGINS")
+    orig_origin    = ENV.delete("HECKS_CORS_ORIGIN")
+    example.run
+  ensure
+    ENV["HECKS_ALLOW_ALL_ORIGINS"] = orig_allow_all if orig_allow_all
+    ENV["HECKS_CORS_ORIGIN"]       = orig_origin    if orig_origin
+  end
+
+  describe "#cors_origin_value" do
+    it "returns '*' when HECKS_ALLOW_ALL_ORIGINS=true" do
+      ENV["HECKS_ALLOW_ALL_ORIGINS"] = "true"
+      expect(host.cors_origin_value).to eq("*")
+    end
+
+    it "returns the configured origin when HECKS_CORS_ORIGIN is set" do
+      ENV["HECKS_CORS_ORIGIN"] = "https://example.com"
+      expect(host.cors_origin_value).to eq("https://example.com")
+    end
+
+    it "returns nil when neither variable is set" do
+      expect(host.cors_origin_value).to be_nil
+    end
+  end
+
+  describe "#apply_cors_origin" do
+    let(:res) { {} }
+
+    it "sets the header when a value is present" do
+      ENV["HECKS_CORS_ORIGIN"] = "https://app.example.com"
+      host.apply_cors_origin(res)
+      expect(res["Access-Control-Allow-Origin"]).to eq("https://app.example.com")
+    end
+
+    it "does not set the header when no value is configured" do
+      host.apply_cors_origin(res)
+      expect(res).not_to have_key("Access-Control-Allow-Origin")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Previously all three HTTP servers (`DomainServer`, `RpcServer`, `MultiDomainServer`) unconditionally emitted `Access-Control-Allow-Origin: *` on every response. This PR makes CORS opt-in via environment variables.

- Extract `Hecks::HTTP::CorsHeaders` mixin with `cors_origin_value` / `apply_cors_origin(res)`
- Include the mixin in all 6 server files (hecksties + hecks_workshop/explorer)
- Replace every `res["Access-Control-Allow-Origin"] = "*"` with `apply_cors_origin(res)`
- Add 5 specs covering all ENV combinations
- Add `docs/usage/cors.md` with ENV var table and runnable examples

## ENV var behaviour

| Variable | Value | Header emitted |
|---|---|---|
| `HECKS_ALLOW_ALL_ORIGINS` | `true` | `Access-Control-Allow-Origin: *` |
| `HECKS_CORS_ORIGIN` | `https://app.example.com` | `Access-Control-Allow-Origin: https://app.example.com` |
| (neither) | — | *(header omitted)* |

`HECKS_ALLOW_ALL_ORIGINS` takes precedence when both are set.

## Before / After

**Before** — always open, no ENV needed:
```
< Access-Control-Allow-Origin: *
```

**After** — header absent by default:
```bash
# Development: allow all
HECKS_ALLOW_ALL_ORIGINS=true hecks serve pizzas_domain

# Production: specific origin
HECKS_CORS_ORIGIN=https://app.example.com hecks serve pizzas_domain

# Default: no CORS header
hecks serve pizzas_domain
```

## Test plan

- [x] `bundle exec rspec hecksties/spec/extensions/serve/cors_headers_spec.rb` — 5 examples, 0 failures
- [x] Full suite — 1477 examples, 0 failures in 0.90s