### PR TITLE
HEC-126: deep_inspect command with Navigator/Renderer

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -237,6 +237,9 @@
 ### Named Constants & System Browser
 - Named constants: `aggregate("Cat")` creates `Cat` constant in the REPL
 - System browser: `browse` prints a tree of all domain elements
+- Deep inspect: `deep_inspect` prints full structural breakdown of all aggregates with nested value objects, entities, commands, params, events, policies, validations, queries, scopes, specifications, subscribers, and references
+- Deep inspect single aggregate: `deep_inspect("Pizza")` inspects one aggregate only
+- Navigator/Renderer architecture: Navigator walks the domain IR tree, Renderer formats each element — composable for custom output formats
 
 ### One-Line Dot Syntax
 - Implicit attributes: `Post.title String` adds attribute via method_missing

--- a/docs/usage/deep_inspect.md
+++ b/docs/usage/deep_inspect.md
@@ -1,0 +1,85 @@
+# deep_inspect — Full Structural Breakdown
+
+The `deep_inspect` command prints a detailed tree of every element in your
+domain: aggregates, attributes, value objects, entities, commands with
+parameters, events, policies, validations, queries, scopes, specifications,
+subscribers, and references.
+
+## Usage
+
+```ruby
+workshop = Hecks.workshop("Pizzas")
+
+workshop.aggregate "Pizza" do
+  attribute :name, String
+  attribute :style, String
+
+  value_object "Topping" do
+    attribute :name, String
+    attribute :quantity, Integer
+  end
+
+  command "CreatePizza" do
+    attribute :name, String
+    attribute :style, String
+  end
+
+  command "RenamePizza" do
+    attribute :name, String
+  end
+
+  validation :name, presence: true
+  query "ByStyle" do |style| { style: style } end
+  scope :classic, style: "classic"
+end
+
+# Inspect the full domain
+workshop.deep_inspect
+
+# Inspect a single aggregate
+workshop.deep_inspect("Pizza")
+```
+
+## Example Output
+
+```
+Pizzas Domain
+
+  Pizza
+    name: String
+    style: String
+    [value_object] Topping
+      name: String
+      quantity: Integer
+    [command] CreatePizza
+      name: String
+      style: String
+      -> emits CreatedPizza
+    [command] RenamePizza
+      name: String
+      -> emits RenamedPizza
+    [event] CreatedPizza(name: String, style: String)
+    [event] RenamedPizza(name: String)
+    [query] ByStyle
+    [validation] name: presence: true
+    [scope] classic
+```
+
+## Architecture
+
+`deep_inspect` is built on two composable components:
+
+- **Navigator** — walks the domain IR tree, yielding each element with its
+  depth and label. Use it to build custom traversals.
+- **Renderer** — formats each IR element into a human-readable string.
+  Swap it out for JSON, HTML, or any other format.
+
+```ruby
+domain = workshop.to_domain
+navigator = Hecks::Workshop::Navigator.new(domain)
+renderer  = Hecks::Workshop::Renderer.new
+
+navigator.walk_all do |element, depth, label|
+  puts renderer.render(element, depth: depth, label: label)
+end
+```

--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -2,6 +2,9 @@ require "fileutils"
 require_relative "workshop/build_actions"
 require_relative "workshop/play_mode"
 require_relative "workshop/presenter"
+require_relative "workshop/navigator"
+require_relative "workshop/renderer"
+require_relative "workshop/deep_inspect"
 require_relative "workshop/handles/aggregate_handle"
 require_relative "workshop/system_browser"
 require_relative "workshop/workshop_runner"
@@ -38,6 +41,7 @@ module Hecks
     include BuildActions
     include PlayMode
     include Presenter
+    include DeepInspect
     include SystemBrowser
 
     attr_reader :name, :playground, :aggregate_builders

