### PR TITLE
HEC-115: Console tour — guided sketch → play → build walkthrough

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -249,6 +249,11 @@
 - Reference attributes: `Post.order_id reference_to("Order")`
 - Terse single-line feedback after every operation (e.g. "title attribute added to Post")
 
+### Console Tour
+- Guided walkthrough via `hecks tour` — 15-step tour of sketch, play, and build
+- Also available inside the console: `tour`
+- CI-friendly: skips Enter pauses when stdin is not a TTY
+
 ### Web Console
 - Browser-based REPL via `hecks web_console [NAME]` — terminal-like interface at localhost:4567
 - Safe command parser: no eval, only whitelisted Grammar commands execute

--- a/docs/usage/console_tour.md
+++ b/docs/usage/console_tour.md
@@ -1,0 +1,31 @@
+# Console Tour
+
+A guided walkthrough of the Hecks workshop's sketch, play, and build loop.
+
+## Usage
+
+```bash
+hecks tour
+```
+
+## What it covers
+
+The tour walks through 15 steps:
+
+1. Create a Post aggregate
+2. Add title and body attributes
+3. Define a lifecycle with status transitions
+4. Add a CreatePost command with attributes
+5. Browse and validate the domain
+6. Enter play mode and execute commands
+7. Query data and inspect events
+8. Return to sketch mode and build a gem
+
+Each step shows the code being run and pauses for Enter (skipped in CI).
+
+## From the console
+
+```ruby
+# Inside hecks console:
+tour
+```

--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -6,6 +6,7 @@ require_relative "workshop/handles/aggregate_handle"
 require_relative "workshop/system_browser"
 require_relative "workshop/workshop_runner"
 require_relative "workshop/playground"
+require_relative "workshop/tour"
 require_relative "workshop/web_runner"
 
 module Hecks

--- a/hecks_workshop/lib/hecks/workshop/commands/tour.rb
+++ b/hecks_workshop/lib/hecks/workshop/commands/tour.rb
@@ -1,0 +1,10 @@
+# Hecks::CLI tour command
+#
+# Launches a guided walkthrough of the sketch -> play -> build loop.
+# Demonstrates domain modeling from aggregate creation through play mode.
+#
+#   hecks tour
+#
+Hecks::CLI.register_command(:tour, "Guided walkthrough of the workshop") do
+  Hecks::Workshop::WorkshopRunner.new.tour
+end

