### PR TITLE
HEC-32: Domain services — fill remaining gaps

### DIFF
--- a/docs/usage/domain_services.md
+++ b/docs/usage/domain_services.md
@@ -1,0 +1,81 @@
+# Domain Services
+
+Domain services orchestrate operations that span multiple aggregates. Unlike commands, which operate on a single aggregate, services coordinate cross-aggregate workflows that don't naturally belong to any one aggregate.
+
+## Defining a Service
+
+Use the `service` keyword at the domain level:
+
+```ruby
+Hecks.domain "Banking" do
+  aggregate "Account" do
+    attribute :balance, Float
+
+    command "Deposit" do
+      attribute :account_id, String
+      attribute :amount, Float
+    end
+
+    command "Withdraw" do
+      attribute :account_id, String
+      attribute :amount, Float
+    end
+  end
+
+  service "TransferMoney" do
+    attribute :source_id, String
+    attribute :target_id, String
+    attribute :amount, Float
+
+    coordinates "Account"
+
+    call do
+      dispatch "Withdraw", account_id: source_id, amount: amount
+      dispatch "Deposit",  account_id: target_id, amount: amount
+    end
+  end
+end
+```
+
+## DSL Reference
+
+Inside a `service` block:
+
+| Method | Purpose |
+|--------|---------|
+| `attribute :name, Type` | Declare an input attribute |
+| `coordinates "Agg1", "Agg2"` | Document which aggregates the service touches |
+| `call { ... }` | The orchestration body -- dispatches commands |
+
+The `call` block has access to all declared attributes as local methods and a `dispatch(command_name, **attrs)` helper that sends commands through the command bus.
+
+## Runtime Usage
+
+Services are wired as singleton methods on the domain module, using the underscored service name:
+
+```ruby
+app = Hecks.load(domain)
+
+mod = Object.const_get("BankingDomain")
+mod.transfer_money(source_id: source.id, target_id: target.id, amount: 250.0)
+```
+
+Each `dispatch` call within the service body publishes its own domain event, so a service that dispatches two commands produces two events.
+
+## How It Works
+
+1. `ServiceBuilder` collects attributes and the call body during DSL evaluation
+2. The builder produces a `DomainModel::Behavior::Service` IR node
+3. At runtime, `ServiceSetup.bind` wires each service as a method on the domain module
+4. When invoked, a `ServiceContext` is created with the command bus and attribute values
+5. The call body runs inside that context, with `dispatch` forwarding to the command bus
+
+## When to Use Services vs. Policies
+
+| Mechanism | Trigger | Use Case |
+|-----------|---------|----------|
+| **Service** | Explicit call | Orchestrate multiple commands in a defined sequence |
+| **Policy** | Reactive (event) | React to one event by triggering another command |
+| **Saga** | Long-running | Multi-step process with compensation on failure |
+
+Services are synchronous and caller-initiated. Policies are asynchronous and event-driven. Use a service when you need to guarantee ordering and collect results from multiple commands in one call.

--- a/hecks_ai/lib/hecks_ai/mcp_server.rb
+++ b/hecks_ai/lib/hecks_ai/mcp_server.rb
@@ -6,6 +6,7 @@ require_relative "aggregate_lifecycle_tools"
 require_relative "inspect_tools"
 require_relative "build_tools"
 require_relative "play_tools"
+require_relative "service_tools"
 
 module Hecks
   # Hecks::McpServer
@@ -15,9 +16,10 @@ module Hecks
   # domain modeling MCP server (as opposed to DomainServer which serves a
   # pre-built domain).
   #
-  # Registers five tool groups:
+  # Registers six tool groups:
   #   - +SessionTools+    -- create/load domain sessions
   #   - +AggregateTools+  -- add/remove domain structures
+  #   - +ServiceTools+    -- add domain services (cross-aggregate orchestration)
   #   - +InspectTools+    -- read-only domain introspection
   #   - +BuildTools+      -- validate, build, save, serve
   #   - +PlayTools+       -- interactive playground for testing
@@ -47,6 +49,7 @@ module Hecks
       @server = ::MCP::Server.new(name: "hecks", version: Hecks::VERSION)
       Hecks::MCP::SessionTools.register(@server, self)
       Hecks::MCP::AggregateTools.register(@server, self)
+      Hecks::MCP::ServiceTools.register(@server, self)
       Hecks::MCP::InspectTools.register(@server, self)
       Hecks::MCP::BuildTools.register(@server, self)
       Hecks::MCP::PlayTools.register(@server, self)

