### PR TITLE
HEC-457: Bubble contexts — named sub-boundaries within a domain

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -81,6 +81,14 @@
 - `prefer` accepts optional `definition:` kwarg to document preferred terms inline
 - Glossary `generate` produces a "Ubiquitous Language" section with definitions and avoid lists
 
+### Bubble Contexts
+- `bubble_context "Fulfillment" { aggregate "Order"; aggregate "Shipment" }` — named sub-boundary grouping existing aggregates
+- Acts as an anti-corruption layer within a domain, presenting a simplified view of a subset
+- Aggregates are referenced by name; an aggregate can appear in multiple bubble contexts
+- Stored as `BubbleContext` IR nodes on `domain.bubble_contexts`
+- Round-trips through `DslSerializer` for lossless serialization
+- Web Explorer exposes `bubble_contexts` and `bubble_context_for(aggregate_name)` via IRIntrospector
+
 ### World Goals
 - `world_goals :transparency, :consent, :privacy, :security` — opt-in ethical validation rules
 - `:transparency` — commands must emit events (no silent mutations)

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -20,6 +20,7 @@ module Hecks
         lines.concat(serialize_aggregate(agg))
       end
       @domain.policies.each { |pol| lines.concat(serialize_domain_policy(pol)) }
+      @domain.bubble_contexts.each { |bc| lines.concat(serialize_bubble_context(bc)) }
       lines << "end"
       lines.join("\n") + "\n"
     end
@@ -167,6 +168,13 @@ module Hecks
         lines << "    map #{mapping}"
       end
       lines << "    condition { |event| #{Hecks::Utils.block_source(pol.condition)} }" if pol.condition
+      lines << "  end"
+      lines
+    end
+
+    def serialize_bubble_context(bc)
+      lines = ["", "  bubble_context \"#{bc.name}\" do"]
+      bc.aggregate_names.each { |name| lines << "    aggregate \"#{name}\"" }
       lines << "  end"
       lines
     end

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -57,6 +57,7 @@ module Hecks
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
       autoload :Reference,         "hecks/domain_model/structure/reference"
       autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
+      autoload :BubbleContext,     "hecks/domain_model/structure/bubble_context"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/bubble_context.rb
+++ b/bluebook/lib/hecks/domain_model/structure/bubble_context.rb
@@ -1,0 +1,32 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::BubbleContext
+    #
+    # A logical sub-boundary within a domain that groups existing aggregates
+    # under a named context. Bubble contexts act as anti-corruption layers,
+    # presenting a simplified view of a subset of the domain's aggregates.
+    #
+    # Aggregates are referenced by name; the actual Aggregate IR nodes live
+    # on the parent Domain. A BubbleContext is purely organizational metadata.
+    #
+    #   BubbleContext.new(name: "Fulfillment", aggregate_names: ["Order", "Shipment"])
+    #   bc.name             # => "Fulfillment"
+    #   bc.aggregate_names  # => ["Order", "Shipment"]
+    #
+    class BubbleContext
+      # @return [String] the context name (e.g. "Fulfillment", "Billing")
+      attr_reader :name
+
+      # @return [Array<String>] names of aggregates grouped under this context
+      attr_reader :aggregate_names
+
+      def initialize(name:, aggregate_names: [])
+        @name = name
+        @aggregate_names = aggregate_names
+      end
+    end
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -67,6 +67,9 @@ module Hecks
       # @return [Array<Hash>] logical module groupings within this domain
       attr_reader :modules
 
+      # @return [Array<BubbleContext>] named sub-boundaries grouping aggregates
+      attr_reader :bubble_contexts
+
       # @return [Array<Symbol>] declared world goals for this domain
       #   (e.g. :transparency, :consent, :privacy, :security)
       attr_reader :world_goals
@@ -102,7 +105,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil, world_goals: [])
+                     version: nil, world_goals: [], bubble_contexts: [])
         validate_version!(version)
         @name = name
         @version = version
@@ -120,6 +123,7 @@ module Hecks
         @tenancy = tenancy
         @event_subscribers = event_subscribers
         @world_goals = world_goals.map(&:to_sym)
+        @bubble_contexts = bubble_contexts
       end
 
       # Returns the sanitized Ruby constant name for this domain.

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -66,6 +66,7 @@ module Hecks
         @tenancy = nil
         @event_subscribers = []
         @world_goals = []
+        @bubble_contexts = []
       end
 
       # Declare world goals that this domain aspires to uphold.
@@ -125,6 +126,20 @@ module Hecks
           mod[:aggregates] = sub.aggregate_names
         end
         @modules << mod
