### PR TITLE
HEC-455: Domain versioning — snapshot, diff, pin

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -292,6 +292,15 @@
 - Implicit foreign key detection: warns when `_id String` should be `reference_to("Aggregate")`
 - Validator collects non-blocking warnings alongside blocking errors
 
+## Domain Interface Versioning
+- `hecks version_tag <version>` — snapshot current domain DSL to `db/hecks_versions/<version>.rb` with metadata header
+- `hecks version_log` — list all tagged versions newest-first with date and one-line change summary
+- `hecks diff --v1 <v1> --v2 <v2>` — diff two tagged version snapshots with breaking change classification
+- `hecks diff --v1 <v1>` — diff a tagged version against the working domain file
+- `hecks diff` — diff working domain against latest tagged version (falls back to build snapshot)
+- Breaking change classification: removed commands, removed attributes, removed aggregates marked as BREAKING
+- Non-breaking changes: added commands, added attributes, added queries, added scopes
+
 ## Migrations & Schema Evolution
 - `DomainDiff` detects added/removed aggregates, attributes, VOs, entities, indexes, commands, policies, validations, invariants, queries, scopes, subscribers, specifications
 - SQL migration strategy generates Sequel-compatible files

--- a/docs/usage/versioning.md
+++ b/docs/usage/versioning.md
@@ -1,0 +1,80 @@
+# Domain Interface Versioning
+
+Tag, log, and diff domain interface versions to track breaking changes
+across releases.
+
+## Tag a version
+
+Snapshot the current domain DSL as a named version:
+
+```bash
+hecks version_tag 1.0.0
+# Tagged Banking as v1.0.0
+#   Snapshot: db/hecks_versions/1.0.0.rb
+```
+
+The snapshot file contains a metadata header followed by the full DSL:
+
+```ruby
+# Hecks domain snapshot
+# version: 1.0.0
+# tagged_at: 2026-04-01
+Hecks.domain "Banking" do
+  aggregate "Account" do
+    attribute :name, String
+    command "CreateAccount" do
+      attribute :name, String
+    end
+  end
+end
+```
+
+## List versions
+
+```bash
+hecks version_log
+# 2.1.0  2026-04-01  +FreezeAccount command, +tags attribute
+# 1.0.0  2026-02-01  Initial snapshot
+```
+
+## Diff versions
+
+Diff two tagged versions:
+
+```bash
+hecks diff --v1 1.0.0 --v2 2.1.0
+# 3 changes (v1.0.0 -> v2.1.0):
+#
+#   + command: Account.FreezeAccount
+#   - command: Account.CloseAccount  <- BREAKING
+#   + attribute: Account.tags (String)
+#
+# 1 breaking change!
+```
+
+Diff a tagged version against the working domain file:
+
+```bash
+hecks diff --v1 1.0.0
+# 2 changes (v1.0.0 -> working):
+#   ...
+```
+
+Diff working domain against the latest tagged version:
+
+```bash
+hecks diff
+# No changes detected (v2.1.0 -> working).
+```
+
+## Breaking change rules
+
+A change is **BREAKING** if:
+- A command is removed or renamed
+- A required attribute is removed
+- An aggregate is removed
+
+A change is **non-breaking** if:
+- A command is added
+- An attribute is added
+- A query, scope, or specification is added

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -49,6 +49,7 @@ module Hecks
   autoload :LlmsGenerator,     "hecks/domain/llms_generator"
   autoload :DomainVisualizer,  "hecks/domain/visualizer"
   autoload :DslSerializer,     "hecks/domain/dsl_serializer"
+  autoload :DomainVersioning,  "hecks/domain_versioning"
   autoload :FlowGenerator,     "hecks/domain/flow_generator"
 
   # = Hecks::ValidationRules

