### PR TITLE
HEC-130: Show last event in REPL prompt + real method call output

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -233,6 +233,9 @@
 - Interactive session for incremental domain building (`Hecks.session`)
 - `sketch!` / `play!` toggling — switch between modeling and execution modes
 - Dynamic REPL prompt: `hecks(scratch sketch)`, `hecks(banking play)`
+- Last event in prompt: `hecks(pizzas play) [CreatedPizza]` — shows most recent domain event
+- `last_event` — returns the most recent event object for inspection
+- Real return values: commands return the aggregate with a concise `inspect` showing attributes, not just "ok"
 
 ### Named Constants & System Browser
 - Named constants: `aggregate("Cat")` creates `Cat` constant in the REPL

--- a/docs/usage/repl_prompt_and_output.md
+++ b/docs/usage/repl_prompt_and_output.md
@@ -1,0 +1,55 @@
+# REPL Prompt and Output
+
+The Hecks workshop REPL shows contextual feedback in two ways:
+
+1. **Last event in prompt** -- after executing a command, the prompt shows which event fired
+2. **Real return values** -- commands return the aggregate with a readable inspect
+
+## Last Event in Prompt
+
+After any command execution in play mode, the REPL prompt updates to show the
+most recent domain event:
+
+```
+hecks(pizzas sketch)> play!
+hecks(pizzas play)> Pizza.create(name: "Margherita", style: "NY")
+=> #<Pizza id:abc12345 name: "Margherita" style: "NY">
+
+hecks(pizzas play) [CreatedPizza]> Pizza.rename(name: "Classic Margherita")
+=> #<Pizza id:abc12345 name: "Classic Margherita" style: "NY">
+
+hecks(pizzas play) [RenamedPizza]>
+```
+
+The prompt format is: `hecks(<domain> <mode>) [<last event>]`
+
+## Inspecting the Last Event
+
+Call `last_event` to get the full event object:
+
+```ruby
+hecks(pizzas play) [CreatedPizza]> last_event
+=> #<CreatedPizza occurred_at: 2026-04-01 ...>
+```
+
+Returns `nil` when not in play mode or when no events have been emitted.
+
+## Real Return Values
+
+Commands return the actual aggregate instance with a concise `inspect`:
+
+```ruby
+pizza = Pizza.create(name: "Margherita", style: "NY")
+# => #<Pizza id:a1b2c3d4 name: "Margherita" style: "NY">
+
+pizza.name
+# => "Margherita"
+
+Pizza.find(pizza.id)
+# => #<Pizza id:a1b2c3d4 name: "Margherita" style: "NY">
+
+Pizza.all
+# => [#<Pizza id:a1b2c3d4 name: "Margherita" style: "NY">]
+```
+
+The inspect format shows: `#<ClassName id:<first 8 chars> attr1: val1 attr2: val2>`

--- a/hecks_workshop/lib/hecks/workshop/play_mode.rb
+++ b/hecks_workshop/lib/hecks/workshop/play_mode.rb
@@ -92,6 +92,14 @@ module Hecks
         @playground.execute(command_name, **attrs)
       end
 
+      # Return the most recent event captured during play mode.
+      #
+      # @return [Object, nil] the last event or nil if no events yet
+      def last_event
+        return nil unless play? && @playground
+        @playground.events.last
+      end
+
       # Return all events captured during play mode.
       #
       # @return [Array] list of event objects recorded by the playground

