### PR TITLE
HEC-409: GoCodeBuilder class + migrate 5 generators

### DIFF
--- a/hecks_targets/go/lib/go_hecks.rb
+++ b/hecks_targets/go/lib/go_hecks.rb
@@ -13,6 +13,7 @@
 #   hecks build --target go
 #
 require_relative "go_hecks/go_utils"
+require_relative "go_hecks/go_code_builder"
 require_relative "go_hecks/generators/aggregate_generator"
 require_relative "go_hecks/generators/value_object_generator"
 require_relative "go_hecks/generators/command_generator"

--- a/hecks_targets/go/lib/go_hecks/generators/errors_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/errors_generator.rb
@@ -3,6 +3,8 @@
 # Generates Go error types matching the hecks error hierarchy.
 # All errors implement error interface and have JSON serialization.
 #
+#   ErrorsGenerator.new(package: "domain").generate
+#
 module GoHecks
   class ErrorsGenerator
     def initialize(package:)
@@ -10,40 +12,38 @@ module GoHecks
     end
 
     def generate
-      <<~GO
-        package #{@package}
+      b = GoCodeBuilder.new(@package)
+      b.imports('"encoding/json"')
 
-        import "encoding/json"
+      b.struct("ValidationError") do |s|
+        s.field("Field", "string", json: "field")
+        s.field("Message", "string", json: "message")
+        s.field("Rule", "string", json: "rule,omitempty")
+      end
+      b.one_liner("ValidationError", "Error", "string", "return e.Message")
+      b.blank
+      b.receiver("ValidationError", "AsJSON", "[]byte") do |m|
+        m.line("b, _ := json.Marshal(e)")
+        m.line("return b")
+      end
+      b.blank
 
-        type ValidationError struct {
-        \tField   string `json:"field"`
-        \tMessage string `json:"message"`
-        \tRule    string `json:"rule,omitempty"`
-        }
+      b.struct("GuardRejected") do |s|
+        s.field("Command", "string", json: "command")
+        s.field("Aggregate", "string", json: "aggregate,omitempty")
+        s.field("Message", "string", json: "message")
+      end
+      b.one_liner("GuardRejected", "Error", "string", "return e.Message")
+      b.blank
 
-        func (e *ValidationError) Error() string { return e.Message }
+      b.struct("GateAccessDenied") do |s|
+        s.field("Role", "string", json: "role")
+        s.field("Action", "string", json: "action")
+        s.field("Message", "string", json: "message")
+      end
+      b.one_liner("GateAccessDenied", "Error", "string", "return e.Message")
 
-        func (e *ValidationError) AsJSON() []byte {
-        \tb, _ := json.Marshal(e)
-        \treturn b
-        }
-
-        type GuardRejected struct {
-        \tCommand   string `json:"command"`
-        \tAggregate string `json:"aggregate,omitempty"`
-        \tMessage   string `json:"message"`
-        }
-
-        func (e *GuardRejected) Error() string { return e.Message }
-
-        type GateAccessDenied struct {
-        \tRole    string `json:"role"`
-        \tAction  string `json:"action"`
-        \tMessage string `json:"message"`
-        }
-
-        func (e *GateAccessDenied) Error() string { return e.Message }
-      GO
+      b.to_s
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/event_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/event_generator.rb
@@ -3,6 +3,8 @@
 # Generates a Go struct for a domain event. Events are immutable value
 # types with an OccurredAt timestamp and an EventName() method.
 #
+#   EventGenerator.new(event, aggregate: agg, package: "domain").generate
+#
 module GoHecks
   class EventGenerator
     include GoUtils
@@ -15,38 +17,37 @@ module GoHecks
     end
 
     def generate
-      lines = []
-      lines << "package #{@package}"
-      lines << ""
-      lines << "import \"time\""
-      lines << ""
+      b = GoCodeBuilder.new(@package)
+      b.imports('"time"')
 