--- a/hecksties/lib/hecks/domain_versioning.rb
+++ b/hecksties/lib/hecks/domain_versioning.rb
@@ -1,0 +1,94 @@
+# Hecks::DomainVersioning
+#
+# Manages domain interface version snapshots. Snapshots are copies of the
+# domain DSL file stored in db/hecks_versions/ with a metadata header.
+# Supports tagging, listing, loading, and diffing version snapshots.
+#
+#   Hecks::DomainVersioning.tag("2.1.0", domain, base_dir: Dir.pwd)
+#   versions = Hecks::DomainVersioning.log(base_dir: Dir.pwd)
+#   domain   = Hecks::DomainVersioning.load_version("2.1.0", base_dir: Dir.pwd)
+#
+require_relative "domain_versioning/breaking_classifier"
+
+module Hecks
+  module DomainVersioning
+    VERSIONS_DIR = "db/hecks_versions"
+
+    # Tag the current domain as a named version snapshot.
+    #
+    # @param version [String] semantic version label (e.g. "2.1.0")
+    # @param domain [Hecks::DomainModel::Domain] the domain to snapshot
+    # @param base_dir [String] project root directory
+    # @return [String] path to the written snapshot file
+    def self.tag(version, domain, base_dir: Dir.pwd)
+      dir = File.join(base_dir, VERSIONS_DIR)
+      FileUtils.mkdir_p(dir)
+
+      content = DslSerializer.new(domain).serialize
+      header = "# Hecks domain snapshot\n# version: #{version}\n# tagged_at: #{Date.today}\n"
+      path = File.join(dir, "#{version}.rb")
+      File.write(path, header + content)
+      path
+    end
+
+    # List all tagged versions, newest first.
+    #
+    # @param base_dir [String] project root directory
+    # @return [Array<Hash>] each with :version, :tagged_at, :path keys
+    def self.log(base_dir: Dir.pwd)
+      dir = File.join(base_dir, VERSIONS_DIR)
+      return [] unless File.directory?(dir)
+
+      Dir[File.join(dir, "*.rb")].sort.reverse.map do |path|
+        meta = parse_header(path)
+        { version: meta[:version], tagged_at: meta[:tagged_at], path: path }
+      end
+    end
+
+    # Load a domain from a version snapshot file.
+    #
+    # @param version [String] version label
+    # @param base_dir [String] project root directory
+    # @return [Hecks::DomainModel::Domain, nil]
+    def self.load_version(version, base_dir: Dir.pwd)
+      path = File.join(base_dir, VERSIONS_DIR, "#{version}.rb")
+      return nil unless File.exist?(path)
+
+      Kernel.load(path)
+      Hecks.last_domain
+    end
+
+    # Check if a version snapshot exists.
+    #
+    # @param version [String] version label
+    # @param base_dir [String] project root directory
+    # @return [Boolean]
+    def self.exists?(version, base_dir: Dir.pwd)
+      File.exist?(File.join(base_dir, VERSIONS_DIR, "#{version}.rb"))
+    end
+
+    # Return the latest tagged version label, or nil if none exist.
+    #
+    # @param base_dir [String] project root directory
+    # @return [String, nil]
+    def self.latest_version(base_dir: Dir.pwd)
+      entries = log(base_dir: base_dir)
+      entries.first&.fetch(:version)
+    end
+
+    # Parse metadata header from a snapshot file.
+    #
+    # @param path [String] file path
+    # @return [Hash] with :version and :tagged_at keys
+    def self.parse_header(path)
+      version = nil
+      tagged_at = nil
+      File.foreach(path) do |line|
+        break unless line.start_with?("#")
+        version = $1 if line =~ /^# version:\s*(.+)/
+        tagged_at = $1 if line =~ /^# tagged_at:\s*(.+)/
+      end
+      { version: version, tagged_at: tagged_at }
+    end
+  end
+end