--- a/hecks_workshop/lib/hecks/workshop/playground.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground.rb
@@ -76,16 +76,12 @@ module Hecks
       agg_snake = domain_snake_name(agg_def.name)
       method_name = domain_snake_name(command_name).sub(/_#{agg_snake}$/, "").to_sym
 
+      events_before = @events.size
       result = agg_class.send(method_name, **attrs)
 
-      event = @events.last
-      if event
+      new_events = @events[events_before..]
+      new_events.each do |event|
         event_name = Hecks::Utils.const_short_name(event)
-        puts "Command: #{command_name}"
-        puts "  Event: #{event_name}"
-        attrs.each { |k, v| puts "    #{k}: #{v.inspect}" }
-        puts "    occurred_at: #{event.occurred_at}"
-
         triggered = check_policies(event)
         triggered.each do |policy|
           puts "  Policy: #{policy.name} -> #{policy.trigger_command}"

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -86,10 +86,16 @@ module Hecks
     def inspect
       mode = @workshop&.play? ? "play" : "sketch"
       name = @workshop&.name&.downcase || "scratch"
-      "hecks(#{name} #{mode})"
+      event = last_event_label
+      event ? "hecks(#{name} #{mode}) [#{event}]" : "hecks(#{name} #{mode})"
     end
 
     def to_s = inspect
+
+    def last_event
+      return nil unless @workshop&.play? && @workshop&.playground
+      @workshop.playground.events.last
+    end
 
     def tour
       @workshop = Hecks.workshop("Tour")
@@ -115,6 +121,13 @@ module Hecks
     end
 
     private
+
+    def last_event_label
+      return nil unless @workshop&.play? && @workshop&.playground
+      event = @workshop.playground.events.last
+      return nil unless event
+      Hecks::Utils.const_short_name(event)
+    end
 
     def launch_irb
       history_file = File.join(Dir.home, ".hecks_history")

--- a/hecks_workshop/spec/play_mode_spec.rb
+++ b/hecks_workshop/spec/play_mode_spec.rb
@@ -156,6 +156,30 @@ RSpec.describe "Play mode" do
       end
     end
 
+    describe "aggregate inspect" do
+      it "shows a concise representation with attributes" do
+        pizza = @mod::Pizza.create(name: "Margherita", style: "NY")
+        output = pizza.inspect
+        expect(output).to include("Pizza")
+        expect(output).to include("name: \"Margherita\"")
+        expect(output).to include("style: \"NY\"")
+        expect(output).to match(/id:\w{8}/)
+      end
+    end
+
+    describe "last_event" do
+      it "returns the most recent event" do
+        @mod::Pizza.create(name: "Test", style: "NY")
+        event = @wb.last_event
+        expect(Hecks::Utils.const_short_name(event)).to eq("CreatedPizza")
+      end
+
+      it "returns nil when no events" do
+        fresh_wb = Hecks::Workshop.new("Fresh")
+        expect(fresh_wb.last_event).to be_nil
+      end
+    end
+
     describe "persistence" do
       it "persists aggregates after execute" do
         result = @mod::Pizza.create(name: "Margherita", style: "NY")

--- a/hecks_workshop/spec/playground_spec.rb
+++ b/hecks_workshop/spec/playground_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe Hecks::Workshop::Playground do
       pizza = playground.execute("CreatePizza", name: "Seed")
       playground.execute("PlaceOrder", pizza: pizza.id, quantity: 2)
 
-      expect(output).to include("Command: PlaceOrder")
       expect(output).to include("  Policy: ReserveIngredients -> ReserveStock")
     end
 

--- a/hecks_workshop/spec/workshop_runner_spec.rb
+++ b/hecks_workshop/spec/workshop_runner_spec.rb
@@ -42,6 +42,34 @@ RSpec.describe Hecks::Workshop::WorkshopRunner do
     end
   end
 
+  describe "#inspect" do
+    it "shows mode in prompt" do
+      expect(runner.inspect).to eq("hecks(test sketch)")
+    end
+
+    it "shows last event in prompt after play-mode execution" do
+      runner.aggregate("Cat") { attribute :name, String; command("Meow") { attribute :name, String } }
+      runner.play!
+      mod = Object.const_get("TestDomain")
+      mod::Cat.meow(name: "Henry")
+      expect(runner.inspect).to match(/\[Meowed\]/)
+    end
+  end
+
+  describe "#last_event" do
+    it "returns nil in sketch mode" do
+      expect(runner.last_event).to be_nil
+    end
+
+    it "returns the last event in play mode" do
+      runner.aggregate("Cat") { attribute :name, String; command("Meow") { attribute :name, String } }
+      runner.play!
+      mod = Object.const_get("TestDomain")
+      mod::Cat.meow(name: "Henry")
+      expect(runner.last_event).not_to be_nil
+    end
+  end
+
   describe "delegated methods" do
     it "delegates validate" do
       runner.aggregate("Cat") { attribute :name, String; command("AdoptCat") { attribute :name, String } }

--- a/hecksties/lib/hecks/mixins/model.rb
+++ b/hecksties/lib/hecks/mixins/model.rb
@@ -158,6 +158,24 @@ module Hecks
       [self.class, id].hash
     end
 
+    # Returns a concise, human-readable representation of the aggregate.
+    #
+    # Shows the short class name, truncated id, and all user-defined
+    # attribute values. Designed for REPL readability.
+    #
+    # @return [String] e.g. '#<Pizza id:abc123 name:"Margherita" style:"NY">'
+    def inspect
+      short_class = self.class.name&.split("::")&.last || self.class.to_s
+      short_id = id.to_s[0, 8]
+      attrs = self.class.hecks_attributes.map do |attr|
+        val = instance_variable_get(:"@#{attr[:name]}")
+        "#{attr[:name]}: #{val.inspect}"
+      end
+      "#<#{short_class} id:#{short_id} #{attrs.join(' ')}>"
+    end
+
+    alias to_s inspect
+
     private
 
     # Validation hook called at the end of +#initialize+. Override in


### PR DESCRIPTION
## Summary

- REPL prompt now shows the last domain event: `hecks(pizzas play) [CreatedPizza]>`
- Commands return aggregates with a concise `inspect`: `#<Pizza id:a1b2c3d4 name: "Margherita" style: "NY">`
- Removed verbose `Command:` / `Event:` / attribute printing from `Playground#execute` -- the return value and prompt context replace it
- Added `last_event` method to Workshop and WorkshopRunner for direct event inspection

## Example

Before:
```
hecks(pizzas play)> Pizza.create(name: "Margherita", style: "NY")
Command: CreatePizza
  Event: CreatedPizza
    name: "Margherita"
    style: "NY"
    occurred_at: 2026-04-01 ...
=> #<ScratchDomain::Pizza:0x00007f...>

hecks(pizzas play)>
```

After:
```
hecks(pizzas play)> Pizza.create(name: "Margherita", style: "NY")
=> #<Pizza id:a1b2c3d4 name: "Margherita" style: "NY">

hecks(pizzas play) [CreatedPizza]> last_event
=> #<CreatedPizza occurred_at: 2026-04-01 ...>
```

## Test plan
- [ ] `bundle exec rspec` -- 1672 examples, 0 failures
- [ ] `ruby -Ilib examples/pizzas/app.rb` -- smoke test passes
- [ ] New specs cover prompt with last event, `last_event` method, and aggregate `inspect`
- [ ] Verify `Playground#execute` still reports triggered policies