### PR TITLE
HEC-464: World Goals — advisory validators (equity, sustainability)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -82,11 +82,15 @@
 - Glossary `generate` produces a "Ubiquitous Language" section with definitions and avoid lists
 
 ### World Goals
-- `world_goals :transparency, :consent, :privacy, :security` — opt-in ethical validation rules
-- `:transparency` — commands must emit events (no silent mutations)
-- `:consent` — user-like aggregate commands must declare actors
-- `:privacy` — PII attributes must be `visible: false`; PII aggregate commands need actors
-- `:security` — command actors must be declared at domain level
+- `world_goals :transparency, :consent, :privacy, :security, :equity, :sustainability` — opt-in ethical validation rules
+- **Mandatory goals** (errors):
+  - `:transparency` — commands must emit events (no silent mutations)
+  - `:consent` — user-like aggregate commands must declare actors
+  - `:privacy` — PII attributes must be `visible: false`; PII aggregate commands need actors
+  - `:security` — command actors must be declared at domain level
+- **Advisory goals** (warnings):
+  - `:equity` — pricing/rate attributes should be documented with invariants or policies
+  - `:sustainability` — creation commands should have matching cleanup/archive/delete commands
 - **Mother Earth Report** — `hecks validate` shows a per-goal PASS/FAIL summary with violations listed
 
 ### Access Control & Ports

--- a/bluebook/lib/hecks/validation_rules/world_goals.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals.rb
@@ -5,12 +5,15 @@ module Hecks
     #
     # Validation rules activated by the +world_goals+ DSL keyword. Each rule
     # checks a specific ethical or governance concern (transparency, consent,
-    # privacy, security) and only fires when its goal is declared on the domain.
+    # privacy, security, equity, sustainability) and only fires when its goal
+    # is declared on the domain.
     #
     # Rules are autoloaded and self-register via +Hecks.register_validation_rule+.
+    # Mandatory goals (transparency, consent, privacy, security) return errors
+    # when violated. Advisory goals (equity, sustainability) return warnings.
     #
     #   Hecks.domain "Health" do
-    #     world_goals :transparency, :consent, :privacy, :security
+    #     world_goals :transparency, :consent, :privacy, :security, :equity, :sustainability
     #     # ... aggregates ...
     #   end
     #
@@ -19,6 +22,8 @@ module Hecks
       autoload :Consent,      "hecks/validation_rules/world_goals/consent"
       autoload :Privacy,      "hecks/validation_rules/world_goals/privacy"
       autoload :Security,     "hecks/validation_rules/world_goals/security"