--- a/hecksties/lib/hecks/domain_versioning/breaking_classifier.rb
+++ b/hecksties/lib/hecks/domain_versioning/breaking_classifier.rb
@@ -1,0 +1,93 @@
+# Hecks::DomainVersioning::BreakingClassifier
+#
+# Classifies domain diff changes as breaking or non-breaking for
+# interface versioning. Extends the structural diff with a label
+# indicating whether downstream consumers would break.
+#
+#   changes = Hecks::Migrations::DomainDiff.call(old_domain, new_domain)
+#   classified = BreakingClassifier.classify(changes)
+#   classified.each { |c| puts "#{c[:label]} #{c[:breaking] ? 'BREAKING' : ''}" }
+#
+module Hecks
+  module DomainVersioning
+    module BreakingClassifier
+      BREAKING_KINDS = %i[
+        remove_aggregate
+        remove_attribute
+        remove_command
+        remove_value_object
+        remove_entity
+      ].freeze
+
+      NON_BREAKING_KINDS = %i[
+        add_aggregate
+        add_attribute
+        add_command
+        add_value_object
+        add_entity
+        add_query
+        add_scope
+        add_specification
+        add_policy
+        add_subscriber
+        add_validation
+        add_index
+        add_reference
+        add_invariant
+      ].freeze
+
+      # Classify a list of DomainDiff::Change objects.
+      #
+      # @param changes [Array<Hecks::Migrations::DomainDiff::Change>]
+      # @return [Array<Hash>] each with :change, :label, :breaking keys
+      def self.classify(changes)
+        changes.map do |change|
+          { change: change, label: format_label(change), breaking: breaking?(change) }
+        end
+      end
+
+      # Is this change kind breaking?
+      #
+      # @param change [Hecks::Migrations::DomainDiff::Change]
+      # @return [Boolean]
+      def self.breaking?(change)
+        BREAKING_KINDS.include?(change.kind)
+      end
+
+      # Format a human-readable label for a change.
+      #
+      # @param change [Hecks::Migrations::DomainDiff::Change]
+      # @return [String]
+      def self.format_label(change)
+        case change.kind
+        when :add_aggregate       then "+ aggregate: #{change.aggregate}"
+        when :remove_aggregate    then "- aggregate: #{change.aggregate}"
+        when :add_attribute       then "+ attribute: #{change.aggregate}.#{change.details[:name]} (#{change.details[:type]})"
+        when :remove_attribute    then "- attribute: #{change.aggregate}.#{change.details[:name]}"
+        when :add_command         then "+ command: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_command      then "- command: #{change.aggregate}.#{change.details[:name]}"
+        when :add_query           then "+ query: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_query        then "- query: #{change.aggregate}.#{change.details[:name]}"
+        when :add_value_object    then "+ value_object: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_value_object then "- value_object: #{change.aggregate}.#{change.details[:name]}"
+        when :add_entity          then "+ entity: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_entity       then "- entity: #{change.aggregate}.#{change.details[:name]}"
+        when :add_policy          then "+ policy: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_policy       then "- policy: #{change.aggregate}.#{change.details[:name]}"
+        when :add_scope           then "+ scope: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_scope        then "- scope: #{change.aggregate}.#{change.details[:name]}"
+        when :add_specification   then "+ specification: #{change.aggregate}.#{change.details[:name]}"
+        when :remove_specification then "- specification: #{change.aggregate}.#{change.details[:name]}"
+        when :add_validation      then "+ validation: #{change.aggregate}.#{change.details[:field]}"
+        when :remove_validation   then "- validation: #{change.aggregate}.#{change.details[:field]}"
+        when :add_index           then "+ index: #{change.aggregate}"
+        when :remove_index        then "- index: #{change.aggregate}"
+        when :add_reference       then "+ reference: #{change.aggregate}"
+        when :remove_reference    then "- reference: #{change.aggregate}"
+        when :change_policy       then "~ policy: #{change.aggregate}.#{change.details[:name]}"
+        else "#{change.kind}: #{change.aggregate} #{change.details}"
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/diff.rb
+++ b/hecksties/lib/hecks_cli/commands/diff.rb
@@ -1,65 +1,71 @@
-Hecks::CLI.register_command(:diff, "Show changes since last build",
+Hecks::CLI.register_command(:diff, "Show changes between domain versions or since last build",
   options: {
     domain:  { type: :string, desc: "Domain gem name or path" },
-    version: { type: :string, desc: "Domain version" }
+    version: { type: :string, desc: "Domain version" },
+    v1:      { type: :string, desc: "First version to compare (older)" },
+    v2:      { type: :string, desc: "Second version to compare (newer)" }
   }
 ) do
-  domain = resolve_domain_option
-  next unless domain
+  # Resolve the two domains to diff
+  if options[:v1] && options[:v2]
+    old_domain = Hecks::DomainVersioning.load_version(options[:v1], base_dir: Dir.pwd)
+    new_domain = Hecks::DomainVersioning.load_version(options[:v2], base_dir: Dir.pwd)
+    unless old_domain
+      say "Version #{options[:v1]} not found in db/hecks_versions/", :red
+      next
+    end
+    unless new_domain
+      say "Version #{options[:v2]} not found in db/hecks_versions/", :red
+      next
+    end
+    label = "v#{options[:v1]} -> v#{options[:v2]}"
+  elsif options[:v1]
+    old_domain = Hecks::DomainVersioning.load_version(options[:v1], base_dir: Dir.pwd)
+    unless old_domain
+      say "Version #{options[:v1]} not found in db/hecks_versions/", :red
+      next
+    end
+    new_domain = resolve_domain_option
+    next unless new_domain
+    label = "v#{options[:v1]} -> working"
+  else
+    new_domain = resolve_domain_option
+    next unless new_domain
 
-  snapshot_path = Hecks::Migrations::DomainSnapshot::DEFAULT_PATH
-  unless Hecks::Migrations::DomainSnapshot.exists?(path: snapshot_path)
-    say "No snapshot found. Run `hecks build` first to create a baseline.", :yellow
-    next
-  end
-
-  old_domain = Hecks::Migrations::DomainSnapshot.load(path: snapshot_path)
-  changes = Hecks::Migrations::DomainDiff.call(old_domain, domain)
-
-  if changes.empty?
-    say "No changes detected.", :green
-    next
-  end
-
-  format_change = lambda do |change|
-    case change.kind
-    when :add_aggregate       then "+ Added aggregate: #{change.aggregate}"
-    when :remove_aggregate    then "- Removed aggregate: #{change.aggregate}"
-    when :add_attribute       then "+ Added attribute: #{change.aggregate}.#{change.details[:name]}"
-    when :remove_attribute    then "- Removed attribute: #{change.aggregate}.#{change.details[:name]}"
-    when :add_command         then "+ Added command: #{change.details[:name]}"
-    when :remove_command      then "- Removed command: #{change.details[:name]}"
-    when :add_policy          then "+ Added policy: #{change.details[:name]}"
-    when :remove_policy       then "- Removed policy: #{change.details[:name]}"
-    when :change_policy       then "~ Changed policy: #{change.details[:name]}"
-    when :add_validation      then "+ Added validation: #{change.aggregate}.#{change.details[:field]}"
-    when :remove_validation   then "- Removed validation: #{change.aggregate}.#{change.details[:field]}"
-    when :add_value_object    then "+ Added value object: #{change.details[:name]}"
-    when :remove_value_object then "- Removed value object: #{change.details[:name]}"
-    when :add_entity          then "+ Added entity: #{change.details[:name]}"
-    when :remove_entity       then "- Removed entity: #{change.details[:name]}"
-    when :add_query           then "+ Added query: #{change.details[:name]}"
-    when :remove_query        then "- Removed query: #{change.details[:name]}"
-    when :add_scope           then "+ Added scope: #{change.details[:name]}"
-    when :remove_scope        then "- Removed scope: #{change.details[:name]}"
-    when :add_specification   then "+ Added specification: #{change.details[:name]}"
-    when :remove_specification then "- Removed specification: #{change.details[:name]}"
-    else "#{change.kind}: #{change.aggregate} #{change.details}"
+    latest = Hecks::DomainVersioning.latest_version(base_dir: Dir.pwd)
+    if latest
+      old_domain = Hecks::DomainVersioning.load_version(latest, base_dir: Dir.pwd)
+      label = "v#{latest} -> working"
+    else
+      snapshot_path = Hecks::Migrations::DomainSnapshot::DEFAULT_PATH
+      unless Hecks::Migrations::DomainSnapshot.exists?(path: snapshot_path)
+        say "No snapshot or tagged version found. Run `hecks version_tag` or `hecks build` first.", :yellow
+        next
+      end
+      old_domain = Hecks::Migrations::DomainSnapshot.load(path: snapshot_path)
+      label = "snapshot -> working"
     end
   end
 
-  breaking_kinds = %i[remove_aggregate remove_attribute remove_command remove_value_object remove_entity]
+  changes = Hecks::Migrations::DomainDiff.call(old_domain, new_domain)
 
-  say "#{changes.size} change#{"s" if changes.size != 1} detected:", :yellow
-  say ""
-
-  changes.each do |change|
-    label = format_change.call(change)
-    color = breaking_kinds.include?(change.kind) ? :red : :green
-    say "  #{label}", color
+  if changes.empty?
+    say "No changes detected (#{label}).", :green
+    next
   end
 
-  breaking = changes.count { |c| breaking_kinds.include?(c.kind) }
+  classified = Hecks::DomainVersioning::BreakingClassifier.classify(changes)
+
+  say "#{changes.size} change#{"s" if changes.size != 1} (#{label}):", :yellow
+  say ""
+
+  classified.each do |entry|
+    suffix = entry[:breaking] ? "  <- BREAKING" : ""
+    color = entry[:breaking] ? :red : :green
+    say "  #{entry[:label]}#{suffix}", color
+  end
+
+  breaking = classified.count { |e| e[:breaking] }
   if breaking > 0
     say ""
     say "#{breaking} breaking change#{"s" if breaking != 1}!", :red

--- a/hecksties/lib/hecks_cli/commands/version_log.rb
+++ b/hecksties/lib/hecks_cli/commands/version_log.rb
@@ -1,0 +1,17 @@
+require_relative "version_log_formatter"
+
+Hecks::CLI.register_command(:version_log, "List all tagged domain version snapshots",
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" }
+  }
+) do
+  entries = Hecks::DomainVersioning.log(base_dir: Dir.pwd)
+
+  if entries.empty?
+    say "No versions tagged yet. Run `hecks version_tag <version>` to tag one.", :yellow
+    next
+  end
+
+  lines = Hecks::CLI::VersionLogFormatter.format(entries)
+  lines.each { |line| say line }
+end

