### PR TITLE
HEC-366: Add port visualization to domain diagrams

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -353,6 +353,7 @@
   - `--type behavior` — flowchart of command-to-event flows and policy chains
   - `--type flows` — sequenceDiagram of reactive chain flows
   - `--type slices` — slice flowchart with subgraph per vertical slice
+  - `--type ports` — hexagonal port diagram showing driving/driven adapters around the domain
   - `--browser` — self-contained HTML with Mermaid CDN opened in browser
   - `--output <file>` — write Mermaid markdown to a file
 - Domain glossary with English descriptions

--- a/bluebook/lib/hecks/domain/visualizer.rb
+++ b/bluebook/lib/hecks/domain/visualizer.rb
@@ -1,5 +1,6 @@
 require_relative "visualizer_parts/structure_diagram"
 require_relative "visualizer_parts/behavior_diagram"
+require_relative "visualizer_parts/port_diagram"
 
 module Hecks
   # Hecks::DomainVisualizer
@@ -19,6 +20,7 @@ module Hecks
   class DomainVisualizer
     include StructureDiagram
     include BehaviorDiagram
+    include PortDiagram
 
     # @param domain [Hecks::DomainModel::Domain] the domain IR to visualize
     def initialize(domain)

--- a/bluebook/lib/hecks/domain/visualizer_parts/port_diagram.rb
+++ b/bluebook/lib/hecks/domain/visualizer_parts/port_diagram.rb
@@ -1,0 +1,88 @@
+# Hecks::DomainVisualizer::PortDiagram
+#
+# Builds a Mermaid flowchart showing the hexagonal architecture of a domain:
+# driving ports (HTTP, MCP, CLI, etc.) on the left, the domain hexagon in
+# the center, and driven ports (persistence, auth, logging, etc.) on the
+# right. Arrows show data flow direction.
+#
+# Extension metadata is read from Hecks.extension_meta when available.
+# An explicit +extensions+ parameter can override this for testing.
+#
+#   include PortDiagram
+#   generate_ports  # => "flowchart LR\n    subgraph Driving Ports\n..."
+#
+module Hecks
+  class DomainVisualizer
+    module PortDiagram
+      # Generate a Mermaid flowchart showing driving ports, the domain
+      # hexagon, and driven ports with directional arrows.
+      #
+      # @param extensions [Hash, nil] extension metadata hash; defaults to
+      #   Hecks.extension_meta if available
+      # @return [String] Mermaid flowchart source code
+      def generate_ports(extensions: nil)
+        meta = resolve_extension_meta(extensions)
+        driving = extract_by_type(meta, :driving)
+        driven  = extract_by_type(meta, :driven)
+
+        lines = ["flowchart LR"]
+        driving_nodes(lines, driving)
+        domain_node(lines)
+        driven_nodes(lines, driven)
+        flow_arrows(lines, driving, driven)
+        lines.join("\n")
+      end
+
+      private
+
+      def resolve_extension_meta(explicit)
+        return explicit if explicit
+        return Hecks.extension_meta if defined?(Hecks.extension_meta) && Hecks.extension_meta.any?
+
+        {}
+      end
+
+      def extract_by_type(meta, type)
+        entries = meta.respond_to?(:select) ? meta.select { |_, m| m[:adapter_type] == type } : []
+        entries.map { |name, m| { name: name, description: m[:description] } }
+      end
+
+      def driving_nodes(lines, driving)
+        return if driving.empty?
+
+        lines << "    subgraph Driving[\"Driving Ports\"]"
+        driving.each do |ext|
+          lines << "        #{port_id(ext[:name])}[\"#{ext[:name]}: #{ext[:description]}\"]"
+        end
+        lines << "    end"
+      end
+
+      def domain_node(lines)
+        lines << "    Domain{{\"#{@domain.name}\"}}"
+      end
+
+      def driven_nodes(lines, driven)
+        return if driven.empty?
+
+        lines << "    subgraph Driven[\"Driven Ports\"]"
+        driven.each do |ext|
+          lines << "        #{port_id(ext[:name])}[\"#{ext[:name]}: #{ext[:description]}\"]"
+        end
+        lines << "    end"
+      end
+
+      def flow_arrows(lines, driving, driven)
+        driving.each do |ext|
+          lines << "    #{port_id(ext[:name])} --> Domain"
+        end
+        driven.each do |ext|
+          lines << "    Domain --> #{port_id(ext[:name])}"
+        end
+      end
+
+      def port_id(name)
+        "port_#{name}"
+      end
+    end
+  end
+end

