### PR TITLE
HEC-470: Extract CRUD into opt-in auto_crud concern

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -10,6 +10,7 @@
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains
 - Domain version pinning and local path loading in configuration
+- Opt-in CRUD: `no_crud` on an aggregate disables write methods (create, update, destroy) while keeping reads (find, all, count) — gates HTTP DELETE routes, RPC methods, and OpenAPI paths
 
 ### Attributes & Types
 - Define typed attributes with String, Integer, Float, Boolean, JSON, Date, DateTime, etc.

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -101,6 +101,8 @@ module Hecks
       # @param lifecycle [Lifecycle, nil] optional state machine definition
       # @param versioned [Boolean] whether this aggregate tracks version history
       # @param attachable [Boolean] whether this aggregate supports file attachments
+      # @param auto_crud [Boolean] whether write CRUD methods (create, update, destroy)
+      #   are auto-generated. Read methods (find, all, count) are always available.
       #
       # @return [Aggregate] a new Aggregate instance
       def initialize(name:, attributes: [], value_objects: [], entities: [], commands: [],
@@ -109,7 +111,7 @@ module Hecks
                      specifications: [], references: [],
                      factories: [], computed_attributes: [],
                      lifecycle: nil, versioned: false,
-                     attachable: false, metadata: {}, origin_domain: nil,
+                     attachable: false, auto_crud: true, metadata: {}, origin_domain: nil,
                      identity_fields: nil)
         @name = Names.aggregate_name(name)
         @attributes = attributes
@@ -131,6 +133,7 @@ module Hecks
         @lifecycle = lifecycle
         @versioned = versioned
         @attachable = attachable
+        @auto_crud = auto_crud
         @metadata = metadata
         @origin_domain = origin_domain
         @identity_fields = identity_fields
@@ -158,6 +161,15 @@ module Hecks
       # @return [Boolean] true if file attachment support is enabled
       def attachable?
         @attachable
+      end
+
+      # Returns true if write CRUD methods (create, update, destroy) are
+      # auto-generated. Read methods (find, all, count) are always available
+      # regardless of this flag.
+      #
+      # @return [Boolean] true if auto CRUD is enabled (default)
+      def auto_crud?
+        @auto_crud
       end
 
     end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -82,6 +82,7 @@ module Hecks
         @lifecycle = nil
         @versioned = false
         @attachable = false
+        @auto_crud = true
         @identity_fields = nil
         @metadata = {}
         @facet_data = {}
@@ -97,6 +98,18 @@ module Hecks
 
       def attachable
         @attachable = true
+      end
+
+      # Opt out of automatic write CRUD methods (create, update, destroy).
+      # Read methods (find, all, count) remain available.
+      #
+      #   aggregate "AuditLog" do
+      #     no_crud
+      #     attribute :message, String
+      #   end
+      #
+      def no_crud
+        @auto_crud = false
       end
 
       # Declare a computed (derived) attribute. The block body becomes a
@@ -199,7 +212,7 @@ module Hecks
           scopes: @scopes, queries: @queries,
           subscribers: @subscribers, indexes: @indexes,
           specifications: @specifications, computed_attributes: @computed_attributes,
-          lifecycle: @lifecycle, versioned: @versioned, attachable: @attachable,
+          lifecycle: @lifecycle, versioned: @versioned, attachable: @attachable, auto_crud: @auto_crud,
           metadata: @metadata, references: @references,
           factories: @factories, identity_fields: @identity_fields
         )

--- a/bluebook/lib/hecks/generators/docs/openapi_generator/path_builder.rb
+++ b/bluebook/lib/hecks/generators/docs/openapi_generator/path_builder.rb
@@ -44,11 +44,12 @@ module Hecks
             post: post_path(agg, slug)
           }.compact
 
-          paths["/#{slug}/{id}"] = {
+          id_ops = {
             get: { summary: "Find #{name} by ID", parameters: [id_param], responses: ok_object(name) },
-            patch: patch_path(agg),
-            delete: { summary: "Delete #{name}", parameters: [id_param], responses: ok_message }
-          }.compact
+            patch: patch_path(agg)
+          }
+          id_ops[:delete] = { summary: "Delete #{name}", parameters: [id_param], responses: ok_message } if agg.auto_crud?
+          paths["/#{slug}/{id}"] = id_ops.compact
 
           paths
         end