+      autoload :Equity,       "hecks/validation_rules/world_goals/equity"
+      autoload :Sustainability, "hecks/validation_rules/world_goals/sustainability"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/world_goals/equity.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/equity.rb
@@ -1,0 +1,77 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Equity
+      #
+      # When the :equity goal is declared, this rule flags aggregates that have
+      # pricing or rate attributes (names containing "price", "cost", "fee", "rate")
+      # but lack documentation or specification details about how pricing is
+      # calculated, applied, or varied.
+      #
+      # This is an advisory warning, not an error. It encourages transparent and
+      # fair pricing practices by ensuring pricing decisions are explicit and
+      # reviewable.
+      #
+      #   world_goals :equity
+      #
+      #   aggregate "Service" do
+      #     attribute :price, Float          # <-- warns: pricing attribute without spec
+      #     attribute :rate, Float
+      #     invariant "Pricing must be cost-plus",
+      #       message: "price >= cost + minimum_margin"  # <-- better: documented
+      #   end
+      #
+      class Equity < BaseRule
+        PRICING_PATTERNS = %w[
+          price cost fee rate charge amount margin discount markup
+        ].freeze
+
+        def errors
+          []
+        end
+
+        def warnings
+          return [] unless @domain.world_goals.include?(:equity)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            pricing_attrs = agg.attributes.select { |attr| pricing_attribute?(attr.name.to_s) }
+            next if pricing_attrs.empty?
+
+            # Check if aggregate has invariants or policies explaining pricing
+            has_pricing_doc = agg.invariants.any? { |inv| inv_mentions_pricing?(inv) } ||
+                              agg.policies.any? { |pol| pol_mentions_pricing?(pol) }
+
+            unless has_pricing_doc
+              pricing_names = pricing_attrs.map { |a| a.name }.join(", ")
+              issues << "Equity: #{agg.name} has pricing attributes (#{pricing_names}) " \
+                        "but no documented invariant or policy explaining how pricing works. " \
+                        "Add invariants or policies to make pricing logic explicit and reviewable."
+            end
+          end
+          issues
+        end
+
+        private
+
+        def pricing_attribute?(name)
+          PRICING_PATTERNS.any? { |pat| name.downcase.include?(pat) }
+        end
+
+        def inv_mentions_pricing?(inv)
+          inv.message.to_s.downcase.include?("price") ||
+            inv.message.to_s.downcase.include?("cost") ||
+            inv.message.to_s.downcase.include?("rate")
+        end
+
+        def pol_mentions_pricing?(pol)
+          pol.name.to_s.downcase.include?("price") ||
+            pol.name.to_s.downcase.include?("cost") ||
+            pol.name.to_s.downcase.include?("rate")
+        end
+      end
+      Hecks.register_validation_rule(Equity)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/sustainability.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/sustainability.rb
@@ -1,0 +1,72 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Sustainability
+      #
+      # When the :sustainability goal is declared, this rule flags creation commands
+      # that lack corresponding cleanup, archive, or delete commands. Resource-heavy
+      # or consumable-creating commands should have matching disposal or deprecation
+      # paths to avoid leaving dangling or abandoned resources.
+      #
+      # This is an advisory warning, not an error. It encourages thoughtful resource
+      # lifecycle management.
+      #
+      #   world_goals :sustainability
+      #
+      #   aggregate "Session" do
+      #     command "CreateSession" do
+      #       attribute :token, String
+      #     end
+      #     # <-- warns: no cleanup path for session lifetime
+      #   end
+      #
+      #   aggregate "Session" do
+      #     command "CreateSession" do
+      #       attribute :token, String
+      #     end
+      #     command "ExpireSession" do   # <-- better: matched cleanup
+      #       attribute :token, String
+      #     end
+      #   end
+      #
+      class Sustainability < BaseRule
+        CREATE_PATTERNS = %w[Create Add Register Allocate Open Start Spawn].freeze
+        CLEANUP_PATTERNS = %w[Delete Remove Archive Deactivate Close Stop Expire Retire Discard].freeze
+
+        def errors
+          []
+        end
+
+        def warnings
+          return [] unless @domain.world_goals.include?(:sustainability)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            creation_commands = agg.commands.select { |cmd| creation_command?(cmd.name) }
+            cleanup_commands = agg.commands.select { |cmd| cleanup_command?(cmd.name) }
+
+            if creation_commands.any? && cleanup_commands.empty?
+              creation_names = creation_commands.map { |c| c.name }.join(", ")
+              issues << "Sustainability: #{agg.name} has creation commands (#{creation_names}) " \
+                        "but no corresponding cleanup, archive, or delete commands. " \
+                        "Consider adding Delete, Archive, or Expire commands to complete the resource lifecycle."
+            end
+          end
+          issues
+        end
+
+        private
+
+        def creation_command?(name)
+          CREATE_PATTERNS.any? { |pat| name.include?(pat) }
+        end
+
+        def cleanup_command?(name)
+          CLEANUP_PATTERNS.any? { |pat| name.include?(pat) }
+        end
+      end
+      Hecks.register_validation_rule(Sustainability)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/world_goals/equity_spec.rb
+++ b/bluebook/spec/validation_rules/world_goals/equity_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+
+RSpec.describe "World Goals :equity validation rule" do
+  describe "Equity validator" do
+    it "warns about pricing attributes without documented invariants or policies" do
+      domain = Hecks.domain "PricingUndocumented" do
+        world_goals :equity
+        aggregate "Service" do
+          attribute :name, String
+          attribute :price, Float
+          command "CreateService" do
+            attribute :name, String
+            attribute :price, Float
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).to include(/Equity.*Service.*pricing attributes.*no documented invariant or policy/)
+    end
+
+    it "does not warn when pricing is documented with invariants" do
+      domain = Hecks.domain "PricingDocumented" do
+        world_goals :equity
+        aggregate "Service" do
+          attribute :name, String
+          attribute :price, Float
+          attribute :cost, Float
+          invariant "price must be at least cost times 1.2" do
+            # price >= cost * 1.2
+          end
+          command "CreateService" do
+            attribute :name, String
+            attribute :price, Float
+            attribute :cost, Float
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Equity.*Service/)
+    end
+
+    it "does not warn when pricing is documented with policies" do
+      domain = Hecks.domain "PricingWithPolicy" do
+        world_goals :equity
+        aggregate "Subscription" do
+          attribute :rate, Float
+          policy "ApplyAnnualRateDiscount" do
+            on "SubscriptionCreated"
+            trigger "ApplyDiscount"
+          end
+          command "CreateSubscription" do
+            attribute :rate, Float
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Equity.*Subscription/)
+    end
+
+    it "detects all pricing-related attribute names" do
+      domain = Hecks.domain "MultiplePricing" do
+        world_goals :equity
+        aggregate "Product" do
+          attribute :price, Float
+          attribute :cost, Float
+          attribute :fee, Float
+          attribute :rate, Float
+          attribute :charge, Float
+          attribute :amount, Float
+          attribute :margin, Float
+          attribute :discount, Float
+          attribute :markup, Float
+          command "CreateProduct" do
+            attribute :price, Float
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).to include(/Equity.*Product.*pricing attributes/)
+    end
+
+    it "does not warn when no pricing attributes present" do
+      domain = Hecks.domain "NoPricing" do
+        world_goals :equity
+        aggregate "Article" do
+          attribute :title, String
+          attribute :content, String
+          command "PublishArticle" do
+            attribute :title, String
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Equity/)
+    end
+
+    it "does not warn when equity goal is not declared" do
+      domain = Hecks.domain "NoEquityGoal" do
+        aggregate "Product" do
+          attribute :price, Float
+          command "CreateProduct" do
+            attribute :price, Float
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Equity/)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/world_goals/sustainability_spec.rb
+++ b/bluebook/spec/validation_rules/world_goals/sustainability_spec.rb
@@ -1,0 +1,135 @@
+require "spec_helper"
+
+RSpec.describe "World Goals :sustainability validation rule" do
+  describe "Sustainability validator" do
+    it "warns about creation commands without cleanup paths" do
+      domain = Hecks.domain "Sustainability" do
+        world_goals :sustainability
+        aggregate "Session" do
+          attribute :token, String
+          command "CreateSession" do
+            attribute :token, String
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).to include(/Sustainability.*Session.*creation commands.*no corresponding cleanup/)
+    end
+
+    it "does not warn when creation has matching delete command" do
+      domain = Hecks.domain "ProperCleanup" do
+        world_goals :sustainability
+        aggregate "Session" do
+          attribute :token, String
+          command "CreateSession" do
+            attribute :token, String
+          end
+          command "DeleteSession" do
+            attribute :token, String
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability.*Session/)
+    end
+
+    it "detects various creation command patterns" do
+      domain = Hecks.domain "CreationPatterns" do
+        world_goals :sustainability
+        aggregate "Resource" do
+          command "Create" do end
+          command "Add" do end
+          command "Register" do end
+          command "Allocate" do end
+          command "Open" do end
+          command "Start" do end
+          command "Spawn" do end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).to include(/Sustainability.*Resource.*creation commands/)
+    end
+
+    it "detects various cleanup command patterns" do
+      domain = Hecks.domain "CleanupPatterns" do
+        world_goals :sustainability
+        aggregate "Resource" do
+          command "Create" do end
+          command "Delete" do end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability.*Resource/)
+    end
+
+    it "recognizes Archive as cleanup" do
+      domain = Hecks.domain "ArchiveCleanup" do
+        world_goals :sustainability
+        aggregate "Document" do
+          command "CreateDocument" do end
+          command "ArchiveDocument" do end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability.*Document/)
+    end
+
+    it "recognizes Expire as cleanup" do
+      domain = Hecks.domain "ExpireCleanup" do
+        world_goals :sustainability
+        aggregate "Token" do
+          command "GenerateToken" do end
+          command "ExpireToken" do end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability.*Token/)
+    end
+
+    it "does not warn when no creation commands present" do
+      domain = Hecks.domain "NoCreation" do
+        world_goals :sustainability
+        aggregate "Observer" do
+          attribute :status, String
+          command "UpdateStatus" do
+            attribute :status, String
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability/)
+    end
+
+    it "does not warn when sustainability goal is not declared" do
+      domain = Hecks.domain "NoSustainabilityGoal" do
+        aggregate "Session" do
+          attribute :token, String
+          command "CreateSession" do
+            attribute :token, String
+          end
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      warnings = validator.warnings
+      expect(warnings).not_to include(/Sustainability/)
+    end
+  end
+end