--- a/bluebook/spec/domain/port_diagram_spec.rb
+++ b/bluebook/spec/domain/port_diagram_spec.rb
@@ -1,0 +1,106 @@
+require "spec_helper"
+
+RSpec.describe Hecks::DomainVisualizer::PortDiagram do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+      end
+    end
+  end
+
+  subject(:visualizer) { Hecks::DomainVisualizer.new(domain) }
+
+  let(:extensions) do
+    {
+      http: { description: "REST server", adapter_type: :driving },
+      mcp:  { description: "MCP server", adapter_type: :driving },
+      sqlite: { description: "SQLite persistence", adapter_type: :driven },
+      auth: { description: "Authorization", adapter_type: :driven }
+    }
+  end
+
+  let(:output) { visualizer.generate_ports(extensions: extensions) }
+
+  describe "#generate_ports" do
+    it "produces a flowchart LR" do
+      expect(output).to include("flowchart LR")
+    end
+
+    it "groups driving ports in a subgraph" do
+      expect(output).to include('subgraph Driving["Driving Ports"]')
+      expect(output).to include('port_http["http: REST server"]')
+      expect(output).to include('port_mcp["mcp: MCP server"]')
+    end
+
+    it "shows the domain hexagon node" do
+      expect(output).to include('Domain{{"Pizzas"}}')
+    end
+
+    it "groups driven ports in a subgraph" do
+      expect(output).to include('subgraph Driven["Driven Ports"]')
+      expect(output).to include('port_sqlite["sqlite: SQLite persistence"]')
+      expect(output).to include('port_auth["auth: Authorization"]')
+    end
+
+    it "draws arrows from driving ports to domain" do
+      expect(output).to include("port_http --> Domain")
+      expect(output).to include("port_mcp --> Domain")
+    end
+
+    it "draws arrows from domain to driven ports" do
+      expect(output).to include("Domain --> port_sqlite")
+      expect(output).to include("Domain --> port_auth")
+    end
+  end
+
+  describe "with no extensions" do
+    let(:output) { visualizer.generate_ports(extensions: {}) }
+
+    it "still produces a flowchart with the domain node" do
+      expect(output).to include("flowchart LR")
+      expect(output).to include('Domain{{"Pizzas"}}')
+    end
+
+    it "omits port subgraphs" do
+      expect(output).not_to include("Driving Ports")
+      expect(output).not_to include("Driven Ports")
+    end
+  end
+
+  describe "with only driving ports" do
+    let(:output) do
+      visualizer.generate_ports(extensions: { http: { description: "REST", adapter_type: :driving } })
+    end
+
+    it "shows driving subgraph but no driven subgraph" do
+      expect(output).to include("Driving Ports")
+      expect(output).not_to include("Driven Ports")
+    end
+  end
+
+  describe "with only driven ports" do
+    let(:output) do
+      visualizer.generate_ports(extensions: { sqlite: { description: "SQLite", adapter_type: :driven } })
+    end
+
+    it "shows driven subgraph but no driving subgraph" do
+      expect(output).not_to include("Driving Ports")
+      expect(output).to include("Driven Ports")
+    end
+  end
+
+  describe "skips untyped extensions" do
+    let(:output) do
+      visualizer.generate_ports(extensions: {
+        http: { description: "REST", adapter_type: :driving },
+        unknown: { description: "Mystery", adapter_type: nil }
+      })
+    end
+
+    it "does not include untyped extensions" do
+      expect(output).not_to include("unknown")
+      expect(output).to include("port_http")
+    end
+  end
+end

--- a/docs/usage/port_visualization.md
+++ b/docs/usage/port_visualization.md
@@ -1,0 +1,59 @@
+# Port Visualization
+
+Show the hexagonal architecture of your domain: driving ports on the left, the domain in the center, and driven ports on the right.
+
+## CLI Usage
+
+```bash
+# Generate the port diagram
+hecks visualize --type ports
+
+# Open in browser
+hecks visualize --type ports --browser
+
+# Write to file
+hecks visualize --type ports --output ports.md
+```
+
+## Example Output
+
+Given a Pizzas domain with HTTP, MCP (driving) and SQLite, Auth (driven) extensions:
+
+```mermaid
+flowchart LR
+    subgraph Driving["Driving Ports"]
+        port_http["http: REST and JSON-RPC server with OpenAPI docs"]
+        port_mcp["mcp: MCP server for AI-assisted domain modeling"]
+    end
+    Domain{{"Pizzas"}}
+    subgraph Driven["Driven Ports"]
+        port_sqlite["sqlite: SQLite persistence via Sequel"]
+        port_auth["auth: Actor-based authorization via port guards"]
+    end
+    port_http --> Domain
+    port_mcp --> Domain
+    Domain --> port_sqlite
+    Domain --> port_auth
+```
+
+## Programmatic Usage
+
+```ruby
+domain = Hecks.domain("Pizzas") { aggregate("Pizza") { attribute :name, String } }
+viz = Hecks::DomainVisualizer.new(domain)
+
+# Uses Hecks.extension_meta automatically
+puts viz.generate_ports
+
+# Or pass explicit extension metadata for testing
+puts viz.generate_ports(extensions: {
+  http: { description: "REST server", adapter_type: :driving },
+  sqlite: { description: "SQLite persistence", adapter_type: :driven }
+})
+```
+
+## How It Works
+
+The port diagram reads from `Hecks.extension_meta`, which is populated by each extension's `Hecks.describe_extension` call. Extensions declare themselves as `:driving` (inbound adapters like HTTP, CLI, MCP) or `:driven` (outbound adapters like persistence, auth, logging).
+
+Arrows show data flow direction: driving ports push data into the domain, and the domain pushes data out to driven ports.

