### PR TITLE
HEC-12: CLI tree command and --format json support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -404,12 +404,14 @@
 - `hecks validate` — check domain against DDD rules
 - `hecks mcp` — start MCP server
 - `hecks inspect` — show full domain definition including business logic (attributes, lifecycle, commands, policies, invariants, etc.)
+- `hecks tree` — print all CLI commands as a grouped tree; `--format json` for tooling
 - `hecks glossary` — print domain glossary to stdout; `--export` writes `glossary.md`
 - `hecks dump` — show glossary, visualizer, and DSL output
 - `hecks migrations` — schema migration management
 - `hecks interview` — conversational onboarding that walks through domain definition interactively (name, aggregates, attributes, commands) and writes a Bluebook file
 - `hecks docs update` — sync doc headers and READMEs
 - All commands accept `--domain` flag consistently
+- `--format json` on `validate`, `inspect`, and `tree` commands for Studio/tooling consumption
 
 ## Rails Integration (ActiveHecks)
 - `Hecks.configure` block for Rails initializers

--- a/docs/usage/cli_json_format.md
+++ b/docs/usage/cli_json_format.md
@@ -1,0 +1,72 @@
+# CLI JSON Format
+
+Several CLI commands support `--format json` for machine-readable output,
+useful for IDE integration, Studio consumption, and CI pipelines.
+
+## Commands with JSON support
+
+### hecks validate --format json
+
+```bash
+hecks validate --format json
+```
+
+```json
+{
+  "valid": true,
+  "domain": "Pizzas",
+  "aggregates": [
+    {
+      "name": "Pizza",
+      "attributes": ["name", "description"],
+      "commands": ["CreatePizza"],
+      "events": ["CreatedPizza"]
+    }
+  ],
+  "errors": [],
+  "warnings": []
+}
+```
+
+### hecks inspect --format json
+
+```bash
+hecks inspect --format json
+hecks inspect --format json --aggregate Order
+```
+
+```json
+{
+  "domain": "Shop",
+  "aggregates": [
+    {
+      "name": "Order",
+      "attributes": [
+        { "name": "name", "type": "String" },
+        { "name": "total", "type": "Float" }
+      ],
+      "commands": [
+        { "name": "CreateOrder", "attributes": [{ "name": "name", "type": "String" }] }
+      ],
+      "events": ["OrderCreated"],
+      "value_objects": ["LineItem"]
+    }
+  ]
+}
+```
+
+### hecks tree --format json
+
+```bash
+hecks tree --format json
+```
+
+Returns all registered commands grouped by source module. See `docs/usage/cli_tree.md`.
+
+### hecks stats --json
+
+```bash
+hecks stats --json
+```
+
+Returns comprehensive project statistics as JSON.

--- a/docs/usage/cli_tree.md
+++ b/docs/usage/cli_tree.md
@@ -1,0 +1,44 @@
+# CLI Tree Command
+
+Print all registered CLI commands grouped by source module.
+
+## Usage
+
+```bash
+# Text tree output
+hecks tree
+
+# JSON output for tooling/Studio
+hecks tree --format json
+```
+
+## Text Output Example
+
+```
+Hecks CLI Commands
+
+Cli/
+  |-- build  [--domain, --version, --target, --static]  # Generate the domain gem
+  |-- inspect  [--domain, --aggregate, --format]  # Show full domain definition
+  |-- validate  [--domain, --format]  # Validate the domain definition
+  \-- tree  [--format]  # Print all commands as a grouped tree
+
+Workshop/
+  |-- console  # Start the interactive workshop
+  \-- web_workshop  # Start the browser-based workshop
+```
+
+## JSON Output Example
+
+```bash
+hecks tree --format json
+```
+
+```json
+{
+  "Cli": [
+    { "name": "build", "description": "Generate the domain gem", "options": ["domain", "version", "target", "static"] },
+    { "name": "validate", "description": "Validate the domain definition", "options": ["domain", "format"] }
+  ]
+}
+```

--- a/hecksties/lib/hecks/stats/commands/stats.rb
+++ b/hecksties/lib/hecks/stats/commands/stats.rb
@@ -8,7 +8,11 @@
 #
 # stats merged into hecksties
 
-Hecks::CLI.register_command(:stats, "Show comprehensive domain statistics") do
+Hecks::CLI.register_command(:stats, "Show comprehensive domain statistics",
+  options: {
+    json: { type: :boolean, desc: "Output as JSON" }
+  }
+) do
   require "json" if options[:json]
   project_root = Dir.pwd
   stats = Hecks::Stats::ProjectStats.new(project_root)