-      lines << "type #{@go_name} struct {"
-      lines << "\tAggregateID string    `json:\"aggregate_id\"`"
-      @event.attributes.each do |attr|
-        field = GoUtils.pascal_case(attr.name)
-        go_t = GoUtils.go_type(attr)
-        tag = GoUtils.json_tag(attr.name)
-        lines << "\t#{field} #{go_t} `json:\"#{tag}\"`"
+      b.struct(@go_name) do |s|
+        s.field("AggregateID", "string", json: "aggregate_id")
+        each_event_attr { |f, t, j| s.field(f, t, json: j) }
+        each_extra_agg_attr { |f, t, j| s.field(f, t, json: j) }
+        s.field("OccurredAt", "time.Time", json: "occurred_at")
       end
-      # Add aggregate attrs that aren't already in the event
+
+      b.one_liner(@go_name, "EventName", "string", "return \"#{@event.name}\"", pointer: false)
+      b.blank
+      b.one_liner(@go_name, "GetOccurredAt", "time.Time", "return e.OccurredAt", pointer: false)
+
+      b.to_s
+    end
+
+    private
+
+    def each_event_attr
+      @event.attributes.each do |attr|
+        yield GoUtils.pascal_case(attr.name), GoUtils.go_type(attr), GoUtils.json_tag(attr.name)
+      end
+    end
+
+    def each_extra_agg_attr
       agg_attrs = @aggregate.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
       agg_attrs.each do |attr|
         next if @event.attributes.any? { |ea| ea.name == attr.name }
-        field = GoUtils.pascal_case(attr.name)
-        go_t = GoUtils.go_type(attr)
-        tag = GoUtils.json_tag(attr.name)
-        lines << "\t#{field} #{go_t} `json:\"#{tag}\"`"
+        yield GoUtils.pascal_case(attr.name), GoUtils.go_type(attr), GoUtils.json_tag(attr.name)
       end
-      lines << "\tOccurredAt time.Time `json:\"occurred_at\"`"
-      lines << "}"
-      lines << ""
-
-      lines << "func (e #{@go_name}) EventName() string { return \"#{@event.name}\" }"
-      lines << ""
-      lines << "func (e #{@go_name}) GetOccurredAt() time.Time { return e.OccurredAt }"
-
-      lines.join("\n") + "\n"
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/lifecycle_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/lifecycle_generator.rb
@@ -3,6 +3,8 @@
 # Generates Go lifecycle support: status type, state constants,
 # predicate methods, and transition validation.
 #
+#   LifecycleGenerator.new(lifecycle, aggregate_name: "Order", package: "domain").generate
+#
 module GoHecks
   class LifecycleGenerator
     include GoUtils
@@ -14,51 +16,49 @@ module GoHecks
     end
 
     def generate
-      field = GoUtils.pascal_case(@lc.field)
-      lines = []
-      lines << "package #{@package}"
-      lines << ""
+      @field = GoUtils.pascal_case(@lc.field)
+      b = GoCodeBuilder.new(@package)
 
-      # State constants
-      lines << "const ("
-      @lc.states.each do |state|
-        const_name = "#{@agg}Status#{GoUtils.pascal_case(state)}"
-        lines << "\t#{const_name} = \"#{state}\""
-      end
-      lines << ")"
-      lines << ""
-
-      # Predicate methods
-      @lc.states.each do |state|
-        method = "Is#{GoUtils.pascal_case(state)}"
-        const_name = "#{@agg}Status#{GoUtils.pascal_case(state)}"
-        lines << "func (a *#{@agg}) #{method}() bool { return a.#{field} == #{const_name} }"
-      end
-      lines << ""
-
-      # Transition validation
-      lines << "func (a *#{@agg}) ValidTransition(target string) bool {"
-      lines << "\tswitch {"
-      @lc.transitions.each do |cmd_name, _|
-        target = @lc.target_for(cmd_name)
-        from = @lc.from_for(cmd_name)
-        next unless target
-        if from
-          if from.is_a?(Array)
-            from_check = from.map { |f| "a.#{field} == \"#{f}\"" }.join(" || ")
-          else
-            from_check = "a.#{field} == \"#{from}\""
-          end
-          lines << "\tcase target == \"#{target}\" && (#{from_check}): return true"
-        else
-          lines << "\tcase target == \"#{target}\": return true"
+      b.const_block do |c|
+        @lc.states.each do |state|
+          c.value("#{@agg}Status#{GoUtils.pascal_case(state)}", "\"#{state}\"")
         end
       end
