### PR TITLE
HEC-452: Domain extractor — hecks extract [path]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -350,6 +350,10 @@
 ### Rails Import (Reverse Engineering)
 - `hecks import rails /path/to/app` — extract domain from existing Rails app
 - `hecks import schema /path/to/schema.rb` — schema-only import
+- `hecks extract /path/to/project` — auto-detect project type and extract domain
+- Model-only extraction: works without schema.rb using belongs_to/has_many/validations/enums/AASM
+- `Hecks::Import.from_directory(path)` — programmatic auto-detecting extraction
+- `Hecks::Import.from_models(models_dir)` — programmatic model-only extraction
 - Parses db/schema.rb: tables → aggregates, columns → typed attributes, foreign keys → references
 - Parses app/models: validates → validations, enum → enum constraints, AASM → lifecycles
 - Auto-generates Create commands for each aggregate

--- a/docs/usage/extract.md
+++ b/docs/usage/extract.md
@@ -1,0 +1,96 @@
+# `hecks extract` — Domain Extractor
+
+Auto-detects a project's type and generates a Hecks domain definition.
+
+## Usage
+
+```bash
+# Extract from a Rails app (auto-detects schema.rb)
+hecks extract /path/to/rails/app
+
+# Preview without writing
+hecks extract /path/to/rails/app --preview
+
+# Specify output file and domain name
+hecks extract /path/to/app --output MyDomain --name Blog
+```
+
+## How It Works
+
+The extractor checks the given directory for `db/schema.rb`:
+
+- **With schema.rb**: Uses the full Rails import pipeline (SchemaParser + ModelParser + DomainAssembler). Column types, foreign keys, validations, enums, and state machines are all captured.
+- **Without schema.rb**: Falls back to model-only extraction (ModelParser + ModelOnlyAssembler). Derives structure from `belongs_to`, `has_many`, validations, enums, and AASM state machines.
+
+## Options
+
+| Flag        | Default      | Description                              |
+|-------------|--------------|------------------------------------------|
+| `--output`  | `Bluebook`   | Output file path                         |
+| `--preview` | `false`      | Print DSL to stdout without writing      |
+| `--name`    | *(inferred)* | Domain name (defaults to directory name) |
+
+## Examples
+
+### Rails app with schema
+
+```bash
+$ hecks extract ~/Projects/blog --preview --name Blog
+
+Hecks.domain "Blog" do
+  aggregate "Post" do
+    attribute :title, String
+    attribute :body, String
+    reference_to "Author"
+    validation :title, {:presence=>true}
+
+    lifecycle :status, default: "draft" do
+      transition "PublishPost" => "published"
+    end
+
+    command "CreatePost" do
+      attribute :title, String
+      attribute :body, String
+    end
+  end
+
+  aggregate "Author" do
+    attribute :name, String
+    attribute :email, String
+
+    command "CreateAuthor" do
+      attribute :name, String
+      attribute :email, String
+    end
+  end
+end
+```
+
+### Models-only project (no schema.rb)
+
+```bash
+$ hecks extract ~/Projects/service --preview --name Ordering
+
+Hecks.domain "Ordering" do
+  aggregate "Order" do
+    reference_to "Customer"
+    list_of "LineItem"
+    attribute :status, String, enum: ["pending", "confirmed", "shipped"]
+
+    lifecycle :state, default: "pending" do
+      transition "ConfirmOrder" => "confirmed"
+      transition "ShipOrder" => "shipped"
+    end
+  end
+end
+```
+
+## Programmatic API
+
+```ruby
+# Auto-detect project type
+dsl = Hecks::Import.from_directory("/path/to/app", domain_name: "Blog")
+
+# Model-only extraction
+dsl = Hecks::Import.from_models("/path/to/models", domain_name: "Blog")
+```

