### PR TITLE
HEC-447: Domain interviewer — conversational onboarding

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -382,6 +382,7 @@
 - `hecks inspect` — show full domain definition including business logic (attributes, lifecycle, commands, policies, invariants, etc.)
 - `hecks dump` — show glossary, visualizer, and DSL output
 - `hecks migrations` — schema migration management
+- `hecks interview` — conversational onboarding that walks through domain definition interactively (name, aggregates, attributes, commands) and writes a Bluebook file
 - `hecks docs update` — sync doc headers and READMEs
 - All commands accept `--domain` flag consistently
 

--- a/docs/usage/interview.md
+++ b/docs/usage/interview.md
@@ -1,0 +1,100 @@
+# Domain Interviewer
+
+Conversational onboarding that walks you through defining a domain interactively. Instead of writing DSL by hand, the interviewer asks questions and generates a valid Bluebook file.
+
+## Usage
+
+```sh
+hecks interview
+```
+
+## Example Session
+
+```
+$ hecks interview
+Welcome to Hecks! Let's build your domain together.
+
+Domain name: Pizzas
+
+Now let's define your aggregates (the core entities in your domain).
+Press Enter with a blank name when you're done.
+Aggregate name (blank to finish): Pizza
+  Attributes for Pizza (format: name:Type, blank to finish):
+    attribute: name:String
+    attribute: size:String
+    attribute:
+  Commands for Pizza (blank to finish):
+    command: CreatePizza
+    command: UpdatePizza
+    command:
+Aggregate name (blank to finish): Order
+  Attributes for Order (format: name:Type, blank to finish):
+    attribute: quantity:Integer
+    attribute:
+  Commands for Order (blank to finish):
+    command: PlaceOrder
+    command:
+Aggregate name (blank to finish):
+
+--- Domain Summary ---
+Domain: Pizzas
+  Aggregate: Pizza
+    - name: String
+    - size: String
+    > CreatePizza
+    > UpdatePizza
+  Aggregate: Order
+    - quantity: Integer
+    > PlaceOrder
+---------------------
+Write this domain? [Y/n]: Y
+Created PizzasBluebook
+Created verbs.txt
+
+Next steps:
+  hecks validate          # check your domain
+  hecks build             # generate the domain gem
+  hecks console           # edit interactively
+```
+
+## Generated Output
+
+The interviewer creates a standard Bluebook file:
+
+```ruby
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :size, String
+
+    command "CreatePizza" do
+      attribute :name, String
+      attribute :size, String
+    end
+
+    command "UpdatePizza" do
+      attribute :name, String
+      attribute :size, String
+    end
+  end
+
+  aggregate "Order" do
+    attribute :quantity, Integer
+
+    command "PlaceOrder" do
+      attribute :quantity, Integer
+    end
+  end
+end
+```
+
+## Options
+
+- `--force` — overwrite existing Bluebook without prompting
+
+## Notes
+
+- Blank domain name is rejected; you'll be re-prompted
+- Attribute format is `name:Type` where Type defaults to String if omitted
+- Command attributes are auto-populated from the aggregate's attributes
+- Events are auto-inferred from command names (CreatePizza -> CreatedPizza)

--- a/hecksties/lib/hecks_cli/commands/interview.rb
+++ b/hecksties/lib/hecks_cli/commands/interview.rb
@@ -1,0 +1,29 @@
+require_relative "../interviewer"
+
+Hecks::CLI.register_command(:interview, "Conversational onboarding to define a domain interactively",
+  options: {
+    force: { type: :boolean, desc: "Overwrite without prompting" }
+  }
+) do
+  say "Welcome to Hecks! Let's build your domain together.", :green
+  say ""
+
+  interviewer = Hecks::Interviewer.new(
+    ask: method(:ask),
+    say: method(:say)
+  )
+
+  dsl_source = interviewer.run
+  next say("Interview cancelled.", :yellow) unless dsl_source
+
+  # Extract domain name from the generated DSL to name the file
+  domain_name = dsl_source[/Hecks\.domain "(\w+)"/, 1] || "MyDomain"
+  write_or_diff("#{domain_name}Bluebook", dsl_source)
+  write_or_diff("verbs.txt", "# Add custom action verbs here (one per line)\n# WordNet handles most English verbs automatically\n")
+
+  say ""
+  say "Next steps:", :green
+  say "  hecks validate          # check your domain"
+  say "  hecks build             # generate the domain gem"
+  say "  hecks console           # edit interactively"
+end

