### PR TITLE
HEC-429: Glossary improvements — definitions, CLI command, and export

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -77,6 +77,9 @@
 
 ### Ubiquitous Language
 - `glossary { prefer "customer", not: ["user", "client"] }` — warn when banned terms appear in names across aggregates, commands, and events
+- `glossary { define "aggregate", as: "A cluster of objects" }` — define domain terms for the glossary
+- `prefer` accepts optional `definition:` kwarg to document preferred terms inline
+- Glossary `generate` produces a "Ubiquitous Language" section with definitions and avoid lists
 
 ### World Goals
 - `world_goals :transparency, :consent, :privacy, :security` — opt-in ethical validation rules
@@ -380,6 +383,7 @@
 - `hecks validate` — check domain against DDD rules
 - `hecks mcp` — start MCP server
 - `hecks inspect` — show full domain definition including business logic (attributes, lifecycle, commands, policies, invariants, etc.)
+- `hecks glossary` — print domain glossary to stdout; `--export` writes `glossary.md`
 - `hecks dump` — show glossary, visualizer, and DSL output
 - `hecks migrations` — schema migration management
 - `hecks docs update` — sync doc headers and READMEs

--- a/bluebook/lib/hecks/domain/glossary.rb
+++ b/bluebook/lib/hecks/domain/glossary.rb
@@ -51,6 +51,7 @@ module Hecks
       end
 
       lines.concat(describe_relationships)
+      lines.concat(describe_ubiquitous_language)
       lines
     end
 

--- a/bluebook/lib/hecks/domain/glossary/statement_builders.rb
+++ b/bluebook/lib/hecks/domain/glossary/statement_builders.rb
@@ -71,6 +71,32 @@ module Hecks
         "When #{subject} is #{verb}, the system will #{trigger_verb} #{trigger_target}#{async_note}. (policy)"
       end
 
+      # Build the "Ubiquitous Language" section from glossary rules.
+      # Renders each defined/preferred term with its definition and
+      # any avoided synonyms.
+      #
+      # @return [Array<String>] lines of markdown describing the glossary terms,
+      #   or an empty array if there are no glossary rules
+      def describe_ubiquitous_language
+        rules = Array(@domain.glossary_rules)
+        return [] if rules.empty?
+
+        lines = []
+        lines << "## Ubiquitous Language"
+        lines << ""
+        rules.each do |rule|
+          term = rule[:preferred]
+          defn = rule[:definition]
+          banned = Array(rule[:banned])
+          line = "- **#{term}**"
+          line += " -- #{defn}" if defn
+          line += " (avoid: #{banned.join(', ')})" unless banned.empty?
+          lines << line
+        end
+        lines << ""
+        lines
+      end
+
       # Build the "Relationships" section listing all cross-aggregate
       # references in the domain. Scans all aggregates for reference-type
       # attributes and generates one sentence per reference.

--- a/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
@@ -100,10 +100,11 @@ module Hecks
 
       # Hecks::DSL::DomainBuilder::GlossaryBuilder
       #
-      # Collects term preference rules for ubiquitous language enforcement.
+      # Collects term preference rules and definitions for ubiquitous language.
       #
       #   glossary do
-      #     prefer "stakeholder", not: ["user", "person"]
+      #     define "aggregate", as: "A cluster of domain objects treated as a unit"
+      #     prefer "stakeholder", not: ["user", "person"], definition: "Anyone with interest in the outcome"
       #   end
       #
       class GlossaryBuilder
@@ -111,9 +112,13 @@ module Hecks
           @rules = rules
         end
 
-        def prefer(term, not: [])
+        def prefer(term, not: [], definition: nil)
           banned = binding.local_variable_get(:not)
-          @rules << { preferred: term, banned: banned }
+          @rules << { preferred: term, banned: banned, definition: definition }
+        end
+
+        def define(term, as:)
+          @rules << { preferred: term, banned: [], definition: as }
         end
       end
 

--- a/bluebook/spec/domain/glossary_spec.rb
+++ b/bluebook/spec/domain/glossary_spec.rb
@@ -125,4 +125,39 @@ RSpec.describe Hecks::DomainGlossary do
       expect { domain.glossary }.to output(/Pizzas Domain Glossary/).to_stdout
     end
   end
