### PR TITLE
HEC-471: Clean up primitive obsession with value objects

### DIFF
--- a/bluebook/lib/hecks/domain_model/structure/actor.rb
+++ b/bluebook/lib/hecks/domain_model/structure/actor.rb
@@ -18,15 +18,29 @@ module Hecks
       # @return [String] the name of this actor role (e.g., "Customer", "Admin", "Warehouse Staff")
       attr_reader :name
 
+      # @return [String, nil] optional description of the actor's role
+      attr_reader :description
+
       # Creates a new Actor.
       #
       # @param name [String] the human-readable name of the actor role. This should
       #   correspond to a persona identified during Event Storming -- the person or
       #   system role that initiates commands in the domain.
+      # @param description [String, nil] optional description of the role
       #
       # @return [Actor] a new Actor instance
-      def initialize(name:)
-        @name = name
+      def initialize(name:, description: nil)
+        @name = name.to_s
+        @description = description
+      end
+
+      def ==(other)
+        other.is_a?(Actor) && name == other.name && description == other.description
+      end
+      alias eql? ==
+
+      def hash
+        [name, description].hash
       end
     end
     end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -50,7 +50,7 @@ module Hecks
       #   When set, the runtime scopes all repository operations to the current tenant.
       attr_reader :tenancy
 
-      # @return [Array<Hash>] actors (roles) that interact with this domain
+      # @return [Array<Actor>] actors (roles) that interact with this domain
       attr_reader :actors
 
 
@@ -71,7 +71,7 @@ module Hecks
       #   (e.g. :transparency, :consent, :privacy, :security)
       attr_reader :world_goals
 
-      # @return [Array] event subscriber registrations at the domain level
+      # @return [Array<DomainModel::SubscriberRegistration>] event subscriber registrations at the domain level
       attr_reader :event_subscribers
 
       # @return [String, nil] the filesystem path where this domain's source files live.

--- a/bluebook/lib/hecks/domain_model/subscriber_registration.rb
+++ b/bluebook/lib/hecks/domain_model/subscriber_registration.rb
@@ -1,0 +1,19 @@
+module Hecks
+  module DomainModel
+
+    # Hecks::DomainModel::SubscriberRegistration
+    #
+    # Value object representing a domain-level event subscriber registration.
+    # Replaces plain hashes `{ event_name:, block: }` with a proper struct
+    # that supports both method access and hash-style [] access.
+    #
+    # Part of the DomainModel IR layer. Built by DomainBuilder's `on_event`
+    # method, consumed by Runtime::SubscriberSetup.
+    #
+    #   reg = SubscriberRegistration.new(event_name: "CreatedPizza", block: -> (e) { ... })
+    #   reg.event_name  # => "CreatedPizza"
+    #   reg.block       # => #<Proc>
+    #
+    SubscriberRegistration = Struct.new(:event_name, :block, keyword_init: true)
+  end
+end

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -81,7 +81,7 @@ module Hecks
       end
 
       def actor(name, description: nil)
-        @actors << { name: name.to_s, description: description }
+        @actors << Structure::Actor.new(name: name.to_s, description: description)
       end
 
 
@@ -156,7 +156,9 @@ module Hecks
       # @yield block invoked when the event fires
       # @return [void]
       def on_event(event_name, &block)
-        @event_subscribers << { event_name: event_name.to_s, block: block }
+        @event_subscribers << DomainModel::SubscriberRegistration.new(
+          event_name: event_name.to_s, block: block
+        )
       end
 
       # Load partial domain definitions from a file.

--- a/bluebook/lib/hecks/features.rb
+++ b/bluebook/lib/hecks/features.rb
@@ -3,6 +3,7 @@
 # Vertical slice architecture. Extracts vertical slices from domain
 # reactive chains, validates slice boundaries, and generates diagrams.
 #
+require_relative "features/slice_step"
 require_relative "features/vertical_slice"
 require_relative "features/slice_extractor"
 require_relative "features/leaky_slice_detection"

--- a/bluebook/lib/hecks/features/slice_diagram.rb
+++ b/bluebook/lib/hecks/features/slice_diagram.rb
@@ -30,20 +30,20 @@ module Hecks::Features
 
         slice.steps.each_with_index do |step, j|
           node_id = "s#{i}_#{j}"
-          case step[:type]
+          case step.type
           when :command
-            lines << "    #{node_id}[#{step[:command]}]"
+            lines << "    #{node_id}[#{step.command}]"
             event_id = "#{node_id}_evt"
-            lines << "    #{event_id}([#{step[:event]}])"
+            lines << "    #{event_id}([#{step.event}])"
             lines << "    #{node_id} --> #{event_id}"
           when :policy
