### PR TITLE
HEC-478: Standardize extension format with consistent describe/register pattern

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -101,6 +101,10 @@
 - Adapter type classification: `adapter_type: :driven` or `:driving` on `describe_extension`
 - Two-phase boot: driven extensions (repos, middleware) fire before driving extensions (HTTP, queues)
 - Query helpers: `Hecks.driven_extensions` and `Hecks.driving_extensions`
+- Extension aliasing: `Hecks.alias_extension(:short, :long)` registers a shorthand key for an existing extension
+- Standard extension format: describe, register, namespace under `Hecks::` (e.g. `Hecks::Audit`, `Hecks::PII`, `Hecks::Queue`)
+- Every extension declares its config keys in `describe_extension` for introspection
+- Every extension has a "Future gem" comment documenting its intended gem name
 
 ### Persistence Extensions
 - `hecks_sqlite` — SQLite persistence, auto-wires when in Gemfile

--- a/docs/usage/creating_extensions.md
+++ b/docs/usage/creating_extensions.md
@@ -1,0 +1,104 @@
+# Creating Extensions
+
+Extensions add cross-cutting capabilities to Hecks domains -- persistence,
+authorization, logging, queues, and more. Every extension follows a standard
+file layout so the framework can discover, describe, and wire it automatically.
+
+## File Layout
+
+Each extension lives in a single file under `lib/hecks/extensions/`. The file
+name becomes the registration key (e.g. `audit.rb` registers as `:audit`).
+
+```ruby
+# Hecks::MyExtension
+#
+# One-paragraph description of what this extension does.
+#
+# Future gem: hecks_my_extension
+#
+# Usage:
+#   app = Hecks.boot(__dir__) do
+#     extend :my_extension
+#   end
+#
+
+# 1. Describe -- declare metadata for introspection
+Hecks.describe_extension(:my_extension,
+  description: "What this extension does in one line",
+  adapter_type: :driven,          # :driven or :driving
+  config: {
+    MY_ENV_VAR: { default: 42, desc: "What it controls" }
+  },
+  wires_to: :command_bus)         # :command_bus, :event_bus, or :repository
+
+# 2. Register -- the boot hook that wires the extension
+Hecks.register_extension(:my_extension) do |domain_mod, domain, runtime|
+  # Wire middleware, swap adapters, or subscribe to events here.
+end
+
+# 3. Supporting classes (if any) -- namespaced under Hecks::
+module Hecks::MyExtension
+  # Helper classes go here.
+end
+```
+
+## describe_extension Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `description` | yes | One-line summary shown in `hecks extensions` |
+| `adapter_type` | yes | `:driven` (repos, middleware) or `:driving` (HTTP, queues) |
+| `config` | no | Hash of config keys with `default:` and `desc:` |
+| `wires_to` | no | What the extension attaches to: `:command_bus`, `:event_bus`, or `:repository` |
+
+## Naming Rules
+
+- **File name = registration key.** `rate_limit.rb` registers as `:rate_limit`.
+- **Supporting classes** live under `Hecks::` namespace (e.g. `Hecks::Audit`, `Hecks::PII`).
+- **Future gem name** follows the pattern `hecks_<key>` (e.g. `hecks_audit`).
+- **Aliases** use `Hecks.alias_extension(:short, :long)` instead of direct registry mutation.
+
+## Driven vs Driving
+
+**Driven extensions** (`:driven`) are infrastructure adapters that the domain
+calls out to -- persistence, validation, auth, logging. They fire first at boot
+so the runtime is fully configured before any driving adapters see it.
+
+**Driving extensions** (`:driving`) are entry points that call into the domain
+-- HTTP servers, message queues, Slack webhooks. They fire second at boot so
+they see the final wired runtime.
+
+## Example: A Metrics Extension
+
+```ruby
+# Hecks::Metrics
+#
+# Counts command executions per aggregate. Exposes totals via
+# domain_mod.metrics for dashboards.
+#
+# Future gem: hecks_metrics
+#
+# Usage:
+#   app = Hecks.boot(__dir__) do
+#     extend :metrics
+#   end
+#   PizzasDomain.metrics  # => { "Pizza" => 3 }
+#
+Hecks.describe_extension(:metrics,
+  description: "Command execution counters per aggregate",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :command_bus)
+
+Hecks.register_extension(:metrics) do |domain_mod, _domain, runtime|
+  counts = Hash.new(0)
+
+  runtime.use :metrics do |command, next_handler|
+    agg = command.class.name.split("::")[-3]
+    counts[agg] += 1
+    next_handler.call
+  end
+
+  domain_mod.define_singleton_method(:metrics) { counts.dup }
+end
+```

