### PR TITLE
HEC-347: Fix arrowheads getting cut off in web explorer diagram

### DIFF
--- a/hecks_workshop/lib/hecks/workshop/web_runner/views/js/domain_diagram.js
+++ b/hecks_workshop/lib/hecks/workshop/web_runner/views/js/domain_diagram.js
@@ -21,7 +21,7 @@ class DomainDiagram extends HTMLElement {
         ${BASE_STYLES}
         :host { display: block; position: relative; }
         .container { position: relative; transform-origin: top left; }
-        svg { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; }
+        svg { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; overflow: visible; }
         .cards { position: relative; z-index: 1; }
         .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
         .title { color: ${COLORS.blue}; font-weight: 600; font-size: 14px; }
@@ -143,6 +143,7 @@ class DomainDiagram extends HTMLElement {
       maxH = Math.max(maxH, (parseFloat(c.style.top)||0) + c.offsetHeight + 10);
     });
     svg.setAttribute('width', maxW); svg.setAttribute('height', maxH);
+    svg.style.overflow = 'visible';
     this._ports = new PortSpreader();
     this._state.aggregates.forEach(agg => {
       agg.attributes.forEach(a => {


### PR DESCRIPTION
## Summary
- Fixed SVG overflow clipping arrowheads in the domain diagram visualization
- Added `overflow: visible` to CSS rule for svg element
- Set `svg.style.overflow = 'visible'` dynamically after sizing in _drawLines()

## Example
Before: Arrowheads on diagram edges would be clipped when they extended beyond computed SVG bounds, making connection directions unclear.

After: Arrowheads now fully visible, providing clear visual indication of reference direction between aggregates.

## Test plan
- Run `bundle exec rspec hecks_workshop/spec/web_runner_spec.rb` — all 1665 tests pass
- Smoke test with `ruby -Ilib examples/pizzas/app.rb` — runs without errors
- Visual inspection in web explorer: verify arrowheads on diagram edges are fully visible and not clipped