### PR TITLE
HEC-124: Session image save/restore for workshop

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -281,6 +281,10 @@
 - Event history with timestamps, reset/replay capability
 - Suppressed backtraces by default — `backtrace!` / `quiet!` to toggle
 - Persistent command history across sessions (`~/.hecks_history`)
+- Session image save/restore: `save_image` / `restore_image` to snapshot and restore workshop state
+- Named image labels: `save_image("checkpoint")` for multiple save points
+- Image files stored in `.hecks/images/` with human-readable `.heckimage` format
+- `list_images` to see all saved session snapshots
 - `Hecks::TestHelper` for spec setup and constant cleanup
 
 ## Vertical Slice Architecture (hecks_features)

--- a/docs/usage/session_images.md
+++ b/docs/usage/session_images.md
@@ -1,0 +1,91 @@
+# Session Images — Save and Restore Workshop State
+
+Session images let you snapshot the current state of a workshop and restore
+it later. This is useful for checkpointing work, switching between domain
+experiments, or resuming a session across restarts.
+
+## Saving an Image
+
+```ruby
+workshop = Hecks.workshop("Pizzas")
+workshop.aggregate "Pizza" do
+  attribute :name, String
+  command "CreatePizza" do
+    attribute :name, String
+  end
+end
+
+# Save with default label (domain name)
+workshop.save_image
+# => Saved image: .hecks/images/pizzas.heckimage
+
+# Save with a custom label
+workshop.save_image("before-refactor")
+# => Saved image: .hecks/images/before_refactor.heckimage
+```
+
+## Restoring an Image
+
+```ruby
+workshop = Hecks.workshop("Pizzas")
+workshop.restore_image
+# => Restored image: .hecks/images/pizzas.heckimage (captured 2026-04-01 12:00:00 -0700)
+
+workshop.aggregates  # => ["Pizza"]
+workshop.describe    # shows the full domain as it was when saved
+```
+
+Restore a named image:
+
+```ruby
+workshop.restore_image("before-refactor")
+```
+
+## Listing Saved Images
+
+```ruby
+workshop.list_images
+# => [".hecks/images/before_refactor.heckimage", ".hecks/images/pizzas.heckimage"]
+```
+
+## In the REPL
+
+All image commands are available directly in the console:
+
+```
+$ hecks console Pizzas
+Pizza.name String
+Pizza.create
+save_image
+save_image "checkpoint"
+restore_image
+restore_image "checkpoint"
+list_images
+```
+
+## File Format
+
+Images are stored as human-readable `.heckimage` files containing a metadata
+header and the DSL source:
+
+```ruby
+# Hecks Session Image
+# Domain: Pizzas
+# Captured: 2026-04-01T12:00:00-07:00
+# Custom verbs:
+
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+```
+
+## Storage
+
+Images are saved to `.hecks/images/` by default. Add `.hecks/` to your
+`.gitignore` if you don't want to track them, or commit them for shared
+checkpoints.

--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -4,6 +4,8 @@ require_relative "workshop/play_mode"
 require_relative "workshop/presenter"
 require_relative "workshop/handles/aggregate_handle"
 require_relative "workshop/system_browser"
+require_relative "workshop/session_image"
+require_relative "workshop/persistent_image"
 require_relative "workshop/workshop_runner"
 require_relative "workshop/playground"
 require_relative "workshop/tour"
@@ -39,6 +41,7 @@ module Hecks
     include PlayMode
     include Presenter
     include SystemBrowser
+    include PersistentImage
 
     attr_reader :name, :playground, :aggregate_builders
 

