### PR TITLE
HEC-461: Extract raise_validation_errors into ValidationError.for_domain

### DIFF
--- a/bluebook/lib/hecks/domain/compiler.rb
+++ b/bluebook/lib/hecks/domain/compiler.rb
@@ -31,7 +31,7 @@ module Hecks
     def build(domain, version: "0.1.0", output_dir: ".")
       valid, errors = validate(domain)
       unless valid
-        raise Hecks::ValidationError, "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+        raise Hecks::ValidationError.for_domain(errors)
       end
 
       ValidationRules::Naming::ReservedNames.reserved_attr_warnings(domain).each do |w|
@@ -77,7 +77,7 @@ module Hecks
       unless skip_validation
         validator = Validator.new(domain)
         unless validator.valid?
-          raise Hecks::ValidationError, "Domain validation failed:\n#{validator.errors.map { |e| "  - #{e}" }.join("\n")}"
+          raise Hecks::ValidationError.for_domain(validator.errors)
         end
       end
 
@@ -104,7 +104,7 @@ module Hecks
     def build_static(domain, version: "0.1.0", output_dir: ".", smoke_test: true)
       valid, errors = validate(domain)
       unless valid
-        raise Hecks::ValidationError, "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+        raise Hecks::ValidationError.for_domain(errors)
       end
 
       require "hecks_static"
@@ -122,7 +122,7 @@ module Hecks
     def build_go(domain, output_dir: ".", smoke_test: true)
       valid, errors = validate(domain)
       unless valid
-        raise Hecks::ValidationError, "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+        raise Hecks::ValidationError.for_domain(errors)
       end
 
       require "go_hecks"
@@ -140,7 +140,7 @@ module Hecks
     def build_node(domain, output_dir: ".")
       valid, errors = validate(domain)
       unless valid
-        raise Hecks::ValidationError, "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+        raise Hecks::ValidationError.for_domain(errors)
       end
 
       require "node_hecks"
@@ -156,7 +156,7 @@ module Hecks
     def build_rails(domain, output_dir: ".")
       valid, errors = validate(domain)
       unless valid
-        raise Hecks::ValidationError, "Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}"
+        raise Hecks::ValidationError.for_domain(errors)
       end
 
       require "hecks/generators/rails_generator"

--- a/hecksties/lib/hecks/errors.rb
+++ b/hecksties/lib/hecks/errors.rb
@@ -54,6 +54,16 @@ module Hecks
   #
   #   raise Hecks::ValidationError.new("Name cannot be blank", field: :name, rule: :presence)
   class ValidationError < Error
+    # Build a ValidationError from a list of domain validation error strings.
+    #
+    # @param errors [Array<String>] validation error messages
+    # @return [ValidationError] formatted error with bullet-pointed message
+    #
+    #   Hecks::ValidationError.for_domain(["No fields", "Missing event"])
+    def self.for_domain(errors)
+      new("Domain validation failed:\n#{errors.map { |e| "  - #{e}" }.join("\n")}")
+    end
+
     # @return [Symbol, String, nil] the field that failed validation
     attr_reader :field
 

--- a/hecksties/spec/error_handling_spec.rb
+++ b/hecksties/spec/error_handling_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe "Error handling" do
   end
 
   describe "domain validation errors" do
+    it "formats multiple validation errors with for_domain" do
+      errors = ["Aggregate 'Pizza' has no fields", "Command 'Create' missing event"]
+      error = Hecks::ValidationError.for_domain(errors)
+      expect(error.message).to include("Domain validation failed:")
+      expect(error.message).to include("- Aggregate 'Pizza' has no fields")
+    end
+
     it "raises ValidationError for invalid domains" do
       domain = Hecks.domain "BadDomain" do
         aggregate "Widget" do


### PR DESCRIPTION
## Summary
- Add `ValidationError.for_domain(errors)` class method for consistent error formatting
- Replace inline error formatting in compiler.rb with the new method

## Example
Before: `raise Hecks::ValidationError, "Domain validation failed:\n#{validator.errors.map { |e| "  - #{e}" }.join("\n")}"`
After: `raise Hecks::ValidationError.for_domain(validator.errors)`

## Test plan
- [x] All specs pass (1666 examples, 0 failures)
- [x] ValidationError.for_domain formats errors correctly
- [x] Smoke test passes