### PR TITLE
HEC-462: Extract repeated inline patterns in Node.js generators

### DIFF
--- a/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
@@ -106,16 +106,13 @@ module NodeHecks
     end
 
     def event_return_block(id_expr)
-      lines = []
-      lines << "  return {"
-      lines << "    type: \"#{@event.name}\","
-      lines << "    aggregateId: #{id_expr},"
-      @cmd.attributes.each do |a|
-        lines << "    #{NodeUtils.camel_case(a.name)}: attrs.#{NodeUtils.camel_case(a.name)},"
-      end
-      lines << "    occurredAt: now,"
-      lines << "  };"
-      lines
+      pairs = [
+        ["type", "\"#{@event.name}\""],
+        ["aggregateId", id_expr],
+      ]
+      @cmd.attributes.each { |a| pairs << [NodeUtils.camel_case(a.name), "attrs.#{NodeUtils.camel_case(a.name)}"] }
+      pairs << ["occurredAt", "now"]
+      NodeUtils.ts_return_object("  ", pairs)
     end
 
     def ts_default(attr)

--- a/hecks_targets/node/lib/node_hecks/generators/server_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/server_generator.rb
@@ -64,29 +64,15 @@ module NodeHecks
 
         lines << ""
         lines << "// #{agg.name} routes"
-        lines << "app.get(\"/#{plural}\", (_req, res) => {"
-        lines << "  res.json(#{repo_var}.all());"
-        lines << "});"
+        lines.concat(NodeUtils.express_list_route("/#{plural}", repo_var))
         lines << ""
-        lines << "app.get(\"/#{plural}/:id\", (req, res) => {"
-        lines << "  const entity = #{repo_var}.find(req.params.id);"
-        lines << "  if (!entity) { res.status(404).json({ error: \"Not found\" }); return; }"
-        lines << "  res.json(entity);"
-        lines << "});"
+        lines.concat(NodeUtils.express_detail_route("/#{plural}", repo_var))
 
         agg.commands.each do |cmd|
           fn = NodeUtils.camel_case(cmd.name)
           cmd_slug = NodeUtils.snake_case(cmd.name)
           lines << ""
-          lines << "app.post(\"/#{plural}/#{cmd_slug}\", (req, res) => {"
-          lines << "  try {"
-          lines << "    const event = #{fn}(req.body, #{repo_var});"
-          lines << "    res.status(201).json(event);"
-          lines << "  } catch (err: unknown) {"
-          lines << "    const message = err instanceof Error ? err.message : \"Unknown error\";"
-          lines << "    res.status(422).json({ error: message });"
-          lines << "  }"
-          lines << "});"
+          lines.concat(NodeUtils.express_command_route("/#{plural}/#{cmd_slug}", fn, repo_var))
         end
       end
       lines

--- a/hecks_targets/node/lib/node_hecks/node_utils.rb
+++ b/hecks_targets/node/lib/node_hecks/node_utils.rb
@@ -58,5 +58,60 @@ module NodeHecks
     def join_lines(lines)
       lines.join("\n") + "\n"
     end
+
+    # Builds an indented object literal from [key, value] pairs.
+    #   ts_object("  ", [["type", '"Foo"'], ["id", "x"]])
+    #   # => ["  {", '    type: "Foo",', "    id: x,", "  }"]
+    def ts_object(indent, pairs)
+      lines = ["#{indent}{"]
+      pairs.each { |k, v| lines << "#{indent}  #{k}: #{v}," }
+      lines << "#{indent}}"
+      lines
+    end
+
+    # Builds a return statement with an object literal.
+    #   ts_return_object("  ", [["type", '"Foo"']])
+    #   # => ["  return {", '    type: "Foo",', "  };"]
+    def ts_return_object(indent, pairs)
+      lines = ["#{indent}return {"]
+      pairs.each { |k, v| lines << "#{indent}  #{k}: #{v}," }
+      lines << "#{indent}};"
+      lines
+    end
+
+    # Express GET list route: responds with repo.all()
+    def express_list_route(path, repo_var)
+      [
+        "app.get(\"#{path}\", (_req, res) => {",
+        "  res.json(#{repo_var}.all());",
+        "});",
+      ]
+    end
+
+    # Express GET detail route: finds by id or returns 404
+    def express_detail_route(path, repo_var)
+      [
+        "app.get(\"#{path}/:id\", (req, res) => {",
+        "  const entity = #{repo_var}.find(req.params.id);",
+        "  if (!entity) { res.status(404).json({ error: \"Not found\" }); return; }",
+        "  res.json(entity);",
+        "});",
+      ]
+    end
+
+    # Express POST command route: calls fn(req.body, repo), returns 201 or 422
+    def express_command_route(path, fn_name, repo_var)
+      [
+        "app.post(\"#{path}\", (req, res) => {",
+        "  try {",
+        "    const event = #{fn_name}(req.body, #{repo_var});",
+        "    res.status(201).json(event);",
+        "  } catch (err: unknown) {",
+        "    const message = err instanceof Error ? err.message : \"Unknown error\";",
+        "    res.status(422).json({ error: message });",
+        "  }",
+        "});",
+      ]
+    end
   end
 end

