### PR TITLE
HEC-438: HTTP adapter — command bus port between routes and domain

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -428,6 +428,14 @@
 - `add_attribute` tool for adding individual attributes to existing aggregates
 - All tool output uses `capture_output` to show the same terse feedback as the REPL
 
+### Command Bus Port (HTTP Adapter Boundary)
+- `Hecks::HTTP::CommandBusPort` — explicit port between HTTP routes and the domain
+- Mutations route through the `CommandBus` middleware pipeline via `port.dispatch`
+- Reads validate against a safety whitelist (blocks `eval`, `system`, `exec`, `send`, etc.)
+- Port-level middleware fires before the command bus — `port.use(:name) { |cmd, attrs, next_fn| ... }`
+- Port middleware can short-circuit requests without reaching the domain
+- `DomainServer` and `RpcServer` both use the port for all dispatch
+
 ### Self-Discoverable HTTP API
 - `GET /_openapi` returns the OpenAPI 3.0 spec as JSON
 - `GET /_schema` returns JSON Schema definitions

--- a/docs/usage/command_bus_port.md
+++ b/docs/usage/command_bus_port.md
@@ -1,0 +1,91 @@
+# Command Bus Port (HTTP Adapter Boundary)
+
+The `Hecks::HTTP::CommandBusPort` is the explicit boundary between HTTP routes
+and the domain layer. All mutations flow through the `CommandBus` middleware
+pipeline. All reads are validated against a safety whitelist before calling
+public methods on aggregate classes.
+
+## Architecture
+
+```
+HTTP Request
+    |
+    v
+RouteBuilder (routes)
+    |
+    v
+CommandBusPort          <-- new boundary
+    |           |
+    v           v
+ dispatch()   read()
+    |           |
+    v           |
+CommandBus      |     (middleware pipeline)
+    |           |
+    v           v
+   Domain Layer
+```
+
+## Usage
+
+```ruby
+# Build a port from a command bus
+port = Hecks::HTTP::CommandBusPort.new(command_bus: app.command_bus)
+
+# Mutations go through the command bus pipeline
+port.dispatch("CreatePizza", name: "Margherita")
+
+# Reads call public methods after safety validation
+port.read(PizzaClass, "Pizza", :all)
+port.read(PizzaClass, "Pizza", :find, some_id)
+```
+
+## Port Middleware
+
+Port-level middleware fires before the command reaches the bus. This is useful
+for HTTP-specific concerns (rate limiting, request logging, authentication)
+that should not live in the domain command bus.
+
+```ruby
+port.use(:http_auth) do |command_name, attrs, next_fn|
+  raise "Unauthorized" unless current_user_authorized?(command_name)
+  next_fn.call
+end
+
+port.use(:request_timing) do |command_name, attrs, next_fn|
+  start = Time.now
+  result = next_fn.call
+  puts "#{command_name} took #{Time.now - start}s"
+  result
+end
+```
+
+Middleware can short-circuit by not calling `next_fn`:
+
+```ruby
+port.use(:blocker) do |command_name, attrs, next_fn|
+  :blocked  # command bus never reached
+end
+```
+
+## Read Safety
+
+The port blocks dangerous method calls via `FORBIDDEN_READS`:
+
+```ruby
+port.read(klass, "Pizza", :eval)    # => raises DispatchNotAllowed
+port.read(klass, "Pizza", :system)  # => raises DispatchNotAllowed
+port.read(klass, "Pizza", :send)    # => raises DispatchNotAllowed
+```
+
+Safe reads pass through to `public_send`:
+
+```ruby
+port.read(klass, "Pizza", :all)     # => klass.public_send(:all)
+port.read(klass, "Pizza", :find, id) # => klass.public_send(:find, id)
+```
+
+## Integration
+
+Both `DomainServer` and `RpcServer` build a `CommandBusPort` at boot and
+thread it through to route handlers. No HTTP handler calls the domain directly.