-      lines << "\tdefault: return false"
-      lines << "\t}"
-      lines << "}"
 
-      lines.join("\n") + "\n"
+      predicate_methods(b)
+      b.blank
+      transition_method(b)
+
+      b.to_s
+    end
+
+    private
+
+    def predicate_methods(b)
+      @lc.states.each do |state|
+        const = "#{@agg}Status#{GoUtils.pascal_case(state)}"
+        b.one_liner(@agg, "Is#{GoUtils.pascal_case(state)}", "bool", "return a.#{@field} == #{const}")
+      end
+    end
+
+    def transition_method(b)
+      b.receiver(@agg, "ValidTransition(target string)", "bool") do |m|
+        m.line("switch {")
+        @lc.transitions.each do |cmd_name, _|
+          target = @lc.target_for(cmd_name)
+          from = @lc.from_for(cmd_name)
+          next unless target
+          if from
+            from_list = from.is_a?(Array) ? from : [from]
+            from_check = from_list.map { |f| "a.#{@field} == \"#{f}\"" }.join(" || ")
+            m.line("case target == \"#{target}\" && (#{from_check}): return true")
+          else
+            m.line("case target == \"#{target}\": return true")
+          end
+        end
+        m.line("default: return false")
+        m.line("}")
+      end
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/port_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/port_generator.rb
@@ -3,6 +3,8 @@
 # Generates a Go interface for a repository port. Ports are Go's native
 # abstraction — compile-time enforcement, not runtime NotImplementedError.
 #
+#   PortGenerator.new(aggregate, package: "domain").generate
+#
 module GoHecks
   class PortGenerator
     include GoUtils
@@ -13,18 +15,17 @@ module GoHecks
     end
 
     def generate
-      lines = []
-      lines << "package #{@package}"
-      lines << ""
-      lines << "type #{@agg.name}Repository interface {"
-      lines << "\tFind(id string) (*#{@agg.name}, error)"
-      lines << "\tSave(#{GoUtils.camel_case(@agg.name)} *#{@agg.name}) error"
-      lines << "\tAll() ([]*#{@agg.name}, error)"
-      lines << "\tDelete(id string) error"
-      lines << "\tCount() (int, error)"
-      lines << "}"
-
-      lines.join("\n") + "\n"
+      n = @agg.name
+      v = GoUtils.camel_case(n)
+      b = GoCodeBuilder.new(@package)
+      b.line("type #{n}Repository interface {")
+      b.line("\tFind(id string) (*#{n}, error)")
+      b.line("\tSave(#{v} *#{n}) error")
+      b.line("\tAll() ([]*#{n}, error)")
+      b.line("\tDelete(id string) error")
+      b.line("\tCount() (int, error)")
+      b.line("}")
+      b.to_s
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/value_object_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/value_object_generator.rb
@@ -4,6 +4,8 @@
 # validates invariants. Value objects are plain structs — immutability
 # is by convention (no pointer receiver mutators).
 #
+#   ValueObjectGenerator.new(vo, package: "domain").generate
+#
 module GoHecks
   class ValueObjectGenerator
     include GoUtils
@@ -14,52 +16,40 @@ module GoHecks
     end
 
     def generate
-      lines = []
-      lines << "package #{@package}"
-      lines << ""
+      b = GoCodeBuilder.new(@package)
+      b.imports('"fmt"') if @vo.invariants.any?
 
