### PR TITLE
HEC-473: Inline aggregate definition keyword

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,6 +6,7 @@
 - Define domains with `Hecks.domain "Name" { }` block syntax
 - Declare an explicit domain version with `Hecks.domain "Name", version: "2.1.0" { }` — semver and CalVer supported; propagates to generated gemspec and Go server header
 - Define aggregates with attributes, commands, events, policies, queries, and scopes
+- Inline aggregate definitions with `definition:` keyword — attaches a human-readable description to the aggregate IR, surfaced in `Hecks.aggregates` inspector output
 - Define value objects as immutable nested types within aggregates
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains

--- a/bluebook/lib/hecks/domain/inspector.rb
+++ b/bluebook/lib/hecks/domain/inspector.rb
@@ -74,7 +74,8 @@ module Hecks
     def aggregates
       each_aggregate.map do |agg|
         attrs = agg.attributes.map { |a| "#{a.name}: #{Utils.type_label(a)}" }.join(", ")
-        "#{agg.name} (#{attrs})"
+        base = "#{agg.name} (#{attrs})"
+        agg.description ? "#{base} — #{agg.description}" : base
       end
     end
 

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -187,13 +187,14 @@ module Hecks
       # @return [void]
       # @raise [ArgumentError] if an aggregate with the same name already exists
       # @raise [Hecks::ValidationError] if the block raises a non-Hecks error
-      def aggregate(name, description = nil, &block)
+      def aggregate(name, description = nil, definition: nil, &block)
         if @aggregates.any? { |a| a.name == name }
           raise ArgumentError, "Duplicate aggregate name: #{name}"
         end
 
         builder = AggregateBuilder.new(name)
-        builder.instance_variable_get(:@metadata)[:description] = description if description
+        desc = definition || description
+        builder.instance_variable_get(:@metadata)[:description] = desc if desc
         begin
           builder.instance_eval(&block) if block
         rescue Hecks::Error
@@ -250,10 +251,10 @@ module Hecks
 
       # Implicit DSL support. PascalCase calls at the domain level create aggregates.
       # Example: `Pizza do ... end` is sugar for `aggregate "Pizza" do ... end`
-      def method_missing(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
         if name.to_s =~ /\A[A-Z]/ && block_given?
           desc = args.first.is_a?(String) ? args.first : nil
-          aggregate(name.to_s, desc, &block)
+          aggregate(name.to_s, desc, **kwargs, &block)
         else
           super
         end

--- a/bluebook/spec/dsl/domain_builder_spec.rb
+++ b/bluebook/spec/dsl/domain_builder_spec.rb
@@ -289,6 +289,58 @@ RSpec.describe Hecks::DSL::DomainBuilder do
     end
   end
 
+  describe "aggregate definition keyword" do
+    it "stores definition via definition: kwarg" do
+      domain = Hecks.domain("Banking") do
+        aggregate "Account", definition: "Manages customer funds and balances" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("Manages customer funds and balances")
+    end
+
+    it "stores definition via positional description" do
+      domain = Hecks.domain("Banking") do
+        aggregate "Account", "Manages customer funds" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("Manages customer funds")
+    end
+
+    it "definition: kwarg takes precedence over positional description" do
+      domain = Hecks.domain("Banking") do
+        aggregate "Account", "positional", definition: "kwarg wins" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("kwarg wins")
+    end
+
+    it "works with implicit PascalCase syntax" do
+      domain = Hecks.domain("Banking") do
+        Account definition: "Manages customer funds" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("Manages customer funds")
+    end
+
+    it "returns nil when no definition is provided" do
+      domain = Hecks.domain("Banking") do
+        aggregate "Account" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to be_nil
+    end
+  end
+
   describe "explicit domain events" do
     it "includes explicit events alongside inferred ones" do
       domain = Hecks.domain("Gov") do

--- a/docs/usage/aggregate_definition.md
+++ b/docs/usage/aggregate_definition.md
@@ -1,0 +1,52 @@
+# Aggregate Definition
+
+Attach a human-readable definition to any aggregate using the `definition:` keyword.
+The definition is stored in the aggregate IR and surfaced by `Hecks.aggregates`.
+
+## Usage
+
+```ruby
+Hecks.domain "Banking" do
+  aggregate "Account", definition: "Manages customer funds and balances" do
+    attribute :name, String
+    attribute :balance, Float
+    command("CreateAccount") { attribute :name, String }
+  end
+
+  aggregate "Loan", definition: "Tracks borrowed principal and repayment schedule" do
+    attribute :principal, Float
+    command("CreateLoan") { attribute :principal, Float }
+  end
+end
+```
+
+## Implicit PascalCase syntax
+
+```ruby
+Hecks.domain "Banking" do
+  Account definition: "Manages customer funds and balances" do
+    attribute :name, String
+    command("CreateAccount") { attribute :name, String }
+  end
+end
+```
+
+## Inspector output
+
+```ruby
+Hecks.aggregates
+# => ["Account (name: String, balance: Float) — Manages customer funds and balances",
+#     "Loan (principal: Float) — Tracks borrowed principal and repayment schedule"]
+```
+
+## Positional description (legacy)
+
+The positional argument still works for backward compatibility:
+
+```ruby
+aggregate "Account", "Manages customer funds" do
+  # ...
+end
+```
+
+When both are provided, `definition:` takes precedence.


### PR DESCRIPTION
## Summary
- Add `definition:` keyword argument to the `aggregate` DSL method for inline human-readable descriptions
- Store the definition in aggregate IR metadata (`agg.description`)
- Surface definitions in `DomainInspector#aggregates` output with `— description` suffix
- Support both explicit `aggregate()` calls and implicit PascalCase syntax

## Example

**DSL usage:**
```ruby
Hecks.domain "Banking" do
  aggregate "Account", definition: "Manages customer funds and balances" do
    attribute :name, String
    attribute :balance, Float
    command("CreateAccount") { attribute :name, String }
  end
end
```

**Implicit PascalCase syntax:**
```ruby
Account definition: "Manages customer funds" do
  attribute :name, String
  command("CreateAccount") { attribute :name, String }
end
```

**Inspector output:**
```
Hecks.aggregates
# => ["Account (name: String, balance: Float) — Manages customer funds and balances"]
```

## Test plan
- [x] `definition:` kwarg stores description on aggregate IR
- [x] Positional description argument still works (backward compat)
- [x] `definition:` takes precedence when both are provided
- [x] Works with implicit PascalCase syntax
- [x] Returns nil when no definition is provided
- [x] Inspector output includes description suffix
- [x] All 1777 specs pass
- [x] Smoke test passes