--- a/hecksties/lib/hecks/extensions/serve.rb
+++ b/hecksties/lib/hecks/extensions/serve.rb
@@ -43,6 +43,7 @@ module Hecks
     autoload :MultiDomainServer,  "hecks/extensions/serve/multi_domain_server"
     autoload :RpcServer,          "hecks/extensions/serve/rpc_server"
     autoload :RouteBuilder,       "hecks/extensions/serve/route_builder"
+    autoload :CommandBusPort,     "hecks/extensions/serve/command_bus_port"
     autoload :OpenapiGenerator,   "hecks/generators/docs/openapi_generator"
     autoload :RpcDiscovery,       "hecks/generators/docs/rpc_discovery"
     autoload :JsonSchemaGenerator, "hecks/generators/docs/json_schema_generator"

--- a/hecksties/lib/hecks/extensions/serve/command_bus_port.rb
+++ b/hecksties/lib/hecks/extensions/serve/command_bus_port.rb
@@ -1,0 +1,89 @@
+module Hecks
+  module HTTP
+    # Hecks::HTTP::CommandBusPort
+    #
+    # Explicit HTTP adapter port that owns all dispatch between HTTP routes
+    # and the domain. Mutations route through the CommandBus middleware
+    # pipeline. Reads validate against a safety whitelist before calling
+    # public methods on aggregate classes.
+    #
+    # Supports its own middleware layer (independent from CommandBus
+    # middleware) that wraps every dispatch call. Port middleware fires
+    # before the command reaches the bus.
+    #
+    # Usage:
+    #   port = Hecks::HTTP::CommandBusPort.new(command_bus: bus)
+    #   port.dispatch("CreatePizza", name: "Margherita")
+    #   port.read(PizzaClass, "Pizza", :all)
+    #
+    class CommandBusPort
+      # Methods that must never be callable via the read path.
+      FORBIDDEN_READS = %i[
+        eval system exec send __send__ instance_eval class_eval
+        module_eval define_method remove_method
+      ].freeze
+
+      # Error raised when a read targets a forbidden method.
+      class DispatchNotAllowed < StandardError; end
+
+      # @param command_bus [Hecks::Commands::CommandBus] the bus for mutation dispatch
+      def initialize(command_bus:)
+        @command_bus = command_bus
+        @middlewares = []
+      end
+
+      # Dispatch a mutation through port middleware, then the command bus.
+      #
+      # @param command_name [String] e.g. "CreatePizza"
+      # @param attrs [Hash] keyword arguments for the command
+      # @return [Object] the result from the command bus pipeline
+      def dispatch(command_name, **attrs)
+        run_middlewares(command_name, attrs) do
+          @command_bus.dispatch(command_name, **attrs)
+        end
+      end
+
+      # Execute a read against an aggregate class after safety validation.
+      #
+      # @param klass [Class] the aggregate class (e.g. PizzasDomain::Pizza)
+      # @param agg_name [String] aggregate name for logging/context
+      # @param method_name [Symbol] the method to call (e.g. :all, :find)
+      # @param args [Array] positional arguments forwarded to the method
+      # @return [Object] the method's return value
+      # @raise [DispatchNotAllowed] if method_name is on the forbidden list
+      def read(klass, agg_name, method_name, *args)
+        sym = method_name.to_sym
+        raise DispatchNotAllowed, "Forbidden read method: #{sym}" if FORBIDDEN_READS.include?(sym)
+
+        klass.public_send(sym, *args)
+      end
+
+      # Register port-level middleware that wraps dispatch calls.
+      #
+      # @param name [Symbol, String] a label for the middleware
+      # @yield [command_name, attrs, next_fn] the middleware logic
+      # @yieldparam command_name [String] the command being dispatched
+      # @yieldparam attrs [Hash] command attributes
+      # @yieldparam next_fn [Proc] call to continue the chain
+      # @return [void]
+      def use(name, &block)
+        @middlewares << { name: name, block: block }
+      end
+
+      private
+
+      # Build and execute the port middleware chain around a final block.
+      #
+      # @param command_name [String] the command name for middleware context
+      # @param attrs [Hash] the command attributes for middleware context
+      # @yield the innermost handler (command bus dispatch)
+      # @return [Object] the chain result
+      def run_middlewares(command_name, attrs, &final)
+        chain = @middlewares.reverse.reduce(final) do |next_fn, mw|
+          -> { mw[:block].call(command_name, attrs, next_fn) }
+        end
+        chain.call
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -3,6 +3,7 @@ require "json"
 require "stringio"
 require "tmpdir"
 require_relative "route_builder"