-      needs_fmt = !@vo.invariants.empty?
-      if needs_fmt
-        lines << "import \"fmt\""
-        lines << ""
-      end
-
-      # Struct
-      lines << "type #{@vo.name} struct {"
-      @vo.attributes.each do |attr|
-        field = GoUtils.pascal_case(attr.name)
-        go_t = GoUtils.go_type(attr)
-        tag = GoUtils.json_tag(attr.name)
-        lines << "\t#{field} #{go_t} `json:\"#{tag}\"`"
-      end
-      lines << "}"
-      lines << ""
-
-      # Constructor with invariant checks
-      params = @vo.attributes.map { |a| "#{GoUtils.camel_case(a.name)} #{GoUtils.go_type(a)}" }.join(", ")
-      lines << "func New#{@vo.name}(#{params}) (#{@vo.name}, error) {"
-      lines << "\tv := #{@vo.name}{"
-      @vo.attributes.each do |attr|
-        lines << "\t\t#{GoUtils.pascal_case(attr.name)}: #{GoUtils.camel_case(attr.name)},"
-      end
-      lines << "\t}"
-
-      @vo.invariants.each do |inv|
-        # Generate a basic check from the invariant message
-        lines << "\t// #{inv.message}"
-        # Try to extract field and condition from the message
-        if inv.message =~ /(\w+) must be positive/
-          field = GoUtils.pascal_case($1)
-          lines << "\tif v.#{field} <= 0 {"
-          lines << "\t\treturn #{@vo.name}{}, fmt.Errorf(\"#{inv.message}\")"
-          lines << "\t}"
+      b.struct(@vo.name) do |s|
+        @vo.attributes.each do |attr|
+          s.field(GoUtils.pascal_case(attr.name), GoUtils.go_type(attr), json: GoUtils.json_tag(attr.name))
         end
       end
 
-      lines << "\treturn v, nil"
-      lines << "}"
+      params = @vo.attributes.map { |a| "#{GoUtils.camel_case(a.name)} #{GoUtils.go_type(a)}" }.join(", ")
+      b.func("New#{@vo.name}(#{params})", nil, "(#{@vo.name}, error)") do |m|
+        m.line("v := #{@vo.name}{")
+        @vo.attributes.each do |attr|
+          m.line("\t#{GoUtils.pascal_case(attr.name)}: #{GoUtils.camel_case(attr.name)},")
+        end
+        m.line("}")
+        invariant_checks(m)
+        m.line("return v, nil")
+      end
 