--- a/hecksties/lib/hecks_cli/commands/extract.rb
+++ b/hecksties/lib/hecks_cli/commands/extract.rb
@@ -1,0 +1,38 @@
+require_relative "../import"
+
+# Hecks CLI — extract command
+#
+# Auto-detects a project's type (Rails with schema, or models-only)
+# and generates a Hecks domain DSL file from the source.
+#
+#   hecks extract /path/to/rails/app
+#   hecks extract /path/to/app --preview --name Blog
+#
+Hecks::CLI.register_command(:extract, "Extract a domain from an existing project",
+  args: %w[PATH],
+  options: {
+    output:  { type: :string, default: "Bluebook", desc: "Output file path", aliases: "-o" },
+    preview: { type: :boolean, default: false, desc: "Preview without writing" },
+    name:    { type: :string, desc: "Domain name (default: inferred from directory)" }
+  }
+) do |path = nil|
+  unless path
+    puts "Usage: hecks extract /path/to/project"
+    puts "       hecks extract /path/to/project --preview --name Blog"
+    next
+  end
+
+  unless File.directory?(path)
+    puts "Error: #{path} is not a directory"
+    next
+  end
+
+  dsl = Hecks::Import.from_directory(path, domain_name: options[:name])
+  puts dsl
+
+  unless options[:preview]
+    output = options[:output] || "Bluebook"
+    File.write(output, dsl)
+    puts "\nWritten to #{output}"
+  end
+end

--- a/hecksties/lib/hecks_cli/import.rb
+++ b/hecksties/lib/hecks_cli/import.rb
@@ -1,6 +1,7 @@
 require_relative "import/schema_parser"
 require_relative "import/model_parser"
 require_relative "import/domain_assembler"
+require_relative "import/model_only_assembler"
 
 module Hecks
   # Hecks::Import
@@ -27,5 +28,32 @@ module Hecks
       schema_data = SchemaParser.new(schema_path).parse
       DomainAssembler.new(schema_data, {}, domain_name: domain_name).assemble
     end
+
+    def self.from_directory(path, domain_name: nil)
+      schema_path = File.join(path, "db", "schema.rb")
+      domain_name ||= Hecks::Utils.sanitize_constant(File.basename(File.expand_path(path)))
+
+      if File.exist?(schema_path)
+        from_rails(path, domain_name: domain_name)
+      else
+        models_dir = detect_models_dir(path)
+        from_models(models_dir, domain_name: domain_name)
+      end
+    end
+
+    def self.from_models(models_dir, domain_name: "MyDomain")
+      model_data = ModelParser.new(models_dir).parse
+      ModelOnlyAssembler.new(model_data, domain_name: domain_name).assemble
+    end
+
+    def self.detect_models_dir(path)
+      candidates = [
+        File.join(path, "app", "models"),
+        File.join(path, "models"),
+        path
+      ]
+      candidates.find { |d| File.directory?(d) } || path
+    end
+    private_class_method :detect_models_dir
   end
 end

--- a/hecksties/lib/hecks_cli/import/model_only_assembler.rb
+++ b/hecksties/lib/hecks_cli/import/model_only_assembler.rb
@@ -1,0 +1,103 @@
+module Hecks
+  module Import
+    # Hecks::Import::ModelOnlyAssembler
+    #
+    # Builds a Hecks DSL domain definition from Rails model files alone,
+    # without requiring a schema.rb. Derives structure from ActiveRecord
+    # associations, validations, enums, and AASM state machines.
+    #
+    #   models = ModelParser.new("app/models").parse
+    #   ModelOnlyAssembler.new(models, domain_name: "Blog").assemble
+    #   # => 'Hecks.domain "Blog" do ...'
+    #
+    class ModelOnlyAssembler
+      def initialize(model_data, domain_name: "MyDomain")
+        @model_data  = model_data
+        @domain_name = domain_name
+      end
+
+      def assemble
+        lines = ["Hecks.domain \"#{@domain_name}\" do"]
+        @model_data.each_with_index do |(class_name, model), i|
+          lines << "" if i > 0
+          lines.concat(assemble_aggregate(class_name, model))
+        end
+        lines << "end"
+        lines.join("\n") + "\n"
+      end
+
+      private
+
+      def assemble_aggregate(class_name, model)
+        enums  = model[:enums] || {}
+        assocs = model[:associations] || []
+        lines  = ["  aggregate \"#{class_name}\" do"]
+
+        lines.concat(assemble_associations(assocs))
+        lines.concat(assemble_enum_attributes(enums))
+        lines.concat(assemble_validations(model[:validations] || []))
+        lines.concat(assemble_lifecycle(model[:state_machine], class_name))
+
+        lines << "  end"
+        lines
+      end
+
+      def assemble_associations(associations)
+        lines = []
+        associations.each do |assoc|
+          case assoc[:type]
+          when :belongs_to
+            target = classify(assoc[:name])
+            lines << "    reference_to \"#{target}\""
+          when :has_many
+            next if assoc[:through] # skip join-table associations
+            target = classify(assoc[:name])
+            lines << "    list_of \"#{target}\""
+          when :has_one
+            target = classify(assoc[:name])
+            lines << "    reference_to \"#{target}\""
+          end
+        end
+        lines
+      end
+
+      def assemble_enum_attributes(enums)
+        enums.map do |field, values|
+          "    attribute :#{field}, String, enum: #{values.map(&:to_s).inspect}"
+        end
+      end
+
+      def assemble_validations(validations)
+        validations.map do |v|
+          "    validation :#{v[:field]}, #{v[:rules].inspect}"
+        end
+      end
+
+      def assemble_lifecycle(state_machine, class_name)
+        return [] unless state_machine
+
+        lines = [""]
+        default = state_machine[:initial] ? ", default: \"#{state_machine[:initial]}\"" : ""
+        lines << "    lifecycle :#{state_machine[:field]}#{default} do"
+        state_machine[:transitions].each do |t|
+          cmd_name = classify(t[:event]) + class_name
+          lines << "      transition \"#{cmd_name}\" => \"#{t[:to]}\""
+        end
+        lines << "    end"
+        lines
+      end
+
+      def classify(name)
+        name.to_s
+          .split("_")
+          .map(&:capitalize)
+          .join
+          .sub(/ies$/, "y")
+          .sub(/sses$/, "ss")
+          .sub(/([^s])ses$/, '\1se')
+          .sub(/s$/, "")
+          .then { |s| s.empty? ? name.to_s : s }
+      end
+    end
+  end
+end