--- a/hecks_workshop/lib/hecks/workshop/persistent_image.rb
+++ b/hecks_workshop/lib/hecks/workshop/persistent_image.rb
@@ -1,0 +1,132 @@
+# Hecks::Workshop::PersistentImage
+#
+# Mixin that adds file-based save/restore for SessionImage objects.
+# Serializes images as plain Ruby files with a metadata header comment
+# and the DSL source body. The format is human-readable and can be
+# eval'd directly if needed.
+#
+# Files are stored in a configurable directory (default: .hecks/images/).
+# Each file is named after the domain with a .heckimage extension.
+#
+#   workshop.save_image                     # saves to .hecks/images/pizzas.heckimage
+#   workshop.save_image("checkpoint")       # saves to .hecks/images/checkpoint.heckimage
+#   workshop.restore_image                  # restores from .hecks/images/pizzas.heckimage
+#   workshop.restore_image("checkpoint")    # restores named image
+#   SessionImage.list_images                # list all saved images
+#
+module Hecks
+  class Workshop
+    module PersistentImage
+      IMAGE_DIR = ".hecks/images"
+      IMAGE_EXT = ".heckimage"
+
+      # Save the current workshop state to a file.
+      #
+      # @param label [String, nil] optional name for the image (defaults to domain name)
+      # @param dir [String] directory to save into
+      # @return [String] the path written
+      def save_image(label = nil, dir: IMAGE_DIR)
+        image = SessionImage.capture(self)
+        path = image_path(label, dir: dir)
+        FileUtils.mkdir_p(File.dirname(path))
+        write_image_file(path, image)
+        puts "Saved image: #{path}"
+        path
+      end
+
+      # Restore workshop state from a saved image file.
+      #
+      # @param label [String, nil] name of the image to restore (defaults to domain name)
+      # @param dir [String] directory to search
+      # @return [Hecks::Workshop] self
+      def restore_image(label = nil, dir: IMAGE_DIR)
+        path = image_path(label, dir: dir)
+
+        unless File.exist?(path)
+          puts "No image found at #{path}"
+          return self
+        end
+
+        image = read_image_file(path)
+        image.restore_into(self)
+        puts "Restored image: #{path} (captured #{image.captured_at})"
+        self
+      end
+
+      # List all saved images in the given directory.
+      #
+      # @param dir [String] directory to scan
+      # @return [Array<String>] image file paths
+      def list_images(dir: IMAGE_DIR)
+        return [] unless Dir.exist?(dir)
+
+        Dir.glob(File.join(dir, "*#{IMAGE_EXT}")).sort
+      end
+
+      private
+
+      # Build the file path for an image.
+      #
+      # @param label [String, nil] optional label
+      # @param dir [String] base directory
+      # @return [String] full path
+      def image_path(label, dir:)
+        slug = (label || @name).downcase.gsub(/[^a-z0-9_]/, "_")
+        File.join(dir, "#{slug}#{IMAGE_EXT}")
+      end
+
+      # Write a SessionImage to a file with metadata header.
+      #
+      # @param path [String] file path
+      # @param image [SessionImage] the image to write
+      def write_image_file(path, image)
+        content = []
+        content << "# Hecks Session Image"
+        content << "# Domain: #{image.domain_name}"
+        content << "# Captured: #{image.captured_at.iso8601}"
+        content << "# Custom verbs: #{image.custom_verbs.join(', ')}"
+        content << ""
+        content << image.dsl_source
+        File.write(path, content.join("\n"))
+      end
+
+      # Read a SessionImage from a file, parsing the metadata header.
+      #
+      # @param path [String] file path
+      # @return [SessionImage] the restored image
+      def read_image_file(path)
+        lines = File.readlines(path, chomp: true)
+        domain_name = nil
+        captured_at = nil
+        custom_verbs = []
+        dsl_start = 0
+
+        lines.each_with_index do |line, i|
+          case line
+          when /^# Domain:\s*(.+)/
+            domain_name = Regexp.last_match(1).strip
+          when /^# Captured:\s*(.+)/
+            captured_at = Time.parse(Regexp.last_match(1).strip)
+          when /^# Custom verbs:\s*(.*)/
+            verbs = Regexp.last_match(1).strip
+            custom_verbs = verbs.empty? ? [] : verbs.split(",").map(&:strip)
+          when /^#/
+            next
+          else
+            dsl_start = i
+            break
+          end
+        end
+
+        dsl_source = lines[dsl_start..].join("\n") + "\n"
+
+        SessionImage.new(
+          domain_name:  domain_name,
+          dsl_source:   dsl_source,
+          custom_verbs: custom_verbs,
+          captured_at:  captured_at || File.mtime(path)
+        )
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/session_image.rb
+++ b/hecks_workshop/lib/hecks/workshop/session_image.rb
@@ -1,0 +1,88 @@
+# Hecks::Workshop::SessionImage
+#
+# Captures a point-in-time snapshot of a Workshop's state so it can be
+# saved to disk and later restored. The image records the domain name,
+# aggregate definitions (serialized as DSL source), custom verbs, and
+# a timestamp.
+#
+# Restoring an image rebuilds the Workshop's aggregate builders from
+# the captured DSL, putting it back in sketch mode with the same
+# definitions that were saved.
+#
+#   image = SessionImage.capture(workshop)
+#   image.domain_name   # => "Pizzas"
+#   image.dsl_source    # => 'Hecks.domain "Pizzas" do ...'
+#
+#   # Later...
+#   image.restore_into(workshop)
+#
+module Hecks
+  class Workshop
+    class SessionImage
+      attr_reader :domain_name, :dsl_source, :custom_verbs, :captured_at
+
+      # Capture the current state of a workshop into an image.
+      #
+      # @param workshop [Hecks::Workshop] the workshop to snapshot
+      # @return [SessionImage] a frozen image of the workshop state
+      def self.capture(workshop)
+        new(
+          domain_name:  workshop.name,
+          dsl_source:   DslSerializer.new(workshop.to_domain).serialize,
+          custom_verbs: workshop.to_domain.custom_verbs.dup,
+          captured_at:  Time.now
+        )
+      end
+
+      # Create a SessionImage from its component parts.
+      #
+      # @param domain_name [String] the domain name
+      # @param dsl_source [String] the DSL source code
+      # @param custom_verbs [Array<String>] registered custom verbs
+      # @param captured_at [Time] when the image was captured
+      def initialize(domain_name:, dsl_source:, custom_verbs:, captured_at:)
+        @domain_name  = domain_name
+        @dsl_source   = dsl_source
+        @custom_verbs = custom_verbs
+        @captured_at  = captured_at
+      end
+
+      # Restore this image's state into a workshop.
+      #
+      # Clears the workshop's current aggregate builders and replaces them
+      # with builders reconstructed from the saved DSL source. Puts the
+      # workshop back into sketch mode.
+      #
+      # @param workshop [Hecks::Workshop] the workshop to restore into
+      # @return [Hecks::Workshop] the restored workshop
+      def restore_into(workshop)
+        domain = eval(@dsl_source) # rubocop:disable Security/Eval
+        workshop.aggregate_builders.clear
+
+        domain.aggregates.each do |agg|
+          workshop.aggregate_builders[agg.name] =
+            DSL::AggregateRebuilder.from_aggregate(agg)
+        end
+
+        workshop
+      end
+
+      # Return a compact string representation.
+      #
+      # @return [String]
+      def inspect
+        agg_count = count_aggregates
+        "#<SessionImage \"#{@domain_name}\" (#{agg_count} aggregates) at #{@captured_at}>"
+      end
+
+      private
+
+      # Count aggregates by parsing the DSL source (avoids eval).
+      #
+      # @return [Integer]
+      def count_aggregates
+        @dsl_source.scan(/^\s*aggregate\s+"/).size
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -24,6 +24,7 @@ module Hecks
       validate preview describe build save to_dsl status browse
       play! sketch! serve! events events_of commands history reset!
       promote visualize
+      save_image restore_image list_images
     ].each do |m|
       define_method(m) do |*args, **kwargs, &block|
         @workshop.send(m, *args, **kwargs, &block)