--- a/hecks_ai/lib/hecks_ai/service_tools.rb
+++ b/hecks_ai/lib/hecks_ai/service_tools.rb
@@ -1,0 +1,62 @@
+module Hecks
+  module MCP
+    # Hecks::MCP::ServiceTools
+    #
+    # MCP tool for adding domain services -- cross-aggregate operations that
+    # orchestrate multiple commands. Services are domain-level (not scoped to
+    # a single aggregate), so they live in their own tool module.
+    #
+    # Registered tools:
+    #   - +add_service+ -- add a domain service with attributes and coordinated aggregates
+    #
+    #   # Via MCP:
+    #   add_service(name: "TransferMoney", attributes: [{name: "amount", type: "Float"}])
+    #
+    module ServiceTools
+      # Registers the add_service tool on the given MCP server.
+      #
+      # @param server [MCP::Server] the MCP server instance
+      # @param ctx [Hecks::McpServer] shared context with session, capture_output
+      # @return [void]
+      def self.register(server, ctx)
+        server.define_tool(
+          name: "add_service",
+          description: "Add a domain service that coordinates commands across aggregates (e.g. TransferMoney)",
+          input_schema: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Service name (PascalCase, e.g. TransferMoney)" },
+              attributes: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    type: { type: "string" }
+                  }
+                },
+                description: "Input attributes for the service"
+              },
+              coordinates: {
+                type: "array",
+                items: { type: "string" },
+                description: "Aggregate names this service coordinates"
+              }
+            },
+            required: ["name"]
+          }
+        ) do |args|
+          ctx.ensure_session!
+          ctx.capture_output do
+            ctx.workshop.service(args["name"]) do
+              (args["attributes"] || []).each do |attr|
+                attribute attr["name"].to_sym, ctx.resolve_type(attr["type"] || "String")
+              end
+              coordinates(*(args["coordinates"] || []))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/project_generator.rb
@@ -140,6 +140,8 @@ module GoHecks
         write("#{dir}/#{GoUtils.snake_case(pol.name)}_policy.go", gen.generate)
       end
 
+      # TODO: Generate service stubs from @domain.services (HEC-32)
+
       # Errors
       gen = ErrorsGenerator.new(package: @package)
       write("#{dir}/errors.go", gen.generate)

--- a/hecks_targets/node/lib/node_hecks/generators/project_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/project_generator.rb
@@ -30,6 +30,7 @@ module NodeHecks
       generate_package_json
       generate_tsconfig
       generate_readme
+      # TODO: Generate service stubs from @domain.services (HEC-32)
 
       @root
     end

--- a/hecks_workshop/lib/hecks/extensions/ai/mcp_server.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/mcp_server.rb
@@ -4,6 +4,7 @@ require_relative "aggregate_tools"
 require_relative "inspect_tools"
 require_relative "build_tools"
 require_relative "play_tools"
+require_relative "service_tools"
 
 module Hecks
   # Hecks::McpServer
@@ -13,9 +14,10 @@ module Hecks
   # domain modeling MCP server (as opposed to DomainServer which serves a
   # pre-built domain).
   #
-  # Registers five tool groups:
+  # Registers six tool groups:
   #   - +SessionTools+    -- create/load domain sessions
   #   - +AggregateTools+  -- add/remove domain structures
+  #   - +ServiceTools+    -- add domain services (cross-aggregate orchestration)
   #   - +InspectTools+    -- read-only domain introspection
   #   - +BuildTools+      -- validate, build, save, serve
   #   - +PlayTools+       -- interactive playground for testing
@@ -45,6 +47,7 @@ module Hecks
       @server = ::MCP::Server.new(name: "hecks", version: Hecks::VERSION)
       Hecks::MCP::SessionTools.register(@server, self)
       Hecks::MCP::AggregateTools.register(@server, self)
+      Hecks::MCP::ServiceTools.register(@server, self)
       Hecks::MCP::InspectTools.register(@server, self)
       Hecks::MCP::BuildTools.register(@server, self)
       Hecks::MCP::PlayTools.register(@server, self)