--- a/docs/usage/visualize.md
+++ b/docs/usage/visualize.md
@@ -20,6 +20,9 @@ hecks visualize --type flows
 # Print the vertical slice flowchart
 hecks visualize --type slices
 
+# Print the hexagonal port diagram (driving/driven adapters)
+hecks visualize --type ports
+
 # Open a self-contained HTML page with Mermaid rendering in the browser
 hecks visualize --browser
 
@@ -65,6 +68,7 @@ flowchart LR
 | `behavior` | `flowchart LR` | Command-to-event flows, policy links |
 | `flows` | `sequenceDiagram` | Reactive chains traced from entry commands |
 | `slices` | `flowchart LR` | Vertical slices as labeled subgraphs |
+| `ports` | `flowchart LR` | Hexagonal port diagram: driving/driven adapters around domain |
 | (default) | both | `structure` + `behavior` diagrams |
 
 ## Browser Mode

--- a/hecksties/lib/hecks_cli/commands/visualize.rb
+++ b/hecksties/lib/hecks_cli/commands/visualize.rb
@@ -8,13 +8,14 @@
 #   hecks visualize --type behavior      # flowchart only
 #   hecks visualize --type flows         # sequenceDiagram only
 #   hecks visualize --type slices        # slice flowchart only
+#   hecks visualize --type ports         # hexagonal port diagram
 #   hecks visualize --browser            # open HTML in browser
 #   hecks visualize --output diagram.md  # write to file
 #
 Hecks::CLI.register_command(:visualize, "Generate Mermaid diagrams for the domain",
   options: {
     domain:  { type: :string,  desc: "Domain gem name or path" },
-    type:    { type: :string,  desc: "Diagram type: structure, behavior, flows, slices (default: all)" },
+    type:    { type: :string,  desc: "Diagram type: structure, behavior, flows, slices, ports (default: all)" },
     browser: { type: :boolean, desc: "Open diagram as HTML in browser" },
     output:  { type: :string,  desc: "Write diagram to file (e.g. diagram.md)" }
   }
@@ -53,6 +54,8 @@ def build_mermaid(domain, type)
     "```mermaid\n#{Hecks::FlowGenerator.new(domain).generate_mermaid}\n```"
   when :slices
     "```mermaid\n#{Hecks::Features::SliceDiagram.new(domain).generate}\n```"
+  when :ports
+    "```mermaid\n#{Hecks::DomainVisualizer.new(domain).generate_ports}\n```"
   else
     Hecks::DomainVisualizer.new(domain).generate
   end

--- a/hecksties/spec/cli/commands/visualize_spec.rb
+++ b/hecksties/spec/cli/commands/visualize_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe "hecks visualize" do
     end
   end
 
+  it "--type ports produces port flowchart" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestVizBluebook"), BLUEBOOK_DSL)
+      Dir.chdir(dir) do
+        output = run_visualize(cli, { type: "ports" })
+        expect(output).to include("flowchart LR")
+        expect(output).to include("TestViz")
+      end
+    end
+  end
+
   it "--type flows produces sequenceDiagram" do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, "TestVizBluebook"), BLUEBOOK_DSL)


### PR DESCRIPTION
## Summary

- Add hexagonal port diagram (`--type ports`) to `hecks visualize` showing driving ports (HTTP, MCP, CLI) on the left, the domain hexagon in the center, and driven ports (persistence, auth, logging) on the right with directional arrows
- Reads extension metadata from `Hecks.extension_meta` automatically; accepts explicit `extensions:` parameter for testing
- New `PortDiagram` module mixed into `DomainVisualizer`, following the same pattern as `StructureDiagram` and `BehaviorDiagram`

## Example

```bash
hecks visualize --type ports
```

```mermaid
flowchart LR
    subgraph Driving["Driving Ports"]
        port_http["http: REST and JSON-RPC server with OpenAPI docs"]
        port_mcp["mcp: MCP server for AI-assisted domain modeling"]
    end
    Domain{{"Pizzas"}}
    subgraph Driven["Driven Ports"]
        port_sqlite["sqlite: SQLite persistence via Sequel"]
        port_auth["auth: Actor-based authorization via port guards"]
    end
    port_http --> Domain
    port_mcp --> Domain
    Domain --> port_sqlite
    Domain --> port_auth
```

## Test plan

- [x] Unit specs for `PortDiagram` module (driving/driven/empty/mixed scenarios, untyped extension filtering)
- [x] CLI spec for `--type ports` option
- [x] All 1784 existing specs pass
- [x] Smoke test passes
- [ ] Manual: `hecks visualize --type ports` in a booted app with extensions
- [ ] Manual: `hecks visualize --type ports --browser` renders in browser