### PR TITLE
HEC-240: Wire diagram_data into Web Explorer config

### DIFF
--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -141,10 +141,12 @@ module Hecks
         end
         policies = @entries.flat_map { |e| e[:ir].policy_labels }
         roles = @entries.flat_map { |e| e[:ir].available_roles }.uniq
+        diagrams = merge_diagrams
         html = @renderer.render(:config,
           title: "Config — #{@brand}", brand: @brand, nav_items: @nav,
           aggregates: summaries, policies: policies, roles: roles,
-          current_role: "admin", adapter: "memory", events: [])
+          current_role: "admin", adapter: "memory", events: [],
+          **diagrams)
         res["Content-Type"] = "text/html"
         res.body = html
       end
@@ -159,6 +161,17 @@ module Hecks
           return
         end
         serve_ui_route(req, res, entry, sub_path)
+      end
+
+      def merge_diagrams
+        combined = { structure_diagram: "", behavior_diagram: "", flows_diagram: "" }
+        @entries.each do |e|
+          d = e[:ir].diagram_data
+          combined[:structure_diagram] += d[:structure_diagram] + "\n"
+          combined[:behavior_diagram]  += d[:behavior_diagram] + "\n"
+          combined[:flows_diagram]     += d[:flows_diagram] + "\n"
+        end
+        combined.transform_values(&:strip)
       end
 
       def plural(agg)

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -146,10 +146,12 @@ module Hecks
         end
         policies = @entries.flat_map { |e| e[:ir].policy_labels }
         roles = @entries.flat_map { |e| e[:ir].available_roles }.uniq
+        diagrams = merge_diagrams
         html = @renderer.render(:config,
           title: "Config — #{@brand}", brand: @brand, nav_items: @nav,
           aggregates: summaries, policies: policies, roles: roles,
-          current_role: "admin", adapter: "memory", events: [])
+          current_role: "admin", adapter: "memory", events: [],
+          **diagrams)
         res["Content-Type"] = "text/html"
         res.body = html
       end
@@ -170,6 +172,17 @@ module Hecks
           return
         end
         serve_ui_route(req, res, entry, sub_path)
+      end
+
+      def merge_diagrams
+        combined = { structure_diagram: "", behavior_diagram: "", flows_diagram: "" }
+        @entries.each do |e|
+          d = e[:ir].diagram_data
+          combined[:structure_diagram] += d[:structure_diagram] + "\n"
+          combined[:behavior_diagram]  += d[:behavior_diagram] + "\n"
+          combined[:flows_diagram]     += d[:flows_diagram] + "\n"
+        end
+        combined.transform_values(&:strip)
       end
 
       def plural(agg)

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -102,6 +102,16 @@ module Hecks
         HecksTemplating::DisplayContract.available_roles(@domain)
       end
 
+      def diagram_data
+        viz = Hecks::DomainVisualizer.new(@domain)
+        flow = Hecks::FlowGenerator.new(@domain)
+        {
+          structure_diagram: viz.generate_structure,
+          behavior_diagram:  viz.generate_behavior,
+          flows_diagram:     flow.generate_mermaid
+        }
+      end
+
       private
 
       def humanize(name)

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -114,6 +114,14 @@ RSpec.describe "Web Explorer IR introspection" do
       expect(data[:command_names]).to include("Create Pizza")
       expect(data[:attributes]).to be_a(Integer)
     end
+
+    it "returns diagram_data with structure, behavior, and flows" do
+      data = ir.diagram_data
+      expect(data[:structure_diagram]).to include("classDiagram")
+      expect(data[:structure_diagram]).to include("Pizza")
+      expect(data[:behavior_diagram]).to include("flowchart LR")
+      expect(data[:flows_diagram]).to include("sequenceDiagram")
+    end
   end
 
   describe Hecks::WebExplorer::Renderer do


### PR DESCRIPTION
## Summary
- Add `IRIntrospector#diagram_data` that generates Mermaid structure, behavior, and flow diagrams from the domain IR via `DomainVisualizer` and `FlowGenerator`
- Wire diagram data into `MultiDomainServer#serve_config` in both the hecksties and explorer copies via a `merge_diagrams` helper that combines diagrams across all loaded domains
- The config.erb template already had Mermaid rendering blocks guarded by `defined?(structure_diagram)` — this commit activates them

## Example

Before: the `/config` page showed aggregates, roles, policies but the "Domain Wiring" section with Mermaid diagrams was never rendered (diagram locals were never passed).

After: visiting `/config` renders three Mermaid diagrams:
- **Structure** — `classDiagram` with aggregates, attributes, value objects, entities, and reference arrows
- **Behavior** — `flowchart LR` with command-to-event flows and policy chains
- **Flows** — `sequenceDiagram` with reactive chain traces

## Test plan
- [x] New spec: `IRIntrospector#diagram_data` returns structure, behavior, and flows keys with expected Mermaid content
- [x] Existing `view_contract_config_diagrams_spec.rb` continues to pass
- [x] Full suite: 1666 examples, 0 failures
- [x] Smoke test: `ruby -Ilib examples/pizzas/app.rb` passes