### PR TITLE
HEC-469: AI governance extension for MCP server

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -481,6 +481,14 @@
 - `add_attribute` tool for adding individual attributes to existing aggregates
 - All tool output uses `capture_output` to show the same terse feedback as the REPL
 
+### AI Governance
+- `execute_command` MCP tool checks world goals before executing — refuses with structured violations if a command violates declared goals
+- `GovernanceGuard` middleware filters world-goals validation errors to the specific command being executed
+- `explain_governance` MCP tool lists active world goals and their constraints so AI agents can self-orient
+- `check_governance` MCP tool pre-checks a command against governance rules without executing it
+- `Workshop#world_goals` sets governance goals from the workshop (workshop-built domains now carry world goals)
+- Refusal response includes `refused: true`, the command name, violations array, and active goals
+
 ### Command Bus Port (HTTP Adapter Boundary)
 - `Hecks::HTTP::CommandBusPort` — explicit port between HTTP routes and the domain
 - Mutations route through the `CommandBus` middleware pipeline via `port.dispatch`

--- a/docs/usage/ai_governance.md
+++ b/docs/usage/ai_governance.md
@@ -1,0 +1,96 @@
+# AI Governance
+
+When a domain declares `world_goals`, the MCP server enforces governance rules
+on AI actions. Commands that violate declared goals are refused with a structured
+explanation before they execute.
+
+## How It Works
+
+1. The domain declares goals: `world_goals :transparency, :consent, :privacy`
+2. An AI agent calls `execute_command` via MCP
+3. `GovernanceGuard` runs the domain validator and checks for world-goals violations
+4. If violations exist for the specific command, execution is refused with details
+5. If no violations, the command proceeds normally
+
+## MCP Tools
+
+### `explain_governance`
+
+Lists the active world goals and their constraints. Call this first to understand
+what rules are in effect.
+
+```json
+// Request
+{ "tool": "explain_governance" }
+
+// Response (goals declared)
+{
+  "goals": ["transparency", "consent"],
+  "constraints": [
+    { "goal": "transparency", "description": "Every command must emit at least one domain event. Silent mutations are not allowed." },
+    { "goal": "consent", "description": "Commands on user-like aggregates must declare an actor. No anonymous actions on personal data." }
+  ]
+}
+
+// Response (no goals)
+{ "goals": [], "message": "No world goals declared. All actions are allowed." }
+```
+
+### `check_governance`
+
+Pre-check a command before executing it. Returns whether it would be allowed.
+
+```json
+// Request
+{ "tool": "check_governance", "args": { "command": "DeleteRecord" } }
+
+// Response (blocked)
+{
+  "allowed": false,
+  "violations": ["Transparency: Record#DeleteRecord emits no events. Commands must emit events so changes are observable."],
+  "goals": ["transparency"]
+}
+
+// Response (allowed)
+{ "allowed": true, "violations": [], "goals": ["transparency"] }
+```
+
+### `execute_command` (governance-gated)
+
+When governance is active, `execute_command` automatically checks before running.
+If violations are found, it returns a refusal instead of executing:
+
+```json
+// Refused execution
+{
+  "refused": true,
+  "command": "DeleteRecord",
+  "violations": ["Transparency: Record#DeleteRecord emits no events."],
+  "goals": ["transparency"]
+}
+```
+
+## Workshop API
+
+Set world goals on a workshop-built domain:
+
+```ruby
+ws = Hecks.workshop("Healthcare")
+ws.aggregate("Patient") do
+  attribute :name, String
+  command("UpdatePatient") { attribute :name, String; actor "Doctor" }
+end
+ws.world_goals(:consent, :privacy)
+
+domain = ws.to_domain
+domain.world_goals  # => [:consent, :privacy]
+```
+
+## Available Goals
+
+| Goal | Enforces |
+|------|----------|
+| `:transparency` | Every command must emit at least one event |
+| `:consent` | Commands on user-like aggregates must declare an actor |
+| `:privacy` | PII must be `visible: false`; PII aggregates need actors |
+| `:security` | Command actors must be declared at the domain level |

--- a/hecks_ai/lib/hecks_ai.rb
+++ b/hecks_ai/lib/hecks_ai.rb
@@ -18,6 +18,8 @@ module Hecks
     autoload :TypeResolver,     "hecks_ai/type_resolver"
     autoload :LlmClient,        "hecks_ai/llm_client"
     autoload :DomainBuilder,    "hecks_ai/domain_builder"
+    autoload :GovernanceGuard,  "hecks_ai/governance_guard"
+    autoload :GovernanceTools,  "hecks_ai/governance_tools"
 
     module Prompts
       autoload :DomainGeneration, "hecks_ai/prompts/domain_generation"

