### PR TITLE
HEC-460: Clean up caller_locations + respond_to? smell in builder_methods.rb

### DIFF
--- a/bluebook/lib/hecks/domain/builder_methods.rb
+++ b/bluebook/lib/hecks/domain/builder_methods.rb
@@ -38,7 +38,7 @@ module Hecks
       builder = builder_class.new(name, version: version)
       builder.instance_eval(&block)
       result = builder.build
-      result.source_path = caller_locations(1, 1).first.absolute_path if result.respond_to?(:source_path=)
+      result.source_path = caller_locations(1, 1).first.absolute_path
       Hecks.last_domain = result
       result
     end


### PR DESCRIPTION
## Summary

Remove unnecessary  defensive check for  since all Domain objects have this attr_accessor. This eliminates the code smell of defensive runtime type checking and unnecessary conditional evaluation of .

## Code Refactoring

**Before:**
```ruby
result.source_path = caller_locations(1, 1).first.absolute_path if result.respond_to?(:source_path=)
```

**After:**
```ruby
result.source_path = caller_locations(1, 1).first.absolute_path
```

## Why This Matters

1. **Contract-based design**: All Domain objects returned from `builder.build` have this attribute (defined as `attr_accessor :source_path` in Domain class)
2. **Simpler code**: Removes defensive type checking that isn't needed
3. **No performance impact**: `caller_locations` is always called, and its result is always used

## Test Plan

- Verify domain creation still sets source_path correctly
- Confirm source_path is an absolute path
- Run full test suite to ensure no regressions