### PR TITLE
HEC-455: Domain versioning — pin consumers to tagged versions

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -313,6 +313,10 @@
 - `hecks diff` — diff working domain against latest tagged version (falls back to build snapshot)
 - Breaking change classification: removed commands, removed attributes, removed aggregates marked as BREAKING
 - Non-breaking changes: added commands, added attributes, added queries, added scopes
+- `hecks version_pin CONSUMER --version X` — pin a consumer to a tagged version; stored in `db/hecks_versions/.pins.yml`
+- `hecks version_pins` — list all consumer version pins
+- Programmatic API: `DomainVersioning.pin`, `.pinned_version`, `.all_pins`
+- Version round-trip: `DslSerializer` emits `version:` kwarg when domain has a version set
 
 ## Migrations & Schema Evolution
 - `DomainDiff` detects added/removed aggregates, attributes, VOs, entities, indexes, commands, policies, validations, invariants, queries, scopes, subscribers, specifications

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -14,7 +14,9 @@ module Hecks
 
     # @return [String] valid Ruby DSL source code
     def serialize
-      lines = ["Hecks.domain \"#{@domain.name}\" do"]
+      header = "Hecks.domain \"#{@domain.name}\""
+      header += ", version: \"#{@domain.version}\"" if @domain.version
+      lines = ["#{header} do"]
       @domain.aggregates.each_with_index do |agg, i|
         lines << "" if i > 0
         lines.concat(serialize_aggregate(agg))

--- a/bluebook/spec/domain/dsl_serializer_spec.rb
+++ b/bluebook/spec/domain/dsl_serializer_spec.rb
@@ -35,4 +35,27 @@ RSpec.describe Hecks::DslSerializer do
     expect(restored.name).to eq("RoundTrip")
     expect(restored.aggregates.first.name).to eq("Thing")
   end
+
+  it "emits version kwarg when domain has a version" do
+    domain = Hecks.domain "Versioned", version: "2.1.0" do
+      aggregate "Widget" do
+        attribute :name, String
+      end
+    end
+
+    source = described_class.new(domain).serialize
+    expect(source).to include('Hecks.domain "Versioned", version: "2.1.0"')
+  end
+
+  it "omits version kwarg when domain has no version" do
+    domain = Hecks.domain "Plain" do
+      aggregate "Widget" do
+        attribute :name, String
+      end
+    end
+
+    source = described_class.new(domain).serialize
+    expect(source).to include('Hecks.domain "Plain" do')
+    expect(source).not_to include("version:")
+  end
 end

--- a/docs/usage/versioning.md
+++ b/docs/usage/versioning.md
@@ -78,3 +78,53 @@ A change is **non-breaking** if:
 - A command is added
 - An attribute is added
 - A query, scope, or specification is added
+
+## Pin a consumer to a version
+
+Lock a downstream consumer to a specific tagged version:
+
+```bash
+hecks version_pin billing-service --version 1.0.0
+# Pinned billing-service to v1.0.0
+```
+
+Pins are stored in `db/hecks_versions/.pins.yml`:
+
+```yaml
+---
+billing-service: "1.0.0"
+frontend-app: "2.1.0"
+```
+
+## List all pins
+
+```bash
+hecks version_pins
+# billing-service  v1.0.0
+# frontend-app     v2.1.0
+```
+
+## Programmatic API
+
+```ruby
+# Pin a consumer
+Hecks::DomainVersioning.pin("billing-service", "1.0.0", base_dir: Dir.pwd)
+
+# Look up a pin
+Hecks::DomainVersioning.pinned_version("billing-service", base_dir: Dir.pwd)
+# => "1.0.0"
+
+# List all pins
+Hecks::DomainVersioning.all_pins(base_dir: Dir.pwd)
+# => { "billing-service" => "1.0.0", "frontend-app" => "2.1.0" }
+```
+
+## Version round-trip in snapshots
+
+When a domain declares `version:`, the serializer preserves it in snapshot files:
+
+```ruby
+Hecks.domain "Banking", version: "2.1.0" do
+  # ...
+end
+```

--- a/hecksties/lib/hecks/domain_versioning.rb
+++ b/hecksties/lib/hecks/domain_versioning.rb
@@ -8,11 +8,13 @@
 #   versions = Hecks::DomainVersioning.log(base_dir: Dir.pwd)
 #   domain   = Hecks::DomainVersioning.load_version("2.1.0", base_dir: Dir.pwd)
 #