+require_relative "command_bus_port"
 
 module Hecks
   module HTTP
@@ -156,7 +157,8 @@ module Hecks
         end
         @mod = Object.const_get(mod_name)
         @app = Runtime.new(@domain)
-        @routes = RouteBuilder.new(@domain, @mod).build
+        @port = CommandBusPort.new(command_bus: @app.command_bus)
+        @routes = RouteBuilder.new(@domain, @mod, port: @port).build
       end
 
       # Check if a route pattern matches a request path.

--- a/hecksties/lib/hecks/extensions/serve/route_builder.rb
+++ b/hecksties/lib/hecks/extensions/serve/route_builder.rb
@@ -22,9 +22,10 @@ module Hecks
       # @param mod [Module] the domain module constant (e.g. +PizzasDomain+)
       #   that holds the generated aggregate classes
       # @return [RouteBuilder] a new builder ready to generate routes
-      def initialize(domain, mod)
+      def initialize(domain, mod, port: nil)
         @domain = domain
         @mod = mod
+        @port = port
       end
 
       # Build and return an array of route hashes for all aggregates.
@@ -62,32 +63,48 @@ module Hecks
       # @param slug [String] the URL slug (e.g. "pizzas")
       # @return [Array<Hash>] the generated CRUD route hashes
       def crud_routes(agg, klass, slug)
+        port = @port
         routes = []
-        routes << { method: "GET", path: "/#{slug}", handler: ->(_) { klass.all.map { |r| serialize(r) } } }
+        routes << { method: "GET", path: "/#{slug}", handler: ->(_) {
+          results = port ? port.read(klass, agg.name, :all) : klass.all
+          results.map { |r| serialize(r) }
+        }}
         routes << { method: "GET", path: "/#{slug}/:id", handler: ->(req) {
-          result = klass.find(req.path.split("/").last)
+          id = req.path.split("/").last
+          result = port ? port.read(klass, agg.name, :find, id) : klass.find(id)
           result ? serialize(result) : (raise "Not found")
         }}
 
         create_cmd = agg.commands.find { |c| c.name.start_with?("Create") }
         if create_cmd
-          m = derive_method(create_cmd.name, agg.name)
           routes << { method: "POST", path: "/#{slug}", handler: ->(req) {
-            serialize(klass.send(m, **parse_body(req)))
+            if port
+              serialize(port.dispatch(create_cmd.name, **parse_body(req)))
+            else
+              m = derive_method(create_cmd.name, agg.name)
+              serialize(klass.send(m, **parse_body(req)))
+            end
           }}
         end
 
         update_cmd = agg.commands.find { |c| c.name.start_with?("Update") }
         if update_cmd
           routes << { method: "PATCH", path: "/#{slug}/:id", handler: ->(req) {
-            existing = klass.find(req.path.split("/").last)
+            id = req.path.split("/").last
+            existing = port ? port.read(klass, agg.name, :find, id) : klass.find(id)
             raise "Not found" unless existing
             serialize(existing.update(**parse_body(req)))
           }}
         end
 
         routes << { method: "DELETE", path: "/#{slug}/:id", handler: ->(req) {
-          id = req.path.split("/").last; klass.delete(id); { deleted: id }
+          id = req.path.split("/").last
+          if port
+            port.read(klass, agg.name, :delete, id)
+          else
+            klass.delete(id)
+          end
+          { deleted: id }
         }}
         routes
       end
@@ -102,11 +119,17 @@ module Hecks
       # @param slug [String] the URL slug
       # @return [Array<Hash>] the generated query route hashes
       def query_routes(agg, klass, slug)
