### PR TITLE
HEC-334: Auth screens — generate login/signup UI from auth extension

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -118,6 +118,9 @@
 - `hecks_auth` — actor-based authentication & authorization
 - Default-secure auth: raises `ConfigurationError` at boot when actor-protected commands exist but no `:auth` extension is registered
 - Explicit opt-out: `extend :auth, enforce: false` registers a no-op sentinel that satisfies the check
+- Auth screens: auto-generated login/signup/logout HTML pages wired into the serve extension (GET/POST `/login`, GET/POST `/signup`, GET `/logout`)
+- Session management via HttpOnly cookies with Base64-encoded JSON payloads
+- In-memory credential store for development; default role inferred from domain DSL actor declarations
 - `hecks_tenancy` — multi-tenant isolation (`Hecks.tenant = "acme"`)
 - Row-level authorization — `owned_by :field` on gates restricts `find`/`all`/`delete` to the current user; `tenancy: :row` isolates by `Hecks.tenant`
 - `Hecks.current_user` / `Hecks.with_user(user) { }` — thread-local current user context for ownership enforcement

--- a/docs/usage/auth_screens.md
+++ b/docs/usage/auth_screens.md
@@ -1,0 +1,72 @@
+# Auth Screens
+
+When the auth extension is active, the serve extension automatically generates
+login, signup, and logout HTML pages with session management.
+
+## Routes
+
+| Method | Path      | Description                      |
+|--------|-----------|----------------------------------|
+| GET    | /login    | Render login form                |
+| POST   | /login    | Authenticate and set session     |
+| GET    | /signup   | Render signup form               |
+| POST   | /signup   | Create account and set session   |
+| GET    | /logout   | Clear session, redirect to login |
+
+## Domain setup
+
+```ruby
+Hecks.domain "Clinic" do
+  aggregate "Appointment" do
+    attribute :patient, String
+    attribute :date, Date
+
+    command "Book" do
+      actor "Receptionist"
+      attribute :patient, String
+      attribute :date, Date
+    end
+  end
+end
+```
+
+The `actor "Receptionist"` declaration tells the auth extension which roles
+exist. New signups are assigned the first actor role found in the DSL (here,
+"Receptionist").
+
+## How it works
+
+1. **Login form** -- email + password fields with inline CSS, no JS framework.
+2. **Signup form** -- email + password + confirm fields. Validates:
+   - All fields required
+   - Passwords match
+   - Minimum 8 characters
+   - No duplicate emails
+3. **Session cookie** -- `_hecks_session` HttpOnly cookie carries a
+   Base64-encoded JSON payload with `email` and `role`. On each request the
+   server restores `Hecks.actor` from the cookie.
+4. **Logout** -- clears the cookie and sets `Hecks.actor = nil`.
+
+## Serving
+
+```bash
+hecks serve clinic
+# =>
+#   GET    /login
+#   POST   /login
+#   GET    /signup
+#   POST   /signup
+#   GET    /logout
+#   GET    /appointments
+#   ...
+```
+
+Visit `http://localhost:9292/login` to see the login screen. After signing in
+the session cookie ensures `Hecks.actor` is set for every subsequent request,
+so actor-guarded commands work transparently.
+
+## Development store
+
+The in-memory credential store is for development and prototyping only.
+Accounts are lost when the server restarts. Production apps should implement
+a persistent adapter.

