### PR TITLE
HEC-458: Extract route pattern matching into named methods

### DIFF
--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -114,7 +114,7 @@ module Hecks
           return
         end
 
-        route = @routes.find { |r| r[:method] == req.request_method && match?(r[:path], req.path) }
+        route = @routes.find { |r| r[:method] == req.request_method && route_matches_request_path?(r[:path], req.path) }
         unless route
           res.status = 404
           res["Content-Type"] = "application/json"
@@ -181,7 +181,7 @@ module Hecks
       # @param pattern [String] the route pattern (e.g. "/pizzas/:id")
       # @param path [String] the actual request path (e.g. "/pizzas/abc123")
       # @return [Boolean] true if the path matches the pattern
-      def match?(pattern, path)
+      def route_matches_request_path?(pattern, path)
         pp = pattern.split("/"); ap = path.split("/")
         pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
       end

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -157,7 +157,7 @@ module Hecks
       end
 
       def serve_domain_route(req, res, entry, sub_path)
-        route = entry[:routes].find { |r| r[:method] == req.request_method && match?(r[:path], sub_path) }
+        route = entry[:routes].find { |r| r[:method] == req.request_method && route_matches_request_path?(r[:path], sub_path) }
         if route && req["Accept"]&.include?("application/json")
           if csrf_required?(req) && !valid_csrf_json?(req)
             res.status = 403
@@ -189,7 +189,7 @@ module Hecks
         domain_aggregate_slug(agg.name)
       end
 
-      def match?(pattern, path)
+      def route_matches_request_path?(pattern, path)
         pp = pattern.split("/"); ap = path.split("/")
         pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
       end


### PR DESCRIPTION
## Summary

Extract inline `match?` calls into `route_matches_request_path?` for improved readability and clarity in route dispatch logic. Both `DomainServer` and `MultiDomainServer` now use explicitly-named pattern matching methods.

## Changes

- Renamed generic `match?(`pattern, path`) to `route_matches_request_path?\(pattern, path`)
- Updated both call sites in request routing logic
- Maintains identical behavior while improving code clarity

## Example

Before:
```ruby
route = @routes.find { |r| r[:method] == req.request_method && match?(r[:path], req.path) }
```

After:
```ruby
route = @routes.find { |r| r[:method] == req.request_method && route_matches_request_path?(r[:path], req.path) }
```

## Test Plan

- Syntax validation: Both files pass Ruby syntax check
- No functional changes — method behavior unchanged
- Inline calls correctly reference new method name