--- a/hecks_ai/lib/hecks_ai/governance_guard.rb
+++ b/hecks_ai/lib/hecks_ai/governance_guard.rb
@@ -1,0 +1,65 @@
+module Hecks
+  module MCP
+    # Hecks::MCP::GovernanceGuard
+    #
+    # Middleware that checks proposed command executions against the active
+    # domain's world_goals before allowing them to proceed. Runs the domain
+    # validator and extracts world-goals-specific violations. If violations
+    # are found, returns a structured refusal instead of executing.
+    #
+    # Used by PlayTools#execute_command to gate AI actions through governance.
+    #
+    #   guard = GovernanceGuard.new(ctx)
+    #   result = guard.check("CreatePatient", ssn: "123")
+    #   result[:allowed]     # => true or false
+    #   result[:violations]  # => ["Privacy: Patient#CreatePatient ..."]
+    #
+    class GovernanceGuard
+      # @param ctx [Hecks::McpServer] shared MCP context with workshop access
+      def initialize(ctx)
+        @ctx = ctx
+      end
+
+      # Check whether a command is allowed under the active world goals.
+      # Returns a hash with :allowed and :violations keys.
+      #
+      # @param command_name [String] the command to check (e.g. "CreatePatient")
+      # @return [Hash] { allowed: Boolean, violations: Array<String>, goals: Array<Symbol> }
+      def check(command_name)
+        domain = @ctx.workshop.to_domain
+        goals = domain.world_goals
+
+        return { allowed: true, violations: [], goals: [] } if goals.empty?
+
+        validator = Hecks::Validator.new(domain)
+        validator.valid?
+
+        relevant = filter_violations(validator.world_goals_errors, command_name, domain)
+
+        {
+          allowed: relevant.empty?,
+          violations: relevant,
+          goals: goals
+        }
+      end
+
+      private
+
+      # Filter world goals errors to those relevant to the given command.
+      # Matches on the command name or the aggregate that owns it.
+      #
+      # @param errors [Array<String>] all world goals errors
+      # @param command_name [String] the command being executed
+      # @param domain [Hecks::DomainModel::Structure::Domain] the domain
+      # @return [Array<String>] filtered violations
+      def filter_violations(errors, command_name, domain)
+        agg = domain.aggregate_for_command(command_name)
+        return errors if agg.nil?
+
+        errors.select do |err|
+          err.include?(command_name) || err.include?(agg.name)
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/governance_tools.rb
+++ b/hecks_ai/lib/hecks_ai/governance_tools.rb
@@ -1,0 +1,81 @@
+module Hecks
+  module MCP
+    # Hecks::MCP::GovernanceTools
+    #
+    # MCP tools for AI governance. Exposes the domain's world goals and
+    # governance constraints so AI agents can self-orient before acting.
+    #
+    # Registered tools:
+    #   - +explain_governance+ -- lists active world goals and their constraints
+    #   - +check_governance+   -- checks if a specific command passes governance
+    #
+    #   # MCP tool call
+    #   explain_governance({})
+    #   # => { goals: [:transparency, :consent], constraints: [...] }
+    #
+    module GovernanceTools
+      GOAL_DESCRIPTIONS = {
+        transparency: "Every command must emit at least one domain event. " \
+                      "Silent mutations are not allowed.",
+        consent: "Commands on user-like aggregates (User, Account, Patient, etc.) " \
+                 "must declare an actor. No anonymous actions on personal data.",
+        privacy: "PII attributes must be marked visible: false. Commands on " \
+                 "aggregates with PII must declare an actor for audit trails.",
+        security: "Command-level actors must be declared at the domain level. " \
+                  "No dangling or misspelled role references."
+      }.freeze
+
+      # Registers governance tools on the given MCP server.
+      #
+      # @param server [MCP::Server] the MCP server instance
+      # @param ctx [Hecks::McpServer] shared context with session access
+      # @return [void]
+      def self.register(server, ctx)
+        register_explain(server, ctx)
+        register_check(server, ctx)
+      end
+
+      # @api private
+      def self.register_explain(server, ctx)
+        server.define_tool(
+          name: "explain_governance",
+          description: "List active world goals and their constraints for the current domain",
+          input_schema: { type: "object", properties: {} }
+        ) do |_|
+          ctx.ensure_session!
+          domain = ctx.workshop.to_domain
+          goals = domain.world_goals
+
+          if goals.empty?
+            JSON.generate({ goals: [], message: "No world goals declared. All actions are allowed." })
+          else
+            constraints = goals.map do |g|
+              { goal: g, description: GOAL_DESCRIPTIONS.fetch(g, "Custom goal: #{g}") }
+            end
+            JSON.generate({ goals: goals, constraints: constraints })
+          end
+        end
+      end
+
+      # @api private
+      def self.register_check(server, ctx)
+        server.define_tool(
+          name: "check_governance",
+          description: "Check if a command passes governance rules before executing it",
+          input_schema: {
+            type: "object",
+            properties: {
+              command: { type: "string", description: "Command name to check (e.g. CreatePatient)" }
+            },
+            required: ["command"]
+          }
+        ) do |args|
+          ctx.ensure_session!
+          guard = GovernanceGuard.new(ctx)
+          result = guard.check(args["command"])
+          JSON.generate(result)
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/mcp_server.rb
+++ b/hecks_ai/lib/hecks_ai/mcp_server.rb
@@ -6,6 +6,8 @@ require_relative "aggregate_lifecycle_tools"
 require_relative "inspect_tools"
 require_relative "build_tools"
 require_relative "play_tools"