+      end
+
+      # Define a bubble context — a named sub-boundary grouping existing
+      # aggregates under a clean domain interface. Acts as an anti-corruption
+      # layer within the domain.
+      #
+      #   bubble_context "Fulfillment" do
+      #     aggregate "Order"
+      #     aggregate "Shipment"
+      #   end
+      def bubble_context(name, &block)
+        builder = BubbleContextBuilder.new(name)
+        builder.instance_eval(&block) if block
+        @bubble_contexts << builder.build
       end
 
       # Set the multi-tenancy strategy for this domain.
@@ -277,7 +292,8 @@ module Hecks
           event_subscribers: @event_subscribers,
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
           glossary_strict: @glossary_strict || false,
-          world_goals: @world_goals
+          world_goals: @world_goals,
+          bubble_contexts: @bubble_contexts
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
@@ -146,6 +146,34 @@ module Hecks
         end
       end
 
+      # Hecks::DSL::DomainBuilder::BubbleContextBuilder
+      #
+      # Collects aggregate names that belong to a bubble context.
+      # Aggregates are referenced by name (not defined here).
+      #
+      #   bubble_context "Fulfillment" do
+      #     aggregate "Order"
+      #     aggregate "Shipment"
+      #   end
+      #
+      class BubbleContextBuilder
+        def initialize(name)
+          @name = name
+          @aggregate_names = []
+        end
+
+        def aggregate(name)
+          @aggregate_names << name.to_s
+        end
+
+        def build
+          DomainModel::Structure::BubbleContext.new(
+            name: @name,
+            aggregate_names: @aggregate_names
+          )
+        end
+      end
+
     end
   end
 end

--- a/bluebook/spec/dsl/bubble_context_spec.rb
+++ b/bluebook/spec/dsl/bubble_context_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+RSpec.describe "bubble_context DSL" do
+  it "groups aggregates under a named context" do
+    domain = Hecks.domain "ECommerce" do
+      aggregate("Order") { attribute :total, Integer; command("CreateOrder") { attribute :total, Integer } }
+      aggregate("Shipment") { attribute :tracking, String; command("CreateShipment") { attribute :tracking, String } }
+
+      bubble_context "Fulfillment" do
+        aggregate "Order"
+        aggregate "Shipment"
+      end
+    end
+
+    expect(domain.bubble_contexts.size).to eq(1)
+    bc = domain.bubble_contexts.first
+    expect(bc.name).to eq("Fulfillment")
+    expect(bc.aggregate_names).to eq(["Order", "Shipment"])
+  end
+
+  it "supports multiple bubble contexts" do
+    domain = Hecks.domain "ECommerce" do
+      aggregate("Order") { attribute :total, Integer; command("CreateOrder") { attribute :total, Integer } }
+      aggregate("Payment") { attribute :amount, Float; command("CreatePayment") { attribute :amount, Float } }
+      aggregate("Shipment") { attribute :tracking, String; command("CreateShipment") { attribute :tracking, String } }
+
+      bubble_context "Fulfillment" do
+        aggregate "Order"
+        aggregate "Shipment"
+      end
+
+      bubble_context "Billing" do
+        aggregate "Payment"
+      end
+    end
+
+    expect(domain.bubble_contexts.map(&:name)).to eq(["Fulfillment", "Billing"])
+    expect(domain.bubble_contexts.last.aggregate_names).to eq(["Payment"])
+  end
+
+  it "allows an aggregate to appear in multiple bubble contexts" do
+    domain = Hecks.domain "ECommerce" do
+      aggregate("Order") { attribute :total, Integer; command("CreateOrder") { attribute :total, Integer } }
+
+      bubble_context "Fulfillment" do
+        aggregate "Order"
+      end
+
+      bubble_context "CustomerView" do
+        aggregate "Order"
+      end
+    end
+
+    names = domain.bubble_contexts.map(&:name)
+    expect(names).to eq(["Fulfillment", "CustomerView"])
+    expect(domain.bubble_contexts.all? { |bc| bc.aggregate_names.include?("Order") }).to be true
+  end
+
+  it "defaults to empty bubble contexts" do
+    domain = Hecks.domain "Simple" do
+      aggregate("Thing") { attribute :name, String; command("CreateThing") { attribute :name, String } }
+    end
+
+    expect(domain.bubble_contexts).to eq([])
+  end
+
+  it "round-trips through DslSerializer" do
+    domain = Hecks.domain "ECommerce" do
+      aggregate("Order") { attribute :total, Integer; command("CreateOrder") { attribute :total, Integer } }
+
+      bubble_context "Fulfillment" do
+        aggregate "Order"
+      end
+    end
+
+    source = Hecks::DslSerializer.new(domain).serialize
+    expect(source).to include('bubble_context "Fulfillment"')
+    expect(source).to include('aggregate "Order"')
+
+    restored = eval(source)
+    expect(restored.bubble_contexts.size).to eq(1)
+    expect(restored.bubble_contexts.first.name).to eq("Fulfillment")
+    expect(restored.bubble_contexts.first.aggregate_names).to eq(["Order"])
+  end
+end

