### PR TITLE
HEC-346: Cross-domain qualified references in DSL

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -18,7 +18,7 @@
 - Define collection attributes with `list_of("Type")` syntax
 - Define cross-aggregate references with standalone `reference_to "Aggregate"` — first-class domain concept
 - Optional role naming: `reference_to "Team", role: "home_team"`
-- Cross-domain references: `reference_to "Billing::Invoice"`
+- Cross-domain qualified references: `reference_to "Billing::Invoice"` — exempt from compile-time validation, verified at boot (target domain must be loaded), IDOR reference validation resolves from foreign domain module
 - References hold live objects in memory — IDs are purely a persistence concern
 - Enum constraints: `attribute :category, String, enum: %w[low medium high]` — validated at runtime, dropdown in UI
 - Computed attributes: `computed :lot_size do; area / 43560.0; end` — derived values not stored in the database, shown in UI with "(computed)" hint

--- a/bluebook/lib/hecks/validation_rules/references/valid_references.rb
+++ b/bluebook/lib/hecks/validation_rules/references/valid_references.rb
@@ -29,6 +29,10 @@ module Hecks
 
         @domain.aggregates.each do |agg|
           (agg.references || []).each do |ref|
+            # Cross-domain qualified references (ref.domain non-nil) are validated
+            # at boot time by the multi-domain validator, not at compile time.
+            next if ref.domain
+
             ref_name = ref.type.to_s
 
             # Check if referencing a value object instead of an aggregate

--- a/bluebook/spec/domain/validation_rules_spec.rb
+++ b/bluebook/spec/domain/validation_rules_spec.rb
@@ -64,6 +64,33 @@ RSpec.describe "Validation Rules" do
     end
   end
 
+  describe "References::ValidReferences" do
+    it "exempts qualified cross-domain references from compile-time validation" do
+      domain = Hecks.domain("Validation") do
+        aggregate("Order") do
+          attribute :name, String
+          reference_to "Billing::Invoice"
+          command("PlaceOrder") { attribute :name, String }
+        end
+      end
+      valid, errors = validate(domain)
+      expect(valid).to be(true), "Expected qualified ref to pass but got: #{errors}"
+    end
+
+    it "still rejects unknown unqualified references" do
+      domain = Hecks.domain("Validation") do
+        aggregate("Order") do
+          attribute :name, String
+          reference_to "Nonexistent"
+          command("PlaceOrder") { attribute :name, String }
+        end
+      end
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors.any? { |e| e.include?("unknown aggregate") }).to be true
+    end
+  end
+
   describe "References::NoSelfReferences" do
     it "rejects aggregate referencing itself" do
       domain = Hecks.domain("Validation") do

--- a/docs/usage/cross_domain_references.md
+++ b/docs/usage/cross_domain_references.md
@@ -1,0 +1,71 @@
+# Cross-Domain Qualified References
+
+Reference aggregates in other bounded contexts using the `Domain::Aggregate` syntax.
+
+## DSL
+
+```ruby
+Hecks.domain "Shipping" do
+  aggregate "Shipment" do
+    attribute :address, String
+    reference_to "Billing::Invoice"
+
+    command "CreateShipment" do
+      attribute :address, String
+      reference_to "Billing::Invoice"
+    end
+  end
+end
+
+Hecks.domain "Billing" do
+  aggregate "Invoice" do
+    attribute :total, Integer
+    command "CreateInvoice" do
+      attribute :total, Integer
+    end
+  end
+end
+```
+
+## How it works
+
+1. **Compile time** -- qualified references (where the type contains `::`) are
+   exempt from single-domain validation. They cannot be checked until all
+   domains are loaded.
+
+2. **Boot time** -- `MultiDomain::Validator` verifies the target domain is
+   loaded. If you reference `Billing::Invoice` but the Billing domain is not
+   present, boot fails with a clear error.
+
+3. **Runtime** -- IDOR reference validation resolves cross-domain references
+   from the foreign domain's constant (`BillingDomain::Invoice`). Existence
+   checks and authorizer hooks work identically to same-domain references.
+
+## Unqualified references are rejected
+
+If an unqualified `reference_to "Invoice"` happens to match an aggregate in
+another loaded domain, the validator rejects it and suggests the qualified form:
+
+```
+Qualify the reference: reference_to "Billing::Invoice"
+```
+
+## Opting out of runtime validation
+
+Use `validate: false` on the command reference for eventual consistency:
+
+```ruby
+command "CreateShipment" do
+  reference_to "Billing::Invoice", validate: false
+end
+```
+
+## IR
+
+```ruby
+ref = domain.aggregates.first.references.first
+ref.domain        # => "Billing"
+ref.type          # => "Invoice"
+ref.kind          # => :cross_context
+ref.cross_context? # => true
+```