--- a/hecks_workshop/lib/hecks/workshop/deep_inspect.rb
+++ b/hecks_workshop/lib/hecks/workshop/deep_inspect.rb
@@ -1,0 +1,55 @@
+# Hecks::Workshop::DeepInspect
+#
+# Workshop mixin that adds `deep_inspect` for detailed aggregate structure
+# display. Uses Navigator to walk the domain IR tree and Renderer to
+# format each element into readable output. Shows nested value objects,
+# entities, commands with params, events, policies, and all other elements.
+#
+# Mixed into Workshop alongside Presenter, SystemBrowser, etc.
+#
+#   workshop.deep_inspect              # all aggregates
+#   workshop.deep_inspect("Pizza")     # single aggregate
+#
+module Hecks
+  class Workshop
+    module DeepInspect
+      # Print a detailed structural breakdown of aggregates.
+      #
+      # When called without arguments, prints every aggregate with full
+      # nesting. When given an aggregate name, prints only that aggregate.
+      # Uses Navigator for traversal and Renderer for formatting.
+      #
+      # @param aggregate_name [String, nil] optional aggregate to inspect
+      # @return [nil]
+      def deep_inspect(aggregate_name = nil)
+        domain = to_domain
+        navigator = Navigator.new(domain)
+        renderer = Renderer.new
+        lines = []
+
+        if aggregate_name
+          name = normalize_name(aggregate_name)
+          navigator.walk(name) do |element, depth, label|
+            line = renderer.render(element, depth: depth, label: label)
+            lines << line if line
+          end
+
+          if lines.empty?
+            puts "Unknown aggregate: #{aggregate_name}"
+            return nil
+          end
+        else
+          lines << "#{@name} Domain"
+          lines << ""
+          navigator.walk_all do |element, depth, label|
+            line = renderer.render(element, depth: depth + 1, label: label)
+            lines << line if line
+          end
+        end
+
+        puts lines.join("\n")
+        nil
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/navigator.rb
+++ b/hecks_workshop/lib/hecks/workshop/navigator.rb
@@ -1,0 +1,143 @@
+# Hecks::Workshop::Navigator
+#
+# Traverses a domain IR structure and yields each element with its depth
+# and path context. Used by deep_inspect and any feature that needs to
+# walk the full aggregate tree (value objects, entities, commands, events,
+# policies, queries, scopes, specifications, subscribers, references).
+#
+#   navigator = Navigator.new(domain)
+#   navigator.walk("Pizza") { |element, depth, label| ... }
+#   navigator.walk_all { |element, depth, label| ... }
+#
+module Hecks
+  class Workshop
+    class Navigator
+      # @param domain [DomainModel::Structure::Domain]
+      def initialize(domain)
+        @domain = domain
+      end
+
+      # Walk a single aggregate, yielding each structural element.
+      #
+      # @param aggregate_name [String] the aggregate to traverse
+      # @yield [element, depth, label] called for each node in the tree
+      # @yieldparam element [Object] the IR structure node
+      # @yieldparam depth [Integer] nesting level (0 = aggregate root)
+      # @yieldparam label [String] human-readable label for the node
+      # @return [void]
+      def walk(aggregate_name, &block)
+        agg = @domain.aggregates.find { |a| a.name == aggregate_name }
+        return unless agg
+
+        walk_aggregate(agg, &block)
+      end
+
+      # Walk all aggregates in the domain.
+      #
+      # @yield [element, depth, label] called for each node
+      # @return [void]
+      def walk_all(&block)
+        @domain.aggregates.each { |agg| walk_aggregate(agg, &block) }
+      end
+
+      private
+
+      def walk_aggregate(agg, &block)
+        yield agg, 0, "aggregate"
+        walk_attributes(agg, 1, &block)
+        walk_value_objects(agg, 1, &block)
+        walk_entities(agg, 1, &block)
+        walk_lifecycle(agg, 1, &block)
+        walk_commands(agg, 1, &block)
+        walk_events(agg, 1, &block)
+        walk_queries(agg, 1, &block)
+        walk_validations(agg, 1, &block)
+        walk_invariants(agg, 1, &block)
+        walk_policies(agg, 1, &block)
+        walk_scopes(agg, 1, &block)
+        walk_specifications(agg, 1, &block)
+        walk_subscribers(agg, 1, &block)
+        walk_references(agg, 1, &block)
+      end
+
+      def walk_attributes(agg, depth, &block)
+        agg.attributes.each { |attr| yield attr, depth, "attribute" }
+      end
+
+      def walk_value_objects(agg, depth, &block)
+        agg.value_objects.each do |vo|
+          yield vo, depth, "value_object"
+          vo.attributes.each { |attr| yield attr, depth + 1, "attribute" }
+          vo.invariants.each { |inv| yield inv, depth + 1, "invariant" }
+        end
+      end
+
+      def walk_entities(agg, depth, &block)
+        agg.entities.each do |ent|
+          yield ent, depth, "entity"
+          ent.attributes.each { |attr| yield attr, depth + 1, "attribute" }
+          ent.invariants.each { |inv| yield inv, depth + 1, "invariant" }
+        end
+      end
+
+      def walk_lifecycle(agg, depth, &block)
+        return unless agg.lifecycle
+
+        yield agg.lifecycle, depth, "lifecycle"
+        agg.lifecycle.transitions.each do |cmd, transition|
+          yield transition, depth + 1, "transition:#{cmd}"
+        end
+      end
+
+      def walk_commands(agg, depth, &block)
+        agg.commands.each_with_index do |cmd, i|
+          event = agg.events[i]
+          yield cmd, depth, "command"
+          cmd.attributes.each { |attr| yield attr, depth + 1, "param" }
+          cmd.preconditions.each { |c| yield c, depth + 1, "precondition" }
+          cmd.postconditions.each { |c| yield c, depth + 1, "postcondition" }
+          yield event, depth + 1, "emits" if event
+        end
+      end
+
+      def walk_events(agg, depth, &block)
+        agg.events.compact.each do |ev|
+          yield ev, depth, "event"
+          ev.attributes.each { |attr| yield attr, depth + 1, "field" }
+        end
+      end
+
+      def walk_queries(agg, depth, &block)
+        agg.queries.each { |q| yield q, depth, "query" }
+      end
+
+      def walk_validations(agg, depth, &block)
+        agg.validations.each { |v| yield v, depth, "validation" }
+      end
+
+      def walk_invariants(agg, depth, &block)
+        agg.invariants.each { |inv| yield inv, depth, "invariant" }
+      end
+
+      def walk_policies(agg, depth, &block)
+        agg.policies.each { |pol| yield pol, depth, "policy" }
+      end
+
+      def walk_scopes(agg, depth, &block)
+        agg.scopes.each { |s| yield s, depth, "scope" }
+      end
+
+      def walk_specifications(agg, depth, &block)
+        agg.specifications.each { |s| yield s, depth, "specification" }
+      end
+
+      def walk_subscribers(agg, depth, &block)
+        agg.subscribers.each { |s| yield s, depth, "subscriber" }
+      end
+
+      def walk_references(agg, depth, &block)
+        (agg.references || []).each { |ref| yield ref, depth, "reference" }
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/renderer.rb
+++ b/hecks_workshop/lib/hecks/workshop/renderer.rb
@@ -1,0 +1,147 @@
+# Hecks::Workshop::Renderer
+#
+# Formats domain IR elements into human-readable lines for deep_inspect
+# output. Each render method takes an IR node and returns a formatted
+# string. Used by DeepInspect to convert Navigator walk results into
+# printable output.
+#
+#   renderer = Renderer.new
+#   renderer.render_attribute(attr, depth: 1)  # => "  name: String"
+#   renderer.render_command(cmd, depth: 1)      # => "  CreatePizza"
+#
+module Hecks
+  class Workshop
+    class Renderer
+      INDENT = "  "
+
+      # Render any element by dispatching on its label.
+      #
+      # @param element [Object] the IR node
+      # @param depth [Integer] indentation level
+      # @param label [String] the node type label from Navigator
+      # @return [String, nil] formatted line, or nil for section headers
+      def render(element, depth:, label:)
+        case label
+        when "aggregate"     then render_aggregate(element, depth)
+        when "attribute"     then render_attribute(element, depth)
+        when "value_object"  then render_value_object(element, depth)
+        when "entity"        then render_entity(element, depth)
+        when "lifecycle"     then render_lifecycle(element, depth)
+        when /^transition:/  then render_transition(element, depth, label)
+        when "command"       then render_command(element, depth)
+        when "param"         then render_param(element, depth)
+        when "precondition"  then render_condition(element, depth, "pre")
+        when "postcondition" then render_condition(element, depth, "post")
+        when "emits"         then render_emits(element, depth)
+        when "event"         then render_event(element, depth)
+        when "field"         then render_field(element, depth)
+        when "query"         then render_query(element, depth)
+        when "validation"    then render_validation(element, depth)
+        when "invariant"     then render_invariant(element, depth)
+        when "policy"        then render_policy(element, depth)
+        when "scope"         then render_scope(element, depth)
+        when "specification" then render_specification(element, depth)
+        when "subscriber"    then render_subscriber(element, depth)
+        when "reference"     then render_reference(element, depth)
+        end
+      end
+
+      private
+
+      def indent(depth)
+        INDENT * depth
+      end
+
+      def render_aggregate(agg, depth)
+        "#{indent(depth)}#{agg.name}"
+      end
+
+      def render_attribute(attr, depth)
+        "#{indent(depth)}#{attr.name}: #{Hecks::Utils.type_label(attr)}"
+      end
+
+      def render_value_object(vo, depth)
+        "#{indent(depth)}[value_object] #{vo.name}"
+      end
+
+      def render_entity(ent, depth)
+        "#{indent(depth)}[entity] #{ent.name}"
+      end
+
+      def render_lifecycle(lc, depth)
+        states = lc.states.join(", ")
+        "#{indent(depth)}[lifecycle] #{lc.field} (#{lc.default}) -> #{states}"
+      end
+
+      def render_transition(transition, depth, label)
+        cmd = label.sub("transition:", "")
+        target = transition.respond_to?(:target) ? transition.target : transition.to_s
+        "#{indent(depth)}#{cmd} -> #{target}"
+      end
+
+      def render_command(cmd, depth)
+        "#{indent(depth)}[command] #{cmd.name}"
+      end
+
+      def render_param(attr, depth)
+        "#{indent(depth)}#{attr.name}: #{Hecks::Utils.type_label(attr)}"
+      end
+
+      def render_condition(condition, depth, kind)
+        "#{indent(depth)}#{kind}condition: #{condition.message}"
+      end
+
+      def render_emits(event, depth)
+        "#{indent(depth)}-> emits #{event.name}"
+      end
+
+      def render_event(event, depth)
+        attrs = event.attributes.map { |a| "#{a.name}: #{Hecks::Utils.type_label(a)}" }.join(", ")
+        "#{indent(depth)}[event] #{event.name}(#{attrs})"
+      end
+
+      def render_field(attr, depth)
+        "#{indent(depth)}#{attr.name}: #{Hecks::Utils.type_label(attr)}"
+      end
+
+      def render_query(query, depth)
+        "#{indent(depth)}[query] #{query.name}"
+      end
+
+      def render_validation(validation, depth)
+        rules = validation.rules.map { |k, v| "#{k}: #{v}" }.join(", ")
+        "#{indent(depth)}[validation] #{validation.field}: #{rules}"
+      end
+
+      def render_invariant(inv, depth)
+        "#{indent(depth)}[invariant] #{inv.message}"
+      end
+
+      def render_policy(pol, depth)
+        if pol.reactive?
+          "#{indent(depth)}[policy] #{pol.name}: #{pol.event_name} -> #{pol.trigger_command}"
+        else
+          "#{indent(depth)}[policy] #{pol.name}: guard"
+        end
+      end
+
+      def render_scope(scope, depth)
+        "#{indent(depth)}[scope] #{scope.name}"
+      end
+
+      def render_specification(spec, depth)
+        "#{indent(depth)}[spec] #{spec.name}"
+      end
+
+      def render_subscriber(sub, depth)
+        async = sub.async ? " [async]" : ""
+        "#{indent(depth)}[subscriber] on #{sub.event_name}#{async}"
+      end
+
+      def render_reference(ref, depth)
+        kind = ref.respond_to?(:kind) && ref.kind ? " (#{ref.kind})" : ""
+        "#{indent(depth)}[reference] -> #{ref.type}#{kind}"
+      end
+    end
+  end
+end