-            lines << "    #{node_id}{{#{step[:policy]}}}"
-            prev_event = find_event_node(i, step[:event], slice.steps, j)
+            lines << "    #{node_id}{{#{step.policy}}}"
+            prev_event = find_event_node(i, step.event, slice.steps, j)
             lines << "    #{prev_event} -.-> #{node_id}" if prev_event
-            next_cmd = find_command_node(i, step[:command], slice.steps, j)
+            next_cmd = find_command_node(i, step.command, slice.steps, j)
             lines << "    #{node_id} --> #{next_cmd}" if next_cmd
           when :cycle
-            lines << "    #{node_id}>CYCLE: #{step[:command]}]"
+            lines << "    #{node_id}>CYCLE: #{step.command}]"
           end
         end
 
@@ -58,7 +58,7 @@ module Hecks::Features
     def find_event_node(slice_idx, event_name, steps, before_idx)
       steps.each_with_index do |step, j|
         next if j >= before_idx
-        return "s#{slice_idx}_#{j}_evt" if step[:type] == :command && step[:event] == event_name
+        return "s#{slice_idx}_#{j}_evt" if step.type == :command && step.event == event_name
       end
       nil
     end
@@ -66,7 +66,7 @@ module Hecks::Features
     def find_command_node(slice_idx, cmd_name, steps, after_idx)
       steps.each_with_index do |step, j|
         next if j <= after_idx
-        return "s#{slice_idx}_#{j}" if step[:type] == :command && step[:command] == cmd_name
+        return "s#{slice_idx}_#{j}" if step.type == :command && step.command == cmd_name
       end
       nil
     end

--- a/bluebook/lib/hecks/features/slice_extractor.rb
+++ b/bluebook/lib/hecks/features/slice_extractor.rb
@@ -28,15 +28,16 @@ module Hecks::Features
     private
 
     def build_slice(flow)
-      aggregates = flow[:steps]
-        .map { |s| s[:aggregate] }
+      steps = flow[:steps].map { |s| SliceStep.new(**s) }
+      aggregates = steps
+        .map(&:aggregate)
         .compact
         .uniq
 
       VerticalSlice.new(
         name: flow[:name],
-        entry_command: flow[:steps].first[:command],
-        steps: flow[:steps],
+        entry_command: steps.first.command,
+        steps: steps,
         aggregates: aggregates,
         cyclic: flow[:cyclic]
       )

--- a/bluebook/lib/hecks/features/slice_step.rb
+++ b/bluebook/lib/hecks/features/slice_step.rb
@@ -1,0 +1,20 @@
+module Hecks::Features
+
+  # Hecks::Features::SliceStep
+  #
+  # Value object representing a single step in a reactive flow chain.
+  # Replaces plain hashes like `{ type: :command, command:, aggregate:, event: }`
+  # with a proper struct that provides named accessors and hash-style [] access.
+  #
+  # Three step types exist:
+  # - :command -- a command execution with command name, aggregate, and emitted event
+  # - :policy  -- a reactive policy trigger with policy name, source event, and target command
+  # - :cycle   -- marks a cycle back to a previously visited command
+  #
+  #   step = SliceStep.new(type: :command, command: "IssueLoan", aggregate: "Loan", event: "IssuedLoan")
+  #   step.type      # => :command
+  #   step.command   # => "IssueLoan"
+  #   step[:aggregate] # => "Loan" (hash-style access also works)
+  #
+  SliceStep = Struct.new(:type, :command, :aggregate, :event, :policy, keyword_init: true)
+end

--- a/bluebook/lib/hecks/features/vertical_slice.rb
+++ b/bluebook/lib/hecks/features/vertical_slice.rb
@@ -22,7 +22,7 @@ module Hecks::Features
     # @return [String] the command that starts this slice
     attr_reader :entry_command
 
-    # @return [Array<Hash>] ordered steps from FlowGenerator trace
+    # @return [Array<SliceStep>] ordered steps from FlowGenerator trace
     attr_reader :steps
 
     # @return [Array<String>] unique aggregate names involved in this slice
@@ -50,21 +50,21 @@ module Hecks::Features
     #
     # @return [Array<String>]
     def commands
-      steps.select { |s| s[:type] == :command }.map { |s| s[:command] }
+      steps.select { |s| s.type == :command }.map(&:command)
     end
 
     # All event names emitted in this slice.
     #
     # @return [Array<String>]
     def events