--- a/hecksties/lib/hecks_cli/commands/version_log_formatter.rb
+++ b/hecksties/lib/hecks_cli/commands/version_log_formatter.rb
@@ -1,0 +1,74 @@
+# Hecks::CLI::VersionLogFormatter
+#
+# Formats version log entries with change summaries. Loads consecutive
+# version pairs and diffs them to produce a one-line summary of changes
+# between each version.
+#
+#   entries = Hecks::DomainVersioning.log(base_dir: ".")
+#   lines = VersionLogFormatter.format(entries)
+#   # => ["2.1.0  2026-04-01  +FreezeAccount command, +tags attribute", ...]
+#
+module Hecks
+  class CLI < Thor
+    module VersionLogFormatter
+      # Format log entries with change summaries.
+      #
+      # @param entries [Array<Hash>] from DomainVersioning.log
+      # @return [Array<String>] formatted lines
+      def self.format(entries)
+        return [] if entries.empty?
+
+        max_ver = entries.map { |e| e[:version].to_s.length }.max
+        max_date = entries.map { |e| e[:tagged_at].to_s.length }.max
+
+        entries.each_with_index.map do |entry, i|
+          older = entries[i + 1]
+          summary = older ? summarize(older[:path], entry[:path]) : "Initial snapshot"
+          "%-#{max_ver}s  %-#{max_date}s  %s" % [entry[:version], entry[:tagged_at], summary]
+        end
+      end
+
+      # Produce a one-line summary of changes between two snapshot files.
+      #
+      # @param old_path [String] path to older snapshot
+      # @param new_path [String] path to newer snapshot
+      # @return [String] summary line
+      def self.summarize(old_path, new_path)
+        old_domain = load_snapshot(old_path)
+        new_domain = load_snapshot(new_path)
+        return "?" unless old_domain && new_domain
+
+        changes = Hecks::Migrations::DomainDiff.call(old_domain, new_domain)
+        return "No changes" if changes.empty?
+
+        labels = changes.first(3).map { |c| short_label(c) }
+        extra = changes.size > 3 ? ", +#{changes.size - 3} more" : ""
+        labels.join(", ") + extra
+      end
+
+      # @param path [String] snapshot file path
+      # @return [Hecks::DomainModel::Domain, nil]
+      def self.load_snapshot(path)
+        return nil unless File.exist?(path)
+        Kernel.load(path)
+        Hecks.last_domain
+      end
+
+      # Short label for a single change.
+      #
+      # @param change [Hecks::Migrations::DomainDiff::Change]
+      # @return [String]
+      def self.short_label(change)
+        case change.kind
+        when :add_command    then "+#{change.details[:name]} command"
+        when :remove_command then "-#{change.details[:name]} command"
+        when :add_attribute  then "+#{change.details[:name]} attribute"
+        when :remove_attribute then "-#{change.details[:name]} attribute"
+        when :add_aggregate  then "+#{change.aggregate} aggregate"
+        when :remove_aggregate then "-#{change.aggregate} aggregate"
+        else change.kind.to_s.sub("_", " ")
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/version_tag.rb
+++ b/hecksties/lib/hecks_cli/commands/version_tag.rb
@@ -1,0 +1,18 @@
+Hecks::CLI.register_command(:version_tag, "Tag current domain as a named version snapshot",
+  args: ["VERSION"],
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" }
+  }
+) do |version|
+  domain = resolve_domain_option
+  next unless domain
+
+  if Hecks::DomainVersioning.exists?(version, base_dir: Dir.pwd)
+    say "Version #{version} already exists. Choose a different version label.", :red
+    next
+  end
+
+  path = Hecks::DomainVersioning.tag(version, domain, base_dir: Dir.pwd)
+  say "Tagged #{domain.name} as v#{version}", :green
+  say "  Snapshot: #{path}"
+end

