### PR TITLE
HEC-253: Add enum smoke test to renderer tests

### DIFF
--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -64,9 +64,15 @@ module Hecks
 
       def command_fields(cmd, params = {})
         cmd.attributes.map do |a|
-          { type: :input, name: a.name.to_s, label: humanize(a.name),
-            input_type: "text", step: false, required: false,
-            value: params[a.name.to_s] || "" }
+          if a.enum
+            { type: :enum, name: a.name.to_s, label: humanize(a.name),
+              options: a.enum, required: false,
+              value: params[a.name.to_s] || "" }
+          else
+            { type: :input, name: a.name.to_s, label: humanize(a.name),
+              input_type: "text", step: false, required: false,
+              value: params[a.name.to_s] || "" }
+          end
         end
       end
 

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -123,6 +123,42 @@ RSpec.describe "Web Explorer IR introspection" do
     it "escapes HTML special characters via h()" do
       expect(renderer.h("<script>alert(1)</script>")).to eq("&lt;script&gt;alert(1)&lt;/script&gt;")
     end
+
+    it "renders enum fields as <select> dropdowns" do
+      enum_domain = Hecks.domain "EnumSmoke" do
+        aggregate "Ticket" do
+          attribute :priority, String, enum: %w[low medium high]
+          command "CreateTicket" do
+            attribute :priority, String, enum: %w[low medium high]
+          end
+        end
+      end
+
+      enum_ir = Hecks::WebExplorer::IRIntrospector.new(enum_domain)
+      agg = enum_ir.find_aggregate("Ticket")
+      cmd = enum_ir.find_command(agg, "create_ticket")
+      fields = enum_ir.command_fields(cmd)
+
+      priority_field = fields.find { |f| f[:name] == "priority" }
+      expect(priority_field[:type]).to eq(:enum)
+      expect(priority_field[:options]).to eq(%w[low medium high])
+
+      html = renderer.render(:form, {
+        command_name: "CreateTicket",
+        action: "/tickets",
+        csrf_token: "tok",
+        fields: fields,
+        error_message: nil,
+        skip_layout: true
+      })
+
+      expect(html).to include("<select")
+      expect(html).to include('name="priority"')
+      %w[low medium high].each do |val|
+        expect(html).to include("<option value=\"#{val}\">#{val}</option>")
+      end
+      expect(html).not_to include('type="text"')
+    end
   end
 
   describe Hecks::WebExplorer::RuntimeBridge do


### PR DESCRIPTION
## Summary
- Adds a smoke test verifying that enum attributes render as `<select>` dropdowns in the web explorer form template
- Fixes `IRIntrospector#command_fields` to return `type: :enum` with `options:` for attributes that have enum constraints (previously always returned `type: :input`)

## Example

Before: enum attributes rendered as plain text inputs in the web explorer form.

After: `command_fields` detects `a.enum` and returns the correct field type:
```ruby
# DSL
command "CreateTicket" do
  attribute :priority, String, enum: %w[low medium high]
end

# command_fields output
{ type: :enum, name: "priority", label: "Priority",
  options: ["low", "medium", "high"], ... }
```

The form template then renders:
```html
<select name="priority" required>
  <option value="low">low</option>
  <option value="medium">medium</option>
  <option value="high">high</option>
</select>
```

## Test plan
- [x] New spec creates an inline domain with an enum attribute
- [x] Verifies `command_fields` returns `type: :enum` with correct options
- [x] Verifies the rendered HTML contains `<select>` and `<option>` elements
- [x] Verifies no `type="text"` input is rendered for enum fields
- [x] Full suite passes (1666 examples, 0 failures, 1.05s)