### PR TITLE
HEC-451: hecks tour --architecture — contributor walkthrough

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -254,6 +254,11 @@
 - Also available inside the console: `tour`
 - CI-friendly: skips Enter pauses when stdin is not a TTY
 
+### Architecture Tour
+- Contributor walkthrough via `hecks tour --architecture` — 10-step tour of framework internals
+- Covers monorepo layout, Bluebook DSL, Hecksagon IR, compiler pipeline, generators, workshop, AI tools, CLI registration, and spec conventions
+- Each step displays relevant file paths for exploration
+
 ### Web Console
 - Browser-based REPL via `hecks web_console [NAME]` — terminal-like interface at localhost:4567
 - Safe command parser: no eval, only whitelisted Grammar commands execute

--- a/docs/usage/architecture_tour.md
+++ b/docs/usage/architecture_tour.md
@@ -1,0 +1,34 @@
+# Architecture Tour
+
+A guided CLI walkthrough of the Hecks framework internals for contributors.
+
+## Usage
+
+```bash
+hecks tour --architecture
+```
+
+## What it covers
+
+The tour walks through 10 steps:
+
+1. **Monorepo layout** -- the six component gems
+2. **Bluebook DSL** -- builders, validators, domain definitions
+3. **Hecksagon IR** -- the intermediate representation (Domain, Aggregate, Command, etc.)
+4. **Compiler pipeline** -- from domain.rb through validation to code generation
+5. **Hecksties glue** -- Thor CLI, command registration, domain helpers
+6. **Code generators** -- Ruby, Go, and Node targets with cross-target parity
+7. **Workshop** -- sketch mode, play mode, and the interactive REPL
+8. **AI tools** -- MCP server for agent-driven domain modeling
+9. **CLI registration** -- how commands are discovered and grouped
+10. **Spec conventions** -- memory adapters, speed constraints, test layout
+
+Each step displays relevant file paths and pauses for Enter (skipped in CI).
+
+## Without the flag
+
+```bash
+hecks tour
+```
+
+Runs the domain modeler's walkthrough (sketch -> play -> build loop).

--- a/hecks_workshop/lib/hecks/workshop/commands/tour.rb
+++ b/hecks_workshop/lib/hecks/workshop/commands/tour.rb
@@ -1,10 +1,20 @@
 # Hecks::CLI tour command
 #
-# Launches a guided walkthrough of the sketch -> play -> build loop.
-# Demonstrates domain modeling from aggregate creation through play mode.
+# Launches a guided walkthrough. Without flags, runs the domain modeler's
+# sketch -> play -> build loop. With --architecture, runs a contributor's
+# walkthrough of the framework internals.
 #
 #   hecks tour
+#   hecks tour --architecture
 #
-Hecks::CLI.register_command(:tour, "Guided walkthrough of the workshop") do
-  Hecks::Workshop::WorkshopRunner.new.tour
+Hecks::CLI.register_command(
+  :tour,
+  "Guided walkthrough of the workshop (--architecture for internals)",
+  options: { architecture: { type: :boolean, default: false, desc: "Contributor walkthrough of framework components" } }
+) do
+  if options[:architecture]
+    Hecks::ArchitectureTour.new.start
+  else
+    Hecks::Workshop::WorkshopRunner.new.tour
+  end
 end

--- a/hecksties/lib/hecks_cli.rb
+++ b/hecksties/lib/hecks_cli.rb
@@ -22,3 +22,4 @@
 #
 require_relative "hecks_cli/cli"
 require_relative "hecks_cli/import"
+require_relative "hecks_cli/architecture_tour"