--- a/bluebook/lib/hecks/generators/docs/rpc_discovery.rb
+++ b/bluebook/lib/hecks/generators/docs/rpc_discovery.rb
@@ -62,7 +62,9 @@ module Hecks
           methods << { name: "#{agg.name}.find", description: "Find #{agg.name} by ID", params: [{ name: "id", type: "string" }] }
           methods << { name: "#{agg.name}.all", description: "List all #{agg.name}s", params: [] }
           methods << { name: "#{agg.name}.count", description: "Count #{agg.name}s", params: [] }
-          methods << { name: "#{agg.name}.delete", description: "Delete #{agg.name}", params: [{ name: "id", type: "string" }] }
+          if agg.auto_crud?
+            methods << { name: "#{agg.name}.delete", description: "Delete #{agg.name}", params: [{ name: "id", type: "string" }] }
+          end
         end
         methods
       end

--- a/bluebook/spec/domain_model/aggregate_spec.rb
+++ b/bluebook/spec/domain_model/aggregate_spec.rb
@@ -34,4 +34,15 @@ RSpec.describe Hecks::DomainModel::Structure::Aggregate do
       expect(aggregate.commands.map(&:name)).to eq(["CreatePizza"])
     end
   end
+
+  describe "#auto_crud?" do
+    it "defaults to true" do
+      expect(aggregate.auto_crud?).to be true
+    end
+
+    it "can be set to false" do
+      no_crud_agg = described_class.new(name: "AuditLog", auto_crud: false)
+      expect(no_crud_agg.auto_crud?).to be false
+    end
+  end
 end

--- a/bluebook/spec/dsl/domain_builder_spec.rb
+++ b/bluebook/spec/dsl/domain_builder_spec.rb
@@ -289,6 +289,26 @@ RSpec.describe Hecks::DSL::DomainBuilder do
     end
   end
 
+  describe "no_crud" do
+    it "sets auto_crud? to false on the aggregate" do
+      domain = Hecks.domain("ReadOnly") do
+        aggregate("AuditLog") do
+          no_crud
+          attribute :message, String
+          command("CreateAuditLog") { attribute :message, String }
+        end
+      end
+      expect(domain.aggregates.first.auto_crud?).to be false
+    end
+
+    it "defaults auto_crud? to true when no_crud is not called" do
+      domain = Hecks.domain("Normal") do
+        aggregate("Widget") { attribute :name, String; command("CreateWidget") { attribute :name, String } }
+      end
+      expect(domain.aggregates.first.auto_crud?).to be true
+    end
+  end
+
   describe "explicit domain events" do
     it "includes explicit events alongside inferred ones" do
       domain = Hecks.domain("Gov") do

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -339,9 +339,10 @@ aggregate "Pizza" do
     area / 43560.0
   end
 
-  # Versioning and attachments
+  # Versioning, attachments, and CRUD control
   versioned
   attachable
+  no_crud           # disables write CRUD (create, update, destroy); reads remain
 end
 ```
 

--- a/docs/usage/no_crud.md
+++ b/docs/usage/no_crud.md
@@ -1,0 +1,50 @@
+# no_crud -- Opt-in CRUD Control
+
+By default every aggregate gets full CRUD methods (create, update, destroy,
+find, all, count). Use `no_crud` to disable the **write** methods while
+keeping reads available.
+
+## When to use
+
+- Read-only projections or audit logs that should never be mutated through
+  the domain API
+- Aggregates whose writes are exclusively driven by custom commands
+
+## DSL
+
+```ruby
+Hecks.domain "Warehouse" do
+  aggregate "Widget" do
+    attribute :name, String
+    command("CreateWidget") { attribute :name, String }
+  end
+
+  aggregate "AuditLog" do
+    no_crud                       # no create/update/destroy
+    attribute :message, String
+    command("RecordEntry") { attribute :message, String }
+  end
+end
+```
+
+## What changes
+
+| Capability              | Default | `no_crud` |
+|-------------------------|---------|-----------|
+| `.find(id)`             | yes     | yes       |
+| `.all`                  | yes     | yes       |
+| `.count`                | yes     | yes       |
+| `.create(**attrs)`      | yes     | **no**    |
+| `#destroy`              | yes     | **no**    |
+| `#save` (update)        | yes     | **no**    |
+| Custom commands          | yes     | yes       |
+| HTTP DELETE route        | yes     | **no**    |
+| RPC delete method        | yes     | **no**    |
+| OpenAPI delete path      | yes     | **no**    |
+
+## Checking at runtime
+
+```ruby
+aggregate = domain.aggregates.find { |a| a.name == "AuditLog" }
+aggregate.auto_crud?  # => false
+```

