### PR TITLE
HEC-459: Auto-bump domain version on breaking changes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -313,6 +313,7 @@
 - `hecks diff` — diff working domain against latest tagged version (falls back to build snapshot)
 - Breaking change classification: removed commands, removed attributes, removed aggregates marked as BREAKING
 - Non-breaking changes: added commands, added attributes, added queries, added scopes
+- Auto-bump domain version on breaking changes: `hecks build` compares against the latest tagged snapshot and auto-bumps CalVer when breaking changes are detected
 
 ## Migrations & Schema Evolution
 - `DomainDiff` detects added/removed aggregates, attributes, VOs, entities, indexes, commands, policies, validations, invariants, queries, scopes, subscribers, specifications

--- a/docs/usage/versioning.md
+++ b/docs/usage/versioning.md
@@ -67,6 +67,34 @@ hecks diff
 # No changes detected (v2.1.0 -> working).
 ```
 
+## Auto-bump on breaking changes
+
+When you run `hecks build`, the build command compares your current domain
+against the latest tagged snapshot. If any breaking changes are detected,
+the CalVer version is auto-bumped and the breaking changes are printed:
+
+```bash
+hecks build
+# Breaking changes detected — auto-bumped to v2026.04.01.2:
+#   - command: Account.CloseAccount
+# Built banking v2026.04.01.2
+#   Output: banking/
+```
+
+If no previous snapshot exists (first build) or changes are non-breaking,
+the version is assigned normally without a bump.
+
+The `BreakingBumper` service can also be used programmatically:
+
+```ruby
+versioner  = Hecks::Versioner.new(".")
+old_domain = Hecks::DomainVersioning.load_version("1.0.0", base_dir: ".")
+result     = Hecks::DomainVersioning::BreakingBumper.call(old_domain, new_domain, versioner)
+result[:bumped]           # => true
+result[:version]          # => "2026.04.01.2"
+result[:breaking_changes] # => [{ change: ..., label: "- command: Account.CloseAccount", breaking: true }]
+```
+
 ## Breaking change rules
 
 A change is **BREAKING** if:

--- a/hecksties/lib/hecks/domain_versioning.rb
+++ b/hecksties/lib/hecks/domain_versioning.rb
@@ -9,6 +9,7 @@
 #   domain   = Hecks::DomainVersioning.load_version("2.1.0", base_dir: Dir.pwd)
 #
 require_relative "domain_versioning/breaking_classifier"
+require_relative "domain_versioning/breaking_bumper"
 
 module Hecks
   module DomainVersioning

--- a/hecksties/lib/hecks/domain_versioning/breaking_bumper.rb
+++ b/hecksties/lib/hecks/domain_versioning/breaking_bumper.rb
@@ -1,0 +1,42 @@
+# Hecks::DomainVersioning::BreakingBumper
+#
+# Auto-bumps the domain CalVer version when breaking changes are detected.
+# Compares the current domain against the latest tagged snapshot using
+# DomainDiff and BreakingClassifier. If any breaking changes exist, calls
+# versioner.next to bump the version; otherwise returns the current version.
+#
+#   result = BreakingBumper.call(old_domain, new_domain, versioner)
+#   result[:bumped]           # => true
+#   result[:version]          # => "2026.04.01.2"
+#   result[:breaking_changes] # => [{ change: ..., label: "...", breaking: true }]
+#
+module Hecks
+  module DomainVersioning
+    module BreakingBumper
+      # Evaluate whether a version bump is needed based on breaking changes.
+      #
+      # @param old_domain [Hecks::DomainModel::Domain, nil] previous snapshot (nil = first build)
+      # @param new_domain [Hecks::DomainModel::Domain] current domain
+      # @param versioner [Hecks::Versioner] CalVer versioner instance
+      # @return [Hash] with :version, :breaking_changes, :bumped keys
+      def self.call(old_domain, new_domain, versioner)
+        if old_domain.nil?
+          version = versioner.next
+          return { version: version, breaking_changes: [], bumped: false }
+        end
+
+        changes = Hecks::Migrations::DomainDiff.call(old_domain, new_domain)
+        classified = BreakingClassifier.classify(changes)
+        breaking = classified.select { |c| c[:breaking] }
+
+        if breaking.any?
+          version = versioner.next
+          { version: version, breaking_changes: breaking, bumped: true }
+        else
+          version = versioner.current || versioner.next
+          { version: version, breaking_changes: [], bumped: false }
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/build.rb
+++ b/hecksties/lib/hecks_cli/commands/build.rb
@@ -21,7 +21,16 @@ Hecks::CLI.register_command(:build, "Generate the domain gem",
 
   target = options[:target] || (options[:static] ? "static" : "ruby")
   versioner = Hecks::Versioner.new(".")
-  version = versioner.next
+
+  latest_ver = Hecks::DomainVersioning.latest_version(base_dir: ".")
+  old_domain = latest_ver ? Hecks::DomainVersioning.load_version(latest_ver, base_dir: ".") : nil
+  bump_result = Hecks::DomainVersioning::BreakingBumper.call(old_domain, domain, versioner)
+  version = bump_result[:version]
+
+  if bump_result[:bumped]
+    say "Breaking changes detected — auto-bumped to v#{version}:", :yellow
+    bump_result[:breaking_changes].each { |c| say "  #{c[:label]}", :red }
+  end
 
   builder = Hecks.target_registry[target.to_sym]
   unless builder

--- a/hecksties/spec/domain_versioning/breaking_bumper_spec.rb
+++ b/hecksties/spec/domain_versioning/breaking_bumper_spec.rb
@@ -1,0 +1,118 @@
+# breaking_bumper_spec.rb — HEC-459
+#
+# Specs for auto-bumping domain version on breaking changes.
+#
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Hecks::DomainVersioning::BreakingBumper do
+  let(:base_dir) { Dir.mktmpdir("hecks_bump_") }
+  after { FileUtils.rm_rf(base_dir) }
+
+  let(:versioner) { Hecks::Versioner.new(base_dir) }
+
+  let(:domain_v1) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "CloseAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:domain_v2_non_breaking) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+        attribute :tags, String
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "CloseAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:domain_v2_breaking) do
+    Hecks.domain "Banking" do
+      aggregate "Account" do
+        attribute :name, String
+        attribute :balance, Integer
+
+        command "CreateAccount" do
+          attribute :name, String
+        end
+
+        command "FreezeAccount" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  context "when there is no previous snapshot" do
+    it "bumps the version without flagging breaking changes" do
+      result = described_class.call(nil, domain_v1, versioner)
+      expect(result[:bumped]).to be false
+      expect(result[:breaking_changes]).to be_empty
+      expect(result[:version]).not_to be_nil
+    end
+  end
+
+  context "when changes are non-breaking" do
+    it "does not bump the version" do
+      # Establish a current version first
+      versioner.next
+
+      result = described_class.call(domain_v1, domain_v2_non_breaking, versioner)
+      expect(result[:bumped]).to be false
+      expect(result[:breaking_changes]).to be_empty
+    end
+
+    it "returns the current version" do
+      current = versioner.next
+
+      result = described_class.call(domain_v1, domain_v2_non_breaking, versioner)
+      expect(result[:version]).to eq(current)
+    end
+  end
+
+  context "when changes are breaking" do
+    it "bumps the version" do
+      versioner.next
+
+      result = described_class.call(domain_v1, domain_v2_breaking, versioner)
+      expect(result[:bumped]).to be true
+      expect(result[:version]).not_to be_nil
+    end
+
+    it "returns the breaking changes" do
+      versioner.next
+
+      result = described_class.call(domain_v1, domain_v2_breaking, versioner)
+      expect(result[:breaking_changes]).not_to be_empty
+      expect(result[:breaking_changes].all? { |c| c[:breaking] }).to be true
+    end
+
+    it "includes the removed command in breaking changes" do
+      versioner.next
+
+      result = described_class.call(domain_v1, domain_v2_breaking, versioner)
+      labels = result[:breaking_changes].map { |c| c[:label] }
+      expect(labels.any? { |l| l.include?("CloseAccount") }).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `BreakingBumper` service compares the current domain against the latest tagged snapshot using `DomainDiff` + `BreakingClassifier`
- `hecks build` now auto-bumps CalVer version when breaking changes (removed commands, attributes, aggregates, etc.) are detected
- Non-breaking changes and first builds proceed without an extra bump

## Example

Before (removed a command since last tagged version):
```bash
$ hecks build
Breaking changes detected — auto-bumped to v2026.04.01.2:
  - command: Account.CloseAccount
Built banking v2026.04.01.2
  Output: banking/
```

After (only additive changes):
```bash
$ hecks build
Built banking v2026.04.01.1
  Output: banking/
```

Programmatic usage:
```ruby
result = Hecks::DomainVersioning::BreakingBumper.call(old_domain, new_domain, versioner)
result[:bumped]           # => true
result[:breaking_changes] # => [{ label: "- command: Account.CloseAccount", ... }]
```

## Test plan
- [ ] `breaking_bumper_spec.rb`: no prior snapshot, non-breaking changes, breaking changes trigger bump
- [ ] Full suite passes (1671 examples, 0 failures)
- [ ] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)