+
+  describe "ubiquitous language section" do
+    let(:domain) do
+      Hecks.domain "Pizzas" do
+        glossary do
+          define "aggregate", as: "A cluster of domain objects treated as a unit"
+          prefer "stakeholder", not: ["user", "person"], definition: "Anyone with a vested interest"
+          prefer "topping", not: ["ingredient"]
+        end
+
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "includes the Ubiquitous Language heading" do
+      expect(text).to include("## Ubiquitous Language")
+    end
+
+    it "renders defined terms with definitions" do
+      expect(text).to include("- **aggregate** -- A cluster of domain objects treated as a unit")
+    end
+
+    it "renders prefer terms with definitions and avoided words" do
+      expect(text).to include("- **stakeholder** -- Anyone with a vested interest (avoid: user, person)")
+    end
+
+    it "renders prefer terms without definitions but with avoided words" do
+      expect(text).to include("- **topping** (avoid: ingredient)")
+    end
+  end
 end

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -98,6 +98,7 @@ Hecks.domain "Banking" do
 
   # Ubiquitous language enforcement
   glossary do
+    define "stakeholder", as: "Anyone with a vested interest in the outcome"
     prefer "stakeholder", not: ["user", "person"]
   end
 
@@ -141,12 +142,17 @@ end
 
 ## Glossary
 
-The glossary enforces your team's shared vocabulary. It warns when banned terms appear in attribute names, command names, or event names.
+The glossary enforces your team's shared vocabulary and documents domain terms. It warns when banned terms appear in attribute names, command names, or event names.
 
 ```ruby
 Hecks.domain "Banking" do
   glossary do
-    prefer "customer", not: ["user", "client"]
+    # Define a term with a definition (no enforcement, just documentation)
+    define "aggregate", as: "A cluster of domain objects treated as a unit"
+
+    # Prefer a term, ban synonyms, and optionally add a definition
+    prefer "customer", not: ["user", "client"],
+      definition: "The party responsible for payment"
     prefer "account",  not: ["wallet", "fund"]
   end
 end
@@ -154,10 +160,21 @@ end
 
 When a banned term is detected, the compiler emits a warning: `"Use 'customer', not 'user' (found in attribute 'user_name')"`.
 
-Multiple `prefer` rules can be declared in the same block:
+The glossary output includes an "Ubiquitous Language" section:
+
+```
+## Ubiquitous Language
+
+- **aggregate** -- A cluster of domain objects treated as a unit
+- **customer** -- The party responsible for payment (avoid: user, client)
+- **account** (avoid: wallet, fund)
+```
+
+Multiple rules can be declared in the same block:
 
 ```ruby
 glossary do
+  define "bounded context", as: "An explicit boundary within which a domain model exists"
   prefer "invoice",   not: ["bill", "receipt"]
   prefer "customer",  not: ["user", "client", "buyer"]
   prefer "shipment",  not: ["delivery", "parcel"]

--- a/docs/usage/glossary.md
+++ b/docs/usage/glossary.md
@@ -1,0 +1,65 @@
+# Glossary — Ubiquitous Language
+
+Define and enforce domain terminology with the `glossary` DSL block.
+
+## DSL
+
+```ruby
+Hecks.domain "Billing" do
+  glossary do
+    # Define a term with a definition
+    define "invoice", as: "A formal request for payment issued to a customer"
+
+    # Prefer a term over banned synonyms, with an optional definition
+    prefer "customer", not: ["user", "client"],
+      definition: "The party responsible for payment"
+
+    # Prefer without a definition — just enforces naming
+    prefer "line item", not: ["row", "entry"]
+  end
+
+  aggregate "Invoice" do
+    attribute :total, Float
+    command "CreateInvoice" do
+      attribute :total, Float
+    end
+  end
+end
+```
+
+## CLI
+
+```bash
+# Print glossary to stdout
+hecks glossary
+
+# Print glossary for a specific domain
+hecks glossary --domain path/to/domain
+
+# Export to glossary.md
+hecks glossary --export
+```
+
+## Generated Output
+
+The glossary `generate` method produces markdown including an
+"Ubiquitous Language" section:
+
+```
+## Ubiquitous Language
+
+- **invoice** -- A formal request for payment issued to a customer
+- **customer** -- The party responsible for payment (avoid: user, client)
+- **line item** (avoid: row, entry)
+```
+
+## Strict Mode
+
+Use `glossary(strict: true)` to turn glossary violations into errors
+(instead of warnings) during `hecks validate`.
+
+```ruby
+glossary(strict: true) do
+  prefer "stakeholder", not: ["user", "person"]
+end
+```