--- a/hecksties/lib/hecks_cli/interviewer.rb
+++ b/hecksties/lib/hecks_cli/interviewer.rb
@@ -1,0 +1,132 @@
+# Hecks::Interviewer
+#
+# Conversational onboarding that walks a user through defining a domain
+# interactively. Asks for domain name, aggregates, attributes, and commands,
+# then builds a Domain IR via DomainBuilder and serializes it as DSL source.
+#
+# Accepts `ask` and `say` callables for testability (defaults to Thor shell).
+#
+#   interviewer = Hecks::Interviewer.new(ask: method(:ask), say: method(:say))
+#   dsl_source  = interviewer.run
+#
+module Hecks
+  class Interviewer
+    def initialize(ask:, say:)
+      @ask = ask
+      @say = say
+    end
+
+    def run
+      name = ask_domain_name
+      aggregates = ask_aggregates
+      domain = build_domain(name, aggregates)
+      show_summary(domain)
+      return nil unless confirm?
+
+      Hecks::DslSerializer.new(domain).serialize
+    end
+
+    private
+
+    def ask_domain_name
+      loop do
+        answer = @ask.call("Domain name:")
+        next @say.call("Domain name cannot be blank.", :red) if answer.to_s.strip.empty?
+        return Hecks::Utils.sanitize_constant(answer.strip)
+      end
+    end
+
+    def ask_aggregates
+      aggregates = []
+      @say.call("")
+      @say.call("Now let's define your aggregates (the core entities in your domain).")
+      @say.call("Press Enter with a blank name when you're done.")
+
+      loop do
+        answer = @ask.call("Aggregate name (blank to finish):")
+        break if answer.to_s.strip.empty?
+
+        agg_name = Hecks::Utils.sanitize_constant(answer.strip)
+        attrs = ask_attributes(agg_name)
+        commands = ask_commands(agg_name)
+        aggregates << { name: agg_name, attributes: attrs, commands: commands }
+      end
+
+      aggregates
+    end
+
+    def ask_attributes(agg_name)
+      attrs = []
+      @say.call("  Attributes for #{agg_name} (format: name:Type, blank to finish):")
+
+      loop do
+        answer = @ask.call("    attribute:")
+        break if answer.to_s.strip.empty?
+
+        parts = answer.strip.split(":", 2)
+        attr_name = parts[0].strip
+        attr_type = resolve_type((parts[1] || "String").strip)
+        attrs << { name: attr_name, type: attr_type }
+      end
+
+      attrs
+    end
+
+    def ask_commands(agg_name)
+      commands = []
+      @say.call("  Commands for #{agg_name} (blank to finish):")
+
+      loop do
+        answer = @ask.call("    command:")
+        break if answer.to_s.strip.empty?
+        commands << answer.strip
+      end
+
+      commands
+    end
+
+    def resolve_type(type_str)
+      case type_str.downcase
+      when "string"   then "String"
+      when "integer"  then "Integer"
+      when "float"    then "Float"
+      when "boolean"  then "Boolean"
+      when "date"     then "Date"
+      when "datetime" then "DateTime"
+      else type_str
+      end
+    end
+
+    def build_domain(name, aggregates)
+      builder = Hecks::DSL::DomainBuilder.new(name)
+      aggregates.each do |agg|
+        builder.aggregate(agg[:name]) do
+          agg[:attributes].each { |a| attribute a[:name].to_sym, Object.const_get(a[:type]) rescue a[:type] }
+          agg[:commands].each do |cmd_name|
+            command(cmd_name) do
+              agg[:attributes].each { |a| attribute a[:name].to_sym, Object.const_get(a[:type]) rescue a[:type] }
+            end
+          end
+        end
+      end
+      builder.build
+    end
+
+    def show_summary(domain)
+      @say.call("")
+      @say.call("--- Domain Summary ---", :green)
+      @say.call("Domain: #{domain.name}")
+      domain.aggregates.each do |agg|
+        @say.call("  Aggregate: #{agg.name}")
+        agg.attributes.each { |a| @say.call("    - #{a.name}: #{a.type}") }
+        agg.commands.each { |c| @say.call("    > #{c.name}") }
+      end
+      @say.call("---------------------", :green)
+    end
+
+    def confirm?
+      answer = @ask.call("Write this domain? [Y/n]:")
+      !answer.to_s.strip.match?(/\An(o)?\z/i)
+    end
+  end
+end

