### PR TITLE
HEC-476: AST-based domain extractor for safe Bluebook parsing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -362,6 +362,13 @@
 - `{{connections}}` tag generates extension gem listing
 - `{{smalltalk}}` tag generates Smalltalk features section from `SmalltalkFeatures` metadata
 
+## AST-Based Domain Extraction (HEC-476)
+- `Hecks::AstExtractor.extract(source)` — parse Bluebook DSL source into a plain hash IR using `RubyVM::AbstractSyntaxTree`, no eval
+- `Hecks::AstExtractor.extract_file(path)` — read and parse a Bluebook file from disk
+- Extracts: domain name, aggregates, attributes (with types, list, defaults), commands, references, value objects, entities, validations, specifications, queries, invariants, scopes, domain-level policies (with attribute maps), services, world goals, actors, sagas, modules, workflows, views
+- Supports implicit PascalCase aggregate syntax (e.g. `Pizza do ... end` instead of `aggregate "Pizza" do ... end`)
+- Safe for static analysis, linting, and tooling — never executes domain code
+
 ## Gem Architecture
 - Core `hecks` gem has zero runtime dependencies
 - Each extension is a top-level gem candidate at `lib/`

--- a/bluebook/lib/bluebook.rb
+++ b/bluebook/lib/bluebook.rb
@@ -30,6 +30,7 @@ require_relative "hecks/domain/inspector"
 require_relative "hecks/domain/builder_methods"
 require_relative "hecks/domain/compiler"
 require_relative "hecks/domain/in_memory_loader"
+require_relative "hecks/domain/ast_extractor"
 require_relative "hecks/domain/event_storm_importer"
 require_relative "hecks/domain/visualizer_methods"
 