--- a/hecksties/lib/hecks_cli/commands/glossary.rb
+++ b/hecksties/lib/hecks_cli/commands/glossary.rb
@@ -1,0 +1,28 @@
+# Hecks::CLI glossary command
+#
+# Prints the domain glossary to stdout. With --export, writes glossary.md.
+#
+#   hecks glossary
+#   hecks glossary --export
+#   hecks glossary --domain path/to/domain
+#
+Hecks::CLI.register_command(:glossary, "Print the domain glossary",
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" },
+    export: { type: :boolean, desc: "Write glossary.md to disk", default: false }
+  }
+) do
+  domain = resolve_domain_option
+  next unless domain
+
+  glossary = Hecks::DomainGlossary.new(domain)
+  content = glossary.generate.join("\n")
+
+  if options[:export]
+    path = File.join(Dir.pwd, "glossary.md")
+    File.write(path, content + "\n")
+    say "Wrote #{path}", :green
+  else
+    say content
+  end
+end

--- a/hecksties/spec/cli/commands/glossary_spec.rb
+++ b/hecksties/spec/cli/commands/glossary_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+require "hecks_cli"
+
+# Hecks CLI glossary command spec
+#
+# Verifies that `hecks glossary` prints the domain glossary to stdout
+# and that `--export` writes glossary.md to disk.
+RSpec.describe "hecks glossary" do
+  let(:cli) { Hecks::CLI.new }
+
+  before { allow($stdout).to receive(:puts) }
+
+  it "prints glossary to stdout" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Shop" do
+          glossary do
+            define "order", as: "A customer request to purchase items"
+            prefer "customer", not: ["user"]
+          end
+          aggregate "Order" do
+            attribute :name, String
+            command "CreateOrder" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_glossary_output(dir)
+        expect(output).to include("Shop Domain Glossary")
+        expect(output).to include("Ubiquitous Language")
+        expect(output).to include("**order** -- A customer request to purchase items")
+        expect(output).to include("**customer**")
+        expect(output).to include("avoid: user")
+      end
+    end
+  end
+
+  it "exports glossary.md with --export" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            attribute :name, String
+            command "CreateOrder" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_glossary_output(dir, export: true)
+        expect(output).to include("Wrote")
+        expect(File.exist?(File.join(dir, "glossary.md"))).to be true
+        content = File.read(File.join(dir, "glossary.md"))
+        expect(content).to include("Shop Domain Glossary")
+      end
+    end
+  end
+
+  def capture_glossary_output(domain_path, export: false)
+    allow(cli).to receive(:options).and_return(
+      { domain: domain_path, export: export }
+    )
+    output = StringIO.new
+    allow(cli.shell).to receive(:say) { |msg, *| output.puts(msg) }
+    cli.glossary
+    output.string
+  end
+end


### PR DESCRIPTION
## Summary

- Add `define(term, as:)` to GlossaryBuilder for standalone term definitions
- Add optional `definition:` kwarg to existing `prefer` method
- Glossary `generate` now includes a "Ubiquitous Language" section with definitions and avoid lists
- New `hecks glossary` CLI command prints glossary to stdout; `--export` writes `glossary.md`

## Example

### DSL

```ruby
Hecks.domain "Billing" do
  glossary do
    define "aggregate", as: "A cluster of domain objects treated as a unit"
    prefer "customer", not: ["user", "client"],
      definition: "The party responsible for payment"
    prefer "line item", not: ["row", "entry"]
  end
end
```

### CLI output

```
$ hecks glossary

# Billing Domain Glossary

## Ubiquitous Language

- **aggregate** -- A cluster of domain objects treated as a unit
- **customer** -- The party responsible for payment (avoid: user, client)
- **line item** (avoid: row, entry)
```

### Export

```
$ hecks glossary --export
Wrote /path/to/project/glossary.md
```

## Test plan

- [ ] `bundle exec rspec bluebook/spec/domain/glossary_spec.rb` — ubiquitous language section specs
- [ ] `bundle exec rspec hecksties/spec/cli/commands/glossary_spec.rb` — CLI command specs
- [ ] `bundle exec rspec` — full suite passes (1671 examples, 0 failures)
- [ ] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes