### PR TITLE
HEC-411: Standardize extension interface — driven/driving adapter types

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -17,44 +17,55 @@ end
 | **stable** | Integration-tested, suitable for production |
 | **experimental** | Works but not integration-tested — use with caution |
 
-## Persistence
+## Adapter Types
 
-| Extension | Usage | Stability | Description |
-|-----------|-------|-----------|-------------|
-| **sqlite** | `extend :sqlite` | stable | SQLite persistence via Sequel. [README](hecks_persist/README.md) |
-| **memory** | (default) | stable | In-process memory adapter, used in tests. |
-| **filesystem** | `extend :filesystem_store` | stable | JSON file persistence for development. [Source](hecks_runtime/lib/hecks/extensions/filesystem_store.rb) |
-| **postgres** | `extend :postgres` | experimental | PostgreSQL persistence via Sequel — not integration tested. [README](hecks_persist/README.md) |
-| **mysql** | `extend :mysql` | experimental | MySQL persistence via Sequel. [README](hecks_persist/README.md) |
-| **cqrs** | `extend :sqlite, as: :write` | experimental | Named read/write connections for CQRS. [Source](hecks_persist/lib/hecks/extensions/cqrs.rb) |
-| **transactions** | `extend :transactions` | experimental | DB transaction wrapping for SQL adapters. [Source](hecks_persist/lib/hecks/extensions/transactions.rb) |
+Extensions are classified as **driven** or **driving** adapters (hexagonal architecture):
 
-## Application Services
+| Type | Direction | Examples |
+|------|-----------|----------|
+| **driven** | Application calls out (repos, middleware, validation) | sqlite, auth, validations, logging |
+| **driving** | External world calls in (HTTP, queue, Slack) | serve, queue, slack, web_explorer, mcp |
 
-| Extension | Usage | Stability | Description |
-|-----------|-------|-----------|-------------|
-| **validations** | auto | stable | Field-level validation enforcement (presence, format, length). [Source](hecks_runtime/lib/hecks/extensions/validations.rb) |
-| **auth** | `extend :auth` | stable | Actor-based authorization via port definitions. [Source](hecks_runtime/lib/hecks/extensions/auth.rb) |
-| **tenancy** | `extend :tenancy` | experimental | Multi-tenant data isolation — not integration tested. [Source](hecks_runtime/lib/hecks/extensions/tenancy.rb) |
-| **audit** | `extend :audit` | experimental | Audit trail logging for every command execution. [Source](hecks_runtime/lib/hecks/extensions/audit.rb) |
-| **pii** | `extend :pii` | experimental | Encryption and masking for personally identifiable information. [Source](hecks_runtime/lib/hecks/extensions/pii.rb) |
-| **idempotency** | `extend :idempotency` | experimental | Deduplicates identical command dispatches. [Source](hecks_runtime/lib/hecks/extensions/idempotency.rb) |
-| **logging** | `extend :logging` | experimental | Command execution timing and logging. [Source](hecks_runtime/lib/hecks/extensions/logging.rb) |
-| **rate_limit** | `extend :rate_limit` | experimental | Per-command rate limiting. [Source](hecks_runtime/lib/hecks/extensions/rate_limit.rb) |
-| **retry** | `extend :retry` | experimental | Exponential backoff for transient errors. [Source](hecks_runtime/lib/hecks/extensions/retry.rb) |
+Boot fires driven extensions first so driving adapters see the fully wired runtime.
 
-## Infrastructure
+## Persistence (driven)
 
-| Extension | Usage | Stability | Description |
-|-----------|-------|-----------|-------------|
-| **web_explorer** | `extend :http` | stable | Interactive web UI with forms, lifecycle badges, event logs. [Source](hecks_runtime/lib/hecks/extensions/web_explorer.rb) |
-| **serve** | `hecks serve` | stable | WEBrick HTTP server for generated static apps. [README](hecks_cli/README.md) |
-| **mcp** | `hecks mcp` | experimental | MCP server for AI-driven domain modeling. [Source](hecks_workshop/lib/hecks/extensions/ai.rb) |
+| Extension | Usage | Adapter Type | Stability | Description |
+|-----------|-------|-------------|-----------|-------------|
+| **sqlite** | `extend :sqlite` | driven | stable | SQLite persistence via Sequel. [README](hecks_persist/README.md) |
+| **memory** | (default) | driven | stable | In-process memory adapter, used in tests. |
+| **filesystem** | `extend :filesystem_store` | driven | stable | JSON file persistence for development. [Source](hecks_runtime/lib/hecks/extensions/filesystem_store.rb) |
+| **postgres** | `extend :postgres` | driven | experimental | PostgreSQL persistence via Sequel — not integration tested. [README](hecks_persist/README.md) |
+| **mysql** | `extend :mysql` | driven | experimental | MySQL persistence via Sequel. [README](hecks_persist/README.md) |
+| **cqrs** | `extend :sqlite, as: :write` | driven | experimental | Named read/write connections for CQRS. [Source](hecks_persist/lib/hecks/extensions/cqrs.rb) |
+| **transactions** | `extend :transactions` | driven | experimental | DB transaction wrapping for SQL adapters. [Source](hecks_persist/lib/hecks/extensions/transactions.rb) |
 