--- a/docs/usage/bubble_contexts.md
+++ b/docs/usage/bubble_contexts.md
@@ -1,0 +1,75 @@
+# Bubble Contexts
+
+Bubble contexts define named sub-boundaries within a domain, grouping
+existing aggregates under a logical context. They act as anti-corruption
+layers, presenting a simplified view of a subset of the domain.
+
+## DSL
+
+```ruby
+Hecks.domain "ECommerce" do
+  aggregate "Order" do
+    attribute :total, Integer
+    command "CreateOrder" do
+      attribute :total, Integer
+    end
+  end
+
+  aggregate "Shipment" do
+    attribute :tracking_number, String
+    command "CreateShipment" do
+      attribute :tracking_number, String
+    end
+  end
+
+  aggregate "Payment" do
+    attribute :amount, Float
+    command "CreatePayment" do
+      attribute :amount, Float
+    end
+  end
+
+  bubble_context "Fulfillment" do
+    aggregate "Order"
+    aggregate "Shipment"
+  end
+
+  bubble_context "Billing" do
+    aggregate "Payment"
+  end
+end
+```
+
+## Querying bubble contexts
+
+```ruby
+domain = Hecks.domain "ECommerce" do
+  # ... aggregates and bubble_contexts as above
+end
+
+domain.bubble_contexts.map(&:name)
+# => ["Fulfillment", "Billing"]
+
+domain.bubble_contexts.first.aggregate_names
+# => ["Order", "Shipment"]
+```
+
+## Round-trip serialization
+
+Bubble contexts survive DSL round-trips through `DslSerializer`:
+
+```ruby
+source = Hecks::DslSerializer.new(domain).serialize
+restored = eval(source)
+restored.bubble_contexts.first.name  # => "Fulfillment"
+```
+
+## Notes
+
+- Aggregates are referenced by name; they must be defined elsewhere in
+  the same domain.
+- An aggregate can appear in multiple bubble contexts.
+- Bubble contexts are purely organizational metadata -- they do not
+  affect runtime behavior or code generation.
+- The Web Explorer's IRIntrospector exposes `bubble_contexts` and
+  `bubble_context_for(aggregate_name)` for UI rendering.

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -116,6 +116,12 @@ Hecks.domain "Banking" do
     aggregate "GovernancePolicy" do ... end
   end
 
+  # Bubble context — named sub-boundary grouping existing aggregates
+  bubble_context "Fulfillment" do
+    aggregate "Order"
+    aggregate "Shipment"
+  end
+
   # Domain-level event subscriber
   on_event "CreatedPizza" do |event|
     puts event.name

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -108,6 +108,14 @@ module Hecks
         HecksTemplating::DisplayContract.available_roles(@domain)
       end
 
+      def bubble_contexts
+        @domain.bubble_contexts
+      end
+
+      def bubble_context_for(aggregate_name)
+        @domain.bubble_contexts.find { |bc| bc.aggregate_names.include?(aggregate_name) }
+      end
+
       def diagram_data
         viz = Hecks::DomainVisualizer.new(@domain)
         flow = Hecks::FlowGenerator.new(@domain)


### PR DESCRIPTION
## Summary
- Add `bubble_context` DSL keyword that groups existing aggregates under a named sub-boundary
- New `BubbleContext` IR node in `DomainModel::Structure` with `name` and `aggregate_names`
- `DslSerializer` round-trip support for lossless serialization
- `IRIntrospector` exposes `bubble_contexts` and `bubble_context_for(aggregate_name)` for the web explorer
- FEATURES.md, DSL reference, and usage docs updated

## Example

```ruby
Hecks.domain "ECommerce" do
  aggregate "Order" do
    attribute :total, Integer
    command "CreateOrder" do
      attribute :total, Integer
    end
  end

  aggregate "Shipment" do
    attribute :tracking_number, String
    command "CreateShipment" do
      attribute :tracking_number, String
    end
  end

  bubble_context "Fulfillment" do
    aggregate "Order"
    aggregate "Shipment"
  end
end
```

## Test plan
- [ ] `bubble_context_spec.rb` — groups aggregates, multiple contexts, overlapping aggregates, empty default, round-trip serialization
- [ ] Full suite passes (1777 examples, 0 failures)
- [ ] Smoke test passes
- [ ] File sizes under 200 code lines