--- a/hecksties/lib/hecks_cli/commands/inspect_domain.rb
+++ b/hecksties/lib/hecks_cli/commands/inspect_domain.rb
@@ -1,4 +1,4 @@
-# Hecks::CLI — inspect command
+# Hecks::CLI -- inspect command
 #
 # Shows the full domain definition including business logic, formatted
 # for terminal reading. Walks the domain IR to display attributes, value
@@ -8,18 +8,52 @@
 #   hecks inspect                          # full domain
 #   hecks inspect --aggregate Order        # single aggregate
 #   hecks inspect --domain path/to/domain  # explicit domain path
+#   hecks inspect --format json            # JSON output for tooling
 #
 require_relative "../domain_inspector"
 
 Hecks::CLI.register_command(:inspect, "Show full domain definition including business logic",
   options: {
     domain:    { type: :string, desc: "Domain gem name or path" },
-    aggregate: { type: :string, desc: "Filter to a single aggregate by name" }
+    aggregate: { type: :string, desc: "Filter to a single aggregate by name" },
+    format:    { type: :string, desc: "Output format: text (default) or json" }
   }
 ) do
   domain = resolve_domain_option
   next unless domain
 
+  if options[:format] == "json"
+    require "json"
+    aggs = domain.aggregates
+    if options[:aggregate]
+      aggs = aggs.select { |a| a.name == options[:aggregate] }
+    end
+    result = {
+      domain: domain.name,
+      aggregates: aggs.map { |a| aggregate_to_hash(a) }
+    }
+    say JSON.pretty_generate(result)
+    next
+  end
+
   output = Hecks::CLI::DomainInspector.new(domain).generate(aggregate: options[:aggregate])
   say output
+end
+
+def aggregate_to_hash(agg)
+  h = {
+    name: agg.name,
+    attributes: agg.attributes.map { |a| { name: a.name.to_s, type: a.type.to_s } }
+  }
+  h[:value_objects] = agg.value_objects.map(&:name) unless agg.value_objects.empty?
+  h[:entities] = agg.entities.map(&:name) unless agg.entities.empty?
+  h[:commands] = agg.commands.map { |c| { name: c.name, attributes: c.attributes.map { |a| { name: a.name.to_s, type: a.type.to_s } } } } unless agg.commands.empty?
+  h[:events] = agg.events.map(&:name) unless agg.events.empty?
+  h[:queries] = agg.queries.map(&:name) unless agg.queries.empty?
+  h[:policies] = agg.policies.map(&:name) unless agg.policies.empty?
+  if agg.respond_to?(:lifecycle) && agg.lifecycle
+    lc = agg.lifecycle
+    h[:lifecycle] = { field: lc.field.to_s, default: lc.default_state.to_s }
+  end
+  h
 end

--- a/hecksties/lib/hecks_cli/commands/tree.rb
+++ b/hecksties/lib/hecks_cli/commands/tree.rb
@@ -1,0 +1,44 @@
+# Hecks::CLI -- tree command
+#
+# Prints all registered CLI commands organized by group, showing
+# a tree-style overview of the full command surface.
+#
+#   hecks tree
+#   hecks tree --format json
+#
+Hecks::CLI.register_command(:tree, "Print all commands as a grouped tree",
+  options: {
+    format: { type: :string, desc: "Output format: text (default) or json" }
+  }
+) do
+  groups = self.class.command_groups
+
+  if options[:format] == "json"
+    require "json"
+    tree = groups.transform_values do |commands|
+      commands.sort_by { |c| c[:name] }.map do |cmd|
+        entry = { name: cmd[:name].to_s, description: cmd[:description] }
+        entry[:args] = cmd[:args] unless cmd[:args].empty?
+        entry[:options] = cmd[:options].keys.map(&:to_s) unless cmd[:options].empty?
+        entry
+      end
+    end
+    say JSON.pretty_generate(tree)
+    next
+  end
+
+  say "Hecks CLI Commands", :bold
+  say ""
+  groups.each do |group_name, commands|
+    say "#{group_name}/", :green
+    sorted = commands.sort_by { |c| c[:name] }
+    sorted.each_with_index do |cmd, i|
+      connector = i == sorted.length - 1 ? "\\-- " : "|-- "
+      name = cmd[:args].empty? ? cmd[:name].to_s : "#{cmd[:name]} #{cmd[:args].join(' ')}"
+      opts = cmd[:options].keys
+      opt_str = opts.any? ? "  [#{opts.map { |o| "--#{o}" }.join(', ')}]" : ""
+      say "  #{connector}#{name}#{opt_str}  # #{cmd[:description]}"
+    end
+    say ""
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/validate.rb
+++ b/hecksties/lib/hecks_cli/commands/validate.rb
@@ -1,10 +1,45 @@
+# Hecks::CLI -- validate command
+#
+# Validates a domain definition and reports errors, warnings, and
+# an aggregate summary. Supports JSON output for tooling.
+#
+#   hecks validate
+#   hecks validate --domain path/to/domain
+#   hecks validate --format json
+#
 Hecks::CLI.register_command(:validate, "Validate the domain definition",
-  options: { domain: { type: :string, desc: "Domain gem name or path" } }
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" },
+    format: { type: :string, desc: "Output format: text (default) or json" }
+  }
 ) do
   domain = resolve_domain_option
   return unless domain
   validator = Hecks::Validator.new(domain)