--- a/hecksties/spec/import/extract_spec.rb
+++ b/hecksties/spec/import/extract_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe "Import.from_directory" do
+  let(:project_dir) { Dir.mktmpdir }
+
+  after { FileUtils.remove_entry(project_dir) }
+
+  def write_model(name, content)
+    models_dir = File.join(project_dir, "app", "models")
+    FileUtils.mkdir_p(models_dir)
+    File.write(File.join(models_dir, "#{name}.rb"), content)
+  end
+
+  def write_schema(content)
+    schema_dir = File.join(project_dir, "db")
+    FileUtils.mkdir_p(schema_dir)
+    File.write(File.join(schema_dir, "schema.rb"), content)
+  end
+
+  context "with schema.rb present (Rails project)" do
+    before do
+      write_schema(<<~RUBY)
+        ActiveRecord::Schema.define(version: 2024_01_01) do
+          create_table "posts" do |t|
+            t.string "title"
+            t.text "body"
+            t.timestamps
+          end
+        end
+      RUBY
+      write_model("post", <<~RUBY)
+        class Post < ApplicationRecord
+          validates :title, presence: true
+        end
+      RUBY
+    end
+
+    it "uses full Rails import with schema" do
+      dsl = Hecks::Import.from_directory(project_dir, domain_name: "Blog")
+      expect(dsl).to include('Hecks.domain "Blog"')
+      expect(dsl).to include("attribute :title, String")
+      expect(dsl).to include("attribute :body, String")
+      expect(dsl).to include("validation :title")
+    end
+  end
+
+  context "without schema.rb (models only)" do
+    before do
+      write_model("pizza", <<~RUBY)
+        class Pizza < ApplicationRecord
+          belongs_to :restaurant
+          has_many :toppings
+          enum status: { draft: 0, published: 1 }
+        end
+      RUBY
+    end
+
+    it "falls back to model-only extraction" do
+      dsl = Hecks::Import.from_directory(project_dir, domain_name: "Pizzeria")
+      expect(dsl).to include('Hecks.domain "Pizzeria"')
+      expect(dsl).to include('reference_to "Restaurant"')
+      expect(dsl).to include('list_of "Topping"')
+      expect(dsl).to include("attribute :status, String, enum:")
+    end
+  end
+
+  context "with models in a models/ subdirectory" do
+    before do
+      models_dir = File.join(project_dir, "models")
+      FileUtils.mkdir_p(models_dir)
+      File.write(File.join(models_dir, "widget.rb"), <<~RUBY)
+        class Widget < ApplicationRecord
+          validates :name, presence: true
+        end
+      RUBY
+    end
+
+    it "detects models/ directory" do
+      dsl = Hecks::Import.from_directory(project_dir, domain_name: "Widgets")
+      expect(dsl).to include('aggregate "Widget"')
+    end
+  end
+
+  describe ".from_models" do
+    it "extracts from a models directory directly" do
+      models_dir = File.join(project_dir, "app", "models")
+      FileUtils.mkdir_p(models_dir)
+      File.write(File.join(models_dir, "item.rb"), <<~RUBY)
+        class Item < ApplicationRecord
+          belongs_to :category
+        end
+      RUBY
+
+      dsl = Hecks::Import.from_models(models_dir, domain_name: "Store")
+      expect(dsl).to include('Hecks.domain "Store"')
+      expect(dsl).to include('reference_to "Category"')
+    end
+  end
+end