--- a/hecksties/spec/cli/commands/diff_spec.rb
+++ b/hecksties/spec/cli/commands/diff_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "hecks diff" do
         cli.diff
 
         text = messages.map(&:first).join("\n")
-        expect(text).to include("Added aggregate: Gadget")
+        expect(text).to include("+ aggregate: Gadget")
         # Added aggregate is not breaking
-        expect(text).not_to include("breaking")
+        expect(text).not_to include("BREAKING")
       end
     end
   end
@@ -86,8 +86,8 @@ RSpec.describe "hecks diff" do
         cli.diff
 
         text = messages.map(&:first).join("\n")
-        expect(text).to include("Removed attribute")
-        expect(text).to include("breaking")
+        expect(text).to include("- attribute:")
+        expect(text).to include("BREAKING")
       end
     end
   end

--- a/hecksties/spec/cli/commands_spec.rb
+++ b/hecksties/spec/cli/commands_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "CLI commands" do
     it "reports no snapshot when none exists" do
       Dir.chdir(tmpdir) do
         out = run_cli("diff", "--domain", tmpdir)
-        expect(out).to include("No snapshot found")
+        expect(out).to include("No snapshot or tagged version found")
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe "CLI commands" do
         Hecks::Migrations::DomainSnapshot.save(old_domain)
 
         out = run_cli("diff", "--domain", tmpdir)