-  if validator.valid?
+  valid = validator.valid?
+
+  if options[:format] == "json"
+    require "json"
+    result = {
+      valid: valid,
+      domain: domain.name,
+      aggregates: domain.aggregates.map do |agg|
+        entry = { name: agg.name, attributes: agg.attributes.map(&:name).map(&:to_s) }
+        entry[:value_objects] = agg.value_objects.map(&:name) unless agg.value_objects.empty?
+        entry[:entities] = agg.entities.map(&:name) unless agg.entities.empty?
+        entry[:commands] = agg.commands.map(&:name) unless agg.commands.empty?
+        entry[:events] = agg.events.map(&:name) unless agg.events.empty?
+        entry[:policies] = agg.policies.map(&:name) unless agg.policies.empty?
+        entry
+      end,
+      errors: validator.errors,
+      warnings: validator.warnings
+    }
+    say JSON.pretty_generate(result)
+    next
+  end
+
+  if valid
     say "Domain is valid", :green
     say ""
     say "Aggregates:"

--- a/hecksties/spec/cli/commands/inspect_json_spec.rb
+++ b/hecksties/spec/cli/commands/inspect_json_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+require "hecks_cli"
+require "json"
+
+# Hecks CLI inspect --format json spec
+#
+# Verifies that `hecks inspect --format json` outputs a valid JSON
+# document with domain structure suitable for tooling.
+RSpec.describe "hecks inspect --format json" do
+  let(:cli) { Hecks::CLI.new }
+
+  before { allow($stdout).to receive(:puts) }
+
+  it "outputs valid JSON with full domain structure" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            attribute :name, String
+            attribute :total, Float
+
+            value_object "LineItem" do
+              attribute :product, String
+            end
+
+            command "CreateOrder" do
+              attribute :name, String
+            end
+
+            event "OrderCreated"
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_inspect_json(dir)
+        parsed = JSON.parse(output)
+        expect(parsed["domain"]).to eq("Shop")
+        agg = parsed["aggregates"].first
+        expect(agg["name"]).to eq("Order")
+        expect(agg["attributes"].map { |a| a["name"] }).to include("name", "total")
+        expect(agg["commands"].first["name"]).to eq("CreateOrder")
+        expect(agg["events"]).to include("OrderCreated")
+        expect(agg["value_objects"]).to include("LineItem")
+      end
+    end
+  end
+
+  it "filters to a single aggregate" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Multi" do
+          aggregate "Foo" do
+            attribute :x, String
+            command "CreateFoo" do
+              attribute :x, String
+            end
+          end
+          aggregate "Bar" do
+            attribute :y, String
+            command "CreateBar" do
+              attribute :y, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_inspect_json(dir, aggregate: "Foo")
+        parsed = JSON.parse(output)
+        expect(parsed["aggregates"].size).to eq(1)
+        expect(parsed["aggregates"].first["name"]).to eq("Foo")
+      end
+    end
+  end
+
+  def capture_inspect_json(domain_path, aggregate: nil)
+    opts = { domain: domain_path, format: "json" }
+    opts[:aggregate] = aggregate if aggregate
+    allow(cli).to receive(:options).and_return(opts)
+    output = StringIO.new
+    allow(cli.shell).to receive(:say) { |msg, *| output.puts(msg) }
+    cli.inspect
+    output.string
+  end
+end