+        port = @port
         agg.queries.map do |query|
           qn = domain_snake_name(query.name)
           params = query.block.parameters
           { method: "GET", path: "/#{slug}/#{qn}", handler: ->(req) {
-            results = params.empty? ? klass.send(qn.to_sym) : klass.send(qn.to_sym, *params.map { |_, n| req.params[n.to_s] })
+            args = params.map { |_, n| req.params[n.to_s] }
+            results = if port
+              params.empty? ? port.read(klass, agg.name, qn.to_sym) : port.read(klass, agg.name, qn.to_sym, *args)
+            else
+              params.empty? ? klass.send(qn.to_sym) : klass.send(qn.to_sym, *args)
+            end
             results.respond_to?(:map) ? results.map { |r| serialize(r) } : results
           }}
         end

--- a/hecksties/lib/hecks/extensions/serve/rpc_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/rpc_server.rb
@@ -1,6 +1,7 @@
 require "webrick"
 require "json"
 require "tmpdir"
+require_relative "command_bus_port"
 
 module Hecks
   module HTTP
@@ -121,6 +122,7 @@ module Hecks
         end
         @mod = Object.const_get(mod_name)
         @app = Runtime.new(@domain)
+        @port = CommandBusPort.new(command_bus: @app.command_bus)
       end
 
       # Register all RPC methods for all aggregates.
@@ -148,10 +150,10 @@ module Hecks
       # @param klass [Class] the aggregate's Ruby class
       # @return [void]
       def register_commands(agg, klass)
+        port = @port
         agg.commands.each do |cmd|
-          method_name = domain_command_method(cmd.name, agg.name)
           @methods[cmd.name] = ->(params) {
-            serialize(klass.send(method_name, **params.transform_keys(&:to_sym)))
+            serialize(port.dispatch(cmd.name, **params.transform_keys(&:to_sym)))
           }
         end
       end
@@ -166,12 +168,13 @@ module Hecks
       # @param klass [Class] the aggregate's Ruby class
       # @return [void]
       def register_queries(agg, klass)
+        port = @port
         agg.queries.each do |query|
           qn = domain_snake_name(query.name)
           params = query.block.parameters
           @methods["#{agg.name}.#{qn}"] = ->(p) {
             args = params.map { |_, name| p[name.to_s] }
-            results = params.empty? ? klass.send(qn.to_sym) : klass.send(qn.to_sym, *args)
+            results = params.empty? ? port.read(klass, agg.name, qn.to_sym) : port.read(klass, agg.name, qn.to_sym, *args)
             results.respond_to?(:map) ? results.map { |r| serialize(r) } : results
           }
         end
@@ -189,14 +192,15 @@ module Hecks
       # @param klass [Class] the aggregate's Ruby class
       # @return [void]
       def register_crud(agg, klass)
+        port = @port
         name = agg.name
         @methods["#{name}.find"] = ->(p) {
-          result = klass.find(p["id"])
+          result = port.read(klass, name, :find, p["id"])
           result ? serialize(result) : (raise "Not found")
         }
-        @methods["#{name}.all"] = ->(_) { klass.all.map { |r| serialize(r) } }
-        @methods["#{name}.count"] = ->(_) { klass.count }
-        @methods["#{name}.delete"] = ->(p) { klass.delete(p["id"]); { deleted: p["id"] } }
+        @methods["#{name}.all"] = ->(_) { port.read(klass, name, :all).map { |r| serialize(r) } }
+        @methods["#{name}.count"] = ->(_) { port.read(klass, name, :count) }
+        @methods["#{name}.delete"] = ->(p) { port.read(klass, name, :delete, p["id"]); { deleted: p["id"] } }
       end
 
       # Serialize a domain object into a plain Hash using Hecks::Utils.