-      steps.select { |s| s[:type] == :command }.map { |s| s[:event] }.compact
+      steps.select { |s| s.type == :command }.map(&:event).compact
     end
 
     # All policy names in this slice.
     #
     # @return [Array<String>]
     def policies
-      steps.select { |s| s[:type] == :policy }.map { |s| s[:policy] }
+      steps.select { |s| s.type == :policy }.map(&:policy)
     end
 
     # Number of steps in the reactive chain.

--- a/bluebook/lib/hecks/validation_rules/world_goals/security.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/security.rb
@@ -24,7 +24,7 @@ module Hecks
         def errors
           return [] unless @domain.world_goals.include?(:security)
 
-          domain_actor_names = @domain.actors.map { |a| a.is_a?(Hash) ? a[:name] : a.name }
+          domain_actor_names = @domain.actors.map(&:name)
           issues = []
 
           @domain.aggregates.each do |agg|

--- a/bluebook/spec/dsl/domain_builder_spec.rb
+++ b/bluebook/spec/dsl/domain_builder_spec.rb
@@ -243,8 +243,10 @@ RSpec.describe Hecks::DSL::DomainBuilder do
         aggregate("Policy") { attribute :name, String; command("CreatePolicy") { attribute :name, String } }
       end
       expect(domain.actors.length).to eq(2)
-      expect(domain.actors[0]).to eq({ name: "governance_board", description: nil })
-      expect(domain.actors[1]).to eq({ name: "admin", description: "System administrator" })
+      expect(domain.actors[0].name).to eq("governance_board")
+      expect(domain.actors[0].description).to be_nil
+      expect(domain.actors[1].name).to eq("admin")
+      expect(domain.actors[1].description).to eq("System administrator")
     end
   end
 

--- a/hecks_on_rails/lib/active_hecks/domain_model_compat.rb
+++ b/hecks_on_rails/lib/active_hecks/domain_model_compat.rb
@@ -25,7 +25,7 @@ module ActiveHecks
       hash = {}
       hash["id"] = id if respond_to?(:id)
       if self.class.respond_to?(:hecks_attributes)
-        self.class.hecks_attributes.each { |a| hash[a[:name].to_s] = send(a[:name]) }
+        self.class.hecks_attributes.each { |a| hash[a.name.to_s] = send(a.name) }
       else
         self.class.instance_method(:initialize).parameters.each do |_, name|
           next unless name

--- a/hecks_on_rails/spec/active_hecks/domain_model_compat_configure_spec.rb
+++ b/hecks_on_rails/spec/active_hecks/domain_model_compat_configure_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "ActiveHecks::DomainModelCompat (edge cases)" do
       attr_reader :id
 
       def self.hecks_attributes
-        [{ name: :id }]
+        [Hecks::RuntimeAttributeDefinition.new(name: :id)]
       end
     end
     klass.include(ActiveHecks::DomainModelCompat)

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -74,9 +74,10 @@ module Hecks
   # - +Behavior+ -- Behavioral types: Command, Event, Policy, Lifecycle,
   #   Workflow, Guard, Invariant
   module DomainModel
-    autoload :Behavior,  "hecks/domain_model/behavior"
-    autoload :Structure, "hecks/domain_model/structure"
-    autoload :Names,     "hecks/domain_model/names"
+    autoload :Behavior,                "hecks/domain_model/behavior"
+    autoload :Structure,               "hecks/domain_model/structure"
+    autoload :Names,                   "hecks/domain_model/names"
+    autoload :SubscriberRegistration,  "hecks/domain_model/subscriber_registration"
   end
 
   # = Hecks::DSL

--- a/hecksties/lib/hecks/extensions/filesystem_store.rb
+++ b/hecksties/lib/hecks/extensions/filesystem_store.rb
@@ -127,7 +127,7 @@ module Hecks
       when Array then val.map { |v| serialize_value(v) }
       when ->(v) { v.class.respond_to?(:hecks_attributes) }
         h = {}
-        val.class.hecks_attributes.each { |a| h[a[:name].to_s] = serialize_value(val.send(a[:name])) }
+        val.class.hecks_attributes.each { |a| h[a.name.to_s] = serialize_value(val.send(a.name)) }
         h
       else val
       end

--- a/hecksties/lib/hecks/mixins/model.rb
+++ b/hecksties/lib/hecks/mixins/model.rb
@@ -1,4 +1,5 @@
 require "securerandom"
+require_relative "runtime_attribute_definition"
 
 module Hecks
   # Hecks::Model
@@ -73,16 +74,15 @@ module Hecks
       # @return [void]
       def attribute(name, default: nil, freeze: false)
         @hecks_attributes ||= []