+require_relative "governance_guard"
+require_relative "governance_tools"
 
 module Hecks
   # Hecks::McpServer
@@ -15,12 +17,13 @@ module Hecks
   # domain modeling MCP server (as opposed to DomainServer which serves a
   # pre-built domain).
   #
-  # Registers five tool groups:
-  #   - +SessionTools+    -- create/load domain sessions
-  #   - +AggregateTools+  -- add/remove domain structures
-  #   - +InspectTools+    -- read-only domain introspection
-  #   - +BuildTools+      -- validate, build, save, serve
-  #   - +PlayTools+       -- interactive playground for testing
+  # Registers six tool groups:
+  #   - +SessionTools+      -- create/load domain sessions
+  #   - +AggregateTools+    -- add/remove domain structures
+  #   - +InspectTools+      -- read-only domain introspection
+  #   - +BuildTools+        -- validate, build, save, serve
+  #   - +PlayTools+         -- interactive playground for testing
+  #   - +GovernanceTools+   -- AI governance (world goals alignment)
   #
   # The server runs over stdio transport and acts as a shared context (+ctx+)
   # for all tool modules, providing:
@@ -50,6 +53,7 @@ module Hecks
       Hecks::MCP::InspectTools.register(@server, self)
       Hecks::MCP::BuildTools.register(@server, self)
       Hecks::MCP::PlayTools.register(@server, self)
+      Hecks::MCP::GovernanceTools.register(@server, self)
     end
 
     # Starts the MCP server using stdio transport. Blocks until the transport

--- a/hecks_ai/lib/hecks_ai/play_tools.rb
+++ b/hecks_ai/lib/hecks_ai/play_tools.rb
@@ -51,6 +51,18 @@ module Hecks
           }
         ) do |args|
           ctx.ensure_session!
+          guard = GovernanceGuard.new(ctx)
+          result = guard.check(args["command"])
+
+          unless result[:allowed]
+            next JSON.generate({
+              refused: true,
+              command: args["command"],
+              violations: result[:violations],
+              goals: result[:goals]
+            })
+          end
+
           ctx.workshop.play! unless ctx.workshop.play?
           attrs = (args["attrs"] || {}).transform_keys(&:to_sym)
           ctx.capture_output { ctx.workshop.execute(args["command"], **attrs) }