--- a/hecksties/lib/hecks_cli/architecture_tour.rb
+++ b/hecksties/lib/hecks_cli/architecture_tour.rb
@@ -1,0 +1,63 @@
+# Hecks::ArchitectureTour
+#
+# Interactive CLI walkthrough of the Hecks framework internals for
+# contributors. Walks through the monorepo layout, Bluebook DSL,
+# Hecksagon IR, compiler pipeline, glue layer, generators, workshop,
+# AI tools, CLI registration, and spec conventions.
+#
+# Each step prints a title, explanation, and relevant file paths.
+# Pauses for Enter between steps when stdin is a TTY (skips in CI).
+#
+#   Hecks::ArchitectureTour.new.start
+#
+require_relative "architecture_tour/steps"
+
+module Hecks
+  class ArchitectureTour
+    Step = Struct.new(:title, :explanation, :paths, keyword_init: true)
+
+    include Steps
+
+    attr_reader :steps
+
+    def initialize
+      @steps = build_steps
+    end
+
+    def start
+      puts ""
+      puts "=== Hecks Architecture Tour ==="
+      puts "A contributor's guide to how the framework is built."
+      puts ""
+
+      @steps.each_with_index do |step, i|
+        print_step(i + 1, step)
+        wait_for_enter
+      end
+
+      puts "=== Architecture tour complete! ==="
+      puts ""
+      puts "Explore any component with `hecks console`, or run `hecks tour`"
+      puts "for the domain modeler's walkthrough."
+      puts ""
+      nil
+    end
+
+    private
+
+    def print_step(number, step)
+      puts "--- Step #{number}/#{@steps.size}: #{step.title} ---"
+      puts step.explanation
+      puts ""
+      step.paths.each { |p| puts "  #{p}" }
+      puts ""
+    end
+
+    def wait_for_enter
+      return unless $stdin.respond_to?(:tty?) && $stdin.tty?
+
+      print "Press Enter to continue..."
+      $stdin.gets
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/architecture_tour/steps.rb
+++ b/hecksties/lib/hecks_cli/architecture_tour/steps.rb
@@ -1,0 +1,176 @@
+# Hecks::ArchitectureTour::Steps
+#
+# Step definitions for the architecture tour. Each method returns a
+# Step struct with title, explanation, and relevant file paths.
+#
+#   include Steps
+#   monorepo_layout_step  # => ArchitectureTour::Step
+#
+module Hecks
+  class ArchitectureTour
+    module Steps
+      def monorepo_layout_step
+        Step.new(
+          title: "Monorepo layout",
+          explanation: "Hecks is a monorepo with six components, each its own gem.\n" \
+                       "hecksagon is the runtime, hecks_workshop is the REPL,\n" \
+                       "hecksties is the CLI glue, hecks_targets has code generators,\n" \
+                       "hecks_ai provides MCP/AI tooling, and hecks_on_rails is the Rails adapter.",
+          paths: %w[
+            hecksagon/
+            hecks_workshop/
+            hecksties/
+            hecks_targets/
+            hecks_ai/
+            hecks_on_rails/
+          ]
+        )
+      end
+
+      def bluebook_dsl_step
+        Step.new(
+          title: "Bluebook DSL",
+          explanation: "The Bluebook is the DSL source of truth. Domain definitions are\n" \
+                       "written in Ruby blocks and parsed by builders into an IR.\n" \
+                       "Validators enforce DDD rules before anything is generated.",
+          paths: %w[
+            hecksagon/lib/hecksagon/bluebook/
+            hecksagon/lib/hecksagon/bluebook/builders/
+            hecksagon/lib/hecksagon/bluebook/validators/
+          ]
+        )
+      end
+
+      def hecksagon_ir_step
+        Step.new(
+          title: "Hecksagon IR (intermediate representation)",
+          explanation: "The Bluebook DSL compiles into an IR of plain Ruby structs:\n" \
+                       "Domain, Aggregate, Attribute, Command, Event, Policy, etc.\n" \
+                       "Every downstream tool (generators, MCP, CLI) reads this IR.",
+          paths: %w[
+            hecksagon/lib/hecksagon/domain.rb
+            hecksagon/lib/hecksagon/aggregate.rb
+            hecksagon/lib/hecksagon/attribute.rb
+            hecksagon/lib/hecksagon/command.rb
+          ]
+        )
+      end
+
+      def compiler_pipeline_step
+        Step.new(
+          title: "Compiler pipeline",
+          explanation: "The compiler reads a domain.rb file, builds the IR via Bluebook,\n" \
+                       "validates it, then hands it to a target (Ruby, Go, Node) for\n" \
+                       "code generation. Each target uses contracts to guarantee parity.",
+          paths: %w[
+            hecksagon/lib/hecksagon/compiler.rb
+            hecks_targets/lib/hecks_targets/
+          ]
+        )
+      end
+
+      def hecksties_glue_step
+        Step.new(
+          title: "Hecksties glue layer",
+          explanation: "Hecksties wires everything together: the Thor-based CLI,\n" \
+                       "command registration, domain helpers, and the import system\n" \
+                       "that reverse-engineers Rails apps into Hecks domains.",
+          paths: %w[
+            hecksties/lib/hecks_cli/cli.rb
+            hecksties/lib/hecks_cli/commands/
+            hecksties/lib/hecks_cli/import.rb
+          ]
+        )
+      end
+
+      def code_generators_step
+        Step.new(
+          title: "Code generators and targets",
+          explanation: "Each target generates a full application from the IR.\n" \
+                       "The Ruby target produces a gem with aggregates, commands,\n" \
+                       "repositories, and a Sinatra server. Go and Node targets\n" \
+                       "follow the same contracts for cross-target parity.",
+          paths: %w[
+            hecks_targets/lib/hecks_targets/ruby_target/
+            hecks_targets/lib/hecks_targets/go_target/
+            hecks_targets/lib/hecks_targets/node_target/
+          ]
+        )
+      end
+
+      def workshop_step
+        Step.new(
+          title: "Workshop (interactive REPL)",
+          explanation: "The workshop provides sketch mode (design aggregates, commands,\n" \
+                       "lifecycles) and play mode (execute commands, query data, inspect\n" \
+                       "events). `hecks console` launches it; `hecks tour` demos it.",
+          paths: %w[
+            hecks_workshop/lib/hecks/workshop.rb
+            hecks_workshop/lib/hecks/workshop/sketch_mode.rb
+            hecks_workshop/lib/hecks/workshop/play_mode.rb
+            hecks_workshop/lib/hecks/workshop/tour.rb
+          ]
+        )
+      end
+
+      def ai_tools_step
+        Step.new(
+          title: "AI tools (MCP server)",
+          explanation: "hecks_ai exposes the domain compiler as an MCP server so AI\n" \
+                       "agents can create aggregates, add commands, validate, and build\n" \
+                       "domains through tool calls. `hecks mcp` starts the server.",
+          paths: %w[
+            hecks_ai/lib/hecks_ai/
+            hecks_ai/lib/hecks_ai/mcp_server.rb
+          ]
+        )
+      end
+
+      def cli_registration_step
+        Step.new(
+          title: "CLI command registration",
+          explanation: "Each component registers commands via Hecks::CLI.register_command.\n" \
+                       "The CLI auto-discovers commands from hecks*/lib/**/commands/*.rb,\n" \
+                       "groups them by component, and installs them as Thor methods.",
+          paths: %w[
+            hecksties/lib/hecks_cli/cli.rb
+            hecks_workshop/lib/hecks/workshop/commands/tour.rb
+            hecksties/lib/hecks_cli/commands/
+          ]
+        )
+      end
+
+      def spec_conventions_step
+        Step.new(
+          title: "Spec conventions",
+          explanation: "Tests use memory adapters for speed (suite must run under 1 second).\n" \
+                       "Each component has its own spec/ directory. Integration specs live\n" \
+                       "in hecksties/spec/. Stub $stdin.tty? for interactive features.",
+          paths: %w[
+            hecksagon/spec/
+            hecks_workshop/spec/
+            hecksties/spec/
+            hecks_targets/spec/
+          ]
+        )
+      end
+
+      private
+
+      def build_steps
+        [
+          monorepo_layout_step,
+          bluebook_dsl_step,
+          hecksagon_ir_step,
+          compiler_pipeline_step,
+          hecksties_glue_step,
+          code_generators_step,
+          workshop_step,
+          ai_tools_step,
+          cli_registration_step,
+          spec_conventions_step
+        ]
+      end
+    end
+  end
+end