-      lines.join("\n") + "\n"
+      b.to_s
+    end
+
+    private
+
+    def invariant_checks(m)
+      @vo.invariants.each do |inv|
+        m.line("// #{inv.message}")
+        next unless inv.message =~ /(\w+) must be positive/
+        field = GoUtils.pascal_case($1)
+        m.line("if v.#{field} <= 0 {")
+        m.line("\treturn #{@vo.name}{}, fmt.Errorf(\"#{inv.message}\")")
+        m.line("}")
+      end
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/go_code_builder.rb
+++ b/hecks_targets/go/lib/go_hecks/go_code_builder.rb
@@ -1,0 +1,208 @@
+# GoHecks::GoCodeBuilder
+#
+# Fluent builder for generating Go source files. Encapsulates the
+# recurring patterns shared by all Go generators: package declarations,
+# import blocks, struct definitions, receiver methods, and functions.
+#
+#   b = GoCodeBuilder.new("domain")
+#   b.imports("time", "fmt")
+#   b.struct("Pizza") do |s|
+#     s.field("Name", "string", json: "name")
+#   end
+#   b.receiver("Pizza", "Validate", "error") do |m|
+#     m.line('return nil')
+#   end
+#   b.to_s  # => Go source string
+#
+module GoHecks
+  class GoCodeBuilder
+    def initialize(package)
+      @package = package
+      @sections = []
+      @import_set = []
+    end
+
+    # Add one or more import paths. Duplicates are ignored.
+    def imports(*paths)
+      paths.each { |p| @import_set << p unless @import_set.include?(p) }
+      self
+    end
+
+    # Add a blank line between sections.
+    def blank
+      @sections << ""
+      self
+    end
+
+    # Add a raw line of Go code.
+    def line(text)
+      @sections << text
+      self
+    end
+
+    # Add a raw block of lines.
+    def lines(arr)
+      @sections.concat(arr)
+      self
+    end
+
+    # Add a comment line.
+    def comment(text)
+      @sections << "// #{text}"
+      self
+    end
+
+    # Build a struct definition. Yields a StructBuilder for adding fields.
+    def struct(name)
+      sb = StructBuilder.new(name)
+      yield sb if block_given?
+      @sections.concat(sb.to_lines)
+      @sections << ""
+      self
+    end
+
+    # Build a const block. Yields a ConstBuilder for adding constants.
+    def const_block
+      cb = ConstBuilder.new
+      yield cb
+      @sections.concat(cb.to_lines)
+      @sections << ""
+      self
+    end
+
+    # Build a receiver method: func (recv *Type) Name() ReturnType { ... }
+    # method_name can include params: "Validate" or "ValidTransition(target string)"
+    def receiver(type_name, method_name, return_type, pointer: true)
+      recv_var = type_name[0].downcase
+      recv = pointer ? "*#{type_name}" : type_name
+      qualified = method_name.include?("(") ? method_name : "#{method_name}()"
+      mb = MethodBuilder.new("(#{recv_var} #{recv}) #{qualified}", return_type)
+      yield mb if block_given?
+      @sections.concat(mb.to_lines)
+      self
+    end
+
+    # Build a standalone function: func Name(params) ReturnType { ... }
+    # Pass the full signature (with parens) as name when params is nil.
+    def func(name, params, return_type)
+      if params.nil?
+        sig = name
+      elsif params.empty?
+        sig = "#{name}()"
+      else
+        sig = "#{name}(#{params})"
+      end
+      mb = MethodBuilder.new(sig, return_type)
+      yield mb if block_given?
+      @sections.concat(mb.to_lines)
+      self
+    end
+
+    # Build a one-line receiver method.
+    def one_liner(type_name, method_name, return_type, body, pointer: true)
+      recv_var = type_name[0].downcase
+      recv = pointer ? "*#{type_name}" : type_name
+      @sections << "func (#{recv_var} #{recv}) #{method_name}() #{return_type} { #{body} }"
+      self
+    end
+
+    # Render the complete Go source file.
+    def to_s
+      out = []
+      out << "package #{@package}"
+      out << ""
+      unless @import_set.empty?
+        if @import_set.size == 1
+          out << "import #{@import_set.first}"
+        else
+          out << "import ("
+          @import_set.each { |i| out << "\t#{i}" }
+          out << ")"
+        end
+        out << ""
+      end
+      out.concat(@sections)
+      out.join("\n") + "\n"
+    end
+
+    # Nested builder for struct fields.
+    class StructBuilder
+      def initialize(name)
+        @name = name
+        @fields = []
+      end
+
+      def field(go_name, go_type, json: nil)
+        if json
+          @fields << "\t#{go_name} #{go_type} `json:\"#{json}\"`"
+        else
+          @fields << "\t#{go_name} #{go_type}"
+        end
+        self
+      end
+
+      def raw(line)
+        @fields << "\t#{line}"
+        self
+      end
+
+      def empty_struct
+        @fields.clear
+        self
+      end
+
+      def to_lines
+        if @fields.empty?
+          ["type #{@name} struct{}"]
+        else
+          ["type #{@name} struct {"] + @fields + ["}"]
+        end
+      end
+    end
+
+    # Nested builder for const blocks.
+    class ConstBuilder
+      def initialize
+        @entries = []
+      end
+
+      def value(name, val)
+        @entries << "\t#{name} = #{val}"
+        self
+      end
+
+      def to_lines
+        ["const ("] + @entries + [")"]
+      end
+    end
+
+    # Nested builder for method/function bodies.
+    class MethodBuilder
+      def initialize(signature, return_type)
+        @signature = signature
+        @return_type = return_type
+        @body = []
+      end
+
+      def line(text)
+        @body << "\t#{text}"
+        self
+      end
+
+      def lines(arr)
+        arr.each { |l| @body << "\t#{l}" }
+        self
+      end
+
+      def raw(text)
+        @body << text
+        self
+      end
+
+      def to_lines
+        rt = @return_type && !@return_type.empty? ? " #{@return_type}" : ""
+        ["func #{@signature}#{rt} {"] + @body + ["}"]
+      end
+    end
+  end
+end

