### PR TITLE
HEC-475: Custom world goals — user-defined goals that compose extensions

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -88,6 +88,11 @@
 - `:privacy` — PII attributes must be `visible: false`; PII aggregate commands need actors
 - `:security` — command actors must be declared at domain level
 - **Mother Earth Report** — `hecks validate` shows a per-goal PASS/FAIL summary with violations listed
+- **Custom World Goals** — `Hecks.define_goal(:name) { validate { |domain| [...] } }` to define user goals that compose extensions
+  - `requires_extension :audit` declares extension dependencies
+  - Custom goals activate via the same `world_goals :name` DSL keyword
+  - Idempotent: redefining a goal replaces the previous definition
+  - Appears in Mother Earth Report alongside built-in goals
 
 ### Access Control & Ports
 - Define access-control ports that whitelist allowed methods per consumer

--- a/bluebook/lib/hecks/domain/validator.rb
+++ b/bluebook/lib/hecks/domain/validator.rb
@@ -91,7 +91,7 @@ module Hecks
     end
 
     def goal_failing?(goal)
-      label = goal.to_s.capitalize
+      label = goal.to_s.split("_").map(&:capitalize).join(" ")
       @world_goals_errors.any? { |e| e.start_with?("#{label}:") }
     end
   end

--- a/bluebook/lib/hecks/validation_rules/world_goals.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals.rb
@@ -19,6 +19,7 @@ module Hecks
       autoload :Consent,      "hecks/validation_rules/world_goals/consent"
       autoload :Privacy,      "hecks/validation_rules/world_goals/privacy"
       autoload :Security,     "hecks/validation_rules/world_goals/security"