--- a/hecks_targets/node/spec/generators/node_generator_spec.rb
+++ b/hecks_targets/node/spec/generators/node_generator_spec.rb
@@ -177,4 +177,46 @@ RSpec.describe NodeHecks::NodeGenerator do
       expect(File.exist?(File.join(output_path, "README.md"))).to be true
     end
   end
+
+  describe NodeHecks::NodeUtils do
+    describe ".ts_object" do
+      it "builds an indented object literal from key-value pairs" do
+        result = described_class.ts_object("  ", [["name", '"hi"'], ["age", "42"]])
+        expect(result).to eq(["  {", '    name: "hi",', "    age: 42,", "  }"])
+      end
+    end
+
+    describe ".ts_return_object" do
+      it "builds a return statement with an object literal" do
+        result = described_class.ts_return_object("  ", [["ok", "true"]])
+        expect(result).to eq(["  return {", "    ok: true,", "  };"])
+      end
+    end
+
+    describe ".express_list_route" do
+      it "generates a GET list handler" do
+        lines = described_class.express_list_route("/pizzas", "pizzaRepo")
+        expect(lines.first).to include('app.get("/pizzas"')
+        expect(lines).to include("  res.json(pizzaRepo.all());")
+      end
+    end
+
+    describe ".express_detail_route" do
+      it "generates a GET by-id handler with 404 fallback" do
+        lines = described_class.express_detail_route("/pizzas", "pizzaRepo")
+        expect(lines.first).to include('app.get("/pizzas/:id"')
+        expect(lines.join).to include("404")
+      end
+    end
+
+    describe ".express_command_route" do
+      it "generates a POST handler with try/catch" do
+        lines = described_class.express_command_route("/pizzas/create", "createPizza", "pizzaRepo")
+        expect(lines.first).to include('app.post("/pizzas/create"')
+        expect(lines.join).to include("createPizza(req.body, pizzaRepo)")
+        expect(lines.join).to include("201")
+        expect(lines.join).to include("422")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Extract Express route handler patterns (`express_list_route`, `express_detail_route`, `express_command_route`) into `NodeUtils` helpers, replacing 20+ inline string lines in `ServerGenerator`
- Extract TypeScript object literal building (`ts_object`, `ts_return_object`) into `NodeUtils`, replacing inline string assembly in `CommandGenerator#event_return_block`
- Add 5 new specs covering all extracted helpers

## Example

**Before** (`server_generator.rb` routes method):
```ruby
lines << "app.get(\"/#{plural}\", (_req, res) => {"
lines << "  res.json(#{repo_var}.all());"
lines << "});"
```

**After**:
```ruby
lines.concat(NodeUtils.express_list_route("/#{plural}", repo_var))
```

**Before** (`command_generator.rb` event_return_block):
```ruby
lines << "  return {"
lines << "    type: \"#{@event.name}\","
lines << "    aggregateId: #{id_expr},"
@cmd.attributes.each { |a| lines << "    #{NodeUtils.camel_case(a.name)}: ..." }
lines << "    occurredAt: now,"
lines << "  };"
```

**After**:
```ruby
pairs = [["type", "\"#{@event.name}\""], ["aggregateId", id_expr]]
@cmd.attributes.each { |a| pairs << [NodeUtils.camel_case(a.name), "attrs.#{...}"] }
pairs << ["occurredAt", "now"]
NodeUtils.ts_return_object("  ", pairs)
```

Generated TypeScript output is byte-identical before and after.

## Test plan
- [x] All 1777 specs pass (including 5 new NodeUtils helper specs)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] Generated TypeScript output verified identical before and after refactor
- [x] All lib files under 200-line limit