--- a/hecksties/lib/hecks/extensions/auth/screen_routes.rb
+++ b/hecksties/lib/hecks/extensions/auth/screen_routes.rb
@@ -1,0 +1,158 @@
+# Hecks::Auth::ScreenRoutes
+#
+# Mixin for DomainServer that adds login, signup, and logout HTTP
+# routes when the auth extension is active. Renders ERB templates
+# from the auth/views directory with inline CSS (no JS framework).
+# Uses a session cookie to track the authenticated actor.
+#
+# Routes:
+#   GET  /login  — render login form
+#   POST /login  — authenticate and set session cookie
+#   GET  /signup — render signup form
+#   POST /signup — create account and set session cookie
+#   GET  /logout — clear session cookie and redirect to login
+#
+#   include Hecks::Auth::ScreenRoutes
+#   # then call handle_auth_route(req, res) from the server dispatch
+#
+require "erb"
+require_relative "session_store"
+
+module Hecks
+  module Auth
+    module ScreenRoutes
+      include SessionStore
+
+      VIEWS_DIR = File.expand_path("views", __dir__)
+      AUTH_PATHS = %w[/login /signup /logout].freeze
+
+      # Check whether the request path is an auth screen route.
+      #
+      # @param path [String] the request path
+      # @return [Boolean]
+      def auth_route?(path)
+        AUTH_PATHS.include?(path)
+      end
+
+      # Dispatch an auth route request to the appropriate handler.
+      #
+      # @param req [WEBrick::HTTPRequest] the incoming request
+      # @param res [WEBrick::HTTPResponse] the outgoing response
+      # @return [void]
+      def handle_auth_route(req, res)
+        case [req.request_method, req.path]
+        when ["GET", "/login"]   then render_login(req, res)
+        when ["POST", "/login"]  then process_login(req, res)
+        when ["GET", "/signup"]  then render_signup(req, res)
+        when ["POST", "/signup"] then process_signup(req, res)
+        when ["GET", "/logout"]  then process_logout(req, res)
+        end
+      end
+
+      private
+
+      # Render the login form.
+      def render_login(req, res)
+        token = ensure_csrf_cookie(req, res)
+        serve_auth_html(res, :login, error_message: nil, csrf_token: token)
+      end
+
+      # Authenticate the user and set a session cookie.
+      def process_login(req, res)
+        params = parse_form_params(req)
+        email = params["email"].to_s.strip
+        password = params["password"].to_s
+
+        if email.empty? || password.empty?
+          token = read_csrf_cookie(req) || ensure_csrf_cookie(req, res)
+          serve_auth_html(res, :login,
+            error_message: "Email and password are required",
+            csrf_token: token)
+          return
+        end
+
+        actor = resolve_actor(email, password)
+        unless actor
+          token = read_csrf_cookie(req) || ensure_csrf_cookie(req, res)
+          serve_auth_html(res, :login,
+            error_message: "Invalid email or password",
+            csrf_token: token)
+          return
+        end
+
+        set_session(res, actor)
+        res.set_redirect(WEBrick::HTTPStatus::SeeOther, "/")
+      end
+
+      # Render the signup form.
+      def render_signup(req, res)
+        token = ensure_csrf_cookie(req, res)
+        serve_auth_html(res, :signup, error_message: nil, csrf_token: token)
+      end
+
+      # Create a new account and set a session cookie.
+      def process_signup(req, res)
+        params = parse_form_params(req)
+        email = params["email"].to_s.strip
+        password = params["password"].to_s
+        confirmation = params["password_confirmation"].to_s
+
+        error = validate_signup(email, password, confirmation)
+        if error
+          token = read_csrf_cookie(req) || ensure_csrf_cookie(req, res)
+          serve_auth_html(res, :signup,
+            error_message: error, csrf_token: token)
+          return
+        end
+
+        actor = create_actor(email, password)
+        set_session(res, actor)
+        res.set_redirect(WEBrick::HTTPStatus::SeeOther, "/")
+      end
+
+      # Clear the session cookie and redirect to login.
+      def process_logout(_req, res)
+        cookie = "#{SessionStore::SESSION_COOKIE}=; Path=/; Max-Age=0; HttpOnly"
+        res["Set-Cookie"] = cookie
+        Hecks.actor = nil
+        res.set_redirect(WEBrick::HTTPStatus::SeeOther, "/login")
+      end
+
+      # Render an auth template and set the response body.
+      def serve_auth_html(res, name, **locals)
+        html = render_auth_template(name, **locals)
+        res["Content-Type"] = "text/html"
+        res.body = html
+      end
+
+      # Render an auth ERB template with the given locals.
+      #
+      # @param name [Symbol] template name (:login or :signup)
+      # @param locals [Hash] template variables
+      # @return [String] rendered HTML
+      def render_auth_template(name, **locals)
+        locals[:domain_name] = @domain.name
+        path = File.join(VIEWS_DIR, "#{name}.erb")
+        template = File.read(path)
+        b = Hecks::Auth::TemplateBinding.new(locals)
+        ERB.new(template, trim_mode: "-").result(b.get_binding)
+      end
+    end
+
+    # Minimal binding for auth screen ERB templates.
+    # Locals become methods so templates can reference them directly.
+    class TemplateBinding
+      def initialize(locals)
+        locals.each { |k, v| define_singleton_method(k) { v } }
+      end
+
+      def h(text)
+        ERB::Util.html_escape(text.to_s)
+      end
+
+      def get_binding
+        binding
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/auth/session_store.rb
+++ b/hecksties/lib/hecks/extensions/auth/session_store.rb
@@ -1,0 +1,119 @@
+# Hecks::Auth::SessionStore
+#
+# In-memory credential store and cookie-based session management for
+# auth screens. Tracks registered users as a simple hash of email to
+# password+role. Sessions are Base64-encoded JSON in an HttpOnly cookie.
+#
+# This is a development/prototyping store. Production apps should swap
+# in a persistent adapter.
+#
+#   include Hecks::Auth::SessionStore
+#   set_session(res, actor)
+#   actor = restore_session(req)
+#
+require "securerandom"
+require "json"
+require "base64"
+require "ostruct"
+require "uri"
+
+module Hecks
+  module Auth
+    module SessionStore
+      SESSION_COOKIE = "_hecks_session".freeze
+
+      # Set a session cookie encoding the actor as JSON.
+      #
+      # @param res [WEBrick::HTTPResponse] the response
+      # @param actor [OpenStruct] the authenticated actor
+      # @return [void]
+      def set_session(res, actor)
+        payload = Base64.strict_encode64(
+          JSON.generate(email: actor.email, role: actor.role))
+        res["Set-Cookie"] =
+          "#{SESSION_COOKIE}=#{payload}; Path=/; HttpOnly; SameSite=Lax"
+        Hecks.actor = actor
+      end
+
+      # Read the session cookie and restore the actor.
+      #
+      # @param req [WEBrick::HTTPRequest] the request
+      # @return [OpenStruct, nil] the actor or nil if no valid session
+      def restore_session(req)
+        cookie_header = req["Cookie"] || ""
+        match = cookie_header.match(
+          /(?:^|;\s*)#{Regexp.escape(SESSION_COOKIE)}=([^;]+)/)
+        return nil unless match
+
+        data = JSON.parse(Base64.strict_decode64(match[1]))
+        OpenStruct.new(email: data["email"], role: data["role"])
+      rescue
+        nil
+      end
+
+      # Look up an actor by email and password from the in-memory store.
+      #
+      # @param email [String] the user email
+      # @param password [String] the plaintext password
+      # @return [OpenStruct, nil] the actor or nil
+      def resolve_actor(email, password)
+        stored = @auth_store&.dig(email)
+        return nil unless stored && stored[:password] == password
+
+        OpenStruct.new(email: email, role: stored[:role] || "User")
+      end
+
+      # Create a new actor in the in-memory store.
+      #
+      # @param email [String] the user email
+      # @param password [String] the plaintext password
+      # @return [OpenStruct] the new actor
+      def create_actor(email, password)
+        @auth_store ||= {}
+        role = default_auth_role
+        @auth_store[email] = { password: password, role: role }
+        OpenStruct.new(email: email, role: role)
+      end
+
+      # Determine the default role for new signups from the domain DSL.
+      #
+      # @return [String] the first actor role found, or "User"
+      def default_auth_role
+        @domain.aggregates.each do |agg|
+          agg.commands.each do |cmd|
+            next unless cmd.respond_to?(:actors) && cmd.actors&.any?
+            return cmd.actors.first.name
+          end
+        end
+        "User"
+      end
+
+      # Validate signup form fields.
+      #
+      # @param email [String]
+      # @param password [String]
+      # @param confirmation [String]
+      # @return [String, nil] error message or nil if valid
+      def validate_signup(email, password, confirmation)
+        return "All fields are required" if email.empty? || password.empty?
+        return "Passwords do not match" if password != confirmation
+        return "Password must be at least 8 characters" if password.length < 8
+
+        if @auth_store&.key?(email)
+          return "An account with that email already exists"
+        end
+
+        nil
+      end
+
+      # Parse URL-encoded form body params from a POST request.
+      #
+      # @param req [WEBrick::HTTPRequest] the request
+      # @return [Hash{String => String}]
+      def parse_form_params(req)
+        body = req.body || ""
+        URI.decode_www_form(body).to_h
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/auth/views/login.erb
+++ b/hecksties/lib/hecks/extensions/auth/views/login.erb
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login — <%= domain_name %></title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, -apple-system, sans-serif; background: #f5f5f5; color: #333; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: #fff; padding: 2rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
+    h1 { margin-bottom: 1.5rem; color: #1a1a2e; text-align: center; font-size: 1.4rem; }
+    .brand { text-align: center; color: #4361ee; font-weight: 700; font-size: 1.1rem; margin-bottom: 0.5rem; }
+    label { display: block; margin-bottom: 0.3rem; font-weight: 500; font-size: 0.9rem; }
+    input { width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 1rem; font-size: 0.9rem; }
+    input:focus { outline: none; border-color: #4361ee; }
+    .btn { display: block; width: 100%; padding: 0.6rem; background: #4361ee; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.95rem; font-weight: 500; }
+    .btn:hover { background: #3a56d4; }
+    .flash-error { padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; background: #f8d7da; color: #721c24; font-size: 0.9rem; }
+    .link { text-align: center; margin-top: 1rem; font-size: 0.9rem; }
+    .link a { color: #4361ee; text-decoration: none; }
+    .link a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand"><%= domain_name %></div>
+    <h1>Login</h1>
+    <% if error_message %>
+      <div class="flash-error"><%= error_message %></div>
+    <% end %>
+    <form method="post" action="/login">
+      <input type="hidden" name="_csrf_token" value="<%= csrf_token %>">
+      <label>Email</label>
+      <input name="email" type="email" required autofocus>
+      <label>Password</label>
+      <input name="password" type="password" required>
+      <button class="btn" type="submit">Sign in</button>
+    </form>
+    <div class="link">
+      Don't have an account? <a href="/signup">Sign up</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/hecksties/lib/hecks/extensions/auth/views/signup.erb
+++ b/hecksties/lib/hecks/extensions/auth/views/signup.erb
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign Up — <%= domain_name %></title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, -apple-system, sans-serif; background: #f5f5f5; color: #333; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: #fff; padding: 2rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
+    h1 { margin-bottom: 1.5rem; color: #1a1a2e; text-align: center; font-size: 1.4rem; }
+    .brand { text-align: center; color: #4361ee; font-weight: 700; font-size: 1.1rem; margin-bottom: 0.5rem; }
+    label { display: block; margin-bottom: 0.3rem; font-weight: 500; font-size: 0.9rem; }
+    input { width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 1rem; font-size: 0.9rem; }
+    input:focus { outline: none; border-color: #4361ee; }
+    .btn { display: block; width: 100%; padding: 0.6rem; background: #4361ee; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.95rem; font-weight: 500; }
+    .btn:hover { background: #3a56d4; }
+    .flash-error { padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; background: #f8d7da; color: #721c24; font-size: 0.9rem; }
+    .link { text-align: center; margin-top: 1rem; font-size: 0.9rem; }
+    .link a { color: #4361ee; text-decoration: none; }
+    .link a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand"><%= domain_name %></div>
+    <h1>Create Account</h1>
+    <% if error_message %>
+      <div class="flash-error"><%= error_message %></div>
+    <% end %>
+    <form method="post" action="/signup">
+      <input type="hidden" name="_csrf_token" value="<%= csrf_token %>">
+      <label>Email</label>
+      <input name="email" type="email" required autofocus>
+      <label>Password</label>
+      <input name="password" type="password" required minlength="8">
+      <label>Confirm Password</label>
+      <input name="password_confirmation" type="password" required minlength="8">
+      <button class="btn" type="submit">Create Account</button>
+    </form>
+    <div class="link">
+      Already have an account? <a href="/login">Sign in</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -6,6 +6,7 @@ require_relative "route_builder"
 require_relative "cors_headers"
 require_relative "command_bus_port"
 require_relative "csrf_helpers"
+require_relative "../auth/screen_routes"
 
 module Hecks
   module HTTP
@@ -28,6 +29,7 @@ module Hecks
       include HecksTemplating::NamingHelpers
       include Hecks::HTTP::CorsHeaders
       include CsrfHelpers
+      include Hecks::Auth::ScreenRoutes
       # Initialize the server, boot the domain gem, and build routes.
       #
       # Builds the domain gem into a temporary directory, requires it,
@@ -60,6 +62,11 @@ module Hecks
         puts "Hecks serving #{@domain.name} on http://localhost:#{@port}"
         puts ""
         @routes.each { |r| puts "  #{r[:method].ljust(6)} #{r[:path]}" }
+        puts "  GET    /login"
+        puts "  POST   /login"
+        puts "  GET    /signup"
+        puts "  POST   /signup"
+        puts "  GET    /logout"
         puts "  GET    /events (SSE)"
         puts "  GET    /_openapi"
         puts "  GET    /_schema"
@@ -87,6 +94,13 @@ module Hecks
       def handle(req, res)
         set_cors(res)
         return if req.request_method == "OPTIONS"
+
+        restore_actor_from_session(req)
+
+        if auth_route?(req.path)
+          handle_auth_route(req, res)
+          return
+        end
 
         if csrf_required?(req) && !valid_csrf_json?(req)
           res.status = 403
@@ -130,6 +144,15 @@ module Hecks
         res.status = 422
         res["Content-Type"] = "application/json"
         res.body = JSON.generate(error: e.message)
+      end
+
+      # Restore the actor from the session cookie if present.
+      #
+      # @param req [WEBrick::HTTPRequest] the incoming request
+      # @return [void]
+      def restore_actor_from_session(req)
+        actor = restore_session(req)
+        Hecks.actor = actor if actor
       end
 
       # Start a WebSocket server for real-time event streaming.

--- a/hecksties/spec/extensions/auth_screens_spec.rb
+++ b/hecksties/spec/extensions/auth_screens_spec.rb
@@ -1,0 +1,238 @@
+require "spec_helper"
+require "hecks/extensions/auth"
+require "hecks/extensions/auth/screen_routes"
+require "ostruct"
+require "base64"
+require "json"
+
+RSpec.describe "Auth Screens" do
+  let(:domain) do
+    Hecks.domain "AuthScreens" do
+      aggregate "Account" do
+        attribute :email, String
+        attribute :balance, Float
+
+        command "Deposit" do
+          actor "Admin"
+          attribute :amount, Float
+        end
+      end
+    end
+  end
+
+  # Minimal request/response doubles for testing without WEBrick
+  let(:cookies) { {} }
+
+  def make_req(method, path, body: nil, cookie: nil)
+    req = OpenStruct.new(
+      request_method: method,
+      path: path,
+      body: body,
+      query: {}
+    )
+    req.define_singleton_method(:[]) do |name|
+      return cookie if name == "Cookie"
+      nil
+    end
+    req
+  end
+
+  def make_res
+    headers = {}
+    res = OpenStruct.new(status: 200, body: nil)
+    res.define_singleton_method(:[]=) { |k, v| headers[k] = v }
+    res.define_singleton_method(:[]) { |k| headers[k] }
+    res.define_singleton_method(:headers) { headers }
+    res.define_singleton_method(:set_redirect) { |_status, loc| headers["Location"] = loc }
+    res
+  end
+
+  # Build a test object that includes the mixin
+  let(:handler) do
+    d = domain
+    obj = Object.new
+    obj.instance_variable_set(:@domain, d)
+    obj.instance_variable_set(:@auth_store, {})
+    obj.extend(Hecks::HTTP::CsrfHelpers)
+    obj.extend(Hecks::Auth::ScreenRoutes)
+    obj
+  end
+
+  before do
+    @app = Hecks.load(domain)
+  end
+
+  after { Hecks.actor = nil }
+
+  describe "auth_route?" do
+    it "recognizes login path" do
+      expect(handler.auth_route?("/login")).to be true
+    end
+
+    it "recognizes signup path" do
+      expect(handler.auth_route?("/signup")).to be true
+    end
+
+    it "recognizes logout path" do
+      expect(handler.auth_route?("/logout")).to be true
+    end
+
+    it "rejects non-auth paths" do
+      expect(handler.auth_route?("/accounts")).to be false
+    end
+  end
+
+  describe "GET /login" do
+    it "renders the login form HTML" do
+      req = make_req("GET", "/login")
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res["Content-Type"]).to eq("text/html")
+      expect(res.body).to include("Login")
+      expect(res.body).to include('action="/login"')
+      expect(res.body).to include('type="email"')
+      expect(res.body).to include('type="password"')
+    end
+  end
+
+  describe "GET /signup" do
+    it "renders the signup form HTML" do
+      req = make_req("GET", "/signup")
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res["Content-Type"]).to eq("text/html")
+      expect(res.body).to include("Create Account")
+      expect(res.body).to include('action="/signup"')
+      expect(res.body).to include("password_confirmation")
+    end
+  end
+
+  describe "POST /signup" do
+    it "creates an account and redirects" do
+      body = URI.encode_www_form(
+        "email" => "test@example.com",
+        "password" => "secret123",
+        "password_confirmation" => "secret123"
+      )
+      req = make_req("POST", "/signup", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.headers["Location"]).to eq("/")
+      expect(res["Set-Cookie"]).to include("_hecks_session=")
+    end
+
+    it "rejects mismatched passwords" do
+      body = URI.encode_www_form(
+        "email" => "test@example.com",
+        "password" => "secret123",
+        "password_confirmation" => "different"
+      )
+      req = make_req("POST", "/signup", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.body).to include("Passwords do not match")
+    end
+
+    it "rejects short passwords" do
+      body = URI.encode_www_form(
+        "email" => "test@example.com",
+        "password" => "short",
+        "password_confirmation" => "short"
+      )
+      req = make_req("POST", "/signup", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.body).to include("Password must be at least 8 characters")
+    end
+  end
+
+  describe "POST /login" do
+    before do
+      # Register a user first
+      body = URI.encode_www_form(
+        "email" => "user@example.com",
+        "password" => "password123",
+        "password_confirmation" => "password123"
+      )
+      req = make_req("POST", "/signup", body: body)
+      handler.handle_auth_route(req, make_res)
+    end
+
+    it "authenticates valid credentials and redirects" do
+      body = URI.encode_www_form(
+        "email" => "user@example.com",
+        "password" => "password123"
+      )
+      req = make_req("POST", "/login", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.headers["Location"]).to eq("/")
+      expect(res["Set-Cookie"]).to include("_hecks_session=")
+    end
+
+    it "rejects invalid credentials" do
+      body = URI.encode_www_form(
+        "email" => "user@example.com",
+        "password" => "wrong"
+      )
+      req = make_req("POST", "/login", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.body).to include("Invalid email or password")
+    end
+
+    it "rejects empty fields" do
+      body = URI.encode_www_form("email" => "", "password" => "")
+      req = make_req("POST", "/login", body: body)
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.body).to include("Email and password are required")
+    end
+  end
+
+  describe "GET /logout" do
+    it "clears the session and redirects to login" do
+      Hecks.actor = OpenStruct.new(role: "Admin")
+      req = make_req("GET", "/logout")
+      res = make_res
+      handler.handle_auth_route(req, res)
+
+      expect(res.headers["Location"]).to eq("/login")
+      expect(res["Set-Cookie"]).to include("Max-Age=0")
+      expect(Hecks.actor).to be_nil
+    end
+  end
+
+  describe "session restore" do
+    it "restores actor from session cookie" do
+      payload = Base64.strict_encode64(
+        JSON.generate(email: "test@example.com", role: "Admin"))
+      cookie = "_hecks_session=#{payload}"
+      req = make_req("GET", "/login", cookie: cookie)
+
+      actor = handler.restore_session(req)
+      expect(actor.email).to eq("test@example.com")
+      expect(actor.role).to eq("Admin")
+    end
+
+    it "returns nil for missing session" do
+      req = make_req("GET", "/login")
+      expect(handler.restore_session(req)).to be_nil
+    end
+  end
+
+  describe "default role detection" do
+    it "picks the first actor role from domain commands" do
+      role = handler.send(:default_auth_role)
+      expect(role).to eq("Admin")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Auto-generate login, signup, and logout HTML pages when the auth extension is active
- Wire auth screen routes (GET/POST `/login`, GET/POST `/signup`, GET `/logout`) into the serve extension's DomainServer
- Session management via HttpOnly cookies with Base64-encoded JSON payloads; actor restored on each request
- In-memory credential store for development; default role inferred from domain DSL actor declarations

## Example

After defining a domain with actor-guarded commands:

```ruby
Hecks.domain "Clinic" do
  aggregate "Appointment" do
    command "Book" do
      actor "Receptionist"
      attribute :patient, String
    end
  end
end
```

Running `hecks serve clinic` exposes:

```
GET    /login
POST   /login
GET    /signup
POST   /signup
GET    /logout
GET    /appointments
...
```

Login screen (email + password, inline CSS, no JS framework):

```
POST /login  →  sets _hecks_session cookie  →  redirects to /
```

Signup screen (email + password + confirm, validates match/length/uniqueness):

```
POST /signup  →  creates account with role "Receptionist"  →  redirects to /
```

## Test plan

- [x] Auth route detection (`/login`, `/signup`, `/logout` recognized; other paths rejected)
- [x] Login form renders HTML with email/password fields
- [x] Signup form renders HTML with email/password/confirm fields
- [x] POST /signup creates account and sets session cookie
- [x] POST /signup rejects mismatched passwords, short passwords
- [x] POST /login authenticates valid credentials, rejects invalid/empty
- [x] GET /logout clears session and redirects to /login
- [x] Session restore reads actor from cookie
- [x] Default role inferred from domain DSL actors
- [x] All 1788 specs pass under 1.5s speed limit
- [x] Smoke test passes (`ruby -Ilib examples/pizzas/app.rb`)