--- a/hecksties/spec/cli/commands/interview_spec.rb
+++ b/hecksties/spec/cli/commands/interview_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+require "hecks_cli"
+
+RSpec.describe "hecks interview" do
+  before { allow($stdout).to receive(:puts) }
+
+  it "builds a domain from scripted answers" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+
+        # Script: domain name, aggregate name, attributes, commands, then confirm
+        answers = [
+          "Pizzas",          # domain name
+          "Pizza",           # aggregate name
+          "name:String",     # attribute
+          "size:String",     # attribute
+          "",                # done with attributes
+          "CreatePizza",     # command
+          "",                # done with commands
+          "",                # done with aggregates
+          "Y"                # confirm
+        ]
+        call_count = 0
+        allow(cli).to receive(:ask) { answers[call_count].tap { call_count += 1 } }
+
+        cli.interview
+
+        bluebook = File.join(dir, "PizzasBluebook")
+        expect(File.exist?(bluebook)).to be true
+
+        content = File.read(bluebook)
+        expect(content).to include('Hecks.domain "Pizzas"')
+        expect(content).to include('aggregate "Pizza"')
+        expect(content).to include("attribute :name, String")
+        expect(content).to include("attribute :size, String")
+        expect(content).to include('command "CreatePizza"')
+      end
+    end
+  end
+
+  it "cancels when user declines confirmation" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+
+        answers = ["Pizzas", "Pizza", "name:String", "", "CreatePizza", "", "", "n"]
+        call_count = 0
+        allow(cli).to receive(:ask) { answers[call_count].tap { call_count += 1 } }
+
+        cli.interview
+
+        expect(Dir[File.join(dir, "*Bluebook")]).to be_empty
+      end
+    end
+  end
+
+  it "reprompts on blank domain name" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+
+        answers = ["", "Orders", "Order", "total:Integer", "", "PlaceOrder", "", "", "Y"]
+        call_count = 0
+        allow(cli).to receive(:ask) { answers[call_count].tap { call_count += 1 } }
+
+        cli.interview
+
+        bluebook = File.join(dir, "OrdersBluebook")
+        expect(File.exist?(bluebook)).to be true
+        expect(File.read(bluebook)).to include('Hecks.domain "Orders"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `hecks interview` CLI command that walks users through defining a domain interactively
- Asks for domain name, aggregates, attributes (name:Type), and commands in a conversational flow
- Builds domain IR via DomainBuilder, serializes with DslSerializer, writes Bluebook via write_or_diff

## Example usage

```
$ hecks interview
Welcome to Hecks! Let's build your domain together.

Domain name: Pizzas

Now let's define your aggregates (the core entities in your domain).
Press Enter with a blank name when you're done.
Aggregate name (blank to finish): Pizza
  Attributes for Pizza (format: name:Type, blank to finish):
    attribute: name:String
    attribute: size:String
    attribute:
  Commands for Pizza (blank to finish):
    command: CreatePizza
    command:
Aggregate name (blank to finish):

--- Domain Summary ---
Domain: Pizzas
  Aggregate: Pizza
    - name: String
    - size: String
    > CreatePizza
---------------------
Write this domain? [Y/n]: Y
Created PizzasBluebook
Created verbs.txt
```

## Generated output

```ruby
Hecks.domain "Pizzas" do
  aggregate "Pizza" do
    attribute :name, String
    attribute :size, String

    command "CreatePizza" do
      attribute :name, String
      attribute :size, String
    end
  end
end
```

## Test plan
- [ ] `hecks interview` with full scripted input produces correct Bluebook file
- [ ] Declining confirmation (n) skips file creation
- [ ] Blank domain name triggers re-prompt
- [ ] `bundle exec rspec hecksties/spec/` — all 1668 examples pass
- [ ] Smoke test `ruby -Ilib examples/pizzas/app.rb` passes