--- a/hecksties/lib/hecks/mixins/command/reference_validation.rb
+++ b/hecksties/lib/hecks/mixins/command/reference_validation.rb
@@ -69,16 +69,27 @@ module Hecks
       private
 
       # Resolves the Ruby class for a reference from the command's domain module.
+      # For cross-domain references (ref.domain non-nil), resolves from the
+      # foreign domain's constant (e.g., BillingDomain::Invoice).
       #
       # @param ref [Hecks::DomainModel::Structure::Reference] the reference IR node
       # @return [Class, nil] the resolved aggregate class, or nil if unresolvable
       def resolve_reference_class(ref)
-        domain_mod = self.class.name.split("::")[0..-4].join("::")
-        mod = domain_mod.empty? ? Object : Object.const_get(domain_mod)
-        begin
-          mod.const_get(ref.type)
-        rescue NameError
-          nil
+        if ref.domain
+          foreign_mod = "#{ref.domain}Domain"
+          begin
+            Object.const_get(foreign_mod).const_get(ref.type)
+          rescue NameError
+            nil
+          end
+        else
+          domain_mod = self.class.name.split("::")[0..-4].join("::")
+          mod = domain_mod.empty? ? Object : Object.const_get(domain_mod)
+          begin
+            mod.const_get(ref.type)
+          rescue NameError
+            nil
+          end
         end
       end
     end

--- a/hecksties/lib/hecks_multidomain/validator.rb
+++ b/hecksties/lib/hecks_multidomain/validator.rb
@@ -1,7 +1,9 @@
 # Hecks::MultiDomain::Validator
 #
-# Rejects references that cross domain boundaries.
-# Cross-domain references must use plain String IDs, not reference_to.
+# Validates references that cross domain boundaries. Qualified references
+# (+reference_to "Billing::Invoice"+) are allowed when the target domain is
+# loaded. Unqualified references that happen to match a foreign aggregate
+# are rejected — the developer must qualify the path explicitly.
 #
 #   Hecks::MultiDomain::Validator.validate_no_cross_domain_references(domains)
 #
@@ -33,22 +35,34 @@ module Hecks
 
       def validate_no_cross_domain_references(domains)
         errors = []
+        domain_names = domains.map(&:name)
         domains.each do |domain|
           own_aggs = domain.aggregates.map(&:name)
           domain.aggregates.each do |agg|
             (agg.references || []).each do |ref|
               ref_name = ref.type.to_s
+
+              if ref.domain
+                # Qualified cross-domain reference — verify the target domain is loaded
+                unless domain_names.include?(ref.domain)
+                  errors << "#{domain.name}::#{agg.name} uses reference_to(\"#{ref.domain}::#{ref_name}\") " \
+                            "but domain '#{ref.domain}' is not loaded. Loaded domains: #{domain_names.join(', ')}"
+                end
+                next
+              end
+
               next if own_aggs.include?(ref_name)
               owner = domains.find { |d| d.aggregates.any? { |a| a.name == ref_name } }
               if owner
                 errors << "#{domain.name}::#{agg.name} uses reference_to(\"#{ref_name}\") " \
-                          "which belongs to #{owner.name}. Use: attribute :#{domain_snake_name(ref_name)}_id, String"
+                          "which belongs to #{owner.name}. " \
+                          "Qualify the reference: reference_to \"#{owner.name}::#{ref_name}\""
               end
             end
           end
         end
         unless errors.empty?
-          raise Hecks::ValidationError, "Cross-domain reference_to detected:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+          raise Hecks::ValidationError, "Cross-domain reference_to errors:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
         end
       end
     end

--- a/hecksties/spec/runtime/multi_domain_spec.rb
+++ b/hecksties/spec/runtime/multi_domain_spec.rb
@@ -94,3 +94,124 @@ RSpec.describe "Multi-domain with shared event bus" do
     expect(defined?(BillingDomain::Pizza)).to be_nil
   end
 end
