### PR TITLE
HEC-125: Add reload! command to workshop REPL

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -232,6 +232,7 @@
 ### Sketch & Play
 - Interactive session for incremental domain building (`Hecks.session`)
 - `sketch!` / `play!` toggling — switch between modeling and execution modes
+- `reload!` — re-read the domain DSL and reboot the playground without leaving play mode; clears events and data
 - Dynamic REPL prompt: `hecks(scratch sketch)`, `hecks(banking play)`
 
 ### Named Constants & System Browser

--- a/bluebook/lib/bluebook/grammar.rb
+++ b/bluebook/lib/bluebook/grammar.rb
@@ -14,7 +14,7 @@ module BlueBook
   module Grammar
     BARE_COMMANDS = %w[
       describe browse validate preview status aggregates diagram
-      play! sketch! reset! events history save to_dsl
+      play! sketch! reset! reload! events history save to_dsl
     ].freeze
 
     HANDLE_METHODS = begin

--- a/docs/usage/reload.md
+++ b/docs/usage/reload.md
@@ -1,0 +1,47 @@
+# reload! — Hot-reload the domain in play mode
+
+Re-reads the current domain DSL definitions and reboots the playground
+runtime without leaving play mode. Events and repository data are cleared
+on reload.
+
+## When to use
+
+You've entered play mode, tested some commands, then realized you need to
+add an attribute or tweak a command. Instead of `sketch!` / edit / `play!`,
+just make the change and call `reload!`.
+
+## REPL example
+
+```ruby
+# Start a workshop and enter play mode
+workshop = Hecks.workshop("Pizzas")
+pizza = workshop.aggregate("Pizza")
+pizza.attr :name, String
+pizza.command("CreatePizza") { attribute :name, String }
+workshop.play!
+
+# Execute a command
+PizzasDomain::Pizza.create(name: "Margherita")
+workshop.events  # => [#<CreatedPizza ...>]
+
+# Add a new attribute while still in play mode
+pizza.attr :size, String
+
+# Reload picks up the change — events are cleared
+workshop.reload!
+
+# The new attribute is now available
+PizzasDomain::Pizza.new(name: "Margherita", size: "Large")
+```
+
+## Web console
+
+Type `reload!` in the web console input. In sketch mode it reloads the
+domain files from disk; in play mode it recompiles and reboots the runtime.
+
+## Notes
+
+- Requires play mode — raises `RuntimeError` if called in sketch mode.
+- Validates the domain before reloading. If invalid, prints errors and
+  keeps the previous playground running.
+- All captured events and in-memory repository data are cleared on reload.

--- a/hecks_workshop/lib/hecks/workshop/play_mode.rb
+++ b/hecks_workshop/lib/hecks/workshop/play_mode.rb
@@ -54,6 +54,7 @@ module Hecks
           puts "  events                    # event log"
           puts "  history                   # numbered timeline"
           puts "  reset!                    # clear all data"
+          puts "  reload!                   # re-read DSL, reboot runtime"
           puts "  sketch!                   # back to sketch mode"
         else
           puts "Entering play mode"
@@ -136,6 +137,31 @@ module Hecks
       def reset!
         ensure_play_mode!
         @playground.reset!
+      end
+
+      # Re-read the domain DSL and reboot the playground without leaving
+      # play mode. Validates the updated domain; if invalid, prints errors
+      # and keeps the previous playground running. Events and repository
+      # data are cleared on a successful reload.
+      #
+      #   workshop.aggregate("Pizza") { attribute :size, String }
+      #   workshop.reload!   # picks up the new attribute
+      #
+      # @return [Session] self
+      def reload!
+        ensure_play_mode!
+        domain = to_domain
+        valid, errors = Hecks.validate(domain)
+
+        unless valid
+          puts "Reload failed - domain is invalid:"
+          errors.each { |e| puts "  - #{e}" }
+          return self
+        end
+
+        @playground = Playground.new(domain)
+        puts "Reloaded domain"
+        self
       end
 
       # Apply an extension to the live runtime without rebooting.