--- a/bluebook/lib/hecks/domain/ast_extractor.rb
+++ b/bluebook/lib/hecks/domain/ast_extractor.rb
@@ -1,0 +1,85 @@
+# Hecks::AstExtractor
+#
+# Extracts domain structure from Bluebook DSL files using Ruby's built-in
+# AST parser. Reads the file, parses it into an abstract syntax tree via
+# RubyVM::AbstractSyntaxTree, then walks the tree to extract domain name,
+# aggregates, attributes, commands, events, policies, services, specifications,
+# references, value objects, entities, validations, and world concerns --
+# all without eval.
+#
+# Returns a plain hash IR that mirrors the DomainBuilder's output, suitable
+# for static analysis, linting, or feeding into the normal Domain constructor.
+#
+#   result = Hecks::AstExtractor.extract_file("examples/pizzas/PizzasBluebook")
+#   result[:name]        # => "Pizzas"
+#   result[:aggregates]  # => [{ name: "Pizza", attributes: [...], ... }, ...]
+#
+require_relative "ast_extractor/node_readers"
+require_relative "ast_extractor/aggregate_visitor"
+require_relative "ast_extractor/domain_visitor"
+
+module Hecks
+  class AstExtractor
+    include NodeReaders
+
+    # Extract domain structure from a Bluebook source string.
+    #
+    # @param source [String] Ruby source code containing a Hecks.domain block
+    # @return [Hash] domain IR hash with :name, :aggregates, :policies, etc.
+    def self.extract(source)
+      new(source).extract
+    end
+
+    # Extract domain structure from a Bluebook file path.
+    #
+    # @param path [String] filesystem path to a Bluebook file
+    # @return [Hash] domain IR hash
+    def self.extract_file(path)
+      extract(File.read(path))
+    end
+
+    def initialize(source)
+      @source = source
+    end
+
+    def extract
+      ast = RubyVM::AbstractSyntaxTree.parse(@source)
+      domain_call = find_domain_call(ast)
+      return empty_domain unless domain_call
+
+      DomainVisitor.new(domain_call).visit
+    end
+
+    private
+
+    def find_domain_call(node)
+      return nil unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+
+      if domain_call?(node)
+        return node
+      end
+
+      node.children.each do |child|
+        result = find_domain_call(child)
+        return result if result
+      end
+      nil
+    end
+
+    def domain_call?(node)
+      return false unless node.type == :ITER
+
+      call = node.children[0]
+      return false unless call.type == :CALL
+
+      receiver = call.children[0]
+      method_name = call.children[1]
+      receiver.type == :CONST && receiver.children[0] == :Hecks && method_name == :domain
+    end
+
+    def empty_domain
+      { name: nil, aggregates: [], policies: [], services: [],
+        views: [], workflows: [], world_goals: [] }
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain/ast_extractor/aggregate_visitor.rb
+++ b/bluebook/lib/hecks/domain/ast_extractor/aggregate_visitor.rb
@@ -1,0 +1,161 @@
+# Hecks::AstExtractor::AggregateVisitor
+#
+# Walks an AST node for an aggregate block, extracting attributes, commands,
+# value objects, entities, policies, validations, specifications, references,
+# and queries. Each DSL method maps to a specific extraction method.
+#
+#   visitor = AggregateVisitor.new(iter_node)
+#   visitor.visit  # => { name: "Pizza", attributes: [...], commands: [...], ... }
+#
+module Hecks
+  class AstExtractor
+    class AggregateVisitor
+      include NodeReaders
+
+      def initialize(node)
+        @node = node
+      end
+
+      def visit
+        name = call_args(@node).first
+        scope = @node.children[1]
+        stmts = block_statements(scope)
+
+        result = new_aggregate(name)
+        stmts.each { |stmt| visit_statement(stmt, result) }
+        result
+      end
+
+      private
+
+      def new_aggregate(name)
+        { name: name, attributes: [], value_objects: [], entities: [],
+          commands: [], policies: [], validations: [], specifications: [],
+          references: [], queries: [], invariants: [], scopes: [],
+          subscribers: [], indexes: [] }
+      end
+
+      def visit_statement(stmt, agg)
+        method = call_method_name(stmt)
+        case method
+        when :attribute    then agg[:attributes] << extract_attribute(stmt)
+        when :value_object then agg[:value_objects] << extract_nested_type(stmt, :value_object)
+        when :entity       then agg[:entities] << extract_nested_type(stmt, :entity)
+        when :command      then agg[:commands] << extract_command(stmt)
+        when :policy       then agg[:policies] << extract_policy(stmt)
+        when :validation   then agg[:validations] << extract_validation(stmt)
+        when :specification then agg[:specifications] << extract_specification(stmt)
+        when :reference_to then agg[:references] << extract_reference(stmt)
+        when :query        then agg[:queries] << extract_query(stmt)
+        when :event        then nil # explicit events handled by domain builder
+        when :scope        then agg[:scopes] << extract_scope(stmt)
+        end
+      end
+
+      def extract_attribute(node)
+        args = call_args(node)
+        kwargs = call_kwargs(node)
+        name = args[0]
+        type_arg = args[1]
+        type_info = resolve_type(type_arg)
+        { name: name, type: type_info[:type], list: type_info[:list],
+          default: kwargs[:default] }.compact
+      end
+
+      def resolve_type(type_arg)
+        case type_arg
+        when Hash then { type: type_arg[:list], list: true }
+        when String
+          if %w[String Integer Float Date DateTime].include?(type_arg)
+            { type: type_arg, list: false }
+          else
+            { type: type_arg, list: false }
+          end
+        when nil then { type: "String", list: false }
+        else { type: type_arg.to_s, list: false }
+        end
+      end
+
+      def extract_nested_type(node, kind)
+        name = call_args(node).first
+        scope = node.children[1]
+        stmts = block_statements(scope)
+        result = { name: name, attributes: [], invariants: [] }
+        stmts.each do |stmt|
+          m = call_method_name(stmt)
+          case m
+          when :attribute then result[:attributes] << extract_attribute(stmt)
+          when :invariant then result[:invariants] << extract_invariant(stmt)
+          end
+        end
+        result
+      end
+
+      def extract_command(node)
+        name = call_args(node).first
+        scope = node.children[1]
+        stmts = block_statements(scope)
+        cmd = { name: name, attributes: [], references: [] }
+        stmts.each do |stmt|
+          m = call_method_name(stmt)
+          case m
+          when :attribute    then cmd[:attributes] << extract_attribute(stmt)
+          when :reference_to then cmd[:references] << extract_reference(stmt)
+          end
+        end
+        cmd
+      end
+
+      def extract_policy(node)
+        name = call_args(node).first
+        scope = node.children[1]
+        stmts = block_statements(scope)
+        pol = { name: name, event_name: nil, trigger_command: nil, async: false }
+        stmts.each do |stmt|
+          m = call_method_name(stmt)
+          case m
+          when :on      then pol[:event_name] = call_args(stmt).first
+          when :trigger then pol[:trigger_command] = call_args(stmt).first
+          when :async   then pol[:async] = true
+          end
+        end
+        pol
+      end
+
+      def extract_validation(node)
+        args = call_args(node)
+        kwargs = call_kwargs(node)
+        { field: args.first, rules: kwargs }
+      end
+
+      def extract_specification(node)
+        { name: call_args(node).first }
+      end
+
+      def extract_reference(node)
+        args = call_args(node)
+        kwargs = call_kwargs(node)
+        type_str = args.first.to_s
+        parts = type_str.split("::")
+        target = parts.last
+        domain = parts.length > 1 ? parts[0..-2].join("::") : nil
+        { type: target, domain: domain, role: kwargs[:role],
+          validate: kwargs.fetch(:validate, true) }
+      end
+
+      def extract_query(node)
+        { name: call_args(node).first }
+      end
+
+      def extract_invariant(node)
+        { message: call_args(node).first }
+      end
+
+      def extract_scope(node)
+        args = call_args(node)
+        kwargs = call_kwargs(node)
+        { name: args.first, conditions: kwargs }
+      end
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain/ast_extractor/domain_visitor.rb
+++ b/bluebook/lib/hecks/domain/ast_extractor/domain_visitor.rb
@@ -1,0 +1,137 @@
+# Hecks::AstExtractor::DomainVisitor
+#
+# Walks the top-level domain ITER node, extracting the domain name and all
+# domain-level declarations: aggregates, policies, services, views,
+# workflows, and world goals. Delegates aggregate extraction to
+# AggregateVisitor.
+#
+#   visitor = DomainVisitor.new(iter_node)
+#   visitor.visit  # => { name: "Pizzas", aggregates: [...], policies: [...], ... }
+#
+module Hecks
+  class AstExtractor
+    class DomainVisitor
+      include NodeReaders
+
+      def initialize(node)
+        @node = node
+      end
+
+      def visit
+        name = extract_domain_name
+        scope = @node.children[1]
+        stmts = block_statements(scope)
+
+        result = new_domain(name)
+        stmts.each { |stmt| visit_statement(stmt, result) }
+        result
+      end
+
+      private
+
+      def extract_domain_name
+        call_node = @node.children[0]
+        args_node = call_node.children[2]
+        read_args(args_node).first
+      end
+
+      def new_domain(name)
+        { name: name, aggregates: [], policies: [], services: [],
+          views: [], workflows: [], world_goals: [], actors: [],
+          sagas: [], glossary_rules: [], modules: [] }
+      end
+
+      def visit_statement(stmt, domain)
+        method = call_method_name(stmt)
+        case method
+        when :aggregate    then domain[:aggregates] << AggregateVisitor.new(stmt).visit
+        when :policy       then domain[:policies] << extract_domain_policy(stmt)
+        when :service      then domain[:services] << extract_service(stmt)
+        when :view         then domain[:views] << extract_view(stmt)
+        when :workflow     then domain[:workflows] << extract_workflow(stmt)
+        when :world_goals  then extract_world_goals(stmt, domain)
+        when :actor        then domain[:actors] << extract_actor(stmt)
+        when :saga         then domain[:sagas] << extract_saga(stmt)
+        when :domain_module then domain[:modules] << extract_module(stmt)
+        else
+          visit_implicit_aggregate(stmt, domain) if implicit_aggregate?(stmt)
+        end
+      end
+
+      def extract_domain_policy(stmt)
+        scope = stmt.children[1]
+        stmts = block_statements(scope)
+        pol = { name: call_args(stmt).first, event_name: nil,
+                trigger_command: nil, async: false, attribute_map: {} }
+        stmts.each do |s|
+          m = call_method_name(s)
+          case m
+          when :on      then pol[:event_name] = call_args(s).first
+          when :trigger then pol[:trigger_command] = call_args(s).first
+          when :async   then pol[:async] = true
+          when :map     then pol[:attribute_map] = call_kwargs(s)
+          end
+        end
+        pol
+      end
+
+      def extract_service(stmt)
+        name = call_args(stmt).first
+        scope = stmt.children[1]
+        stmts = block_statements(scope)
+        svc = { name: name, attributes: [], coordinates: [] }
+        stmts.each do |s|
+          m = call_method_name(s)
+          case m
+          when :attribute   then svc[:attributes] << extract_attribute_hash(s)
+          when :coordinates then svc[:coordinates] = call_args(s).map(&:to_s)
+          end
+        end
+        svc
+      end
+
+      def extract_view(stmt)
+        { name: call_args(stmt).first }
+      end
+
+      def extract_workflow(stmt)
+        { name: call_args(stmt).first }
+      end
+
+      def extract_world_goals(stmt, domain)
+        args = call_args(stmt)
+        domain[:world_goals].concat(args.map { |a| a.is_a?(Symbol) ? a : a.to_sym })
+      end
+
+      def extract_actor(stmt)
+        { name: call_args(stmt).first.to_s }
+      end
+
+      def extract_saga(stmt)
+        { name: call_args(stmt).first }
+      end
+
+      def extract_module(stmt)
+        { name: call_args(stmt).first }
+      end
+
+      def extract_attribute_hash(node)
+        args = call_args(node)
+        { name: args[0], type: (args[1] || "String").to_s }
+      end
+
+      def implicit_aggregate?(stmt)
+        return false unless stmt.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        return false unless stmt.type == :ITER
+        fcall = stmt.children[0]
+        return false unless fcall&.type == :FCALL
+        name = fcall.children[0].to_s
+        name.match?(/\A[A-Z]/)
+      end
+
+      def visit_implicit_aggregate(stmt, domain)
+        domain[:aggregates] << AggregateVisitor.new(stmt).visit
+      end
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain/ast_extractor/node_readers.rb
+++ b/bluebook/lib/hecks/domain/ast_extractor/node_readers.rb
@@ -1,0 +1,155 @@
+# Hecks::AstExtractor::NodeReaders
+#
+# Low-level AST node reading utilities. Extracts literal values, constant
+# names, method arguments, keyword arguments, and block bodies from
+# RubyVM::AbstractSyntaxTree nodes. Shared by all visitor modules.
+#
+#   include NodeReaders
+#   read_literal(lit_node)    # => :name
+#   read_const(const_node)    # => "String"
+#   read_string(str_node)     # => "Pizza"
+#
+module Hecks
+  class AstExtractor
+    module NodeReaders
+      # Read a literal value from a LIT node.
+      # @param node [RubyVM::AbstractSyntaxTree::Node]
+      # @return [Object] the literal value (Symbol, Integer, Float, etc.)
+      def read_literal(node)
+        return nil unless node&.type == :LIT
+        node.children[0]
+      end
+
+      # Read a string value from a STR node.
+      # @param node [RubyVM::AbstractSyntaxTree::Node]
+      # @return [String, nil]
+      def read_string(node)
+        return nil unless node&.type == :STR
+        node.children[0]
+      end
+
+      # Read a constant name from a CONST node, returning the string form.
+      # @param node [RubyVM::AbstractSyntaxTree::Node]
+      # @return [String, nil] e.g. "String", "Integer", "Float"
+      def read_const(node)
+        return nil unless node&.type == :CONST
+        node.children[0].to_s
+      end
+
+      # Read a scalar value from any node type (LIT, STR, CONST, TRUE, FALSE, NIL).
+      # @param node [RubyVM::AbstractSyntaxTree::Node]
+      # @return [Object, nil]
+      def read_value(node)
+        return nil unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        case node.type
+        when :LIT   then node.children[0]
+        when :STR   then node.children[0]
+        when :CONST then node.children[0].to_s
+        when :TRUE  then true
+        when :FALSE then false
+        when :NIL   then nil
+        else nil
+        end
+      end
+
+      # Read positional arguments from an argument LIST node.
+      # @param node [RubyVM::AbstractSyntaxTree::Node] a LIST node
+      # @return [Array<Object>] extracted values
+      def read_args(node)
+        return [] unless node&.type == :LIST
+        node.children.compact.filter_map { |c| read_arg_value(c) }
+      end
+
+      # Read a single argument value, handling FCALL for list_of().
+      def read_arg_value(child)
+        return nil unless child.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        case child.type
+        when :LIT, :STR, :CONST, :TRUE, :FALSE, :NIL
+          read_value(child)
+        when :FCALL
+          read_fcall_value(child)
+        when :HASH
+          read_hash(child)
+        else
+          nil
+        end
+      end
+
+      # Read an FCALL node value (e.g., list_of("Topping")).
+      def read_fcall_value(node)
+        method = node.children[0]
+        if method == :list_of
+          inner = read_args(node.children[1])
+          { list: inner.first }
+        else
+          nil
+        end
+      end
+
+      # Read keyword arguments from a HASH node.
+      # @param node [RubyVM::AbstractSyntaxTree::Node] a HASH node
+      # @return [Hash{Symbol => Object}]
+      def read_hash(node)
+        return {} unless node&.type == :HASH
+        list = node.children[0]
+        return {} unless list&.type == :LIST
+        pairs = list.children.compact
+        result = {}
+        pairs.each_slice(2) { |k, v| result[read_value(k)] = read_value(v) if k && v }
+        result
+      end
+
+      # Collect block statements from a SCOPE node's body.
+      # Returns BLOCK children or a single-statement array.
+      def block_statements(scope_node)
+        return [] unless scope_node&.type == :SCOPE
+        body = scope_node.children[2]
+        return [] unless body
+        body.type == :BLOCK ? body.children : [body]
+      end
+
+      # Check if a node is an FCALL/CALL with the given method name.
+      def method_call?(node, name)
+        return false unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        (node.type == :FCALL || node.type == :CALL) && node.children.first == name ||
+          (node.type == :FCALL && node.children[0] == name)
+      end
+
+      # Check if a node is an ITER wrapping an FCALL with the given method name.
+      def iter_call?(node, name)
+        return false unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        node.type == :ITER && node.children[0]&.type == :FCALL &&
+          node.children[0].children[0] == name
+      end
+
+      # Extract method name from FCALL or ITER>FCALL.
+      def call_method_name(node)
+        return nil unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        if node.type == :FCALL
+          node.children[0]
+        elsif node.type == :ITER && node.children[0]&.type == :FCALL
+          node.children[0].children[0]
+        end
+      end
+
+      # Extract positional args from FCALL or ITER>FCALL.
+      def call_args(node)
+        fcall = node.type == :ITER ? node.children[0] : node
+        return [] unless fcall&.type == :FCALL
+        args_node = fcall.children[1]
+        read_args(args_node)
+      end
+
+      # Extract keyword args from FCALL. They appear as the last HASH in the LIST.
+      def call_kwargs(node)
+        fcall = node.type == :ITER ? node.children[0] : node
+        return {} unless fcall&.type == :FCALL
+        args_node = fcall.children[1]
+        return {} unless args_node&.type == :LIST
+        last_child = args_node.children.compact.last
+        return {} unless last_child.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        last_child.type == :HASH ? read_hash(last_child) : {}
+      end
+    end
+  end
+end