-        expect(out).to include("Added aggregate: Part")
+        expect(out).to include("+ aggregate: Part")
       end
     end
   end

--- a/hecksties/spec/domain_versioning_spec.rb
+++ b/hecksties/spec/domain_versioning_spec.rb
@@ -1,0 +1,186 @@
+# domain_versioning_spec.rb — HEC-455
+#
+# Specs for domain interface versioning: tag, log, load, diff,
+# and breaking change classification.
+#
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Hecks::DomainVersioning do
+  let(:base_dir) { Dir.mktmpdir("hecks_ver_") }
+  after { FileUtils.rm_rf(base_dir) }
+
+  let(:domain_v1) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "CloseAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:domain_v2) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+        attribute :tags, String
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "FreezeAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  describe ".tag" do
+    it "writes a snapshot file with metadata header" do
+      path = described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      expect(File.exist?(path)).to be true
+      content = File.read(path)
+      expect(content).to include("# version: 1.0.0")
+      expect(content).to include("# tagged_at: #{Date.today}")
+      expect(content).to include('Hecks.domain "Banking"')
+    end
+
+    it "creates the db/hecks_versions directory" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      expect(File.directory?(File.join(base_dir, "db/hecks_versions"))).to be true
+    end
+  end
+
+  describe ".exists?" do
+    it "returns false when no snapshot exists" do
+      expect(described_class.exists?("1.0.0", base_dir: base_dir)).to be false
+    end
+
+    it "returns true after tagging" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      expect(described_class.exists?("1.0.0", base_dir: base_dir)).to be true
+    end
+  end
+
+  describe ".log" do
+    it "returns empty array when no versions exist" do
+      expect(described_class.log(base_dir: base_dir)).to eq([])
+    end
+
+    it "lists versions newest first" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      described_class.tag("2.0.0", domain_v2, base_dir: base_dir)
+      entries = described_class.log(base_dir: base_dir)
+      expect(entries.map { |e| e[:version] }).to eq(["2.0.0", "1.0.0"])
+    end
+
+    it "includes tagged_at date" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      entries = described_class.log(base_dir: base_dir)
+      expect(entries.first[:tagged_at]).to eq(Date.today.to_s)
+    end
+  end
+
+  describe ".load_version" do
+    it "returns nil for nonexistent version" do
+      expect(described_class.load_version("9.9.9", base_dir: base_dir)).to be_nil
+    end
+
+    it "loads a tagged domain snapshot" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      loaded = described_class.load_version("1.0.0", base_dir: base_dir)
+      expect(loaded).not_to be_nil
+      expect(loaded.name).to eq("Banking")
+      expect(loaded.aggregates.first.commands.map(&:name)).to include("CloseAccount")
+    end
+  end
+
+  describe ".latest_version" do
+    it "returns nil when no versions exist" do
+      expect(described_class.latest_version(base_dir: base_dir)).to be_nil
+    end
+
+    it "returns the newest version" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      described_class.tag("2.0.0", domain_v2, base_dir: base_dir)
+      expect(described_class.latest_version(base_dir: base_dir)).to eq("2.0.0")
+    end
+  end
+end
+
+RSpec.describe Hecks::DomainVersioning::BreakingClassifier do
+  let(:domain_v1) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "CloseAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:domain_v2) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+        attribute :tags, String
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "FreezeAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:changes) { Hecks::Migrations::DomainDiff.call(domain_v1, domain_v2) }
+  let(:classified) { described_class.classify(changes) }
+
+  it "classifies added attributes as non-breaking" do
+    added_attr = classified.find { |c| c[:change].kind == :add_attribute }
+    expect(added_attr[:breaking]).to be false
+  end
+
+  it "classifies removed commands as breaking" do
+    removed_cmd = classified.find { |c| c[:change].kind == :remove_command }
+    expect(removed_cmd).not_to be_nil
+    expect(removed_cmd[:breaking]).to be true
+  end
+
+  it "classifies added commands as non-breaking" do
+    added_cmd = classified.find { |c| c[:change].kind == :add_command }
+    expect(added_cmd[:breaking]).to be false
+  end
+
+  it "formats labels with aggregate and detail names" do
+    added_attr = classified.find { |c| c[:change].kind == :add_attribute }
+    expect(added_attr[:label]).to include("Account")
+    expect(added_attr[:label]).to include("tags")
+  end
+
+  it "marks removed commands with BREAKING in label context" do
+    removed_cmd = classified.find { |c| c[:change].kind == :remove_command }
+    expect(removed_cmd[:label]).to include("CloseAccount")
+  end
+end