--- a/hecks_workshop/lib/hecks/workshop/tour.rb
+++ b/hecks_workshop/lib/hecks/workshop/tour.rb
@@ -1,0 +1,95 @@
+# Hecks::Workshop::Tour
+#
+# Guided walkthrough of the sketch -> play -> build loop. Runs 15 steps
+# that demonstrate domain modeling from scratch: creating aggregates,
+# adding attributes, defining lifecycles, entering play mode, executing
+# commands, and building the domain gem.
+#
+# Each step displays a title, explanation, and the code being run, then
+# executes the action against a fresh workshop. Pauses for Enter between
+# steps when stdin is a TTY (skips pauses in CI).
+#
+#   Tour.new(runner).start
+#
+require_relative "tour/sketch_steps"
+require_relative "tour/play_steps"
+
+module Hecks
+  class Workshop
+    class Tour
+      Step = Struct.new(:title, :explanation, :code, :action, keyword_init: true)
+
+      include SketchSteps
+      include PlaySteps
+
+      attr_reader :steps
+
+      def initialize(runner)
+        @runner = runner
+        @steps = build_steps
+      end
+
+      def start
+        puts ""
+        puts "=== Hecks Workshop Tour ==="
+        puts "Walk through the sketch -> play -> build loop."
+        puts ""
+
+        @steps.each_with_index do |step, i|
+          print_step(i + 1, step)
+          wait_for_enter
+          execute_step(step)
+          puts ""
+        end
+
+        puts "=== Tour complete! ==="
+        puts ""
+        puts "You just sketched a domain, played with it live, and built a gem."
+        puts "Run `hecks console` to start your own workshop."
+        puts ""
+        nil
+      end
+
+      private
+
+      def print_step(number, step)
+        puts "--- Step #{number}/#{@steps.size}: #{step.title} ---"
+        puts step.explanation
+        puts ""
+        puts "  >> #{step.code}"
+        puts ""
+      end
+
+      def wait_for_enter
+        return unless $stdin.respond_to?(:tty?) && $stdin.tty?
+
+        print "Press Enter to continue..."
+        $stdin.gets
+      end
+
+      def execute_step(step)
+        step.action.call(@runner)
+      end
+
+      def build_steps
+        [
+          create_aggregate_step,
+          add_title_step,
+          add_body_step,
+          add_lifecycle_step,
+          add_transition_step,
+          add_create_command_step,
+          browse_step,
+          validate_step,
+          describe_step,
+          enter_play_step,
+          create_instance_step,
+          query_all_step,
+          check_events_step,
+          return_to_sketch_step,
+          build_step
+        ]
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/tour/play_steps.rb
+++ b/hecks_workshop/lib/hecks/workshop/tour/play_steps.rb
@@ -1,0 +1,87 @@
+# Hecks::Workshop::Tour::PlaySteps
+#
+# Tour step definitions for the play phase: entering play mode,
+# executing commands, querying data, checking events, returning
+# to sketch mode, and building the domain gem.
+#
+#   include PlaySteps
+#   enter_play_step  # => Tour::Step
+#
+module Hecks
+  class Workshop
+    class Tour
+      module PlaySteps
+        def enter_play_step
+          Step.new(
+            title: "Enter play mode",
+            explanation: "Play mode compiles the domain and boots a live runtime.\n" \
+                         "You can now execute commands and query data.",
+            code: "play!",
+            action: ->(r) { r.play! }
+          )
+        end
+
+        def create_instance_step
+          Step.new(
+            title: "Create a post",
+            explanation: "Execute the CreatePost command with real data.",
+            code: 'Post.create(title: "Hello", body: "World")',
+            action: ->(r) {
+              workshop = r.instance_variable_get(:@workshop)
+              workshop.execute("CreatePost", title: "Hello", body: "World")
+            }
+          )
+        end
+
+        def query_all_step
+          Step.new(
+            title: "Query all posts",
+            explanation: "Query the in-memory repository for all posts.",
+            code: "Post.all",
+            action: ->(r) {
+              mod = Object.const_get("TourDomain")
+              results = mod::Post.all
+              results.each { |post| puts "  #{post.inspect}" }
+              puts "#{results.size} post(s) found"
+            }
+          )
+        end
+
+        def check_events_step
+          Step.new(
+            title: "Check the event log",
+            explanation: "Every command emits an event. Let's see what happened.",
+            code: "events",
+            action: ->(r) { r.events }
+          )
+        end
+
+        def return_to_sketch_step
+          Step.new(
+            title: "Return to sketch mode",
+            explanation: "Switch back to sketch mode to continue editing your domain.",
+            code: "sketch!",
+            action: ->(r) { r.sketch! }
+          )
+        end
+
+        def build_step
+          Step.new(
+            title: "Build the domain gem",
+            explanation: "Generate a full Ruby gem from your domain definition.\n" \
+                         "The gem includes models, commands, events, and persistence.",
+            code: "build",
+            action: ->(r) {
+              require "tmpdir"
+              workshop = r.instance_variable_get(:@workshop)
+              tmpdir = Dir.mktmpdir("hecks-tour-")
+              output = workshop.build(version: "1.0.0", output_dir: tmpdir)
+              puts "Built to: #{output}"
+              FileUtils.rm_rf(tmpdir)
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/tour/sketch_steps.rb
+++ b/hecks_workshop/lib/hecks/workshop/tour/sketch_steps.rb
@@ -1,0 +1,109 @@
+# Hecks::Workshop::Tour::SketchSteps
+#
+# Tour step definitions for the sketch phase: creating an aggregate,
+# adding attributes, lifecycle, transitions, commands, browsing,
+# validating, and describing the domain.
+#
+#   include SketchSteps
+#   create_aggregate_step  # => Tour::Step
+#
+module Hecks
+  class Workshop
+    class Tour
+      module SketchSteps
+        def create_aggregate_step
+          Step.new(
+            title: "Create an aggregate",
+            explanation: "Aggregates are the main building blocks of your domain.\n" \
+                         "Let's create a Post aggregate.",
+            code: 'aggregate("Post")',
+            action: ->(r) { r.aggregate("Post") }
+          )
+        end
+
+        def add_title_step
+          Step.new(
+            title: "Add a title attribute",
+            explanation: "Attributes define the data an aggregate holds.",
+            code: "Post.title String",
+            action: ->(r) { r.aggregate("Post").attr(:title, String) }
+          )
+        end
+
+        def add_body_step
+          Step.new(
+            title: "Add a body attribute",
+            explanation: "Add another attribute for the post content.",
+            code: "Post.body String",
+            action: ->(r) { r.aggregate("Post").attr(:body, String) }
+          )
+        end
+
+        def add_lifecycle_step
+          Step.new(
+            title: "Add a lifecycle",
+            explanation: "Lifecycles track state transitions.\n" \
+                         "This adds a status field defaulting to \"draft\".",
+            code: 'Post.lifecycle :status, default: "draft"',
+            action: ->(r) { r.aggregate("Post").lifecycle(:status, default: "draft") }
+          )
+        end
+
+        def add_transition_step
+          Step.new(
+            title: "Add a transition",
+            explanation: "Transitions define how status changes.\n" \
+                         "PublishPost will move status to \"published\".",
+            code: 'Post.transition "PublishPost" => "published"',
+            action: ->(r) { r.aggregate("Post").transition("PublishPost" => "published") }
+          )
+        end
+
+        def add_create_command_step
+          Step.new(
+            title: "Add a create command with attributes",
+            explanation: "Commands represent actions users can take.\n" \
+                         "CreatePost accepts title and body, and emits a CreatedPost event.",
+            code: 'Post.command("CreatePost") { attribute :title, String; attribute :body, String }',
+            action: ->(r) {
+              r.aggregate("Post").command("CreatePost") do
+                attribute :title, String
+                attribute :body, String
+              end
+            }
+          )
+        end
+
+        def browse_step
+          Step.new(
+            title: "Browse the domain",
+            explanation: "The system browser shows a tree of your domain structure.",
+            code: "browse",
+            action: ->(r) { r.browse }
+          )
+        end
+
+        def validate_step
+          Step.new(
+            title: "Validate the domain",
+            explanation: "Check that the domain is well-formed before going live.",
+            code: "validate",
+            action: ->(r) {
+              result = r.validate
+              puts result ? "Domain is valid!" : "Domain has errors."
+            }
+          )
+        end
+
+        def describe_step
+          Step.new(
+            title: "Describe the domain",
+            explanation: "See a full summary of aggregates, attributes, and commands.",
+            code: "describe",
+            action: ->(r) { r.describe }
+          )
+        end
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -91,6 +91,11 @@ module Hecks
 
     def to_s = inspect
 
+    def tour
+      @workshop = Hecks.workshop("Tour")
+      Tour.new(self).start
+    end
+
     def run
       require "irb"
       @workshop = setup_session

--- a/hecks_workshop/spec/tour_spec.rb
+++ b/hecks_workshop/spec/tour_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Workshop::Tour do
+  let(:runner) { Hecks::Workshop::WorkshopRunner.new }
+
+  before do
+    runner.instance_variable_set(:@workshop, Hecks::Workshop.new("Tour"))
+    allow($stdin).to receive(:tty?).and_return(false)
+  end
+
+  describe "#steps" do
+    it "has 15 steps" do
+      tour = described_class.new(runner)
+      expect(tour.steps.size).to eq(15)
+    end
+
+    it "each step has title, explanation, code, and action" do
+      tour = described_class.new(runner)
+      tour.steps.each do |step|
+        expect(step.title).to be_a(String)
+        expect(step.explanation).to be_a(String)
+        expect(step.code).to be_a(String)
+        expect(step.action).to respond_to(:call)
+      end
+    end
+  end
+
+  describe "#start" do
+    it "executes all steps without error" do
+      tour = described_class.new(runner)
+      output = StringIO.new
+      $stdout = output
+      tour.start
+      $stdout = STDOUT
+      text = output.string
+
+      expect(text).to include("Hecks Workshop Tour")
+      expect(text).to include("Tour complete!")
+      expect(text).to include("Create an aggregate")
+      expect(text).to include("play mode")
+      expect(text).to include("sketch mode")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `hecks tour` CLI command — interactive 15-step walkthrough of the framework
- Tour class with sketch steps (aggregate, attributes, lifecycle, transitions, commands, browse, validate, describe) and play steps (play!, execute, query, events, sketch!, build)
- Auto-executes each step, user presses Enter to advance
- TTY detection — skips pauses in CI/piped environments
- Creates fresh "Tour" workshop, cleans up after itself

## Tour flow
1. Create aggregate (Post)
2. Add attributes (title, body)
3. Add lifecycle (status → draft)
4. Add transition (PublishPost → published)
5. Add command (create with attributes)
6. Browse the domain
7. Validate
8. Describe
9. Enter play mode
10. Execute a command
11. Query results
12. Check events
13. Return to sketch
14. Build gem
15. Done

## Test plan
- [x] Spec verifies 15 steps, structure, full execution
- [x] Suite passes under 1 second (borderline ~0.99s)
- [x] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)