-        @hecks_attributes << { name: name.to_sym, default: default, freeze: freeze }
+        @hecks_attributes << RuntimeAttributeDefinition.new(name: name.to_sym, default: default, freeze: freeze)
         attr_reader name
         attr_writer name
         rebuild_initializer
       end
 
       # Returns the list of declared attribute definitions for this model.
-      # Each entry is a Hash with keys +:name+, +:default+, and +:freeze+.
       #
-      # @return [Array<Hash>] attribute definitions, empty array if none declared
+      # @return [Array<RuntimeAttributeDefinition>] attribute definitions, empty array if none declared
       def hecks_attributes
         @hecks_attributes || []
       end
@@ -100,10 +100,10 @@ module Hecks
           @id = id || SecureRandom.uuid
           @_pristine = {}
           attrs.each do |attr|
-            val = kwargs.fetch(attr[:name], attr[:default])
+            val = kwargs.fetch(attr.name, attr.default)
             val = val.freeze if attr[:freeze]
-            instance_variable_set(:"@#{attr[:name]}", val)
-            @_pristine[attr[:name]] = val
+            instance_variable_set(:"@#{attr.name}", val)
+            @_pristine[attr.name] = val
           end
           validate!
           check_invariants!
@@ -168,8 +168,8 @@ module Hecks
       short_class = self.class.name&.split("::")&.last || self.class.to_s
       short_id = id.to_s[0, 8]
       attrs = self.class.hecks_attributes.map do |attr|
-        val = instance_variable_get(:"@#{attr[:name]}")
-        "#{attr[:name]}: #{val.inspect}"
+        val = instance_variable_get(:"@#{attr.name}")
+        "#{attr.name}: #{val.inspect}"
       end
       "#<#{short_class} id:#{short_id} #{attrs.join(' ')}>"
     end

--- a/hecksties/lib/hecks/mixins/runtime_attribute_definition.rb
+++ b/hecksties/lib/hecks/mixins/runtime_attribute_definition.rb
@@ -1,0 +1,16 @@
+module Hecks
+
+  # Hecks::RuntimeAttributeDefinition
+  #
+  # Value object representing a declared attribute on a runtime model class.
+  # Replaces plain hashes `{ name:, default:, freeze: }` with a proper struct
+  # that supports both method access and hash-style [] access.
+  #
+  #   attr_def = RuntimeAttributeDefinition.new(name: :title, default: nil, freeze: false)
+  #   attr_def.name     # => :title
+  #   attr_def[:name]   # => :title (hash-style access)
+  #   attr_def.default  # => nil
+  #   attr_def[:freeze] # => false
+  #
+  RuntimeAttributeDefinition = Struct.new(:name, :default, :freeze, keyword_init: true)
+end

--- a/hecksties/lib/hecks/ports/repository/collection_proxy.rb
+++ b/hecksties/lib/hecks/ports/repository/collection_proxy.rb
@@ -192,7 +192,7 @@ module Hecks
           attrs = { id: @owner.id }
           if @owner.class.respond_to?(:hecks_attributes)
             @owner.class.hecks_attributes.each do |a|
-              attrs[a[:name]] = a[:name] == @attr_name ? new_items : @owner.send(a[:name])
+              attrs[a.name] = a.name == @attr_name ? new_items : @owner.send(a.name)
             end
           else
             @owner.class.instance_method(:initialize).parameters.each do |_, name|

--- a/hecksties/lib/hecks/ports/repository/repository_methods.rb
+++ b/hecksties/lib/hecks/ports/repository/repository_methods.rb
@@ -114,7 +114,7 @@ module Hecks
       # @return [Array<Symbol>] the attribute names (excluding :id)
       def self.attr_names(klass)
         if klass.respond_to?(:hecks_attributes)
-          klass.hecks_attributes.map { |a| a[:name] }
+          klass.hecks_attributes.map(&:name)
         else
           klass.instance_method(:initialize).parameters
             .select { |type, _| type == :key || type == :keyreq }

--- a/hecksties/lib/hecks/runtime/subscriber_setup.rb
+++ b/hecksties/lib/hecks/runtime/subscriber_setup.rb
@@ -50,8 +50,9 @@ module Hecks
 
         # Wires domain-level event subscribers (defined via +on_event+ in the domain DSL).
         #
-        # These are simple block-based subscribers stored as hashes with +:event_name+
-        # and +:block+ keys. Each block is subscribed directly to the event bus.
+        # These are block-based subscribers stored as SubscriberRegistration structs
+        # with +event_name+ and +block+ members. Each block is subscribed directly
+        # to the event bus.
         #
         # Returns immediately if the domain does not support +event_subscribers+
         # (backward compatibility with older domain definitions).