--- a/bluebook/spec/domain/ast_extractor_spec.rb
+++ b/bluebook/spec/domain/ast_extractor_spec.rb
@@ -1,0 +1,289 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AstExtractor do
+  describe ".extract" do
+    it "extracts domain name" do
+      result = described_class.extract('Hecks.domain "Pizzas" do; end')
+      expect(result[:name]).to eq("Pizzas")
+    end
+
+    it "returns empty domain for non-domain source" do
+      result = described_class.extract("puts 'hello'")
+      expect(result[:name]).to be_nil
+      expect(result[:aggregates]).to eq([])
+    end
+
+    it "extracts aggregate names" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Product" do
+            attribute :name, String
+          end
+          aggregate "Order" do
+            attribute :total, Float
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      names = result[:aggregates].map { |a| a[:name] }
+      expect(names).to eq(["Product", "Order"])
+    end
+
+    it "extracts attributes with types" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Product" do
+            attribute :name, String
+            attribute :price, Float
+            attribute :quantity, Integer
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      attrs = result[:aggregates].first[:attributes]
+      expect(attrs).to contain_exactly(
+        hash_including(name: :name, type: "String", list: false),
+        hash_including(name: :price, type: "Float", list: false),
+        hash_including(name: :quantity, type: "Integer", list: false)
+      )
+    end
+
+    it "extracts list_of attributes" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Pizza" do
+            attribute :toppings, list_of("Topping")
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      attr = result[:aggregates].first[:attributes].first
+      expect(attr[:name]).to eq(:toppings)
+      expect(attr[:type]).to eq("Topping")
+      expect(attr[:list]).to be true
+    end
+
+    it "extracts attribute defaults" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            attribute :status, String, default: "pending"
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      attr = result[:aggregates].first[:attributes].first
+      expect(attr[:default]).to eq("pending")
+    end
+
+    it "extracts commands with attributes" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Product" do
+            command "CreateProduct" do
+              attribute :name, String
+              attribute :price, Float
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      cmd = result[:aggregates].first[:commands].first
+      expect(cmd[:name]).to eq("CreateProduct")
+      expect(cmd[:attributes].length).to eq(2)
+      expect(cmd[:attributes].first[:name]).to eq(:name)
+    end
+
+    it "extracts command references" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            command "PlaceOrder" do
+              reference_to "Product", validate: :exists
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      ref = result[:aggregates].first[:commands].first[:references].first
+      expect(ref[:type]).to eq("Product")
+      expect(ref[:validate]).to eq(:exists)
+    end
+
+    it "extracts value objects" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Pizza" do
+            value_object "Topping" do
+              attribute :name, String
+              attribute :amount, Integer
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      vo = result[:aggregates].first[:value_objects].first
+      expect(vo[:name]).to eq("Topping")
+      expect(vo[:attributes].length).to eq(2)
+    end
+
+    it "extracts value object invariants" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Pizza" do
+            value_object "Topping" do
+              attribute :amount, Integer
+              invariant "must be positive" do
+                amount > 0
+              end
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      inv = result[:aggregates].first[:value_objects].first[:invariants].first
+      expect(inv[:message]).to eq("must be positive")
+    end
+
+    it "extracts entities" do
+      source = <<~RUBY
+        Hecks.domain "Banking" do
+          aggregate "Account" do
+            entity "LedgerEntry" do
+              attribute :amount, Float
+              attribute :description, String
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      ent = result[:aggregates].first[:entities].first
+      expect(ent[:name]).to eq("LedgerEntry")
+      expect(ent[:attributes].length).to eq(2)
+    end
+
+    it "extracts validations" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Product" do
+            validation :name, presence: true
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      val = result[:aggregates].first[:validations].first
+      expect(val[:field]).to eq(:name)
+      expect(val[:rules]).to eq(presence: true)
+    end
+
+    it "extracts specifications" do
+      source = <<~RUBY
+        Hecks.domain "Banking" do
+          aggregate "Loan" do
+            specification "HighRisk" do |loan|
+              loan.principal > 50_000
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      spec = result[:aggregates].first[:specifications].first
+      expect(spec[:name]).to eq("HighRisk")
+    end
+
+    it "extracts aggregate-level references" do
+      source = <<~RUBY
+        Hecks.domain "Banking" do
+          aggregate "Account" do
+            reference_to "Customer"
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      ref = result[:aggregates].first[:references].first
+      expect(ref[:type]).to eq("Customer")
+      expect(ref[:domain]).to be_nil
+    end
+
+    it "extracts queries" do
+      source = <<~RUBY
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            query "Pending" do
+              where(status: "pending")
+            end
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      query = result[:aggregates].first[:queries].first
+      expect(query[:name]).to eq("Pending")
+    end
+
+    it "extracts domain-level policies with attribute maps" do
+      source = <<~RUBY
+        Hecks.domain "Banking" do
+          policy "DisburseFunds" do
+            on "IssuedLoan"
+            trigger "Deposit"
+            map account_id: :account_id, principal: :amount
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      pol = result[:policies].first
+      expect(pol[:name]).to eq("DisburseFunds")
+      expect(pol[:event_name]).to eq("IssuedLoan")
+      expect(pol[:trigger_command]).to eq("Deposit")
+      expect(pol[:attribute_map]).to eq(account_id: :account_id, principal: :amount)
+    end
+
+    it "extracts world goals" do
+      source = <<~RUBY
+        Hecks.domain "GovAI" do
+          world_goals :transparency, :consent, :privacy
+        end
+      RUBY
+      result = described_class.extract(source)
+      expect(result[:world_goals]).to eq([:transparency, :consent, :privacy])
+    end
+
+    it "extracts services" do
+      source = <<~RUBY
+        Hecks.domain "Banking" do
+          service "TransferMoney" do
+            attribute :source_id, String
+            attribute :amount, Float
+            coordinates "Account", "Ledger"
+          end
+        end
+      RUBY
+      result = described_class.extract(source)
+      svc = result[:services].first
+      expect(svc[:name]).to eq("TransferMoney")
+      expect(svc[:attributes].length).to eq(2)
+      expect(svc[:coordinates]).to eq(["Account", "Ledger"])
+    end
+  end
+
+  describe ".extract_file" do
+    let(:root) { File.expand_path("../../..", __dir__) }
+
+    it "extracts from the pizzas example file" do
+      path = File.join(root, "examples/pizzas/PizzasBluebook")
+      result = described_class.extract_file(path)
+      expect(result[:name]).to eq("Pizzas")
+      expect(result[:aggregates].length).to eq(2)
+      agg_names = result[:aggregates].map { |a| a[:name] }
+      expect(agg_names).to contain_exactly("Pizza", "Order")
+    end
+
+    it "extracts from the banking example file" do
+      path = File.join(root, "examples/banking/BankingBluebook")
+      result = described_class.extract_file(path)
+      expect(result[:name]).to eq("Banking")
+      expect(result[:aggregates].length).to eq(4)
+      expect(result[:policies].length).to eq(2)
+    end
+  end
+end