+require "yaml"
 require_relative "domain_versioning/breaking_classifier"
 
 module Hecks
   module DomainVersioning
     VERSIONS_DIR = "db/hecks_versions"
+    PINS_FILE    = ".pins.yml"
 
     # Tag the current domain as a named version snapshot.
     #
@@ -76,6 +78,40 @@ module Hecks
       entries.first&.fetch(:version)
     end
 
+    # Pin a consumer to a specific version.
+    #
+    # @param consumer_name [String] the consumer identifier (e.g. "billing-service")
+    # @param version [String] the version to pin to
+    # @param base_dir [String] project root directory
+    # @return [String] path to the pins file
+    # @raise [ArgumentError] if the version does not exist
+    def self.pin(consumer_name, version, base_dir: Dir.pwd)
+      unless exists?(version, base_dir: base_dir)
+        raise ArgumentError, "Version #{version} does not exist. Tag it first with `hecks version_tag #{version}`."
+      end
+
+      pins = load_pins(base_dir: base_dir)
+      pins[consumer_name] = version
+      write_pins(pins, base_dir: base_dir)
+    end
+
+    # Look up the pinned version for a consumer.
+    #
+    # @param consumer_name [String] the consumer identifier
+    # @param base_dir [String] project root directory
+    # @return [String, nil] the pinned version, or nil if not pinned
+    def self.pinned_version(consumer_name, base_dir: Dir.pwd)
+      load_pins(base_dir: base_dir)[consumer_name]
+    end
+
+    # List all consumer pins.
+    #
+    # @param base_dir [String] project root directory
+    # @return [Hash{String => String}] consumer_name => version mapping
+    def self.all_pins(base_dir: Dir.pwd)
+      load_pins(base_dir: base_dir)
+    end
+
     # Parse metadata header from a snapshot file.
     #
     # @param path [String] file path
@@ -89,6 +125,29 @@ module Hecks
         tagged_at = $1 if line =~ /^# tagged_at:\s*(.+)/
       end
       { version: version, tagged_at: tagged_at }
+    end
+
+    # Load pins from YAML file.
+    #
+    # @param base_dir [String] project root directory
+    # @return [Hash{String => String}]
+    def self.load_pins(base_dir: Dir.pwd)
+      path = File.join(base_dir, VERSIONS_DIR, PINS_FILE)
+      return {} unless File.exist?(path)
+      YAML.safe_load(File.read(path)) || {}
+    end
+
+    # Write pins to YAML file.
+    #
+    # @param pins [Hash{String => String}]
+    # @param base_dir [String] project root directory
+    # @return [String] path to the written file
+    def self.write_pins(pins, base_dir: Dir.pwd)
+      dir = File.join(base_dir, VERSIONS_DIR)
+      FileUtils.mkdir_p(dir)
+      path = File.join(dir, PINS_FILE)
+      File.write(path, YAML.dump(pins))
+      path
     end
   end
 end

--- a/hecksties/lib/hecks_cli/commands/version_pin.rb
+++ b/hecksties/lib/hecks_cli/commands/version_pin.rb
@@ -1,0 +1,23 @@
+# Hecks::CLI version_pin command
+#
+# Pins a consumer to a specific tagged domain version. The pin is stored
+# in db/hecks_versions/.pins.yml. Validates the version exists before pinning.
+#
+#   hecks version_pin billing-service --version 2.1.0
+#
+Hecks::CLI.register_command(:version_pin, "Pin a consumer to a tagged domain version",
+  args: ["CONSUMER"],
+  options: {
+    version: { type: :string, desc: "Version to pin to (required)", required: true }
+  }
+) do |consumer|
+  version = options[:version]
+
+  unless Hecks::DomainVersioning.exists?(version, base_dir: Dir.pwd)
+    say "Version #{version} does not exist. Tag it first with `hecks version_tag #{version}`.", :red
+    next
+  end
+
+  Hecks::DomainVersioning.pin(consumer, version, base_dir: Dir.pwd)
+  say "Pinned #{consumer} to v#{version}", :green
+end