@@ -61,9 +62,9 @@ module Hecks
           return unless @domain.respond_to?(:event_subscribers)
 
           @domain.event_subscribers.each do |sub|
-            block = sub[:block]
-            @event_bus.subscribe(sub[:event_name]) do |event|
-              block.call(event)
+            callback = sub.block
+            @event_bus.subscribe(sub.event_name) do |event|
+              callback.call(event)
             end
           end
         end

--- a/hecksties/lib/hecks/runtime/versioning.rb
+++ b/hecksties/lib/hecks/runtime/versioning.rb
@@ -35,7 +35,7 @@ module Hecks
           versions = version_store[aggregate.id] ||= []
           snapshot = {}
           klass.hecks_attributes.each do |attr_def|
-            snapshot[attr_def[:name]] = existing.send(attr_def[:name])
+            snapshot[attr_def.name] = existing.send(attr_def.name)
           end
           versions << { version: versions.size + 1, state: snapshot, at: Time.now }
         end

--- a/hecksties/lib/hecks/stats/domain_stats.rb
+++ b/hecksties/lib/hecks/stats/domain_stats.rb
@@ -29,7 +29,7 @@ module Hecks::Stats
         validations:     aggs.sum { |a| a.validations.size },
         invariants:      aggs.sum { |a| a.invariants.size },
         references:      references_breakdown(aggs),
-        actors:          (@domain.actors || []).map { |a| a[:name] },
+        actors:          (@domain.actors || []).map(&:name),
         services:        @domain.services.size,
         lifecycles:      aggs.count { |a| a.lifecycle },
         subscribers:     aggs.sum { |a| a.subscribers.size }

--- a/hecksties/lib/hecks/utils.rb
+++ b/hecksties/lib/hecks/utils.rb
@@ -208,7 +208,7 @@ module Hecks
       klass = obj.is_a?(Class) ? obj : obj.class
       names = [:id]
       if klass.respond_to?(:hecks_attributes)
-        names += klass.hecks_attributes.map { |a| a[:name] }
+        names += klass.hecks_attributes.map(&:name)
       else
         klass.instance_method(:initialize).parameters.each do |_, name|
           names << name if name && name != :id

--- a/hecksties/lib/hecks_cli/domain_inspector.rb
+++ b/hecksties/lib/hecks_cli/domain_inspector.rb
@@ -116,8 +116,7 @@ module Hecks
         return [] if @domain.actors.empty?
         lines = ["Actors:"]
         @domain.actors.each do |actor|
-          name = actor.respond_to?(:name) ? actor.name : actor.to_s
-          lines << "  #{name}"
+          lines << "  #{actor.name}"
         end
         lines << ""
       end

--- a/hecksties/spec/runtime/extension_adapter_type_spec.rb
+++ b/hecksties/spec/runtime/extension_adapter_type_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 require "tmpdir"
 require "fileutils"
+require "hecks/extensions/serve"
+require "hecks_ai"
 
 RSpec.describe "Extension adapter_type classification" do
   describe "driven_extensions" do


### PR DESCRIPTION
## Summary
- Replace `actors` plain hashes with `Structure::Actor` value objects (adds `description` support, equality, eliminates `is_a?(Hash)` duck-typing)
- Replace vertical slice step hashes with `Features::SliceStep` Struct (backward-compatible `[]` access via Struct)
- Replace `hecks_attributes` hashes with `RuntimeAttributeDefinition` Struct in the Model mixin
- Replace domain-level event subscriber hashes with `DomainModel::SubscriberRegistration` Struct
- Update all 21 consumers across bluebook, hecksties, hecks_on_rails to use method access

## Example

**Before:**
```ruby
# Duck-typing needed in validation rules
domain_actor_names = @domain.actors.map { |a| a.is_a?(Hash) ? a[:name] : a.name }

# Hash access in model mixins
klass.hecks_attributes.map { |a| a[:name] }

# Hash access in slice steps
steps.select { |s| s[:type] == :command }.map { |s| s[:command] }
```

**After:**
```ruby
# Clean method access everywhere
domain_actor_names = @domain.actors.map(&:name)

# Method access on RuntimeAttributeDefinition
klass.hecks_attributes.map(&:name)

# Method access on SliceStep (Struct#[] still works for backward compat)
steps.select { |s| s.type == :command }.map(&:command)
```

## Test plan
- [x] All 1772 specs pass
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [x] No files over 200-line code limit
- [x] Backward compatibility maintained via Struct `[]` access