### PR TITLE
HEC-474: hecks build --gem — produce a publishable domain gem

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -399,6 +399,7 @@
 ## CLI Commands
 - `hecks new NAME` — scaffold a complete project with interactive world goals onboarding (opt-out by pressing Enter; skipped in non-interactive/CI)
 - `hecks build` — validate and generate versioned gem
+- `hecks build --gem` — produce a publishable `.gem` artifact after building (runs `gem build` on generated output); supported for `ruby` and `static` targets
 - `hecks serve [--rpc]` — start REST or JSON-RPC server
 - `hecks console [NAME]` — interactive REPL with domain loaded
 - `hecks validate` — check domain against DDD rules

--- a/docs/usage/build_gem.md
+++ b/docs/usage/build_gem.md
@@ -1,0 +1,51 @@
+# `hecks build --gem` — Produce a Publishable Domain Gem
+
+The `--gem` flag tells `hecks build` to run `gem build` on the generated
+output after code generation completes, producing a `.gem` artifact ready
+for `gem push` or local installation.
+
+## Usage
+
+```bash
+# Build the domain gem and package it
+hecks build --gem
+
+# Combine with static target
+hecks build --static --gem
+```
+
+## What Happens
+
+1. `hecks build` generates the domain gem as usual (gemspec, lib layout,
+   ports, adapters, specs, docs).
+2. With `--gem`, it then runs `gem build <name>.gemspec` inside the
+   generated directory.
+3. The resulting `.gem` file appears in the generated gem root directory.
+
+## Example
+
+```bash
+$ hecks build --gem
+Built pizzas_domain v2026.04.01.1
+  Docs: ./pizzas_domain/docs/
+  Output: ./pizzas_domain/
+Packaging gem...
+Gem artifact: ./pizzas_domain/pizzas_domain-2026.04.01.1.gem
+
+$ ls ./pizzas_domain/*.gem
+./pizzas_domain/pizzas_domain-2026.04.01.1.gem
+
+$ gem push ./pizzas_domain/pizzas_domain-2026.04.01.1.gem
+```
+
+## Supported Targets
+
+The `--gem` flag works with the `ruby` (default) and `static` targets.
+Other targets (go, node, rails) print a warning and skip gem packaging.
+
+```bash
+$ hecks build --target go --gem
+Built Pizzas Go project
+  Output: ./pizzas_go/
+--gem is only supported for ruby and static targets
+```

--- a/hecksties/lib/hecks_cli/commands/build.rb
+++ b/hecksties/lib/hecks_cli/commands/build.rb
@@ -3,7 +3,8 @@ Hecks::CLI.register_command(:build, "Generate the domain gem",
     domain:  { type: :string,  desc: "Domain gem name or path" },
     version: { type: :string,  desc: "Domain version" },
     target:  { type: :string,  desc: "Build target: ruby (default), static, go, node, rails" },
-    static:  { type: :boolean, desc: "Generate static gem (alias for --target static)" }
+    static:  { type: :boolean, desc: "Generate static gem (alias for --target static)" },
+    gem:     { type: :boolean, desc: "Produce a publishable .gem artifact after building" }
   }
 ) do
 
@@ -77,5 +78,23 @@ Hecks::CLI.register_command(:build, "Generate the domain gem",
     say "Built #{domain.gem_name} v#{version}", :green
     say "  Docs: #{output}/docs/"
     say "  Output: #{output}/"
+  end
+
+  if options[:gem] && %w[ruby static].include?(target)
+    gemspec = Dir.glob(File.join(output, "*.gemspec")).first
+    if gemspec
+      say "Packaging gem..."
+      result = `cd #{output} && BUNDLE_GEMFILE= gem build #{File.basename(gemspec)} 2>&1`
+      gem_file = Dir.glob(File.join(output, "*.gem")).first
+      if gem_file
+        say "Gem artifact: #{gem_file}", :green
+      else
+        say "gem build failed:\n#{result}", :red
+      end
+    else
+      say "No gemspec found in #{output} — cannot build .gem", :red
+    end
+  elsif options[:gem]
+    say "--gem is only supported for ruby and static targets", :yellow
   end
 end

--- a/hecksties/spec/cli/commands/build_spec.rb
+++ b/hecksties/spec/cli/commands/build_spec.rb
@@ -30,4 +30,59 @@ RSpec.describe "hecks build" do
       end
     end
   end
+
+  it "produces a .gem artifact with --gem flag" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "verbs.txt"), "Create\n")
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new([], gem: true)
+        messages = []
+        allow(cli).to receive(:say) { |msg, *| messages << msg }
+        cli.build
+
+        gem_dir = File.join(dir, "test_domain")
+        gem_files = Dir.glob(File.join(gem_dir, "*.gem"))
+        expect(gem_files).not_to be_empty, "Expected a .gem file in #{gem_dir}"
+        expect(messages).to include(match(/Gem artifact:/))
+      end
+    end
+  end
+
+  it "warns when --gem is used with a non-ruby target" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "verbs.txt"), "Create\n")
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Dir.chdir(dir) do
+        # Register a fake target so the build succeeds without extra deps
+        Hecks.target_registry.register(:fake, ->(_domain, **_opts) { dir })
+        cli = Hecks::CLI.new([], gem: true, target: "fake")
+        messages = []
+        allow(cli).to receive(:say) { |msg, *| messages << msg }
+        cli.build
+
+        expect(messages).to include("--gem is only supported for ruby and static targets")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `--gem` flag to `hecks build` that runs `gem build` on the generated output, producing a `.gem` artifact
- Supported for `ruby` (default) and `static` targets; other targets print a warning
- Clears `BUNDLE_GEMFILE` during `gem build` to avoid Bundler resolution issues in the generated gem directory

## Example

```bash
$ hecks build --gem
Built pizzas_domain v2026.04.01.1
  Docs: ./pizzas_domain/docs/
  Output: ./pizzas_domain/
Packaging gem...
Gem artifact: ./pizzas_domain/pizzas_domain-2026.04.01.1.gem

$ hecks build --target go --gem
Built Pizzas Go project
  Output: ./pizzas_go/
--gem is only supported for ruby and static targets
```

## Test plan
- [x] Existing `hecks build` spec still passes (builds domain gem from Bluebook)
- [x] New spec: `--gem` flag produces a `.gem` artifact in the generated directory
- [x] New spec: `--gem` with non-ruby target prints a warning
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] FEATURES.md updated
- [x] `docs/usage/build_gem.md` added with runnable examples