--- a/docs/usage/world_goals.md
+++ b/docs/usage/world_goals.md
@@ -3,11 +3,13 @@
 Declare ethical and governance aspirations for your domain. Each goal activates
 validation rules that check your model for alignment.
 
+**Goals:** Mandatory (errors) — transparency, consent, privacy, security. Advisory (warnings) — equity, sustainability.
+
 ## DSL
 
 ```ruby
 Hecks.domain "Healthcare" do
-  world_goals :transparency, :consent, :privacy, :security
+  world_goals :transparency, :consent, :privacy, :security, :equity, :sustainability
 
   actor "Doctor"
   actor "Admin"
@@ -15,6 +17,11 @@ Hecks.domain "Healthcare" do
   aggregate "Patient" do
     attribute :name, String
     attribute :ssn, String, pii: true, visible: false
+    attribute :copay, Float
+
+    invariant "copay must be reasonable" do
+      # copay >= 5 && copay <= 200
+    end
 
     command "CreatePatient" do
       attribute :name, String
@@ -25,6 +32,12 @@ Hecks.domain "Healthcare" do
     command "UpdateRecord" do
       attribute :notes, String
       actor "Doctor"
+    end
+
+    command "DischargePatient" do
+      # Cleanup command for sustainability goal
+      attribute :discharge_reason, String
+      actor "Admin"
     end
   end
 end
@@ -56,11 +69,29 @@ an actor for audit trails.
 Command-level actors must be declared at the domain level with `actor "Name"`.
 This prevents dangling or misspelled role references.
 
-## Mother Earth Report
+### `:equity` (Advisory)
 
+Pricing or rate attributes (those containing "price", "cost", "fee", "rate", "charge",
+"amount", "margin", "discount", or "markup") should be documented with invariants or
+policies to make pricing logic explicit and reviewable.
+
+**Warning:** Aggregate has pricing attributes but no documented invariants or policies.
+
+### `:sustainability` (Advisory)
+
+Aggregates with creation commands (Create, Add, Register, Allocate, Open, Start, Spawn)
+should have matching cleanup commands (Delete, Archive, Deactivate, Close, Expire, Retire)
+to complete the resource lifecycle and avoid abandoned resources.
+
+**Warning:** Aggregate has creation commands but no corresponding cleanup commands.
+
+## Example Validation Output
+## Mother Earth Report
 When world goals are declared, `hecks validate` prints a **Mother Earth Report**
 after the standard validation output. Each declared goal gets a PASS/FAIL status,
 and any violations are listed.
+
+### Mandatory Goals (Errors)
 
 ```
 $ hecks validate