--- a/hecks_ai/spec/governance_spec.rb
+++ b/hecks_ai/spec/governance_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+require "hecks_ai/governance_guard"
+require "hecks_ai/governance_tools"
+
+RSpec.describe Hecks::MCP::GovernanceGuard do
+  let(:ctx) { double("ctx", workshop: workshop) }
+  let(:guard) { described_class.new(ctx) }
+
+  describe "#check" do
+    context "when no world goals are declared" do
+      let(:workshop) do
+        ws = Hecks.workshop("Shop")
+        ws.aggregate("Product") do
+          attribute :name, String
+          command("CreateProduct") { attribute :name, String }
+        end
+        ws
+      end
+
+      it "allows all commands" do
+        result = guard.check("CreateProduct")
+        expect(result[:allowed]).to be true
+        expect(result[:violations]).to be_empty
+        expect(result[:goals]).to be_empty
+      end
+    end
+
+    context "when transparency goal is declared and command emits no events" do
+      let(:workshop) do
+        ws = Hecks.workshop("Clinic")
+        ws.aggregate("Record") do
+          attribute :title, String
+          command("DeleteRecord") { attribute :id, String; emits [] }
+        end
+        ws.world_goals(:transparency)
+        ws
+      end
+
+      it "refuses the command with a transparency violation" do
+        result = guard.check("DeleteRecord")
+        expect(result[:allowed]).to be false
+        expect(result[:violations].first).to include("Transparency")
+        expect(result[:goals]).to eq([:transparency])
+      end
+    end
+
+    context "when consent goal is declared and user-like aggregate has no actor" do
+      let(:workshop) do
+        ws = Hecks.workshop("Health")
+        ws.aggregate("Patient") do
+          attribute :name, String
+          command("UpdatePatient") { attribute :name, String }
+        end
+        ws.world_goals(:consent)
+        ws
+      end
+
+      it "refuses the command with a consent violation" do
+        result = guard.check("UpdatePatient")
+        expect(result[:allowed]).to be false
+        expect(result[:violations].first).to include("Consent")
+      end
+    end
+
+    context "when goals are met" do
+      let(:workshop) do
+        ws = Hecks.workshop("Health")
+        ws.aggregate("Patient") do
+          attribute :name, String
+          command("UpdatePatient") { attribute :name, String; actor "Doctor" }
+        end
+        ws.world_goals(:consent)
+        ws
+      end
+
+      it "allows the command" do
+        result = guard.check("UpdatePatient")
+        expect(result[:allowed]).to be true
+        expect(result[:violations]).to be_empty
+      end
+    end
+  end
+end
+
+RSpec.describe Hecks::MCP::GovernanceTools do
+  describe "GOAL_DESCRIPTIONS" do
+    it "has descriptions for all four built-in goals" do
+      %i[transparency consent privacy security].each do |goal|
+        expect(described_class::GOAL_DESCRIPTIONS).to have_key(goal)
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop.rb
+++ b/hecks_workshop/lib/hecks/workshop.rb
@@ -60,6 +60,7 @@ module Hecks
       @aggregate_builders = {}
       @handles = {}
       @custom_verbs = []
+      @world_goals = []
       @active_hecks = false
       @mode = :sketch
       @playground = nil
@@ -119,7 +120,10 @@ module Hecks
     # @return [DomainModel::Structure::Domain] the fully assembled domain object
     def to_domain
       aggregates = @aggregate_builders.values.map(&:build)
-      DomainModel::Structure::Domain.new(name: @name, aggregates: aggregates, custom_verbs: @custom_verbs)
+      DomainModel::Structure::Domain.new(
+        name: @name, aggregates: aggregates,
+        custom_verbs: @custom_verbs, world_goals: @world_goals
+      )
     end
 
     # Compile the domain and activate ActiveHecks (Rails persistence layer).
@@ -148,6 +152,19 @@ module Hecks
     # @return [Boolean] true if +active_hecks!+ has been called
     def active_hecks?
       @active_hecks
+    end
+
+    # Declare world goals for this domain.
+    #
+    # World goals activate governance validation rules that check the domain
+    # model for ethical/governance alignment (transparency, consent, privacy,
+    # security).
+    #
+    # @param goals [Array<Symbol>] goal names to activate
+    # @return [Workshop] self, for chaining
+    def world_goals(*goals)
+      @world_goals = goals.flatten.map(&:to_sym)
+      self
     end
 
     # Register a custom verb for use in command naming.


### PR DESCRIPTION
## Summary
- **GovernanceGuard** middleware intercepts `execute_command` tool invocations, validates proposed actions against the domain's `world_goals`, and returns structured refusals with violations when goals are violated
- **GovernanceTools** module adds two new MCP tools: `explain_governance` (list active goals and constraints) and `check_governance` (pre-check a command without executing)
- **Workshop#world_goals** method enables setting governance goals on workshop-built domains, propagating them through `to_domain`

## Example

```json
// AI agent checks what rules are in effect
{ "tool": "explain_governance" }
// => { "goals": ["transparency", "consent"], "constraints": [...] }

// AI agent pre-checks a command
{ "tool": "check_governance", "args": { "command": "DeleteRecord" } }
// => { "allowed": false, "violations": ["Transparency: Record#DeleteRecord emits no events."], "goals": ["transparency"] }

// execute_command auto-refuses when governance fails
{ "tool": "execute_command", "args": { "command": "DeleteRecord" } }
// => { "refused": true, "command": "DeleteRecord", "violations": [...], "goals": ["transparency"] }
```

## Test plan
- [x] GovernanceGuard allows commands when no world goals are declared
- [x] GovernanceGuard refuses commands that violate transparency goal
- [x] GovernanceGuard refuses commands that violate consent goal
- [x] GovernanceGuard allows commands when goals are satisfied
- [x] GovernanceTools has descriptions for all four built-in goals
- [x] Full test suite passes (1777 examples, 0 failures)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)