--- a/hecksties/lib/hecks/conventions/dispatch_contract.rb
+++ b/hecksties/lib/hecks/conventions/dispatch_contract.rb
@@ -12,8 +12,14 @@
 #
 module Hecks::Conventions
   module DispatchContract
-    # Standard CRUD methods present on every generated aggregate class.
-    CRUD_BUILTINS = %i[all find delete count update create].freeze
+    # Read CRUD methods present on every aggregate class.
+    CRUD_READ_BUILTINS = %i[all find delete count].freeze
+
+    # Write CRUD methods only present when auto_crud is enabled.
+    CRUD_WRITE_BUILTINS = %i[update create].freeze
+
+    # All CRUD builtins combined (backward compat).
+    CRUD_BUILTINS = (CRUD_READ_BUILTINS + CRUD_WRITE_BUILTINS).freeze
 
     # Raised when a dispatch target is not in the whitelist.
     class DispatchNotAllowed < SecurityError
@@ -31,7 +37,8 @@ module Hecks::Conventions
     # @return [Hash{String => Set<Symbol>}] allowed methods per aggregate
     def self.build_whitelist(domain)
       domain.aggregates.each_with_object({}) do |agg, wl|
-        allowed = Set.new(CRUD_BUILTINS)
+        builtins = agg.auto_crud? ? CRUD_BUILTINS : CRUD_READ_BUILTINS
+        allowed = Set.new(builtins)
         agg.commands.each do |cmd|
           allowed << Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name)
         end

--- a/hecksties/lib/hecks/extensions/serve/route_builder.rb
+++ b/hecksties/lib/hecks/extensions/serve/route_builder.rb
@@ -100,15 +100,17 @@ module Hecks
           }}
         end
 
-        routes << { method: "DELETE", path: "/#{slug}/:id", handler: ->(req) {
-          id = req.path.split("/").last
-          if port
-            port.read(klass, agg.name, :delete, id)
-          else
-            klass.delete(id)
-          end
-          { deleted: id }
-        }}
+        if agg.auto_crud?
+          routes << { method: "DELETE", path: "/#{slug}/:id", handler: ->(req) {
+            id = req.path.split("/").last
+            if port
+              port.read(klass, agg.name, :delete, id)
+            else
+              klass.delete(id)
+            end
+            { deleted: id }
+          }}
+        end
         routes
       end
 

--- a/hecksties/lib/hecks/extensions/serve/rpc_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/rpc_server.rb
@@ -206,6 +206,7 @@ module Hecks
         }
         @methods["#{name}.all"] = ->(_) { port.read(klass, name, :all).map { |r| serialize(r) } }
         @methods["#{name}.count"] = ->(_) { port.read(klass, name, :count) }
+        return unless agg.auto_crud?
         @methods["#{name}.delete"] = ->(p) { port.read(klass, name, :delete, p["id"]); { deleted: p["id"] } }
       end
 

--- a/hecksties/lib/hecks/ports/repository.rb
+++ b/hecksties/lib/hecks/ports/repository.rb
@@ -47,8 +47,8 @@ module Hecks
       # @param repo [Object] the repository adapter instance (memory or SQL) that
       #   handles actual storage operations (save, find, delete, all)
       # @return [void]
-      def self.bind(klass, aggregate, repo)
-        RepositoryMethods.bind(klass, repo)
+      def self.bind(klass, aggregate, repo, crud: true)
+        RepositoryMethods.bind(klass, repo, crud: crud)
         CollectionMethods.bind(klass, aggregate, repo)
         ReferenceMethods.bind(klass, aggregate)
       end

--- a/hecksties/lib/hecks/ports/repository/repository_methods.rb
+++ b/hecksties/lib/hecks/ports/repository/repository_methods.rb
@@ -39,10 +39,10 @@ module Hecks
       # @param repo [Object] the repository adapter instance that handles
       #   save, find, delete, all, and count operations
       # @return [void]
-      def self.bind(klass, repo)
+      def self.bind(klass, repo, crud: true)
         klass.instance_variable_set(:@__hecks_repo__, repo)
-        bind_class_methods(klass, repo)
-        bind_instance_methods(klass, repo)
+        bind_class_methods(klass, repo, crud: crud)
+        bind_instance_methods(klass, repo, crud: crud)
       end
 
       # Defines class-level CRUD methods on the aggregate class.
@@ -50,13 +50,15 @@ module Hecks
       # @param klass [Class] the aggregate class to augment
       # @param repo [Object] the repository adapter instance
       # @return [void]
