### PR TITLE
HEC-257: Go query parameter type coercion

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -527,6 +527,7 @@
 - `GET /_events` — JSON event log (EventLogContract shape, same for Ruby and Go)
 - `POST /_reset` — clear all data (button on config page, used by smoke tests)
 - Query routes: `GET /aggregates/queries/name` for each DSL-defined query
+- Query parameter type coercion: Integer params use `strconv.ParseInt`, Date params use `time.Parse` instead of raw strings
 - Scope routes: `GET /aggregates/scopes/name` for each DSL-defined scope
 - Specification routes: `GET /aggregates/specifications/name?id=` for predicate checks
 - View routes: `GET /_views/name` for read model state

--- a/hecks_targets/go/lib/go_hecks/generators/query_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/query_generator.rb
@@ -14,6 +14,7 @@ module GoHecks
       @module_path = module_path
       @conditions = extract_conditions
       @params = @query.block.parameters.map { |_, n| n.to_s }
+      @attr_index = @agg.attributes.each_with_object({}) { |a, h| h[a.name.to_s] = a }
     end
 
     def generate
@@ -27,7 +28,7 @@ module GoHecks
       if @params.empty?
         lines << "func #{func_name}(repo #{safe}Repository) ([]*#{safe}, error) {"
       else
-        param_list = @params.map { |p| "#{p} string" }.join(", ")
+        param_list = @params.map { |p| "#{p} #{param_go_type(p)}" }.join(", ")
         lines << "func #{func_name}(repo #{safe}Repository, #{param_list}) ([]*#{safe}, error) {"
       end
 
@@ -59,6 +60,11 @@ module GoHecks
     end
 
     private
+
+    def param_go_type(param_name)
+      attr = @attr_index[param_name]
+      attr ? GoUtils.go_type(attr) : "string"
+    end
 
     # Extract where conditions from the block source.
     # Parses `where(field: "value")` or `where(field: param)` patterns.

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
@@ -34,6 +34,7 @@ module GoHecks
       lines << "\t\"encoding/json\""
       lines << "\t\"fmt\""
       lines << "\t\"net/http\""
+      lines << "\t\"strconv\"" if needs_strconv_import?
       lines << "\t\"time\""
       lines << "\t\"os\""
       lines << "\t\"path/filepath\""
@@ -49,6 +50,18 @@ module GoHecks
     end
 
     private
+
+    def needs_strconv_import?
+      @domain.aggregates.any? do |agg|
+        attr_index = agg.attributes.each_with_object({}) { |a, h| h[a.name.to_s] = a }
+        agg.queries.any? do |q|
+          q.block.parameters.any? do |_, n|
+            attr = attr_index[n.to_s]
+            attr && %w[int64 float64].include?(GoUtils.go_type(attr))
+          end
+        end
+      end
+    end
 
     def app_struct
       lines = []

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/domain_behavior_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/domain_behavior_routes.rb
@@ -64,7 +64,13 @@ module GoHecks
           lines << "\tmux.HandleFunc(\"GET /#{plural}/queries/#{query_snake}\", func(w http.ResponseWriter, r *http.Request) {"
           if query.block.arity > 0
             param_names = query.block.parameters.map { |_, n| n.to_s }
-            args_code = param_names.map { |p| "r.URL.Query().Get(\"#{p}\")" }.join(", ")
+            attr_index = agg.attributes.each_with_object({}) { |a, h| h[a.name.to_s] = a }
+            param_names.each do |p|
+              attr = attr_index[p]
+              go_type = attr ? GoUtils.go_type(attr) : "string"
+              lines.concat(query_param_coercion(p, go_type))
+            end
+            args_code = param_names.map { |p| "qp_#{p}" }.join(", ")
             lines << "\t\tresults, _ := domain.#{func_name}(app.#{safe}Repo, #{args_code})"
           else
             lines << "\t\tresults, _ := domain.#{func_name}(app.#{safe}Repo)"
@@ -91,6 +97,20 @@ module GoHecks
         end
         lines
       end
+      def query_param_coercion(param, go_type)
+        raw = "r.URL.Query().Get(\"#{param}\")"
+        case go_type
+        when "int64"
+          ["\t\tqp_#{param}, _ := strconv.ParseInt(#{raw}, 10, 64)"]
+        when "float64"
+          ["\t\tqp_#{param}, _ := strconv.ParseFloat(#{raw}, 64)"]
+        when "time.Time"
+          ["\t\tqp_#{param}, _ := time.Parse(\"2006-01-02\", #{raw})"]
+        else
+          ["\t\tqp_#{param} := #{raw}"]
+        end
+      end
+
       # Views use a simple in-memory state map. Each view is initialized
       # as an empty map[string]interface{} on the App. The route returns
       # the current state as JSON.

--- a/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
+++ b/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
@@ -148,6 +148,41 @@ RSpec.describe GoHecks::ServerGenerator do
     end
   end
 
+  describe "query parameter type coercion (HEC-257)" do
+    let(:domain) do
+      Hecks.domain("Inventory") do
+        aggregate("Product") do
+          attribute :name, String
+          attribute :quantity, Integer
+          attribute :released_on, Date
+          command("CreateProduct") { attribute :name, String; attribute :quantity, Integer; attribute :released_on, Date }
+          query("ByQuantity") { |quantity| where(quantity: quantity) }
+          query("ByDate") { |released_on| where(released_on: released_on) }
+        end
+      end
+    end
+
+    let(:server) { GoHecks::ServerGenerator.new(domain, module_path: "inventory_domain") }
+    let(:output) { server.generate }
+
+    it "emits strconv.ParseInt for integer query parameters" do
+      expect(output).to include("strconv.ParseInt")
+    end
+
+    it "emits time.Parse for date query parameters" do
+      expect(output).to include('time.Parse("2006-01-02"')
+    end
+
+    it "passes coerced variable to domain function" do
+      expect(output).to include("qp_quantity")
+      expect(output).to include("qp_released_on")
+    end
+
+    it "adds strconv import when integer query params exist" do
+      expect(output).to include('"strconv"')
+    end
+  end
+
   describe "nav items" do
     it "does not include duplicate Home entry" do
       expect(output.scan('"Home"').size).to eq(0)


### PR DESCRIPTION
## Summary
- Query parameters in generated Go code were always typed as `string`, even when the aggregate attribute was `Integer` or `Date`
- Now looks up each query parameter's matching aggregate attribute and emits the correct Go type (`int64`, `time.Time`, etc.)
- Server route handlers emit `strconv.ParseInt` for integers and `time.Parse` for dates before passing coerced values to domain functions
- `strconv` import is conditionally added only when needed

## Example

**Before** (all query params treated as string):
```go
func ProductByQuantity(repo ProductRepository, quantity string) ([]*Product, error) {
```

Route handler:
```go
results, _ := domain.ProductByQuantity(app.ProductRepo, r.URL.Query().Get("quantity"))
```

**After** (params typed to match aggregate attributes):
```go
func ProductByQuantity(repo ProductRepository, quantity int64) ([]*Product, error) {
```

Route handler:
```go
qp_quantity, _ := strconv.ParseInt(r.URL.Query().Get("quantity"), 10, 64)
results, _ := domain.ProductByQuantity(app.ProductRepo, qp_quantity)
```

## Test plan
- [x] New spec `query parameter type coercion (HEC-257)` with 4 assertions: ParseInt, time.Parse, coerced variable names, strconv import
- [x] All 1669 existing tests pass
- [x] Smoke test passes
- [x] No file exceeds 200-line code limit