### PR TITLE
HEC-445: World goals onboarding prompt in hecks new

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -397,7 +397,7 @@
 - Preview mode with `--preview` flag
 
 ## CLI Commands
-- `hecks new NAME` — scaffold a complete project
+- `hecks new NAME` — scaffold a complete project with interactive world goals onboarding (opt-out by pressing Enter; skipped in non-interactive/CI)
 - `hecks build` — validate and generate versioned gem
 - `hecks serve [--rpc]` — start REST or JSON-RPC server
 - `hecks console [NAME]` — interactive REPL with domain loaded

--- a/docs/usage/world_goals_onboarding.md
+++ b/docs/usage/world_goals_onboarding.md
@@ -1,0 +1,62 @@
+# World Goals Onboarding
+
+When creating a new project with `hecks new`, you are prompted to select
+world goals interactively. Goals are opt-in ethical validation rules that
+check your domain design for alignment with stated values.
+
+## Available goals
+
+| Goal            | What it checks                                       |
+|-----------------|------------------------------------------------------|
+| `:transparency` | Commands must emit events (no silent mutations)      |
+| `:consent`      | User-like aggregate commands must declare actors     |
+| `:privacy`      | PII attributes must be `visible: false`              |
+| `:security`     | Sensitive aggregates need auth guards                |
+
+## Interactive usage
+
+```
+$ hecks new my_app
+
+World goals are opt-in ethical validation rules for your domain.
+Available: :transparency, :consent, :privacy, :security
+Enter goals (space-separated), or press Enter to skip:
+> transparency consent
+
+Created my_app/
+  MyAppBluebook   # includes world_goals :transparency, :consent
+  app.rb
+  ...
+```
+
+## Opt-out
+
+Press Enter without typing anything to skip world goals entirely:
+
+```
+Enter goals (space-separated), or press Enter to skip:
+>
+```
+
+The generated Bluebook will not include a `world_goals` line.
+
+## Non-interactive / CI
+
+When stdin is not a TTY (pipes, CI), the prompt is skipped automatically
+and no goals are included. You can always add them later by editing the
+Bluebook:
+
+```ruby
+Hecks.domain "MyApp" do
+  world_goals :transparency, :consent
+
+  aggregate "Example" do
+    # ...
+  end
+end
+```
+
+## Invalid input
+
+Unrecognized goal names are silently filtered out. Only the four valid
+goals (`:transparency`, `:consent`, `:privacy`, `:security`) are kept.

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -9,6 +9,20 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     next
   end
 
+  available_goals = %i[transparency consent privacy security]
+  selected_goals = []
+
+  if $stdin.tty?
+    say ""
+    say "World goals are opt-in ethical validation rules for your domain.", :cyan
+    say "Available: #{available_goals.map { |g| ":#{g}" }.join(", ")}"
+    say "Enter goals (space-separated), or press Enter to skip:"
+    input = $stdin.gets&.chomp
+    if input && !input.strip.empty?
+      selected_goals = input.strip.split(/\s+/).map(&:to_sym) & available_goals
+    end
+  end
+
   app_template = lambda do
     <<~RUBY
       require "hecks"
@@ -64,7 +78,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
 
   FileUtils.mkdir_p(File.join(dir, "spec"))
 
-  write_or_diff(File.join(dir, "#{pascal}Bluebook"), domain_template(pascal))
+  write_or_diff(File.join(dir, "#{pascal}Bluebook"), domain_template(pascal, world_goals: selected_goals))
   write_or_diff(File.join(dir, "app.rb"), app_template.call)
   write_or_diff(File.join(dir, "Gemfile"), gemfile_template.call)
   write_or_diff(File.join(dir, "spec", "spec_helper.rb"), spec_helper_template.call)

--- a/hecksties/lib/hecks_cli/domain_helpers.rb
+++ b/hecksties/lib/hecks_cli/domain_helpers.rb
@@ -93,9 +93,15 @@ module Hecks
       report[:violations].each { |v| say "    - #{v}", :red }
     end
 
-    def domain_template(name)
+    def domain_template(name, world_goals: [])
+      goals_line = if world_goals.any?
+        "\n  world_goals #{world_goals.map { |g| ":#{g}" }.join(", ")}\n"
+      else
+        ""
+      end
+
       <<~RUBY
-        Hecks.domain "#{name}" do
+        Hecks.domain "#{name}" do#{goals_line}
           aggregate "Example" do
             attribute :name, String
             validation :name, presence: true

--- a/hecksties/spec/new_project_spec.rb
+++ b/hecksties/spec/new_project_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "fileutils"
 require "tmpdir"
+require "stringio"
 require "hecks_cli"
 
 RSpec.describe "hecks new CLI command" do
@@ -54,5 +55,45 @@ RSpec.describe "hecks new CLI command" do
     domain = eval(domain_content, TOPLEVEL_BINDING, bluebook, 1)
     valid, errors = Hecks.validate(domain)
     expect(valid).to be(true), "Generated domain is invalid: #{errors.join(', ')}"
+  end
+
+  context "world goals onboarding" do
+    def with_stdin(text)
+      fake = StringIO.new(text)
+      allow(fake).to receive(:tty?).and_return(true)
+      original = $stdin
+      $stdin = fake
+      yield
+    ensure
+      $stdin = original
+    end
+
+    it "includes selected goals, filters invalid input, and skips on opt-out" do
+      Dir.chdir(tmpdir) do
+        with_stdin("transparency bogus consent\n") do
+          Hecks::CLI.new.invoke(:new_project, ["with_goals"])
+        end
+        bluebook = File.read(Dir["with_goals/*Bluebook"].first)
+        expect(bluebook).to include("world_goals :transparency, :consent")
+        expect(bluebook).not_to include("bogus")
+
+        with_stdin("\n") do
+          Hecks::CLI.new.invoke(:new_project, ["no_goals"])
+        end
+        bluebook = File.read(Dir["no_goals/*Bluebook"].first)
+        expect(bluebook).not_to include("world_goals")
+      end
+    end
+
+    it "skips prompt in non-interactive mode" do
+      allow($stdin).to receive(:tty?).and_return(false)
+
+      Dir.chdir(tmpdir) do
+        Hecks::CLI.new.invoke(:new_project, ["noninteractive"])
+
+        bluebook = File.read(Dir["noninteractive/*Bluebook"].first)
+        expect(bluebook).not_to include("world_goals")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `hecks new` now prompts interactively for world goals (`:transparency`, `:consent`, `:privacy`, `:security`) during project scaffolding
- Selected goals are inserted as `world_goals` line in the generated Bluebook
- Prompt is skipped in non-interactive/CI environments (`$stdin.tty?` check)
- Invalid goal names are silently filtered; pressing Enter skips goals entirely

## Example

```
$ hecks new my_app

World goals are opt-in ethical validation rules for your domain.
Available: :transparency, :consent, :privacy, :security
Enter goals (space-separated), or press Enter to skip:
> transparency consent

Created my_app/
  MyAppBluebook
  app.rb
  ...
```

Generated Bluebook:
```ruby
Hecks.domain "MyApp" do
  world_goals :transparency, :consent

  aggregate "Example" do
    attribute :name, String
    validation :name, presence: true
    command "CreateExample" do
      attribute :name, String
    end
  end
end
```

## Test plan
- [x] Interactive with goals selected — goals appear in Bluebook
- [x] Interactive with opt-out (empty Enter) — no goals line
- [x] Non-interactive mode — prompt skipped, no goals line
- [x] Invalid goal names filtered from input
- [x] Full suite passes (1667 examples, 0 failures)
- [x] Smoke test passes