--- a/docs/usage/ast_extractor.md
+++ b/docs/usage/ast_extractor.md
@@ -1,0 +1,104 @@
+# AST-Based Domain Extraction
+
+Extract domain structure from Bluebook files without eval, using Ruby's
+built-in `RubyVM::AbstractSyntaxTree` parser. Ideal for static analysis,
+linting, and tooling that needs to read domain definitions safely.
+
+## Quick Start
+
+```ruby
+require "hecks"
+
+# From a source string
+result = Hecks::AstExtractor.extract('Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end')
+
+result[:name]                          # => "Pizzas"
+result[:aggregates].first[:name]       # => "Pizza"
+result[:aggregates].first[:commands]   # => [{ name: "CreatePizza", ... }]
+```
+
+## From a File
+
+```ruby
+result = Hecks::AstExtractor.extract_file("examples/pizzas/PizzasBluebook")
+result[:name]        # => "Pizzas"
+result[:aggregates]  # => [{ name: "Pizza", ... }, { name: "Order", ... }]
+```
+
+## What Gets Extracted
+
+The extractor returns a plain Ruby hash with these keys:
+
+| Key               | Type            | Description                          |
+|-------------------|-----------------|--------------------------------------|
+| `:name`           | String          | Domain name                          |
+| `:aggregates`     | Array of Hash   | Aggregate definitions                |
+| `:policies`       | Array of Hash   | Domain-level reactive policies       |
+| `:services`       | Array of Hash   | Domain services                      |
+| `:views`          | Array of Hash   | Read model view definitions          |
+| `:workflows`      | Array of Hash   | Workflow definitions                 |
+| `:world_goals`    | Array of Symbol | Declared world goals                 |
+| `:actors`         | Array of Hash   | Actor definitions                    |
+| `:sagas`          | Array of Hash   | Saga definitions                     |
+| `:modules`        | Array of Hash   | Domain module groupings              |
+
+Each aggregate hash contains:
+
+| Key               | Type          | Description                            |
+|-------------------|---------------|----------------------------------------|
+| `:name`           | String        | Aggregate name                         |
+| `:attributes`     | Array of Hash | `{ name:, type:, list:, default: }`    |
+| `:commands`       | Array of Hash | `{ name:, attributes:, references: }`  |
+| `:value_objects`  | Array of Hash | `{ name:, attributes:, invariants: }`  |
+| `:entities`       | Array of Hash | `{ name:, attributes:, invariants: }`  |
+| `:policies`       | Array of Hash | `{ name:, event_name:, trigger_command:, async: }` |
+| `:validations`    | Array of Hash | `{ field:, rules: }`                   |
+| `:specifications` | Array of Hash | `{ name: }`                            |
+| `:references`     | Array of Hash | `{ type:, domain:, role:, validate: }` |
+| `:queries`        | Array of Hash | `{ name: }`                            |
+| `:invariants`     | Array of Hash | `{ message: }`                         |
+| `:scopes`         | Array of Hash | `{ name:, conditions: }`               |
+
+## Banking Example
+
+```ruby
+result = Hecks::AstExtractor.extract_file("examples/banking/BankingBluebook")
+
+# Domain-level policies with attribute mapping
+result[:policies].first
+# => { name: "DisburseFunds",
+#      event_name: "IssuedLoan",
+#      trigger_command: "Deposit",
+#      async: false,
+#      attribute_map: { account_id: :account_id, principal: :amount } }
+
+# Specifications (name only -- blocks are not evaluable without eval)
+loan = result[:aggregates].find { |a| a[:name] == "Loan" }
+loan[:specifications]  # => [{ name: "HighRisk" }]
+
+# Entities
+account = result[:aggregates].find { |a| a[:name] == "Account" }
+account[:entities].first[:name]  # => "LedgerEntry"
+```
+
+## Comparison with DSL Eval
+
+| Feature              | `Hecks.domain` (eval) | `AstExtractor` (AST) |
+|----------------------|-----------------------|-----------------------|
+| Executes code        | Yes                   | No                    |
+| Returns Domain IR    | Yes (full objects)    | Hash (lightweight)    |
+| Proc/block capture   | Yes                   | No (name only)        |
+| Safe for untrusted   | No                    | Yes                   |
+| Speed                | Fast                  | Fast                  |
+
+The AST extractor captures everything about the domain *structure* but
+not executable blocks (invariant bodies, specification predicates,
+command handlers). Use it when you need to inspect or analyze domain
+definitions without running them.