--- a/hecksties/spec/cli/architecture_tour_spec.rb
+++ b/hecksties/spec/cli/architecture_tour_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "hecks_cli"
+
+RSpec.describe Hecks::ArchitectureTour do
+  before { allow($stdin).to receive(:tty?).and_return(false) }
+
+  describe "#steps" do
+    it "has 10 steps" do
+      tour = described_class.new
+      expect(tour.steps.size).to eq(10)
+    end
+
+    it "each step has title, explanation, and paths" do
+      tour = described_class.new
+      tour.steps.each do |step|
+        expect(step.title).to be_a(String)
+        expect(step.explanation).to be_a(String)
+        expect(step.paths).to be_an(Array)
+        expect(step.paths).not_to be_empty
+      end
+    end
+  end
+
+  describe "#start" do
+    it "prints all steps and completes" do
+      tour = described_class.new
+      output = StringIO.new
+      $stdout = output
+      tour.start
+      $stdout = STDOUT
+      text = output.string
+
+      expect(text).to include("Architecture Tour")
+      expect(text).to include("tour complete!")
+      expect(text).to include("Monorepo layout")
+      expect(text).to include("Bluebook DSL")
+      expect(text).to include("Spec conventions")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `hecks tour --architecture` flag that launches a 10-step interactive walkthrough of the Hecks framework internals for contributors
- New `Hecks::ArchitectureTour` class in hecksties with Step structs covering: monorepo layout, Bluebook DSL, Hecksagon IR, compiler pipeline, hecksties glue, code generators, workshop, AI tools, CLI registration, and spec conventions
- Each step prints a title, explanation, and relevant file paths; pauses for Enter (skipped in CI)

## Example usage

```bash
# Contributor walkthrough of framework internals
$ hecks tour --architecture

=== Hecks Architecture Tour ===
A contributor's guide to how the framework is built.

--- Step 1/10: Monorepo layout ---
Hecks is a monorepo with six components, each its own gem.
hecksagon is the runtime, hecks_workshop is the REPL,
hecksties is the CLI glue, hecks_targets has code generators,
hecks_ai provides MCP/AI tooling, and hecks_on_rails is the Rails adapter.

  hecksagon/
  hecks_workshop/
  hecksties/
  hecks_targets/
  hecks_ai/
  hecks_on_rails/

Press Enter to continue...
...

# Domain modeler walkthrough (unchanged)
$ hecks tour
```

## Test plan
- [ ] `bundle exec rspec hecksties/spec/cli/architecture_tour_spec.rb` passes
- [ ] Full suite passes: `bundle exec rspec`
- [ ] Smoke test passes: `ruby -Ilib examples/pizzas/app.rb`
- [ ] Run `hecks tour --architecture` interactively and verify all 10 steps display
- [ ] Run `hecks tour` (no flag) and verify existing workshop tour still works