-## Cross-Domain
+## Application Services (driven)
 
-| Extension | Usage | Stability | Description |
-|-----------|-------|-----------|-------------|
-| **listen** | `extend CommentsDomain` | experimental | Subscribe to another domain's event bus. |
-| **queue** | `extend :queue, backend: :rabbitmq` | experimental | RabbitMQ-backed async event delivery — not integration tested. |
-| **slack** | `extend :slack, webhook: url` | experimental | Forward events to Slack — not integration tested. |
+| Extension | Usage | Adapter Type | Stability | Description |
+|-----------|-------|-------------|-----------|-------------|
+| **validations** | auto | driven | stable | Field-level validation enforcement (presence, format, length). [Source](hecks_runtime/lib/hecks/extensions/validations.rb) |
+| **auth** | `extend :auth` | driven | stable | Actor-based authorization via port definitions. [Source](hecks_runtime/lib/hecks/extensions/auth.rb) |
+| **tenancy** | `extend :tenancy` | driven | experimental | Multi-tenant data isolation — not integration tested. [Source](hecks_runtime/lib/hecks/extensions/tenancy.rb) |
+| **audit** | `extend :audit` | driven | experimental | Audit trail logging for every command execution. [Source](hecks_runtime/lib/hecks/extensions/audit.rb) |
+| **pii** | `extend :pii` | driven | experimental | Encryption and masking for personally identifiable information. [Source](hecks_runtime/lib/hecks/extensions/pii.rb) |
+| **idempotency** | `extend :idempotency` | driven | experimental | Deduplicates identical command dispatches. [Source](hecks_runtime/lib/hecks/extensions/idempotency.rb) |
+| **logging** | `extend :logging` | driven | experimental | Command execution timing and logging. [Source](hecks_runtime/lib/hecks/extensions/logging.rb) |
+| **rate_limit** | `extend :rate_limit` | driven | experimental | Per-command rate limiting. [Source](hecks_runtime/lib/hecks/extensions/rate_limit.rb) |
+| **retry** | `extend :retry` | driven | experimental | Exponential backoff for transient errors. [Source](hecks_runtime/lib/hecks/extensions/retry.rb) |
+
+## Infrastructure (driving)
+
+| Extension | Usage | Adapter Type | Stability | Description |
+|-----------|-------|-------------|-----------|-------------|
+| **web_explorer** | `extend :http` | driving | stable | Interactive web UI with forms, lifecycle badges, event logs. [Source](hecks_runtime/lib/hecks/extensions/web_explorer.rb) |
+| **serve** | `hecks serve` | driving | stable | WEBrick HTTP server for generated static apps. [README](hecks_cli/README.md) |
+| **mcp** | `hecks mcp` | driving | experimental | MCP server for AI-driven domain modeling. [Source](hecks_workshop/lib/hecks/extensions/ai.rb) |
+
+## Cross-Domain (driving)
+
+| Extension | Usage | Adapter Type | Stability | Description |
+|-----------|-------|-------------|-----------|-------------|
+| **listen** | `extend CommentsDomain` | driving | experimental | Subscribe to another domain's event bus. |
+| **queue** | `extend :queue, backend: :rabbitmq` | driving | experimental | RabbitMQ-backed async event delivery — not integration tested. |
+| **slack** | `extend :slack, webhook: url` | driving | experimental | Forward events to Slack — not integration tested. |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -94,6 +94,9 @@
 ### Extension Registry
 - Extension registry: `Hecks.register_extension(:sqlite) { |mod, domain, runtime| ... }`
 - Add to Gemfile to wire, remove to unwire — no code changes needed