-      def self.bind_class_methods(klass, repo)
+      def self.bind_class_methods(klass, repo, crud: true)
         klass.define_singleton_method(:find) { |id| repo.find(id) }
         klass.define_singleton_method(:all) { repo.all }
         klass.define_singleton_method(:count) { repo.count }
         klass.define_singleton_method(:delete) { |id| repo.delete(id) }
         klass.define_singleton_method(:first) { all.first }
         klass.define_singleton_method(:last) { all.last }
+
+        return unless crud
 
         klass.define_singleton_method(:create) do |**attrs|
           constructor_attrs = {}
@@ -73,7 +75,7 @@ module Hecks
       # @param klass [Class] the aggregate class to augment
       # @param repo [Object] the repository adapter instance
       # @return [void]
-      def self.bind_instance_methods(klass, repo)
+      def self.bind_instance_methods(klass, repo, crud: true)
         klass.define_method(:destroyed?) { !!@__destroyed__ }
 
         klass.define_method(:save) do
@@ -81,6 +83,8 @@ module Hecks
           repo.save(self)
           self
         end
+
+        return unless crud
 
         klass.define_method(:destroy) do
           repo.delete(id)

--- a/hecksties/lib/hecks/runtime/port_setup.rb
+++ b/hecksties/lib/hecks/runtime/port_setup.rb
@@ -57,7 +57,7 @@ module Hecks
         repo = ownership_scoped_repo(agg, @repositories[agg.name])
         defaults = build_defaults(agg)
 
-        Persistence.bind(agg_class, agg, repo)
+        Persistence.bind(agg_class, agg, repo, crud: agg.auto_crud?)
         Commands.bind(agg_class, agg, @command_bus, repo, defaults)
         Querying.bind(agg_class, agg)
         Introspection.bind(agg_class, agg)

--- a/hecksties/spec/conventions/dispatch_contract_spec.rb
+++ b/hecksties/spec/conventions/dispatch_contract_spec.rb
@@ -47,6 +47,32 @@ RSpec.describe Hecks::Conventions::DispatchContract do
         expect(allowed).to respond_to(:include?)
       end
     end
+
+    context "when auto_crud is false" do
+      let(:no_crud_domain) do
+        Hecks.domain "ReadOnly" do
+          aggregate "AuditLog" do
+            no_crud
+            attribute :message, String
+            command("CreateAuditLog") { attribute :message, String }
+          end
+        end
+      end
+
+      let(:no_crud_whitelist) { described_class.build_whitelist(no_crud_domain) }
+
+      it "includes read builtins" do
+        described_class::CRUD_READ_BUILTINS.each do |m|
+          expect(no_crud_whitelist["AuditLog"]).to include(m)
+        end
+      end
+
+      it "excludes write builtins from the builtin set" do
+        # :create is still present because CreateAuditLog command derives it,
+        # but :update is excluded since there's no UpdateAuditLog command
+        expect(no_crud_whitelist["AuditLog"]).not_to include(:update)
+      end
+    end
   end
 
   describe ".validate!" do

--- a/hecksties/spec/runtime/extension_adapter_type_spec.rb
+++ b/hecksties/spec/runtime/extension_adapter_type_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 require "tmpdir"
 require "fileutils"
+require "hecks/extensions/serve"
+require "hecks_ai"
 
 RSpec.describe "Extension adapter_type classification" do
   describe "driven_extensions" do


### PR DESCRIPTION
## Summary

- Adds `no_crud` DSL keyword to opt aggregates out of write CRUD methods (create, update, destroy) while keeping reads (find, all, count) always available
- Gates `RepositoryMethods`, `DispatchContract`, HTTP DELETE routes, RPC delete method, and OpenAPI delete paths behind `auto_crud?`
- Default behavior is unchanged (`auto_crud: true`)

## Example

```ruby
Hecks.domain "Compliance" do
  aggregate "AuditLog" do
    no_crud                       # disables .create, #update, #destroy
    attribute :message, String
    command("RecordEntry") { attribute :message, String }
  end
end
```

```ruby
agg = domain.aggregates.first
agg.auto_crud?  # => false

# AuditLog.find(id)  -- works
# AuditLog.all       -- works
# AuditLog.create    -- NoMethodError
# log.update(...)    -- NoMethodError
# log.destroy        -- NoMethodError
```

## Test plan

- [x] `Aggregate#auto_crud?` defaults to true, can be set to false
- [x] `no_crud` DSL keyword sets `auto_crud?` to false on built aggregate
- [x] `DispatchContract` excludes write builtins when `auto_crud: false`
- [x] All 1778 specs pass, suite under 1.5s
- [x] Smoke test (`ruby -Ilib examples/pizzas/app.rb`) passes