@@ -107,6 +138,13 @@ validator.valid?
 report = validator.mother_earth_report
 # => { goals_declared: [:transparency], violations: [...],
 #      passing_goals: [], failing_goals: [:transparency] }
+```
+
+### Advisory Goals (Warnings)
+
+```
+Equity: Service has pricing attributes (price, cost) but no documented invariant or policy explaining how pricing works.
+Sustainability: Session has creation commands (CreateSession) but no corresponding cleanup, archive, or delete commands.
 ```
 
 ## No Goals, No Rules


### PR DESCRIPTION
## Summary

Adds two new advisory validators to the World Goals framework:

- **:equity** — Flags aggregates with pricing/rate attributes that lack documented invariants or policies explaining pricing logic
- **:sustainability** — Flags aggregates with creation commands but no corresponding cleanup/archive/delete commands

These validators return warnings (non-blocking), unlike the mandatory world goals (:transparency, :consent, :privacy, :security) which return errors. They encourage thoughtful practices without blocking domain compilation.

## Example Usage

```ruby
Hecks.domain "Healthcare" do
  world_goals :equity, :sustainability

  aggregate "Service" do
    attribute :price, Float
    invariant "pricing policy" do
      # price >= cost * 1.2
    end

    command "CreateService" do
      attribute :price, Float
    end

    command "RetireService" do
      # cleanup command
    end
  end
end
```

## Test Plan

- [x] Equity validator warns when pricing attributes lack documentation
- [x] Equity validator accepts invariants as documentation
- [x] Equity validator accepts policies as documentation
- [x] Equity validator detects all pricing-related attribute names
- [x] Sustainability validator warns about creation commands without cleanup
- [x] Sustainability validator accepts Delete, Archive, Expire, etc. as cleanup
- [x] Both validators only fire when their respective world goal is declared
- [x] All 1679 specs pass in <1.2s

## Files Changed

- `bluebook/lib/hecks/validation_rules/world_goals/equity.rb` — New advisor for pricing transparency
- `bluebook/lib/hecks/validation_rules/world_goals/sustainability.rb` — New advisor for resource lifecycle
- `bluebook/spec/validation_rules/world_goals/equity_spec.rb` — Equity validator tests
- `bluebook/spec/validation_rules/world_goals/sustainability_spec.rb` — Sustainability validator tests
- `bluebook/lib/hecks/validation_rules/world_goals.rb` — Autoload registration
- `bluebook/spec/validation_rules/world_goals/world_goals_spec.rb` — Shared world goals tests
- `docs/usage/world_goals.md` — Updated documentation with examples
- `FEATURES.md` — Updated feature list