--- a/hecks_workshop/lib/hecks/extensions/ai/service_tools.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/service_tools.rb
@@ -1,0 +1,62 @@
+module Hecks
+  module MCP
+    # Hecks::MCP::ServiceTools
+    #
+    # MCP tool for adding domain services -- cross-aggregate operations that
+    # orchestrate multiple commands. Services are domain-level (not scoped to
+    # a single aggregate), so they live in their own tool module.
+    #
+    # Registered tools:
+    #   - +add_service+ -- add a domain service with attributes and coordinated aggregates
+    #
+    #   # Via MCP:
+    #   add_service(name: "TransferMoney", attributes: [{name: "amount", type: "Float"}])
+    #
+    module ServiceTools
+      # Registers the add_service tool on the given MCP server.
+      #
+      # @param server [MCP::Server] the MCP server instance
+      # @param ctx [Hecks::McpServer] shared context with session, capture_output
+      # @return [void]
+      def self.register(server, ctx)
+        server.define_tool(
+          name: "add_service",
+          description: "Add a domain service that coordinates commands across aggregates (e.g. TransferMoney)",
+          input_schema: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Service name (PascalCase, e.g. TransferMoney)" },
+              attributes: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    type: { type: "string" }
+                  }
+                },
+                description: "Input attributes for the service"
+              },
+              coordinates: {
+                type: "array",
+                items: { type: "string" },
+                description: "Aggregate names this service coordinates"
+              }
+            },
+            required: ["name"]
+          }
+        ) do |args|
+          ctx.ensure_session!
+          ctx.capture_output do
+            ctx.workshop.service(args["name"]) do
+              (args["attributes"] || []).each do |attr|
+                attribute attr["name"].to_sym, ctx.resolve_type(attr["type"] || "String")
+              end
+              coordinates(*(args["coordinates"] || []))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -59,6 +59,7 @@ module Hecks
       @name = name
       @aggregate_builders = {}
       @handles = {}
+      @service_builders = []
       @custom_verbs = []
       @active_hecks = false
       @mode = :sketch
@@ -111,6 +112,21 @@ module Hecks
       handle
     end
 
+    # Define a domain service that orchestrates commands across aggregates.
+    #
+    # Services are domain-level operations that coordinate multiple aggregates.
+    # The block is evaluated in the context of a ServiceBuilder.
+    #
+    # @param name [String] the service name (e.g. "TransferMoney")
+    # @yield block evaluated in the context of ServiceBuilder
+    # @return [void]
+    def service(name, &block)
+      builder = DSL::ServiceBuilder.new(name)
+      builder.instance_eval(&block) if block
+      @service_builders << builder.build
+      puts "Service #{name} added"
+    end
+
     # Build and return a Domain structure from the current aggregate definitions.
     #
     # Constructs a DomainModel::Structure::Domain by building each aggregate
@@ -119,7 +135,10 @@ module Hecks
     # @return [DomainModel::Structure::Domain] the fully assembled domain object
     def to_domain
       aggregates = @aggregate_builders.values.map(&:build)
-      DomainModel::Structure::Domain.new(name: @name, aggregates: aggregates, custom_verbs: @custom_verbs)
+      DomainModel::Structure::Domain.new(
+        name: @name, aggregates: aggregates,
+        services: @service_builders, custom_verbs: @custom_verbs
+      )
     end
 
     # Compile the domain and activate ActiveHecks (Rails persistence layer).


### PR DESCRIPTION
## Summary
- Add `docs/usage/domain_services.md` with runnable DSL definition and runtime usage examples
- Add `add_service` MCP tool to both `hecks_ai` and `hecks_workshop` MCP servers, enabling AI agents to define domain services interactively
- Add `Workshop#service` method so the MCP tool can wire services through the workshop API
- Add TODO comments in Go and Node target generators for future service stub generation

## Example

### DSL definition
```ruby
Hecks.domain "Banking" do
  aggregate "Account" do
    attribute :balance, Float
    command "Deposit" do
      attribute :account_id, String
      attribute :amount, Float
    end
    command "Withdraw" do
      attribute :account_id, String
      attribute :amount, Float
    end
  end

  service "TransferMoney" do
    attribute :source_id, String
    attribute :target_id, String
    attribute :amount, Float
    coordinates "Account"
    call do
      dispatch "Withdraw", account_id: source_id, amount: amount
      dispatch "Deposit",  account_id: target_id, amount: amount
    end
  end
end
```

### Runtime usage
```ruby
app = Hecks.load(domain)
BankingDomain.transfer_money(source_id: src.id, target_id: tgt.id, amount: 250.0)
# => dispatches Withdraw + Deposit, producing 2 events
```

### MCP tool usage
```json
{ "name": "add_service", "arguments": {
    "name": "TransferMoney",
    "attributes": [{"name": "amount", "type": "Float"}],
    "coordinates": ["Account"]
}}
```

## Test plan
- [x] All 1772 specs pass (under 1.5s speed limit)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] Existing domain services spec covers DSL, runtime dispatch, and IR storage
- [ ] Verify `add_service` MCP tool works in an interactive session
- [ ] Verify Go/Node TODOs are visible for future implementation