--- a/hecks_workshop/spec/deep_inspect_spec.rb
+++ b/hecks_workshop/spec/deep_inspect_spec.rb
@@ -1,0 +1,187 @@
+require "spec_helper"
+
+RSpec.describe "deep_inspect" do
+  subject(:workshop) { Hecks::Workshop.new("Pizzas") }
+
+  before { allow($stdout).to receive(:puts) }
+
+  describe "Navigator" do
+    it "walks all elements of an aggregate" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        value_object "Topping" do
+          attribute :name, String
+        end
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+
+      domain = workshop.to_domain
+      navigator = Hecks::Workshop::Navigator.new(domain)
+
+      labels = []
+      navigator.walk("Pizza") { |_el, _depth, label| labels << label }
+
+      expect(labels).to include("aggregate", "attribute", "value_object", "command", "param", "emits", "event")
+    end
+
+    it "returns nil for unknown aggregates" do
+      domain = workshop.to_domain
+      navigator = Hecks::Workshop::Navigator.new(domain)
+
+      walked = false
+      navigator.walk("Unknown") { walked = true }
+      expect(walked).to be false
+    end
+
+    it "walks all aggregates" do
+      workshop.aggregate("Pizza") { attribute :name, String }
+      workshop.aggregate("Order") { attribute :quantity, Integer }
+
+      domain = workshop.to_domain
+      navigator = Hecks::Workshop::Navigator.new(domain)
+
+      names = []
+      navigator.walk_all do |el, _depth, label|
+        names << el.name if label == "aggregate"
+      end
+
+      expect(names).to eq(["Pizza", "Order"])
+    end
+  end
+
+  describe "Renderer" do
+    it "renders attributes with type labels" do
+      workshop.aggregate("Pizza") { attribute :name, String }
+      domain = workshop.to_domain
+      attr = domain.aggregates.first.attributes.first
+
+      renderer = Hecks::Workshop::Renderer.new
+      line = renderer.render(attr, depth: 1, label: "attribute")
+
+      expect(line).to eq("  name: String")
+    end
+
+    it "renders commands with bracketed labels" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+
+      domain = workshop.to_domain
+      cmd = domain.aggregates.first.commands.first
+
+      renderer = Hecks::Workshop::Renderer.new
+      line = renderer.render(cmd, depth: 1, label: "command")
+
+      expect(line).to eq("  [command] CreatePizza")
+    end
+  end
+
+  describe "Workshop#deep_inspect" do
+    it "prints all aggregates with structure" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        value_object "Topping" do
+          attribute :name, String
+        end
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+
+      expect { workshop.deep_inspect }.to output(
+        /Pizzas Domain.*Pizza.*name: String.*\[value_object\] Topping.*\[command\] CreatePizza/m
+      ).to_stdout
+    end
+
+    it "prints a single aggregate by name" do
+      workshop.aggregate("Pizza") { attribute :name, String }
+      workshop.aggregate("Order") { attribute :quantity, Integer }
+
+      expect { workshop.deep_inspect("Pizza") }.to output(/Pizza.*name: String/m).to_stdout
+      expect { workshop.deep_inspect("Pizza") }.not_to output(/Order/).to_stdout
+    end
+
+    it "reports unknown aggregate" do
+      expect { workshop.deep_inspect("Unknown") }.to output(/Unknown aggregate/).to_stdout
+    end
+
+    it "includes policies" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+        policy "AutoNotify" do
+          on "CreatedPizza"
+          trigger "NotifyChef"
+        end
+        command "NotifyChef" do
+          attribute :name, String
+        end
+      end
+
+      expect { workshop.deep_inspect("Pizza") }.to output(
+        /\[policy\] AutoNotify: CreatedPizza -> NotifyChef/
+      ).to_stdout
+    end
+
+    it "includes validations" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+        validation :name, presence: true
+      end
+
+      expect { workshop.deep_inspect("Pizza") }.to output(
+        /\[validation\] name: presence: true/
+      ).to_stdout
+    end
+
+    it "includes queries and scopes" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        attribute :status, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+        query "ByStyle" do |style|
+          { style: style }
+        end
+        scope :active, status: "active"
+      end
+
+      expect { workshop.deep_inspect("Pizza") }.to output(
+        /\[query\] ByStyle.*\[scope\] active/m
+      ).to_stdout
+    end
+
+    it "includes references" do
+      workshop.aggregate "Pizza" do
+        attribute :name, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+
+      workshop.aggregate "Order" do
+        reference_to "Pizza"
+        attribute :quantity, Integer
+        command "PlaceOrder" do
+          reference_to "Pizza"
+          attribute :quantity, Integer
+        end
+      end
+
+      expect { workshop.deep_inspect("Order") }.to output(
+        /\[reference\] -> Pizza/
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `deep_inspect` command to the Workshop REPL for detailed structural breakdown of domain aggregates
- Introduces Navigator class that walks the domain IR tree yielding each element with depth and label
- Introduces Renderer class that formats each IR node into human-readable output
- Supports inspecting all aggregates (`deep_inspect`) or a single one (`deep_inspect("Pizza")`)

## Example

```ruby
workshop = Hecks.workshop("Pizzas")
workshop.aggregate "Pizza" do
  attribute :name, String
  value_object "Topping" do
    attribute :name, String
  end
  command "CreatePizza" do
    attribute :name, String
  end
  validation :name, presence: true
end

workshop.deep_inspect
```

Output:
```
Pizzas Domain

  Pizza
    name: String
    [value_object] Topping
      name: String
    [command] CreatePizza
      name: String
      -> emits CreatedPizza
    [event] CreatedPizza(name: String)
    [validation] name: presence: true
```

## Test plan
- [x] Navigator walks all aggregate elements (attributes, VOs, entities, commands, events, policies, etc.)
- [x] Navigator returns nothing for unknown aggregates
- [x] Navigator walks all aggregates via walk_all
- [x] Renderer formats attributes with type labels
- [x] Renderer formats commands with bracketed labels
- [x] deep_inspect prints all aggregates with full structure
- [x] deep_inspect filters to a single aggregate by name
- [x] deep_inspect reports unknown aggregates
- [x] deep_inspect includes policies, validations, queries, scopes, references
- [x] All 1677 tests pass under 1.5s
- [x] Smoke test passes