+
+RSpec.describe "Cross-domain qualified references" do
+  after { Hecks::Utils.cleanup_constants! }
+
+  it "allows qualified reference_to across domains" do
+    shipping = Hecks.domain "Shipping" do
+      aggregate "Shipment" do
+        attribute :address, String
+        reference_to "Billing::Invoice"
+
+        command "CreateShipment" do
+          attribute :address, String
+          reference_to "Billing::Invoice", validate: false
+        end
+      end
+    end
+
+    billing = Hecks.domain "Billing" do
+      aggregate "Invoice" do
+        attribute :total, Integer
+
+        command "CreateInvoice" do
+          attribute :total, Integer
+        end
+      end
+    end
+
+    shared_bus = Hecks::EventBus.new
+    Hecks.load(billing, event_bus: shared_bus)
+    Hecks.load(shipping, event_bus: shared_bus)
+
+    # Qualified reference should resolve to the foreign domain's aggregate
+    invoice = BillingDomain::Invoice.create(total: 100)
+    shipment = ShippingDomain::Shipment.create(address: "123 Main", invoice: invoice.id)
+    expect(shipment.address).to eq("123 Main")
+  end
+
+  it "rejects unqualified references that match a foreign aggregate" do
+    shipping = Hecks.domain "Shipping" do
+      aggregate "Shipment" do
+        attribute :address, String
+        reference_to "Invoice"
+
+        command "CreateShipment" do
+          attribute :address, String
+        end
+      end
+    end
+
+    billing = Hecks.domain "Billing" do
+      aggregate "Invoice" do
+        attribute :total, Integer
+
+        command "CreateInvoice" do
+          attribute :total, Integer
+        end
+      end
+    end
+
+    expect {
+      Hecks::MultiDomain::Validator.validate_no_cross_domain_references([shipping, billing])
+    }.to raise_error(Hecks::ValidationError, /Qualify the reference/)
+  end
+
+  it "rejects qualified references to unknown domains" do
+    shipping = Hecks.domain "Shipping" do
+      aggregate "Shipment" do
+        attribute :address, String
+        reference_to "Unknown::Widget"
+
+        command "CreateShipment" do
+          attribute :address, String
+        end
+      end
+    end
+
+    expect {
+      Hecks::MultiDomain::Validator.validate_no_cross_domain_references([shipping])
+    }.to raise_error(Hecks::ValidationError, /not loaded/)
+  end
+
+  it "resolves cross-domain reference for IDOR validation" do
+    billing = Hecks.domain "Billing" do
+      aggregate "Invoice" do
+        attribute :total, Integer
+
+        command "CreateInvoice" do
+          attribute :total, Integer
+        end
+      end
+    end
+
+    shipping = Hecks.domain "Shipping" do
+      aggregate "Shipment" do
+        attribute :address, String
+        reference_to "Billing::Invoice"
+
+        command "CreateShipment" do
+          attribute :address, String
+          reference_to "Billing::Invoice"
+        end
+      end
+    end
+
+    shared_bus = Hecks::EventBus.new
+    Hecks.load(billing, event_bus: shared_bus)
+    Hecks.load(shipping, event_bus: shared_bus)
+
+    # Create an invoice so the reference can resolve
+    invoice = BillingDomain::Invoice.create(total: 50)
+
+    # Should succeed — the cross-domain reference resolves to BillingDomain::Invoice
+    result = ShippingDomain::Shipment.create(address: "456 Elm", invoice: invoice.id)
+    expect(result.address).to eq("456 Elm")
+
+    # Should fail — nonexistent invoice ID
+    expect {
+      ShippingDomain::Shipment.create(address: "789 Oak", invoice: "fake-id")
+    }.to raise_error(Hecks::ReferenceNotFound)
+  end
+end


### PR DESCRIPTION
## Summary

- Exempt qualified references (`reference_to "Billing::Invoice"`) from compile-time validation — cross-domain refs cannot be checked until all domains are loaded
- Multi-domain validator now accepts qualified refs when the target domain is loaded, and suggests the qualified form when an unqualified ref accidentally matches a foreign aggregate
- Runtime IDOR validation resolves cross-domain references from the foreign domain module (`BillingDomain::Invoice`)

## Example

**Before:** `reference_to "Billing::Invoice"` fails validation with "unknown aggregate: Invoice"

**After:**
```ruby
Hecks.domain "Shipping" do
  aggregate "Shipment" do
    reference_to "Billing::Invoice"

    command "CreateShipment" do
      reference_to "Billing::Invoice"
    end
  end
end
```
Compiles cleanly. At boot, verifies Billing domain is loaded. At runtime, resolves `BillingDomain::Invoice` for existence checks.

## Test plan

- [x] Qualified refs exempt from compile-time ValidReferences rule
- [x] Unqualified refs to unknown aggregates still rejected
- [x] Multi-domain validator accepts qualified refs to loaded domains
- [x] Multi-domain validator rejects qualified refs to unknown domains
- [x] Multi-domain validator rejects unqualified refs matching foreign aggregates (suggests qualified form)
- [x] Runtime IDOR validation resolves cross-domain references from foreign domain module
- [x] ReferenceNotFound raised for nonexistent cross-domain IDs
- [x] Full suite: 1671 examples, 0 failures
- [x] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)