+- Adapter type classification: `adapter_type: :driven` or `:driving` on `describe_extension`
+- Two-phase boot: driven extensions (repos, middleware) fire before driving extensions (HTTP, queues)
+- Query helpers: `Hecks.driven_extensions` and `Hecks.driving_extensions`
 
 ### Persistence Extensions
 - `hecks_sqlite` — SQLite persistence, auto-wires when in Gemfile

--- a/docs/usage/extension_adapter_types.md
+++ b/docs/usage/extension_adapter_types.md
@@ -1,0 +1,57 @@
+# Extension Adapter Types
+
+Every Hecks extension can declare an `adapter_type` of `:driven` or `:driving`,
+following hexagonal architecture conventions.
+
+## Concepts
+
+- **Driven** adapters are called *by* the application (repos, validation,
+  auth, logging, retry). They wire infrastructure that the domain reaches out
+  to.
+- **Driving** adapters call *into* the application (HTTP server, Slack
+  webhook, message queue). They expose the domain to the outside world.
+
+## Two-Phase Boot
+
+`Hecks.boot` fires driven extensions first, then driving extensions. This
+guarantees that when a driving adapter (e.g. the HTTP server) starts accepting
+requests, all repos, middleware, and validation are already wired.
+
+## Declaring Adapter Type
+
+```ruby
+Hecks.describe_extension(:sqlite,
+  description: "SQLite persistence via Sequel",
+  adapter_type: :driven,
+  wires_to: :repository)
+
+Hecks.describe_extension(:http,
+  description: "REST and JSON-RPC server",
+  adapter_type: :driving,
+  wires_to: :command_bus)
+```
+
+## Query Helpers
+
+```ruby
+Hecks.driven_extensions
+# => [:sqlite, :auth, :validations, :logging, ...]
+
+Hecks.driving_extensions
+# => [:http, :slack, :queue, :web_explorer, :mcp]
+```
+
+## Example Boot Sequence
+
+```
+1. wire_persistence (sqlite/postgres/mysql)
+2. fire driven extensions:
+   - validations (command bus middleware)
+   - auth (command bus middleware)
+   - logging (command bus middleware)
+   - audit (event bus subscriber)
+3. fire driving extensions:
+   - http (adds .serve method)
+   - web_explorer (registers views)
+   - slack (subscribes to events)
+```

--- a/hecks_workshop/lib/hecks/extensions/ai.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai.rb
@@ -19,6 +19,7 @@
 #
 Hecks.describe_extension(:mcp,
   description: "MCP server for AI-assisted domain modeling",
+  adapter_type: :driving,
   config: { gate: { default: 8080, desc: "MCP server port" } },
   wires_to: :domain)
 

--- a/hecksagon/lib/hecks/extensions/mysql.rb
+++ b/hecksagon/lib/hecks/extensions/mysql.rb
@@ -21,6 +21,7 @@ require_relative "../../hecks_persist"
 
 Hecks.describe_extension(:mysql,
   description: "MySQL persistence via Sequel",
+  adapter_type: :driven,
   config: { host: { default: "localhost", desc: "DB host" }, database: { default: nil, desc: "DB name" } },
   wires_to: :repository)
 

--- a/hecksagon/lib/hecks/extensions/postgres.rb
+++ b/hecksagon/lib/hecks/extensions/postgres.rb
@@ -21,6 +21,7 @@ require_relative "../../hecks_persist"
 
 Hecks.describe_extension(:postgres,
   description: "PostgreSQL persistence via Sequel",
+  adapter_type: :driven,
   config: { host: { default: "localhost", desc: "DB host" }, database: { default: nil, desc: "DB name" } },
   wires_to: :repository)
 

--- a/hecksagon/lib/hecks/extensions/sqlite.rb
+++ b/hecksagon/lib/hecks/extensions/sqlite.rb
@@ -20,6 +20,7 @@ require_relative "../../hecks_persist/sql_boot"
 
 Hecks.describe_extension(:sqlite,
   description: "SQLite persistence via Sequel",
+  adapter_type: :driven,
   config: { database: { default: ":memory:", desc: "Database path" } },
   wires_to: :repository)
 