--- a/examples/governance/examples/demo.rb
+++ b/examples/governance/examples/demo.rb
@@ -99,7 +99,7 @@ puts "\n--- PII protection ---"
   pii = mod.pii_fields
   pii.each { |agg, fields| puts "  #{mod.name.sub('Domain', '')}::#{agg}: #{fields.join(', ')}" } unless pii.empty?
 end
-puts "  Masked email: #{HecksPii.mask("alice@governance.ai")}"
+puts "  Masked email: #{Hecks::PII.mask("alice@governance.ai")}"
 
 puts "\n--- Final state ---"
 { "AiModel" => AiModel, "Vendor" => Vendor, "DataUsageAgreement" => DataUsageAgreement,

--- a/hecksties/lib/hecks/extensions/audit.rb
+++ b/hecksties/lib/hecks/extensions/audit.rb
@@ -1,15 +1,17 @@
-# HecksAudit
+# Hecks::Audit
 #
 # Audit trail extension that records an immutable log entry for every
 # domain event published on the event bus. Captures the event class name,
 # full attribute data, and timestamp. Optionally pairs with command bus
 # middleware to enrich entries with command name, actor, and tenant.
 #
+# Future gem: hecks_audit
+#
 # Usage:
 #   require "hecks_audit"
 #
 #   app = Hecks.load(domain)
-#   audit = HecksAudit.new(app.event_bus)
+#   audit = Hecks::Audit.new(app.event_bus)
 #
 #   # Optional: add command context via middleware
 #   app.use(:audit) { |cmd, nxt| audit.around_command(cmd, nxt) }
@@ -18,7 +20,8 @@
 #   audit.log.last[:event_name]  # => "CreatedPizza"
 #   audit.log.last[:event_data]  # => { name: "Margherita" }
 #
-class HecksAudit
+module Hecks; end
+class Hecks::Audit
   # @return [Array<Hash>] the immutable audit log; each entry is a Hash with
   #   keys :command, :actor, :tenant, :timestamp, :event_name, :event_data
   attr_reader :log
@@ -130,7 +133,7 @@ Hecks.describe_extension(:audit,
 
 Hecks.register_extension(:audit) do |_domain_mod, _domain, runtime|
   bus = Hecks.event_bus || runtime.event_bus
-  audit = HecksAudit.new(bus)
+  audit = Hecks::Audit.new(bus)
   Hecks.instance_variable_set(:@_audit, audit)
   Hecks.define_singleton_method(:audit_log) { @_audit.log }
   runtime.use(:audit) do |cmd, nxt|

--- a/hecksties/lib/hecks/extensions/auth.rb
+++ b/hecksties/lib/hecks/extensions/auth.rb
@@ -25,7 +25,9 @@
 Hecks.describe_extension(:auth,
   description: "Actor-based authorization via port guards",
   adapter_type: :driven,
-  config: {},
+  config: {
+    enforce: { default: true, desc: "Set false to register a no-op sentinel" }
+  },
   wires_to: :command_bus)
 
 Hecks.register_extension(:auth) do |domain_mod, domain, runtime, **opts|

--- a/hecksties/lib/hecks/extensions/filesystem_store.rb
+++ b/hecksties/lib/hecks/extensions/filesystem_store.rb
@@ -151,4 +151,4 @@ module Hecks
 end
 
 # Alias for convenience: adapter: :filesystem
-Hecks.extension_registry[:filesystem] = Hecks.extension_registry[:filesystem_store]
+Hecks.alias_extension(:filesystem, :filesystem_store)

--- a/hecksties/lib/hecks/extensions/idempotency.rb
+++ b/hecksties/lib/hecks/extensions/idempotency.rb
@@ -6,6 +6,8 @@
 # TTL window, the cached result is returned instead of re-executing the
 # command. Expired cache entries are cleaned on each dispatch.
 #
+# Future gem: hecks_idempotency
+#
 # Configuration via environment variable:
 #   HECKS_IDEMPOTENCY_TTL -- cache TTL in seconds (default: 300)
 #
@@ -17,7 +19,9 @@
 Hecks.describe_extension(:idempotency,
   description: "Idempotent command execution via dedup keys",
   adapter_type: :driven,
-  config: {},
+  config: {
+    HECKS_IDEMPOTENCY_TTL: { default: 300, desc: "Cache TTL in seconds" }
+  },
   wires_to: :command_bus)
 
 Hecks.register_extension(:idempotency) do |_domain_mod, _domain, runtime|

--- a/hecksties/lib/hecks/extensions/logging.rb
+++ b/hecksties/lib/hecks/extensions/logging.rb
@@ -5,6 +5,8 @@
 # in milliseconds, and optional actor and tenant context. Uses
 # +Process::CLOCK_MONOTONIC+ for accurate timing.
 #
+# Future gem: hecks_logging
+#
 # Output format:
 #   [hecks] CreatePizza 0.3ms actor=admin tenant=acme
 #

--- a/hecksties/lib/hecks/extensions/pii.rb
+++ b/hecksties/lib/hecks/extensions/pii.rb
@@ -1,4 +1,4 @@
-# HecksPii
+# Hecks::PII
 #
 # PII (Personally Identifiable Information) protection extension for Hecks
 # domains. Reads +pii: true+ markers on aggregate attributes and provides
@@ -25,7 +25,8 @@
 #   # Erasure
 #   CatsDomain.erase_pii(customer_id)
 #
-module HecksPii
+module Hecks; end
+module Hecks::PII
   # Mask a string value for display, preserving the first and last characters
   # and replacing all middle characters with asterisks. Returns "[REDACTED]"
   # for strings shorter than 4 characters.
@@ -34,9 +35,9 @@ module HecksPii
   # @return [String, nil] the masked string, or nil if value was nil
   #
   # @example
-  #   HecksPii.mask("john@example.com")  # => "j**************m"
-  #   HecksPii.mask("Jo")                # => "[REDACTED]"
-  #   HecksPii.mask(nil)                 # => nil
+  #   Hecks::PII.mask("john@example.com")  # => "j**************m"
+  #   Hecks::PII.mask("Jo")                # => "[REDACTED]"
+  #   Hecks::PII.mask(nil)                 # => nil
   def self.mask(value)
     return nil if value.nil?
     s = value.to_s
@@ -74,7 +75,7 @@ Hecks.register_extension(:pii) do |domain_mod, domain, runtime|
   # @return [void]
   domain_mod.define_singleton_method(:erase_pii) do |entity_id|
     domain.aggregates.each do |agg|
-      pii_names = HecksPii.pii_fields(agg)
+      pii_names = Hecks::PII.pii_fields(agg)
       next if pii_names.empty?
 
       repo = runtime[agg.name]
@@ -97,7 +98,7 @@ Hecks.register_extension(:pii) do |domain_mod, domain, runtime|
   # @return [Hash{Symbol => Array<Symbol>}] aggregate name to PII field names
   domain_mod.define_singleton_method(:pii_fields) do
     domain.aggregates.each_with_object({}) do |agg, h|
-      fields = HecksPii.pii_fields(agg)
+      fields = Hecks::PII.pii_fields(agg)
       h[agg.name] = fields unless fields.empty?
     end
   end
@@ -113,7 +114,7 @@ Hecks.register_extension(:pii) do |domain_mod, domain, runtime|
     domain.aggregates.each do |agg|
       agg.commands.each do |cmd|
         fqn = Hecks::Conventions::Names.domain_command_fqn(domain_mod.name, agg.name, cmd.name)
-        pii_names = HecksPii.pii_fields(agg)
+        pii_names = Hecks::PII.pii_fields(agg)
         pii_lookup[fqn] = pii_names unless pii_names.empty?
       end
     end
@@ -125,7 +126,7 @@ Hecks.register_extension(:pii) do |domain_mod, domain, runtime|
         entry = domain_mod.audit_log.last
         if entry && entry[:attributes]
           pii_names.each do |name|
-            entry[:attributes][name] = HecksPii.mask(entry[:attributes][name]) if entry[:attributes].key?(name)
+            entry[:attributes][name] = Hecks::PII.mask(entry[:attributes][name]) if entry[:attributes].key?(name)
           end
         end
       end

--- a/hecksties/lib/hecks/extensions/queue.rb
+++ b/hecksties/lib/hecks/extensions/queue.rb
@@ -1,4 +1,4 @@
-# HecksQueue
+# Hecks::Queue
 #
 # Message queue extension for Hecks. Subscribes to the domain event bus
 # and publishes every event as JSON to a queue adapter (e.g. RabbitMQ).
@@ -7,6 +7,8 @@
 # #call(event_json). If no adapter is provided, events are written
 # to a JSON-lines file at queue_events.jsonl for consumption by
 # external systems.
+#
+# Future gem: hecks_queue
 #
 # Usage:
 #   app = Hecks.boot(__dir__) do
@@ -33,7 +35,7 @@ Hecks.register_extension(:queue) do |domain_mod, domain, runtime|
   next unless config
 
   adapter = config[:adapter] || :file
-  queue_adapter = resolve_queue_adapter(adapter, domain)
+  queue_adapter = Hecks::Queue.resolve_adapter(adapter, domain)
 
   runtime.event_bus.on_any do |event|
     event_name = Hecks::Utils.const_short_name(event)
@@ -48,8 +50,9 @@ Hecks.register_extension(:queue) do |domain_mod, domain, runtime|
   end
 end
 
-module HecksQueue
-  # File-based queue adapter — appends JSON lines to a file.
+module Hecks; end
+module Hecks::Queue
+  # File-based queue adapter -- appends JSON lines to a file.
   # Useful for development and testing without a real broker.
   class FileAdapter
     def initialize(path)
@@ -61,7 +64,7 @@ module HecksQueue
     end
   end
 
-  # RabbitMQ adapter stub — logs to stdout. Replace with bunny gem
+  # RabbitMQ adapter stub -- logs to stdout. Replace with bunny gem
   # integration for production use.
   class RabbitMqAdapter
     def initialize(domain_name)
@@ -72,16 +75,20 @@ module HecksQueue
       $stdout.puts "[queue:#{@exchange}] #{routing_key}: #{payload}"
     end
   end
-end
 
-# Helper to resolve adapter symbol to an adapter instance.
-def resolve_queue_adapter(adapter, domain)
-  case adapter
-  when :file
-    HecksQueue::FileAdapter.new("queue_events.jsonl")
-  when :rabbitmq
-    HecksQueue::RabbitMqAdapter.new(domain.name)
-  else
-    adapter # assume it's a custom adapter object
+  # Resolve adapter symbol to an adapter instance.
+  #
+  # @param adapter [Symbol, Object] :file, :rabbitmq, or a custom adapter
+  # @param domain [Hecks::Domain] the domain definition
+  # @return [Object] the resolved adapter instance
+  def self.resolve_adapter(adapter, domain)
+    case adapter
+    when :file
+      FileAdapter.new("queue_events.jsonl")
+    when :rabbitmq
+      RabbitMqAdapter.new(domain.name)
+    else
+      adapter # assume it's a custom adapter object
+    end
   end
 end

--- a/hecksties/lib/hecks/extensions/rate_limit.rb
+++ b/hecksties/lib/hecks/extensions/rate_limit.rb
@@ -10,6 +10,8 @@
 # the period) are pruned, and if the remaining count meets or exceeds the
 # limit, a +Hecks::RateLimitExceeded+ error is raised.
 #
+# Future gem: hecks_rate_limit
+#
 # Configuration via environment variables:
 #   HECKS_RATE_LIMIT  -- max commands per window (default: 60)
 #   HECKS_RATE_PERIOD -- window size in seconds (default: 60)
@@ -22,7 +24,10 @@
 Hecks.describe_extension(:rate_limit,
   description: "Per-actor sliding window rate limiting",
   adapter_type: :driven,
-  config: {},
+  config: {
+    HECKS_RATE_LIMIT: { default: 60, desc: "Max commands per window" },
+    HECKS_RATE_PERIOD: { default: 60, desc: "Window size in seconds" }
+  },
   wires_to: :command_bus)
 
 Hecks.register_extension(:rate_limit) do |_domain_mod, _domain, runtime|

--- a/hecksties/lib/hecks/extensions/retry.rb
+++ b/hecksties/lib/hecks/extensions/retry.rb
@@ -19,8 +19,6 @@
 #   # Automatically registered -- transient failures will be retried
 #   # up to HECKS_RETRY_MAX times with exponential backoff.
 #
-require "hecks"
-
 Hecks.describe_extension(:retry,
   description: "Automatic command retry with backoff",
   adapter_type: :driven,

--- a/hecksties/lib/hecks/extensions/slack.rb
+++ b/hecksties/lib/hecks/extensions/slack.rb
@@ -3,6 +3,8 @@
 # Slack webhook extension for Hecks. Subscribes to the domain event bus
 # and POSTs a summary of every event to a Slack incoming webhook URL.
 #
+# Future gem: hecks_slack
+#
 # Usage:
 #   app = Hecks.boot(__dir__) do
 #     extend :slack, webhook: ENV["SLACK_URL"]

--- a/hecksties/lib/hecks/registries/extension_registry.rb
+++ b/hecksties/lib/hecks/registries/extension_registry.rb
@@ -35,6 +35,11 @@ module Hecks
       })
     end
 
+    def alias_extension(alias_name, target_name)
+      extension_registry[alias_name] = extension_registry[target_name]
+      extension_meta[alias_name] = extension_meta[target_name] if extension_meta[target_name]
+    end
+
     def driven_extensions
       extension_meta.select { |_, m| m[:adapter_type] == :driven }.map(&:first)
     end

--- a/hecksties/spec/extensions/audit_spec.rb
+++ b/hecksties/spec/extensions/audit_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks/extensions/audit"
 
-RSpec.describe HecksAudit do
+RSpec.describe Hecks::Audit do
   let(:domain) do
     Hecks.domain "Pizzas" do
       aggregate "Pizza" do

--- a/hecksties/spec/extensions/pii_spec.rb
+++ b/hecksties/spec/extensions/pii_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "hecks/extensions/pii"
 
-RSpec.describe "HecksPii" do
+RSpec.describe "Hecks::PII" do
   let(:domain) do
     Hecks.domain "PiiTest" do
       aggregate "Customer" do
@@ -59,17 +59,17 @@ RSpec.describe "HecksPii" do
     end
   end
 
-  describe "HecksPii.mask" do
+  describe "Hecks::PII.mask" do
     it "masks a string value" do
-      expect(HecksPii.mask("alice@example.com")).to eq("a***************m")
+      expect(Hecks::PII.mask("alice@example.com")).to eq("a***************m")
     end
 
     it "redacts short values" do
-      expect(HecksPii.mask("AB")).to eq("[REDACTED]")
+      expect(Hecks::PII.mask("AB")).to eq("[REDACTED]")
     end
 
     it "handles nil" do
-      expect(HecksPii.mask(nil)).to be_nil
+      expect(Hecks::PII.mask(nil)).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary
- Standardized all extensions to follow consistent describe_extension + register_extension pattern
- Renamed top-level classes to Hecks:: namespace: HecksAudit -> Hecks::Audit, HecksPii -> Hecks::PII, HecksQueue -> Hecks::Queue
- Moved resolve_queue_adapter from top-level method to Hecks::Queue.resolve_adapter
- Added alias_extension helper to ExtensionRegistry for cleaner alias registration
- Documented config hashes for auth (enforce:), idempotency (HECKS_IDEMPOTENCY_TTL), and rate_limit (HECKS_RATE_LIMIT, HECKS_RATE_PERIOD)
- Removed stale `require "hecks"` from retry extension
- Added "Future gem" doc comments to: audit, idempotency, logging, queue, rate_limit, slack
- Added docs/usage/creating_extensions.md with standard template, naming rules, driven/driving guidance
- Updated FEATURES.md with extension aliasing and standard format conventions

## Example

**Before** (inconsistent top-level naming):
```ruby
class HecksAudit
  # ...
end

module HecksPii
  # ...
end

def resolve_queue_adapter(adapter, domain)
  # bare method at top level
end
```

**After** (consistent Hecks:: namespace):
```ruby
class Hecks::Audit
  # ...
end

module Hecks::PII
  # ...
end

module Hecks::Queue
  def self.resolve_adapter(adapter, domain)
    # ...
  end
end
```

## Test plan
- [x] All specs pass (1772 examples, 0 failures)
- [x] All extensions follow consistent format with Hecks:: namespace
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] Updated specs reference new class names (Hecks::Audit, Hecks::PII)
- [x] docs/usage/creating_extensions.md documents standard template
- [x] FEATURES.md updated with new extension conventions