--- a/hecksties/spec/extensions/serve/command_bus_port_spec.rb
+++ b/hecksties/spec/extensions/serve/command_bus_port_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+require "hecks/extensions/serve/command_bus_port"
+
+RSpec.describe Hecks::HTTP::CommandBusPort do
+  before(:all) do
+    @domain = Hecks.domain "PortTest" do
+      aggregate "Widget" do
+        attribute :name, String
+
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+    Hecks.load(@domain)
+  end
+
+  let(:event_bus) { Hecks::EventBus.new }
+  let(:command_bus) { Hecks::Commands::CommandBus.new(domain: @domain, event_bus: event_bus) }
+  subject(:port) { described_class.new(command_bus: command_bus) }
+
+  describe "#dispatch" do
+    it "routes through the command bus" do
+      event = port.dispatch("CreateWidget", name: "Sprocket")
+      expect(event.name).to eq("Sprocket")
+    end
+
+    it "triggers command bus middleware" do
+      log = []
+      command_bus.use(:spy) do |command, next_handler|
+        log << command.class.name.split("::").last
+        next_handler.call
+      end
+
+      port.dispatch("CreateWidget", name: "Gear")
+      expect(log).to include("CreateWidget")
+    end
+  end
+
+  describe "#read" do
+    let(:klass) { double("WidgetClass") }
+
+    it "calls a public method on the class" do
+      allow(klass).to receive(:all).and_return([])
+      result = port.read(klass, "Widget", :all)
+      expect(result).to eq([])
+      expect(klass).to have_received(:all)
+    end
+
+    it "raises DispatchNotAllowed for :eval" do
+      expect { port.read(klass, "Widget", :eval) }
+        .to raise_error(Hecks::HTTP::CommandBusPort::DispatchNotAllowed)
+    end
+
+    it "raises DispatchNotAllowed for :system" do
+      expect { port.read(klass, "Widget", :system) }
+        .to raise_error(Hecks::HTTP::CommandBusPort::DispatchNotAllowed)
+    end
+  end
+
+  describe "#use (port middleware)" do
+    it "fires before command bus dispatch" do
+      order = []
+
+      command_bus.use(:bus_mw) do |_cmd, next_handler|
+        order << "bus"
+        next_handler.call
+      end
+
+      port.use(:port_mw) do |_name, _attrs, next_fn|
+        order << "port"
+        next_fn.call
+      end
+
+      port.dispatch("CreateWidget", name: "Bolt")
+      expect(order).to eq(%w[port bus])
+    end
+
+    it "can short-circuit without calling next" do
+      port.use(:blocker) do |_name, _attrs, _next_fn|
+        :blocked
+      end
+
+      result = port.dispatch("CreateWidget", name: "Blocked")
+      expect(result).to eq(:blocked)
+      expect(event_bus.events).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces `Hecks::HTTP::CommandBusPort` as the explicit boundary between HTTP route handlers and the domain layer
- Mutations flow through the `CommandBus` middleware pipeline via `port.dispatch`
- Reads validate against a `FORBIDDEN_READS` whitelist (blocks `eval`, `system`, `exec`, `send`, etc.) before calling `public_send`
- Port supports its own middleware layer (independent from CommandBus middleware) that fires before the command reaches the bus

## Architecture

```
  HTTP Request
       |
       v
  RouteBuilder
       |
       v
  CommandBusPort            <-- new boundary
       |           |
       v           v
   dispatch()    read()
       |           |
       v           |
  CommandBus       |        (middleware pipeline)
       |           |
       v           v
     Domain Layer
```

## Middleware Table

| Layer           | Fires when        | Context params                    | Can short-circuit? |
|-----------------|--------------------|-----------------------------------|--------------------|
| Port middleware  | Every dispatch     | command_name, attrs, next_fn      | Yes                |
| Bus middleware   | Mutation dispatch  | command, next_handler             | Yes                |

## Example usage

```ruby
port = Hecks::HTTP::CommandBusPort.new(command_bus: app.command_bus)
port.dispatch("CreatePizza", name: "Margherita")  # -> CommandBus pipeline
port.read(klass, "Pizza", :all)                   # -> whitelist check + klass.all
```

## Test plan

- [x] `dispatch` routes through command bus (returns event)
- [x] `dispatch` triggers bus middleware
- [x] `read` calls public method on class
- [x] `read` raises `DispatchNotAllowed` for `:eval`
- [x] `read` raises `DispatchNotAllowed` for `:system`
- [x] Port `use` middleware fires before bus dispatch
- [x] Middleware can short-circuit (return early without calling next)
- [x] Full suite: 1479 specs pass in <1s
- [x] Smoke test passes