### PR DESCRIPTION
## Summary

- **`hecks version_tag <version>`** — snapshots current domain DSL to `db/hecks_versions/<version>.rb` with metadata header (version, date)
- **`hecks version_log`** — lists all tagged versions newest-first with date and one-line change summary vs previous version
- **Enhanced `hecks diff`** — now supports `--v1`/`--v2` flags to diff tagged versions, with breaking change classification (`BREAKING` label on removals)

## Example usage

### Tag a version
```
$ hecks version_tag 1.0.0
Tagged Banking as v1.0.0
  Snapshot: db/hecks_versions/1.0.0.rb
```

### View version log
```
$ hecks version_log
2.1.0  2026-04-01  +FreezeAccount command, +tags attribute
1.0.0  2026-02-01  Initial snapshot
```

### Diff with breaking change detection
```
$ hecks diff --v1 1.0.0 --v2 2.1.0
3 changes (v1.0.0 -> v2.1.0):

  + command: Account.FreezeAccount
  - command: Account.CloseAccount  <- BREAKING
  + attribute: Account.tags (String)

1 breaking change!
```

## Test plan
- [x] Unit specs for DomainVersioning (tag, log, load, exists, latest_version)
- [x] Unit specs for BreakingClassifier (breaking vs non-breaking classification)
- [x] Updated existing diff specs for new output format
- [x] All 1488 specs pass in under 1 second
- [x] Smoke test passes
- [x] FEATURES.md updated
- [x] docs/usage/versioning.md added