--- a/hecksties/spec/cli/commands/tree_spec.rb
+++ b/hecksties/spec/cli/commands/tree_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "hecks_cli"
+
+# Hecks CLI tree command spec
+#
+# Verifies that `hecks tree` prints all registered commands
+# grouped by source module, and that `--format json` outputs
+# valid JSON with the same structure.
+RSpec.describe "hecks tree" do
+  let(:cli) { Hecks::CLI.new }
+
+  before { allow($stdout).to receive(:puts) }
+
+  it "prints grouped command tree in text mode" do
+    output = capture_tree_output
+    expect(output).to include("Hecks CLI Commands")
+    expect(output).to include("build")
+    expect(output).to include("validate")
+    expect(output).to include("inspect")
+    expect(output).to include("visualize")
+  end
+
+  it "outputs valid JSON with --format json" do
+    require "json"
+    output = capture_tree_output(format: "json")
+    parsed = JSON.parse(output)
+    expect(parsed).to be_a(Hash)
+    all_names = parsed.values.flatten.map { |c| c["name"] }
+    expect(all_names).to include("build")
+    expect(all_names).to include("validate")
+  end
+
+  def capture_tree_output(format: nil)
+    opts = {}
+    opts[:format] = format if format
+    allow(cli).to receive(:options).and_return(opts)
+    output = StringIO.new
+    allow(cli.shell).to receive(:say) { |msg, *| output.puts(msg) }
+    cli.tree
+    output.string
+  end
+end

--- a/hecksties/spec/cli/commands/validate_json_spec.rb
+++ b/hecksties/spec/cli/commands/validate_json_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "hecks_cli"
+require "json"
+
+# Hecks CLI validate --format json spec
+#
+# Verifies that `hecks validate --format json` outputs a valid JSON
+# document with domain validation results suitable for tooling.
+RSpec.describe "hecks validate --format json" do
+  let(:cli) { Hecks::CLI.new }
+
+  before { allow($stdout).to receive(:puts) }
+
+  it "outputs valid JSON for a valid domain" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_validate_json(dir)
+        parsed = JSON.parse(output)
+        expect(parsed["valid"]).to be true
+        expect(parsed["domain"]).to eq("Test")
+        expect(parsed["aggregates"].first["name"]).to eq("Widget")
+        expect(parsed["aggregates"].first["commands"]).to include("CreateWidget")
+        expect(parsed["errors"]).to eq([])
+      end
+    end
+  end
+
+  it "includes errors for invalid domain" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_validate_json(dir)
+        parsed = JSON.parse(output)
+        expect(parsed["valid"]).to be false
+        expect(parsed["errors"]).not_to be_empty
+      end
+    end
+  end
+
+  def capture_validate_json(domain_path)
+    allow(cli).to receive(:options).and_return(
+      { domain: domain_path, format: "json" }
+    )
+    output = StringIO.new
+    allow(cli.shell).to receive(:say) { |msg, *| output.puts(msg) }
+    cli.validate
+    output.string
+  end
+end


### PR DESCRIPTION
## Summary

- Add `hecks tree` command that prints all registered CLI commands as a grouped tree
- Add `--format json` flag to `validate`, `inspect`, and `tree` commands for Studio/tooling consumption
- Fix `stats` command missing `--json` option registration (was using `options[:json]` without declaring it)

## Example

### hecks tree
```
Hecks CLI Commands

Cli/
  |-- build  [--domain, --version, --target, --static]  # Generate the domain gem
  |-- inspect  [--domain, --aggregate, --format]  # Show full domain definition
  |-- validate  [--domain, --format]  # Validate the domain definition
  \-- tree  [--format]  # Print all commands as a grouped tree
```

### hecks validate --format json
```json
{
  "valid": true,
  "domain": "Test",
  "aggregates": [
    { "name": "Widget", "attributes": ["name"], "commands": ["CreateWidget"] }
  ],
  "errors": [],
  "warnings": []
}
```

### hecks inspect --format json
```json
{
  "domain": "Shop",
  "aggregates": [
    {
      "name": "Order",
      "attributes": [{ "name": "name", "type": "String" }],
      "commands": [{ "name": "CreateOrder", "attributes": [...] }],
      "events": ["OrderCreated"]
    }
  ]
}
```

## Test plan

- [x] `hecks tree` prints grouped command listing (text mode)
- [x] `hecks tree --format json` outputs valid JSON with all commands
- [x] `hecks validate --format json` outputs valid/invalid domain as JSON
- [x] `hecks inspect --format json` outputs full domain structure as JSON
- [x] `hecks inspect --format json --aggregate Foo` filters correctly
- [x] All 1778 specs pass under 1.5s
- [x] Smoke test passes