--- a/hecksagon/lib/hecks/extensions/transactions.rb
+++ b/hecksagon/lib/hecks/extensions/transactions.rb
@@ -20,6 +20,7 @@ require "hecks"
 
 Hecks.describe_extension(:transactions,
   description: "Transactional command execution with rollback",
+  adapter_type: :driven,
   config: {},
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/audit.rb
+++ b/hecksties/lib/hecks/extensions/audit.rb
@@ -124,6 +124,7 @@ end
 # Auto-wire when loaded: subscribe to shared event bus and add middleware.
 Hecks.describe_extension(:audit,
   description: "Immutable audit trail for every domain event",
+  adapter_type: :driven,
   config: {},
   wires_to: :event_bus)
 

--- a/hecksties/lib/hecks/extensions/auth.rb
+++ b/hecksties/lib/hecks/extensions/auth.rb
@@ -24,6 +24,7 @@
 #
 Hecks.describe_extension(:auth,
   description: "Actor-based authorization via port guards",
+  adapter_type: :driven,
   config: {},
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/filesystem_store.rb
+++ b/hecksties/lib/hecks/extensions/filesystem_store.rb
@@ -15,6 +15,7 @@
 #
 Hecks.describe_extension(:filesystem_store,
   description: "JSON file persistence",
+  adapter_type: :driven,
   config: { data_dir: { default: "./data", desc: "Directory for JSON files" } },
   wires_to: :repository)
 

--- a/hecksties/lib/hecks/extensions/idempotency.rb
+++ b/hecksties/lib/hecks/extensions/idempotency.rb
@@ -16,6 +16,7 @@
 #
 Hecks.describe_extension(:idempotency,
   description: "Idempotent command execution via dedup keys",
+  adapter_type: :driven,
   config: {},
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/logging.rb
+++ b/hecksties/lib/hecks/extensions/logging.rb
@@ -16,6 +16,7 @@
 #
 Hecks.describe_extension(:logging,
   description: "Command execution logging",
+  adapter_type: :driven,
   config: {},
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/pii.rb
+++ b/hecksties/lib/hecks/extensions/pii.rb
@@ -59,6 +59,7 @@ end
 
 Hecks.describe_extension(:pii,
   description: "PII field encryption and masking",
+  adapter_type: :driven,
   config: {},
   wires_to: :repository)
 

--- a/hecksties/lib/hecks/extensions/queue.rb
+++ b/hecksties/lib/hecks/extensions/queue.rb
@@ -22,6 +22,7 @@ require "json"
 
 Hecks.describe_extension(:queue,
   description: "Event queue publishing (RabbitMQ, file, custom adapter)",
+  adapter_type: :driving,
   config: { adapter: { default: :file, desc: "Queue adapter (:rabbitmq, :file, or object)" } },
   wires_to: :event_bus)
 

--- a/hecksties/lib/hecks/extensions/rate_limit.rb
+++ b/hecksties/lib/hecks/extensions/rate_limit.rb
@@ -19,6 +19,12 @@
 #   Hecks.actor = current_user
 #   app.run("CreatePizza", name: "Margherita")  # rate-limited per actor
 #
+Hecks.describe_extension(:rate_limit,
+  description: "Per-actor sliding window rate limiting",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :command_bus)
+
 Hecks.register_extension(:rate_limit) do |_domain_mod, _domain, runtime|
   window = {}
   limit = ENV.fetch("HECKS_RATE_LIMIT", "60").to_i

--- a/hecksties/lib/hecks/extensions/retry.rb
+++ b/hecksties/lib/hecks/extensions/retry.rb
@@ -23,6 +23,7 @@ require "hecks"
 
 Hecks.describe_extension(:retry,
   description: "Automatic command retry with backoff",
+  adapter_type: :driven,
   config: { max_attempts: { default: 3, desc: "Max retry attempts" } },
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/serve.rb
+++ b/hecksties/lib/hecks/extensions/serve.rb
@@ -21,6 +21,7 @@
 #
 Hecks.describe_extension(:http,
   description: "REST and JSON-RPC server with OpenAPI docs",
+  adapter_type: :driving,
   config: { gate: { default: 9292, desc: "HTTP port" }, rpc: { default: false, desc: "Enable JSON-RPC mode" } },
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/slack.rb
+++ b/hecksties/lib/hecks/extensions/slack.rb
@@ -17,6 +17,7 @@ require "json"
 
 Hecks.describe_extension(:slack,
   description: "Slack webhook notifications for domain events",
+  adapter_type: :driving,
   config: { webhook: { desc: "Slack incoming webhook URL" } },
   wires_to: :event_bus)
 

--- a/hecksties/lib/hecks/extensions/tenancy.rb
+++ b/hecksties/lib/hecks/extensions/tenancy.rb
@@ -26,6 +26,7 @@ require_relative "tenancy_support/tenant_scoped_repository"
 
 Hecks.describe_extension(:tenancy,
   description: "Multi-tenant column-scoped data isolation",
+  adapter_type: :driven,
   config: { strategy: { default: :column, desc: "Tenancy strategy" } },
   wires_to: :repository)
 

--- a/hecksties/lib/hecks/extensions/validations.rb
+++ b/hecksties/lib/hecks/extensions/validations.rb
@@ -20,6 +20,7 @@
 #
 Hecks.describe_extension(:validations,
   description: "Server-side parameter validation from domain rules",
+  adapter_type: :driven,
   config: {},
   wires_to: :command_bus)
 

--- a/hecksties/lib/hecks/extensions/web_explorer.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer.rb
@@ -20,6 +20,7 @@ require "erb"
 
 Hecks.describe_extension(:web_explorer,
   description: "Domain web explorer UI",
+  adapter_type: :driving,
   config: {},
   wires_to: :http)
 

--- a/hecksties/lib/hecks/registries/extension_registry.rb
+++ b/hecksties/lib/hecks/registries/extension_registry.rb
@@ -1,7 +1,18 @@
 # Hecks::ExtensionRegistryMethods
 #
 # Extension hook and metadata storage. Extracted from the Hecks module
-# to give extensions a focused home.
+# to give extensions a focused home. Each extension can declare an
+# +adapter_type+ of +:driven+ (repos, validation, auth) or +:driving+
+# (HTTP, queue, Slack). Boot fires driven extensions first so driving
+# adapters see the final runtime.
+#
+#   Hecks.describe_extension(:sqlite,
+#     description: "SQLite persistence",
+#     adapter_type: :driven,
+#     wires_to: :repository)
+#
+#   Hecks.driven_extensions  # => [:sqlite, :auth, ...]
+#   Hecks.driving_extensions # => [:http, :slack, ...]
 #
 module Hecks
   module ExtensionRegistryMethods
@@ -17,10 +28,19 @@ module Hecks
       extension_registry.register(name, hook)
     end
 
-    def describe_extension(name, description:, config: {}, wires_to: nil)
+    def describe_extension(name, description:, config: {}, wires_to: nil, adapter_type: nil)
       extension_meta.register(name, {
-        description: description, config: config, wires_to: wires_to
+        description: description, config: config,
+        wires_to: wires_to, adapter_type: adapter_type
       })
+    end
+
+    def driven_extensions
+      extension_meta.select { |_, m| m[:adapter_type] == :driven }.map(&:first)
+    end
+
+    def driving_extensions
+      extension_meta.select { |_, m| m[:adapter_type] == :driving }.map(&:first)
     end
   end
 end

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -93,15 +93,33 @@ module Hecks
       config = Hecks.configuration
       explicit = config&.extensions_explicit?
 
-      Hecks.extension_registry.each do |name, hook|
-        next if persistence_extension?(name)
-        next unless hook.respond_to?(:call)
-        next if explicit && !config.extensions.key?(name)
-        hook.call(mod, domain, runtime)
+      eligible = Hecks.extension_registry.select do |name, hook|
+        next false if persistence_extension?(name)
+        next false unless hook.respond_to?(:call)
+        next false if explicit && !config.extensions.key?(name)
+        true
       end
+
+      driven, driving, untyped = partition_by_adapter_type(eligible)
+      (driven + untyped + driving).each { |_name, hook| hook.call(mod, domain, runtime) }
 
       runtime.check_auth_coverage!
       runtime.check_reference_coverage!
+    end
+
+    def partition_by_adapter_type(extensions)
+      driven  = []
+      driving = []
+      untyped = []
+      extensions.each do |name, hook|
+        meta = Hecks.extension_meta[name]
+        case meta&.dig(:adapter_type)
+        when :driven  then driven  << [name, hook]
+        when :driving then driving << [name, hook]
+        else               untyped << [name, hook]
+        end
+      end
+      [driven, driving, untyped]
     end
 
     def autoload_services(dir)

--- a/hecksties/spec/runtime/extension_adapter_type_spec.rb
+++ b/hecksties/spec/runtime/extension_adapter_type_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe "Extension adapter_type classification" do
+  describe "driven_extensions" do
+    it "returns extensions declared as driven" do
+      driven = Hecks.driven_extensions
+      expect(driven).to include(:auth, :validations, :logging, :idempotency,
+                                :retry, :rate_limit, :pii, :tenancy, :audit,
+                                :filesystem_store)
+    end
+
+    it "does not include driving extensions" do
+      driven = Hecks.driven_extensions
+      expect(driven).not_to include(:http, :mcp)
+    end
+  end
+
+  describe "driving_extensions" do
+    it "returns extensions declared as driving" do
+      driving = Hecks.driving_extensions
+      expect(driving).to include(:http, :mcp)
+    end
+
+    it "does not include driven extensions" do
+      driving = Hecks.driving_extensions
+      expect(driving).not_to include(:auth, :validations, :logging)
+    end
+  end
+
+  describe "extension_meta stores adapter_type" do
+    it "records driven type in metadata" do
+      meta = Hecks.extension_meta[:auth]
+      expect(meta[:adapter_type]).to eq(:driven)
+    end
+
+    it "records driving type in metadata" do
+      meta = Hecks.extension_meta[:http]
+      expect(meta[:adapter_type]).to eq(:driving)
+    end
+
+    it "defaults to nil for untyped extensions" do
+      Hecks.describe_extension(:test_untyped, description: "test")
+      expect(Hecks.extension_meta[:test_untyped][:adapter_type]).to be_nil
+    ensure
+      Hecks.extension_meta.delete(:test_untyped)
+    end
+  end
+
+  describe "two-phase boot ordering" do
+    let(:tmpdir) { Dir.mktmpdir("hecks-adapter-type-") }
+    after { FileUtils.rm_rf(tmpdir) }
+
+    it "fires driven extensions before driving extensions" do
+      order = []
+      Hecks.register_extension(:test_driven) { |*, **| order << :driven }
+      Hecks.describe_extension(:test_driven,
+        description: "test", adapter_type: :driven)
+      Hecks.register_extension(:test_driving) { |*, **| order << :driving }
+      Hecks.describe_extension(:test_driving,
+        description: "test", adapter_type: :driving)
+
+      File.write(File.join(tmpdir, "OrderBluebook"), <<~RUBY)
+        Hecks.domain "AdapterOrderTest" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Hecks.boot(tmpdir)
+      driven_idx = order.index(:driven)
+      driving_idx = order.index(:driving)
+      expect(driven_idx).not_to be_nil
+      expect(driving_idx).not_to be_nil
+      expect(driven_idx).to be < driving_idx
+    ensure
+      Hecks.extension_registry.delete(:test_driven)
+      Hecks.extension_registry.delete(:test_driving)
+      Hecks.extension_meta.delete(:test_driven)
+      Hecks.extension_meta.delete(:test_driving)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `adapter_type:` keyword (`:driven` or `:driving`) to `Hecks.describe_extension`, following hexagonal architecture conventions
- Annotate all 20 extensions: driven (sqlite, postgres, mysql, transactions, filesystem_store, auth, validations, tenancy, pii, idempotency, logging, rate_limit, retry, audit) and driving (http/serve, slack, queue, web_explorer, mcp)
- Replace single `fire_extensions` loop with two-phase boot: driven extensions fire first (repos, middleware wired), then driving extensions (HTTP/queue see final runtime)
- Add `Hecks.driven_extensions` and `Hecks.driving_extensions` query helpers
- Add missing `describe_extension` for `:rate_limit`

## Example

```ruby
# Declaring adapter type on an extension
Hecks.describe_extension(:sqlite,
  description: "SQLite persistence via Sequel",
  adapter_type: :driven,
  wires_to: :repository)

Hecks.describe_extension(:http,
  description: "REST server",
  adapter_type: :driving,
  wires_to: :command_bus)

# Query helpers
Hecks.driven_extensions
# => [:sqlite, :auth, :validations, :logging, :retry, ...]

Hecks.driving_extensions
# => [:http, :slack, :queue, :web_explorer, :mcp]
```

Boot sequence with two-phase ordering:
```
1. wire_persistence (sqlite/postgres/mysql)
2. fire driven: validations, auth, logging, audit, ...
3. fire driving: http, web_explorer, slack, queue, ...
```

## Test plan

- [ ] `driven_extensions` returns all driven adapters, excludes driving
- [ ] `driving_extensions` returns all driving adapters, excludes driven
- [ ] `extension_meta` stores `adapter_type` correctly
- [ ] Two-phase boot fires driven before driving (verified via `Hecks.boot` with tmpdir)
- [ ] Full suite passes (1673 examples, 0 failures)
- [ ] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)