--- a/hecksties/spec/runtime/extension_adapter_type_spec.rb
+++ b/hecksties/spec/runtime/extension_adapter_type_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 require "tmpdir"
 require "fileutils"
+require "hecks/extensions/serve"
+require "hecks_ai"
 
 RSpec.describe "Extension adapter_type classification" do
   describe "driven_extensions" do


### PR DESCRIPTION
## Summary

- Adds `Hecks::AstExtractor` that parses Bluebook DSL files using `RubyVM::AbstractSyntaxTree` instead of eval
- Extracts full domain structure: domain name, aggregates, attributes (with types/list/defaults), commands, references, value objects, entities, validations, specifications, queries, invariants, scopes, domain-level policies (with attribute maps), services, world goals, actors, sagas, modules, workflows, views
- Safe for static analysis and untrusted input -- never executes domain code

## Example

```ruby
# Before: eval-based (executes all code in the file)
Kernel.load("PizzasBluebook")
domain = Hecks.last_domain

# After: AST-based (reads structure without executing)
result = Hecks::AstExtractor.extract_file("PizzasBluebook")
result[:name]                        # => "Pizzas"
result[:aggregates].first[:name]     # => "Pizza"
result[:aggregates].first[:commands] # => [{ name: "CreatePizza", attributes: [...] }]
```

## Test plan

- [x] 20 new specs covering all DSL constructs (attributes, commands, references, policies, etc.)
- [x] Integration tests against real Pizzas and Banking example Bluebook files
- [x] Full suite passes (1792 examples, 0 failures)
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)
- [ ] Review docs/usage/ast_extractor.md for clarity
- [ ] Verify FEATURES.md entry is accurate