+      autoload :GoalBuilder,  "hecks/validation_rules/world_goals/goal_builder"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/world_goals/goal_builder.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/goal_builder.rb
@@ -1,0 +1,90 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::GoalBuilder
+      #
+      # DSL builder for user-defined world goals. Collects extension requirements
+      # and a validation block, then materializes an anonymous BaseRule subclass
+      # that self-registers with the validator.
+      #
+      #   Hecks.define_goal(:audit_trail) do
+      #     requires_extension :audit
+      #     validate do |domain|
+      #       domain.aggregates.flat_map do |agg|
+      #         agg.commands.select { |c| c.actors.empty? }.map do |cmd|
+      #           "#{agg.name}##{cmd.name} has no actor — audit trail incomplete"
+      #         end
+      #       end
+      #     end
+      #   end
+      #
+      class GoalBuilder
+        # @return [Symbol] the goal name
+        attr_reader :name
+
+        # @return [Array<Symbol>] extensions this goal requires
+        attr_reader :required_extensions
+
+        def initialize(name)
+          @name = name.to_sym
+          @required_extensions = []
+          @validate_block = nil
+        end
+
+        # Declare that this goal requires a specific extension to be meaningful.
+        #
+        # @param ext_name [Symbol] the extension name (e.g. :audit, :logging)
+        # @return [void]
+        def requires_extension(ext_name)
+          @required_extensions << ext_name.to_sym
+        end
+
+        # Register the validation block that inspects the domain for violations.
+        # The block receives the domain IR and must return an array of strings.
+        #
+        # @yield [domain] block that returns violation messages
+        # @yieldparam domain [Hecks::DomainModel::Structure::Domain]
+        # @yieldreturn [Array<String>] violation messages (empty = pass)
+        # @return [void]
+        def validate(&block)
+          @validate_block = block
+        end
+
+        # Materialize and register the goal as a BaseRule subclass.
+        #
+        # Creates an anonymous class under WorldGoals, names it with a constant,
+        # and registers it so the Validator picks it up automatically.
+        #
+        # @return [Class] the generated BaseRule subclass
+        def build!
+          goal_name = @name
+          label = goal_name.to_s.split("_").map(&:capitalize).join(" ")
+          vblock = @validate_block
+          required = @required_extensions
+
+          rule_class = Class.new(BaseRule) do
+            define_method(:errors) do
+              return [] unless @domain.world_goals.include?(goal_name)
+
+              raw = vblock ? vblock.call(@domain) : []
+              raw.map { |msg| "#{label}: #{msg}" }
+            end
+
+            define_method(:required_extensions) { required }
+          end
+
+          const_name = goal_name.to_s.split("_").map(&:capitalize).join
+          if WorldGoals.const_defined?(const_name)
+            old = WorldGoals.const_get(const_name)
+            Hecks.deregister_validation_rule(old)
+            WorldGoals.send(:remove_const, const_name)
+          end
+          WorldGoals.const_set(const_name, rule_class)
+          Hecks.register_validation_rule(rule_class)
+          rule_class
+        end
+      end
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/world_goals/custom_goals_spec.rb
+++ b/bluebook/spec/validation_rules/world_goals/custom_goals_spec.rb
@@ -1,0 +1,123 @@
+require "spec_helper"
+
+RSpec.describe "Custom world goals" do
+  def validate(domain)
+    validator = Hecks::Validator.new(domain)
+    [validator.valid?, validator.errors, validator]
+  end
+
+  after do
+    # Clean up custom goal constants and rule registrations
+    %i[Compliance AuditTrail].each do |name|
+      if Hecks::ValidationRules::WorldGoals.const_defined?(name)
+        klass = Hecks::ValidationRules::WorldGoals.const_get(name)
+        Hecks.deregister_validation_rule(klass)
+        Hecks::ValidationRules::WorldGoals.send(:remove_const, name)
+      end
+    end
+  end
+
+  it "defines a custom goal that validates the domain" do
+    Hecks.define_goal(:compliance) do
+      validate do |domain|
+        domain.aggregates.flat_map do |agg|
+          agg.commands.select { |c| c.actors.empty? }.map do |cmd|
+            "#{agg.name}##{cmd.name} has no actor"
+          end
+        end
+      end
+    end
+
+    domain = Hecks.domain "Regulated" do
+      world_goals :compliance
+      aggregate "Report" do
+        attribute :title, String
+        command "FileReport" do
+          attribute :title, String
+        end
+      end
+    end
+
+    valid, errors, = validate(domain)
+    expect(valid).to be false
+    expect(errors).to include(/Compliance.*Report#FileReport.*no actor/)
+  end
+
+  it "passes when the custom goal has no violations" do
+    Hecks.define_goal(:compliance) do
+      validate do |domain|
+        domain.aggregates.flat_map do |agg|
+          agg.commands.select { |c| c.actors.empty? }.map do |cmd|
+            "#{agg.name}##{cmd.name} has no actor"
+          end
+        end
+      end
+    end
+
+    domain = Hecks.domain "Compliant" do
+      world_goals :compliance
+      aggregate "Report" do
+        attribute :title, String
+        command "FileReport" do
+          attribute :title, String
+          actor "Auditor"
+        end
+      end
+    end
+
+    valid, = validate(domain)
+    expect(valid).to be true
+  end
+
+  it "does not fire when the goal is not declared" do
+    Hecks.define_goal(:compliance) do
+      validate { |_domain| ["always fails"] }
+    end
+
+    domain = Hecks.domain "NoGoals" do
+      aggregate "Widget" do
+        attribute :name, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+
+    valid, = validate(domain)
+    expect(valid).to be true
+  end
+
+  it "records required extensions on the rule" do
+    Hecks.define_goal(:audit_trail) do
+      requires_extension :audit
+      requires_extension :logging
+      validate { |_domain| [] }
+    end
+
+    rule = Hecks::ValidationRules::WorldGoals::AuditTrail
+    instance = rule.new(Hecks.domain("X") { aggregate("A") { attribute :n, String; command("C") { attribute :n, String } } })
+    expect(instance.required_extensions).to eq([:audit, :logging])
+  end
+
+  it "shows in mother_earth_report when failing" do
+    Hecks.define_goal(:compliance) do
+      validate { |_domain| ["everything is wrong"] }
+    end
+
+    domain = Hecks.domain "Bad" do
+      world_goals :compliance
+      aggregate "Thing" do
+        attribute :name, String
+        command "DoThing" do
+          attribute :name, String
+        end
+      end
+    end
+
+    _, _, validator = validate(domain)
+    report = validator.mother_earth_report
+    expect(report[:goals_declared]).to include(:compliance)
+    expect(report[:failing_goals]).to include(:compliance)
+    expect(report[:violations]).to include(/Compliance/)
+  end
+end

--- a/docs/usage/custom_world_goals.md
+++ b/docs/usage/custom_world_goals.md
@@ -1,0 +1,82 @@
+# Custom World Goals
+
+Define your own world goals that validate domain design against project-specific
+governance rules. Custom goals integrate seamlessly with the existing
+`world_goals` DSL keyword and appear in the Mother Earth Report.
+
+## Defining a Custom Goal
+
+```ruby
+Hecks.define_goal(:audit_trail) do
+  requires_extension :audit
+
+  validate do |domain|
+    domain.aggregates.flat_map do |agg|
+      agg.commands.select { |c| c.actors.empty? }.map do |cmd|
+        "#{agg.name}##{cmd.name} has no actor — audit trail incomplete"
+      end
+    end
+  end
+end
+```
+
+The `validate` block receives the domain IR and returns an array of violation
+message strings. Return an empty array when the goal passes.
+
+## Activating a Custom Goal
+
+Custom goals are activated in the domain DSL exactly like built-in goals:
+
+```ruby
+Hecks.domain "Regulated" do
+  world_goals :audit_trail, :transparency
+
+  aggregate "Report" do
+    attribute :title, String
+    command "FileReport" do
+      attribute :title, String
+      actor "Auditor"
+    end
+  end
+end
+```
+
+The goal only fires when declared via `world_goals`. Domains that omit it are
+unaffected.
+
+## Extension Requirements
+
+Use `requires_extension` to document which runtime extensions the goal depends
+on. This metadata is available on the generated rule class:
+
+```ruby
+Hecks.define_goal(:compliance) do
+  requires_extension :audit
+  requires_extension :logging
+
+  validate { |domain| [] }
+end
+
+rule = Hecks::ValidationRules::WorldGoals::Compliance
+instance = rule.new(domain)
+instance.required_extensions  # => [:audit, :logging]
+```
+
+## Mother Earth Report
+
+Custom goals appear in the Mother Earth Report alongside built-in goals:
+
+```ruby
+validator = Hecks::Validator.new(domain)
+validator.valid?
+report = validator.mother_earth_report
+# => { goals_declared: [:audit_trail, :transparency],
+#      passing_goals:  [:transparency],
+#      failing_goals:  [:audit_trail],
+#      violations:     ["Audit Trail: Report#FileReport has no actor..."] }
+```
+
+## Idempotency
+
+Redefining a goal with the same name replaces the previous definition. This is
+safe for iterative development and test isolation.

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -90,8 +90,8 @@ Hecks.domain "Banking" do
   actor "Customer"
   actor "Admin", description: "System administrator"
 
-  # World goals (opt-in ethical validation)
-  world_goals :transparency, :consent, :privacy, :security
+  # World goals (opt-in ethical validation — built-in and custom)
+  world_goals :transparency, :consent, :privacy, :security, :audit_trail
 
   # Multi-tenancy
   tenancy :row

--- a/hecksties/lib/hecks/registries/validation_registry.rb
+++ b/hecksties/lib/hecks/registries/validation_registry.rb
@@ -16,6 +16,28 @@ module Hecks
       validation_rule_registry.register(rule_class)
     end
 
+    def deregister_validation_rule(rule_class)
+      validation_rule_registry.deregister(rule_class)
+    end
+
+    # Define a custom world goal with a builder DSL. The goal name becomes
+    # available in the +world_goals+ keyword and activates its validation
+    # rule when declared on a domain.
+    #
+    #   Hecks.define_goal(:audit_trail) do
+    #     requires_extension :audit
+    #     validate { |domain| [] }
+    #   end
+    #
+    # @param name [Symbol] the goal name (used in +world_goals :name+)
+    # @yield block evaluated in the context of GoalBuilder
+    # @return [Class] the generated BaseRule subclass
+    def define_goal(name, &block)
+      builder = ValidationRules::WorldGoals::GoalBuilder.new(name)
+      builder.instance_eval(&block) if block
+      builder.build!
+    end
+
     private
 
     def validation_rule_registry

--- a/hecksties/lib/hecks/set_registry.rb
+++ b/hecksties/lib/hecks/set_registry.rb
@@ -20,6 +20,10 @@ module Hecks
       @items << coerced unless @items.include?(coerced)
     end
 
+    def deregister(item)
+      @items.delete(item)
+    end
+
     def include?(item)
       coerced = item.respond_to?(:to_sym) ? item.to_sym : item
       @items.include?(coerced)


### PR DESCRIPTION
## Summary
- Add `Hecks.define_goal(:name)` class method with a `GoalBuilder` DSL that accepts `requires_extension` and `validate` blocks
- Custom goals self-register as `BaseRule` subclasses under `WorldGoals` and activate via the existing `world_goals :name` keyword
- Fix `goal_failing?` in Validator to support multi-word goal names (e.g. `:audit_trail` -> "Audit Trail:")
- Add `deregister` to `SetRegistry` and `deregister_validation_rule` to `ValidationRegistryMethods` for clean test isolation

## Example

**Define a custom goal:**
```ruby
Hecks.define_goal(:audit_trail) do
  requires_extension :audit

  validate do |domain|
    domain.aggregates.flat_map do |agg|
      agg.commands.select { |c| c.actors.empty? }.map do |cmd|
        "#{agg.name}##{cmd.name} has no actor — audit trail incomplete"
      end
    end
  end
end
```

**Activate it in a domain:**
```ruby
Hecks.domain "Regulated" do
  world_goals :audit_trail, :transparency
  aggregate "Report" do
    attribute :title, String
    command "FileReport" do
      attribute :title, String
      actor "Auditor"
    end
  end
end
```

**Shows in Mother Earth Report:**
```ruby
validator.mother_earth_report
# => { goals_declared: [:audit_trail], failing_goals: [:audit_trail], ... }
```

## Test plan
- [x] Custom goal fires when declared via `world_goals` and produces violations
- [x] Custom goal passes when no violations returned
- [x] Custom goal does not fire when not declared on domain
- [x] `requires_extension` metadata is accessible on the rule instance
- [x] Custom goals appear in Mother Earth Report with correct pass/fail status
- [x] Full suite passes in random order (verified with previously-failing seed 15373)
- [x] Smoke test passes