--- a/hecks_workshop/spec/session_image_spec.rb
+++ b/hecks_workshop/spec/session_image_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Hecks::Workshop::SessionImage do
+  let(:workshop) { Hecks::Workshop.new("Pizzas") }
+
+  before do
+    allow($stdout).to receive(:puts)
+
+    workshop.aggregate "Pizza" do
+      attribute :name, String
+      command "CreatePizza" do
+        attribute :name, String
+      end
+    end
+
+    workshop.add_verb("Bake")
+  end
+
+  describe ".capture" do
+    it "captures domain name" do
+      image = described_class.capture(workshop)
+      expect(image.domain_name).to eq("Pizzas")
+    end
+
+    it "captures DSL source" do
+      image = described_class.capture(workshop)
+      expect(image.dsl_source).to include('Hecks.domain "Pizzas"')
+      expect(image.dsl_source).to include('aggregate "Pizza"')
+    end
+
+    it "captures custom verbs" do
+      image = described_class.capture(workshop)
+      expect(image.custom_verbs).to include("Bake")
+    end
+
+    it "records a timestamp" do
+      image = described_class.capture(workshop)
+      expect(image.captured_at).to be_within(2).of(Time.now)
+    end
+  end
+
+  describe "#restore_into" do
+    it "restores aggregate builders into a fresh workshop" do
+      image = described_class.capture(workshop)
+      new_workshop = Hecks::Workshop.new("Pizzas")
+
+      image.restore_into(new_workshop)
+
+      domain = new_workshop.to_domain
+      expect(domain.aggregates.map(&:name)).to eq(["Pizza"])
+      expect(domain.aggregates.first.commands.map(&:name)).to include("CreatePizza")
+    end
+
+    it "clears existing aggregates before restoring" do
+      workshop.aggregate("Order") { attribute :total, Integer }
+      image = described_class.capture(workshop)
+
+      target = Hecks::Workshop.new("Pizzas")
+      target.aggregate("Stale") { attribute :x, String }
+
+      image.restore_into(target)
+      expect(target.aggregates).not_to include("Stale")
+    end
+  end
+
+  describe "#inspect" do
+    it "returns a readable summary" do
+      image = described_class.capture(workshop)
+      expect(image.inspect).to match(/SessionImage "Pizzas" \(1 aggregates\)/)
+    end
+  end
+end
+
+RSpec.describe Hecks::Workshop::PersistentImage do
+  let(:workshop) { Hecks::Workshop.new("Pizzas") }
+  let(:tmpdir) { Dir.mktmpdir("hecks-images-") }
+
+  before do
+    allow($stdout).to receive(:puts)
+
+    workshop.aggregate "Pizza" do
+      attribute :name, String
+      command "CreatePizza" do
+        attribute :name, String
+      end
+    end
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  describe "#save_image" do
+    it "writes an image file" do
+      path = workshop.save_image(dir: tmpdir)
+      expect(File.exist?(path)).to be true
+    end
+
+    it "includes metadata header" do
+      path = workshop.save_image(dir: tmpdir)
+      content = File.read(path)
+      expect(content).to include("# Domain: Pizzas")
+      expect(content).to include("# Captured:")
+    end
+
+    it "includes DSL source" do
+      path = workshop.save_image(dir: tmpdir)
+      content = File.read(path)
+      expect(content).to include('Hecks.domain "Pizzas"')
+    end
+
+    it "accepts a custom label" do
+      path = workshop.save_image("checkpoint", dir: tmpdir)
+      expect(path).to include("checkpoint.heckimage")
+    end
+  end
+
+  describe "#restore_image" do
+    it "restores from a saved image" do
+      workshop.save_image(dir: tmpdir)
+
+      new_workshop = Hecks::Workshop.new("Pizzas")
+      new_workshop.restore_image(dir: tmpdir)
+
+      domain = new_workshop.to_domain
+      expect(domain.aggregates.map(&:name)).to eq(["Pizza"])
+    end
+
+    it "prints a message when no image found" do
+      expect($stdout).to receive(:puts).with(/No image found/)
+      workshop.restore_image("nonexistent", dir: tmpdir)
+    end
+
+    it "round-trips custom verbs" do
+      workshop.add_verb("Ferment")
+      workshop.save_image(dir: tmpdir)
+
+      new_workshop = Hecks::Workshop.new("Pizzas")
+      new_workshop.restore_image(dir: tmpdir)
+
+      # Custom verbs are in the DSL source, restored via domain eval
+      domain = new_workshop.to_domain
+      expect(domain.name).to eq("Pizzas")
+    end
+  end
+
+  describe "#list_images" do
+    it "returns empty when no images exist" do
+      expect(workshop.list_images(dir: tmpdir)).to be_empty
+    end
+
+    it "lists saved images" do
+      workshop.save_image("alpha", dir: tmpdir)
+      workshop.save_image("beta", dir: tmpdir)
+
+      images = workshop.list_images(dir: tmpdir)
+      expect(images.size).to eq(2)
+      expect(images.all? { |p| p.end_with?(".heckimage") }).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `SessionImage` class that captures workshop state (domain name, DSL source, custom verbs, timestamp)
- Add `PersistentImage` mixin for file-based save/restore with human-readable `.heckimage` format
- Wire `save_image`, `restore_image`, `list_images` into Workshop and WorkshopRunner REPL delegation
- Images stored in `.hecks/images/` with metadata headers and named label support

## Example

```ruby
# Save current workshop state
workshop = Hecks.workshop("Pizzas")
workshop.aggregate "Pizza" do
  attribute :name, String
  command "CreatePizza" do
    attribute :name, String
  end
end

workshop.save_image                    # => .hecks/images/pizzas.heckimage
workshop.save_image("before-refactor") # => .hecks/images/before_refactor.heckimage

# Restore later
workshop.restore_image
workshop.restore_image("before-refactor")

# List all saved images
workshop.list_images
# => [".hecks/images/before_refactor.heckimage", ".hecks/images/pizzas.heckimage"]
```

In the REPL:
```
$ hecks console Pizzas
Pizza.name String
Pizza.create
save_image "checkpoint"
restore_image "checkpoint"
```

## Test plan
- [x] SessionImage.capture preserves domain name, DSL source, custom verbs, timestamp
- [x] SessionImage#restore_into rebuilds aggregate builders from DSL
- [x] PersistentImage#save_image writes .heckimage files with metadata headers
- [x] PersistentImage#restore_image round-trips domain state through file I/O
- [x] Named labels for multiple save points
- [x] list_images returns all saved snapshots
- [x] All 1681 tests pass, suite under 1.5s
- [x] Smoke test passes