--- a/hecksties/spec/import/model_only_assembler_spec.rb
+++ b/hecksties/spec/import/model_only_assembler_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Import::ModelOnlyAssembler do
+  let(:model_data) do
+    {
+      "Pizza" => {
+        associations: [
+          { type: :belongs_to, name: "restaurant" },
+          { type: :has_many, name: "toppings" },
+          { type: :has_many, name: "orders", through: "order_items" },
+          { type: :has_one, name: "nutrition_label" }
+        ],
+        validations: [
+          { field: "name", rules: { presence: true } }
+        ],
+        enums: { "status" => %w[draft published archived] },
+        state_machine: {
+          field: "status", initial: "draft",
+          transitions: [
+            { event: "publish", from: "draft", to: "published" },
+            { event: "archive", from: "published", to: "archived" }
+          ]
+        }
+      },
+      "Topping" => {
+        associations: [{ type: :belongs_to, name: "pizza" }],
+        validations: [],
+        enums: {},
+        state_machine: nil
+      }
+    }
+  end
+
+  subject(:dsl) { described_class.new(model_data, domain_name: "Pizzeria").assemble }
+
+  it "generates valid DSL wrapper" do
+    expect(dsl).to start_with('Hecks.domain "Pizzeria" do')
+    expect(dsl).to end_with("end\n")
+  end
+
+  it "generates aggregates from model classes" do
+    expect(dsl).to include('aggregate "Pizza" do')
+    expect(dsl).to include('aggregate "Topping" do')
+  end
+
+  it "converts belongs_to to reference_to" do
+    expect(dsl).to include('reference_to "Restaurant"')
+  end
+
+  it "converts has_many to list_of" do
+    expect(dsl).to include('list_of "Topping"')
+  end
+
+  it "skips has_many through associations" do
+    expect(dsl).not_to include("Order")
+  end
+
+  it "converts has_one to reference_to" do
+    expect(dsl).to include('reference_to "NutritionLabel"')
+  end
+
+  it "includes enum attributes" do
+    expect(dsl).to include('attribute :status, String, enum: ["draft", "published", "archived"]')
+  end
+
+  it "includes validations" do
+    expect(dsl).to include('validation :name, {:presence=>true}')
+  end
+
+  it "generates lifecycle from state machine" do
+    expect(dsl).to include('lifecycle :status, default: "draft" do')
+    expect(dsl).to include('transition "PublishPizza" => "published"')
+    expect(dsl).to include('transition "ArchivePizza" => "archived"')
+  end
+
+  context "with empty model data" do
+    subject(:dsl) { described_class.new({}, domain_name: "Empty").assemble }
+
+    it "generates a bare domain" do
+      expect(dsl).to eq("Hecks.domain \"Empty\" do\nend\n")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `hecks extract PATH` CLI command — auto-detects project type and generates a `hecks_domain.rb` starter
- Auto-detection: checks for `db/schema.rb` (Rails) or `app/models` (model-only)
- New `ModelOnlyAssembler` — extracts domain from models without a schema (belongs_to → reference_to, has_many → list_of, validations, enums, AASM → lifecycle)
- Options: `--preview` (print without writing), `--name` (override domain name), `--output` (output path)

## Example usage
```bash
# Full Rails app with schema
hecks extract /path/to/rails/app

# Preview without writing
hecks extract . --preview

# Model-only (no schema.rb)
hecks extract /path/to/api --name MyApi
```

## Test plan
- [x] 14 new specs (model_only_assembler + extract integration)
- [x] 1623 total specs pass under 1 second
- [ ] Manual test with a real Rails app

🤖 Generated with [Claude Code](https://claude.com/claude-code)