--- a/hecks_targets/go/spec/go_code_builder_spec.rb
+++ b/hecks_targets/go/spec/go_code_builder_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+require "go_hecks"
+
+RSpec.describe GoHecks::GoCodeBuilder do
+  subject(:builder) { described_class.new("domain") }
+
+  describe "#to_s" do
+    it "outputs a package declaration" do
+      expect(builder.to_s).to start_with("package domain\n")
+    end
+
+    it "renders a single import without parens" do
+      builder.imports('"fmt"')
+      expect(builder.to_s).to include("import \"fmt\"\n")
+    end
+
+    it "renders multiple imports in a grouped block" do
+      builder.imports('"fmt"', '"time"')
+      out = builder.to_s
+      expect(out).to include("import (")
+      expect(out).to include("\t\"fmt\"")
+      expect(out).to include("\t\"time\"")
+    end
+
+    it "deduplicates imports" do
+      builder.imports('"fmt"', '"fmt"')
+      expect(builder.to_s.scan('"fmt"').size).to eq(1)
+    end
+  end
+
+  describe "#struct" do
+    it "generates a struct with json-tagged fields" do
+      builder.struct("Pizza") do |s|
+        s.field("Name", "string", json: "name")
+        s.field("Size", "int", json: "size")
+      end
+      out = builder.to_s
+      expect(out).to include("type Pizza struct {")
+      expect(out).to include("\tName string `json:\"name\"`")
+      expect(out).to include("\tSize int `json:\"size\"`")
+    end
+
+    it "generates an empty struct" do
+      builder.struct("Marker") { |s| s.empty_struct }
+      expect(builder.to_s).to include("type Marker struct{}")
+    end
+  end
+
+  describe "#const_block" do
+    it "generates a const block" do
+      builder.const_block do |c|
+        c.value("StatusActive", '"active"')
+        c.value("StatusDone", '"done"')
+      end
+      out = builder.to_s
+      expect(out).to include("const (")
+      expect(out).to include("\tStatusActive = \"active\"")
+      expect(out).to include("\tStatusDone = \"done\"")
+    end
+  end
+
+  describe "#receiver" do
+    it "generates a pointer receiver method" do
+      builder.receiver("Pizza", "Validate", "error") do |m|
+        m.line("return nil")
+      end
+      expect(builder.to_s).to include("func (p *Pizza) Validate() error {")
+      expect(builder.to_s).to include("\treturn nil")
+    end
+  end
+
+  describe "#one_liner" do
+    it "generates a single-line receiver method" do
+      builder.one_liner("Pizza", "Name", "string", 'return p.Name')
+      expect(builder.to_s).to include('func (p *Pizza) Name() string { return p.Name }')
+    end
+
+    it "generates a value receiver when pointer is false" do
+      builder.one_liner("Event", "EventName", "string", 'return "Created"', pointer: false)
+      expect(builder.to_s).to include('func (e Event) EventName() string { return "Created" }')
+    end
+  end
+
+  describe "#func" do
+    it "generates a standalone function" do
+      builder.func("NewPizza(name string)", nil, "*Pizza") do |m|
+        m.line("return &Pizza{Name: name}")
+      end
+      expect(builder.to_s).to include("func NewPizza(name string) *Pizza {")
+    end
+  end
+
+  describe "#comment" do
+    it "adds a comment line" do
+      builder.comment("TODO: implement")
+      expect(builder.to_s).to include("// TODO: implement")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `GoCodeBuilder` fluent builder class with Go-specific helpers: package declarations, import blocks, struct definitions, const blocks, receiver methods, standalone functions, and one-liners
- Migrated 5 generators to use it: `ErrorsGenerator`, `PortGenerator`, `EventGenerator`, `ValueObjectGenerator`, `LifecycleGenerator`
- 12 new specs covering all builder APIs

## Example

Before (manual line arrays):
```ruby
lines = []
lines << "package #{@package}"
lines << ""
lines << "import \"time\""
lines << ""
lines << "type #{@go_name} struct {"
lines << "\tAggregateID string `json:\"aggregate_id\"`"
# ...
lines << "}"
lines.join("\n") + "\n"
```

After (fluent builder):
```ruby
b = GoCodeBuilder.new(@package)
b.imports('"time"')
b.struct(@go_name) do |s|
  s.field("AggregateID", "string", json: "aggregate_id")
  # ...
end
b.to_s
```

## Test plan
- [x] All 1677 specs pass (0 failures)
- [x] GoCodeBuilder spec covers: package output, single/multi imports, dedup, structs, empty structs, const blocks, receiver methods, one-liners, standalone functions, comments
- [x] Smoke test (`ruby -Ilib examples/pizzas/app.rb`) passes
- [x] All migrated generators produce identical Go output