--- a/hecksties/lib/hecks_cli/commands/version_pins.rb
+++ b/hecksties/lib/hecks_cli/commands/version_pins.rb
@@ -1,0 +1,20 @@
+# Hecks::CLI version_pins command
+#
+# Lists all consumer version pins from db/hecks_versions/.pins.yml.
+# Shows each consumer and the version it is pinned to.
+#
+#   hecks version_pins
+#
+Hecks::CLI.register_command(:version_pins, "List all consumer version pins") do
+  pins = Hecks::DomainVersioning.all_pins(base_dir: Dir.pwd)
+
+  if pins.empty?
+    say "No version pins. Run `hecks version_pin CONSUMER --version X` to pin one.", :yellow
+    next
+  end
+
+  max_name = pins.keys.map(&:length).max
+  pins.each do |consumer, version|
+    say "%-#{max_name}s  v%s" % [consumer, version]
+  end
+end

--- a/hecksties/spec/domain_versioning_spec.rb
+++ b/hecksties/spec/domain_versioning_spec.rb
@@ -116,6 +116,49 @@ RSpec.describe Hecks::DomainVersioning do
       expect(described_class.latest_version(base_dir: base_dir)).to eq("2.0.0")
     end
   end
+
+  describe ".pin" do
+    before { described_class.tag("1.0.0", domain_v1, base_dir: base_dir) }
+
+    it "writes a pin for a consumer" do
+      described_class.pin("billing-service", "1.0.0", base_dir: base_dir)
+      expect(described_class.pinned_version("billing-service", base_dir: base_dir)).to eq("1.0.0")
+    end
+
+    it "overwrites an existing pin" do
+      described_class.tag("2.0.0", domain_v2, base_dir: base_dir)
+      described_class.pin("billing-service", "1.0.0", base_dir: base_dir)
+      described_class.pin("billing-service", "2.0.0", base_dir: base_dir)
+      expect(described_class.pinned_version("billing-service", base_dir: base_dir)).to eq("2.0.0")
+    end
+
+    it "raises ArgumentError for nonexistent version" do
+      expect {
+        described_class.pin("billing-service", "9.9.9", base_dir: base_dir)
+      }.to raise_error(ArgumentError, /does not exist/)
+    end
+  end
+
+  describe ".pinned_version" do
+    it "returns nil when no pin exists" do
+      expect(described_class.pinned_version("unknown", base_dir: base_dir)).to be_nil
+    end
+  end
+
+  describe ".all_pins" do
+    it "returns empty hash when no pins exist" do
+      expect(described_class.all_pins(base_dir: base_dir)).to eq({})
+    end
+
+    it "lists all pinned consumers" do
+      described_class.tag("1.0.0", domain_v1, base_dir: base_dir)
+      described_class.tag("2.0.0", domain_v2, base_dir: base_dir)
+      described_class.pin("billing", "1.0.0", base_dir: base_dir)
+      described_class.pin("frontend", "2.0.0", base_dir: base_dir)
+      pins = described_class.all_pins(base_dir: base_dir)
+      expect(pins).to eq({ "billing" => "1.0.0", "frontend" => "2.0.0" })
+    end
+  end
 end
 
 RSpec.describe Hecks::DomainVersioning::BreakingClassifier do


### PR DESCRIPTION
## Summary

- Add `pin`, `pinned_version`, and `all_pins` methods to `Hecks::DomainVersioning` with YAML storage in `db/hecks_versions/.pins.yml`
- New CLI commands: `hecks version_pin CONSUMER --version X` and `hecks version_pins`
- `DslSerializer` now emits `version:` kwarg when a domain has a version set, so snapshots round-trip correctly

## Example usage

**Pin a consumer:**
```bash
hecks version_pin billing-service --version 1.0.0
# Pinned billing-service to v1.0.0
```

**List all pins:**
```bash
hecks version_pins
# billing-service  v1.0.0
# frontend-app     v2.1.0
```

**Programmatic API:**
```ruby
Hecks::DomainVersioning.pin("billing-service", "1.0.0", base_dir: Dir.pwd)
Hecks::DomainVersioning.pinned_version("billing-service", base_dir: Dir.pwd)  # => "1.0.0"
Hecks::DomainVersioning.all_pins(base_dir: Dir.pwd)  # => {"billing-service" => "1.0.0"}
```

**Version round-trip in snapshots:**
```ruby
# domain declared with version:
Hecks.domain "Banking", version: "2.1.0" do ... end

# serialized output preserves it:
# Hecks.domain "Banking", version: "2.1.0" do ...
```

## Test plan

- [ ] Pin writes, reads, lists, overwrites correctly
- [ ] Error raised for nonexistent version
- [ ] DslSerializer emits version kwarg when set, omits when nil
- [ ] Full suite passes (1673 examples, 0 failures)
- [ ] Smoke test passes