--- a/hecks_workshop/lib/hecks/workshop/web_runner/command_parser.rb
+++ b/hecks_workshop/lib/hecks/workshop/web_runner/command_parser.rb
@@ -53,6 +53,9 @@ module Hecks
 
           # Bare command (no target)
           if target.nil?
+            if method == "reload!" && @web_runner
+              return @web_runner.reload_domain!
+            end
             if method == "reset!" && @web_runner && !@runner.instance_variable_get(:@workshop).play?
               return @web_runner.reload_domain!
             end

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -55,6 +55,17 @@ module Hecks
       result
     end
 
+    def reload!
+      result = @workshop.reload!
+      if @workshop.play? && @workshop.playground
+        mod_name = domain_module_name(@workshop.name)
+        if Object.const_defined?(mod_name)
+          hoist_domain_constants(Object.const_get(mod_name))
+        end
+      end
+      result
+    end
+
     def sketch!
       # Unload the domain module (removes hoisted constants + module itself)
       mod_name = domain_module_name(@workshop.name)
@@ -188,6 +199,7 @@ module Hecks
       puts "  Post.transition \"PublishPost\" => \"published\""
       puts ""
       puts "  play! / sketch!                  # switch modes"
+      puts "  reload!                          # re-read DSL, reboot playground"
       puts "  save / build"
       puts "  validate / describe / preview / browse"
       puts "  visualize                        # print Mermaid diagrams"

--- a/hecks_workshop/spec/play_mode_spec.rb
+++ b/hecks_workshop/spec/play_mode_spec.rb
@@ -181,6 +181,34 @@ RSpec.describe "Play mode" do
     end
   end
 
+  describe "reload!" do
+    it "recompiles the domain and stays in play mode" do
+      wb = build_workshop
+      wb.play!
+      wb.aggregate("Pizza") { attribute :size, String }
+      wb.reload!
+      expect(wb.play?).to be true
+      mod = Object.const_get("ScratchDomain")
+      pizza = mod::Pizza.new(name: "Margherita", style: "NY", size: "Large")
+      expect(pizza.size).to eq("Large")
+    end
+
+    it "clears events on reload" do
+      wb = build_workshop
+      wb.play!
+      mod = Object.const_get("ScratchDomain")
+      mod::Pizza.create(name: "Test", style: "NY")
+      expect(wb.events.size).to be >= 1
+      wb.reload!
+      expect(wb.events).to be_empty
+    end
+
+    it "requires play mode" do
+      wb = build_workshop
+      expect { wb.reload! }.to raise_error(RuntimeError, /Not in play mode/)
+    end
+  end
+
   describe "sketch! / play! toggling" do
     it "can switch back to sketch mode" do
       wb = build_workshop


### PR DESCRIPTION
## Summary
- Adds `reload!` command to PlayMode, WorkshopRunner, and WebRunner
- Re-reads the domain DSL and reboots the playground without leaving play mode
- Events and repository data are cleared on successful reload; invalid domains are rejected gracefully

## Example

```ruby
workshop = Hecks.workshop("Pizzas")
pizza = workshop.aggregate("Pizza")
pizza.attr :name, String
pizza.command("CreatePizza") { attribute :name, String }
workshop.play!

# Execute a command
PizzasDomain::Pizza.create(name: "Margherita")
workshop.events  # => [#<CreatedPizza ...>]

# Add a new attribute while still in play mode
pizza.attr :size, String

# Reload picks up the change — events are cleared
workshop.reload!
# => "Reloaded domain"

PizzasDomain::Pizza.new(name: "Margherita", size: "Large")
# => #<Pizza name="Margherita" size="Large">
```

## Test plan
- [ ] `reload!` recompiles the domain and stays in play mode
- [ ] `reload!` clears events on reload
- [ ] `reload!` raises when called in sketch mode
- [ ] `reload!` recognized as bare command in BlueBook Grammar
- [ ] Web console `reload!` delegates to `reload_domain!`
- [ ] Full suite passes: `SPEC_SPEED_LIMIT=1.5 bundle exec rspec`
- [ ] Smoke test passes: `ruby -Ilib examples/pizzas/app.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)