### PR TITLE
HEC-62: Finder methods for aggregates

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -51,6 +51,7 @@
 ### Queries & Scopes
 - Define named queries with `where`, `order`, `limit`, `offset` chainable DSL
 - Define named scopes as hash conditions or lambda predicates
+- Custom finders: `finder :by_email, :email` — named repository lookup methods with auto-generated memory adapter implementations and port stubs for custom adapters
 
 ### Specifications & Validation
 - Define specifications as reusable composable predicates (`satisfied_by?`, `and`, `or`, `not`)

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -35,6 +35,7 @@ module Hecks
       lines.concat(serialize_validations(agg.validations))
       lines.concat(serialize_invariants(agg.invariants, "    "))
       lines.concat(serialize_scopes(agg.scopes))
+      lines.concat(serialize_finders(agg.finders))
       lines.concat(serialize_computed_attributes(agg.computed_attributes))
       lines.concat(serialize_queries(agg.queries))
       lines.concat(serialize_specifications(agg.specifications))
@@ -84,6 +85,13 @@ module Hecks
         formatted = s.conditions.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")
         ["", "    scope :#{s.name}, #{formatted}"]
       end
+    end
+
+    def serialize_finders(finders)
+      (finders || []).map do |f|
+        param_list = f.params.map { |p| ":#{p}" }.join(", ")
+        ["", "    finder :#{f.name}, #{param_list}"]
+      end.flatten
     end
 
     def serialize_queries(queries)

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -57,6 +57,7 @@ module Hecks
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
       autoload :Reference,         "hecks/domain_model/structure/reference"
       autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
+      autoload :Finder,            "hecks/domain_model/structure/finder"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -72,6 +72,9 @@ module Hecks
       # @return [Array<ComputedAttribute>] derived attributes computed from other attributes
       attr_reader :computed_attributes
 
+      # @return [Array<Finder>] custom named finders for repository lookups
+      attr_reader :finders
+
       # @return [Lifecycle, nil] optional state machine definition
       attr_reader :lifecycle
 
@@ -108,7 +111,7 @@ module Hecks
                      specifications: [], references: [],
                      factories: [], computed_attributes: [],
                      lifecycle: nil, metadata: {}, origin_domain: nil,
-                     identity_fields: nil)
+                     identity_fields: nil, finders: [])
         @name = Names.aggregate_name(name)
         @attributes = attributes
         @value_objects = value_objects
@@ -129,6 +132,7 @@ module Hecks
         @metadata = metadata
         @origin_domain = origin_domain
         @identity_fields = identity_fields
+        @finders = finders
       end
 
       attr_reader :metadata, :origin_domain

--- a/bluebook/lib/hecks/domain_model/structure/finder.rb
+++ b/bluebook/lib/hecks/domain_model/structure/finder.rb
@@ -1,0 +1,41 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::Finder
+    #
+    # Value object representing a custom named finder declared on an aggregate.
+    # A finder has a name and a list of parameter names. At runtime, the memory
+    # adapter auto-generates an implementation that filters by matching each
+    # param against the corresponding attribute. The port module generates
+    # a NotImplementedError stub for custom adapters to implement.
+    #
+    # Part of the DomainModel IR layer. Built by AggregateBuilder and consumed
+    # by generators and the querying subsystem at runtime.
+    #
+    #   Finder.new(name: :by_name, params: [:name])
+    #   Finder.new(name: :by_status_and_priority, params: [:status, :priority])
+    #
+    class Finder
+      # @return [Symbol] the finder name, used as a method name on the repository
+      #   and aggregate class (e.g., :by_name, :by_status_and_priority)
+      attr_reader :name
+
+      # @return [Array<Symbol>] the parameter names for this finder. Each param
+      #   corresponds to an attribute on the aggregate that will be matched
+      #   for equality when the finder is invoked.
+      attr_reader :params
+
+      # Creates a new Finder.
+      #
+      # @param name [Symbol] the finder name
+      # @param params [Array<Symbol>] the parameter names for filtering
+      # @return [Finder] a new Finder instance
+      def initialize(name:, params:)
+        @name = name
+        @params = params
+      end
+    end
+    end
+  end
+end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -51,7 +51,7 @@ module Hecks
       attr_reader :attributes, :commands, :value_objects, :entities,
                   :policies, :validations, :invariants, :scopes,
                   :queries, :subscribers, :specifications,
-                  :references
+                  :references, :finders
       # Writer for lifecycle — used by AggregateHandle to update lifecycle
       # without reaching into instance variables. Reader is the DSL method
       # in BehaviorMethods; use current_lifecycle to read.
@@ -75,6 +75,7 @@ module Hecks
         @subscribers = []
         @specifications = []
         @references = []
+        @finders = []
         @explicit_events = []
         @factories = []
         @computed_attributes = []
@@ -190,7 +191,8 @@ module Hecks
           specifications: @specifications, computed_attributes: @computed_attributes,
           lifecycle: @lifecycle,
           metadata: @metadata, references: @references,
-          factories: @factories, identity_fields: @identity_fields
+          factories: @factories, identity_fields: @identity_fields,
+          finders: @finders
         )
       end
 

--- a/bluebook/lib/hecks/dsl/aggregate_builder/query_methods.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder/query_methods.rb
@@ -25,6 +25,19 @@ module Hecks
         def query(name, &block)
           @queries << DomainModel::Behavior::Query.new(name: name, block: block)
         end
+
+        # Define a custom finder on this aggregate's repository.
+        #
+        # A finder declares a named lookup method with typed parameters.
+        # The memory adapter auto-generates an equality-match implementation;
+        # custom adapters get a NotImplementedError stub in the port module.
+        #
+        # @param name [Symbol] the finder method name (e.g., :by_email)
+        # @param params [Array<Symbol>] attribute names to match against
+        # @return [void]
+        def finder(name, *params)
+          @finders << DomainModel::Structure::Finder.new(name: name, params: params.map(&:to_sym))
+        end
       end
     end
   end

--- a/bluebook/lib/hecks/dsl/aggregate_rebuilder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_rebuilder.rb
@@ -69,6 +69,9 @@ module Hecks
         aggregate.specifications.each do |spec|
           builder.specification(spec.name, &spec.block)
         end
+        (aggregate.finders || []).each do |f|
+          builder.finder(f.name, *f.params)
+        end
         builder
       end
     end

--- a/bluebook/lib/hecks/generators/infrastructure/memory_adapter_generator.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/memory_adapter_generator.rb
@@ -71,6 +71,7 @@ module Hecks
         lines << "      end"
         lines << ""
         lines.concat(query_lines(6))
+        lines.concat(finder_lines(6))
         lines << ""
         lines << "      def clear"
         lines << "        @store.clear"
@@ -89,6 +90,28 @@ module Hecks
       # @return [Array<String>] the lines of the +query+ method
       def operator_module
         @mixin_prefix == "Hecks" ? "Hecks::Querying::Operators" : "#{@mixin_prefix}::Runtime::Operators"
+      end
+
+      # Generates finder method implementations for the memory adapter.
+      #
+      # Each finder filters @store.values by equality on the declared params.
+      #
+      # @param indent [Integer] number of leading spaces for indentation
+      # @return [Array<String>] the lines for all finder methods
+      def finder_lines(indent)
+        return [] if @aggregate.finders.empty?
+
+        pad = " " * indent
+        lines = []
+        @aggregate.finders.each do |finder|
+          param_list = finder.params.join(", ")
+          lines << ""
+          lines << "#{pad}def #{finder.name}(#{param_list})"
+          conditions = finder.params.map { |p| "obj.#{p} == #{p}" }.join(" && ")
+          lines << "#{pad}  @store.values.select { |obj| #{conditions} }"
+          lines << "#{pad}end"
+        end
+        lines
       end
 
       def query_lines(indent)

--- a/bluebook/lib/hecks/generators/infrastructure/port_generator.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/port_generator.rb
@@ -53,12 +53,33 @@ module Hecks
         lines << "      def delete(id)"
         lines << "        raise NotImplementedError, \"\#{self.class}#delete not implemented\""
         lines << "      end"
+        lines.concat(finder_stub_lines(6))
         lines << "    end"
         lines << "  end"
         lines << "end"
         lines.join("\n") + "\n"
       end
 
+      private
+
+      # Generates NotImplementedError stub lines for each finder.
+      #
+      # @param indent [Integer] number of leading spaces for indentation
+      # @return [Array<String>] the lines for all finder stubs
+      def finder_stub_lines(indent)
+        return [] if @aggregate.finders.empty?
+
+        pad = " " * indent
+        lines = []
+        @aggregate.finders.each do |finder|
+          param_list = finder.params.join(", ")
+          lines << ""
+          lines << "#{pad}def #{finder.name}(#{param_list})"
+          lines << "#{pad}  raise NotImplementedError, \"\#{self.class}##{finder.name} not implemented\""
+          lines << "#{pad}end"
+        end
+        lines
+      end
     end
     end
   end

--- a/docs/usage/custom_finders.md
+++ b/docs/usage/custom_finders.md
@@ -1,0 +1,69 @@
+# Custom Finders
+
+Declare named repository lookup methods on aggregates. Each finder specifies
+one or more attribute parameters and returns all records matching by equality.
+
+## DSL
+
+```ruby
+Hecks.domain "Users" do
+  aggregate "User" do
+    attribute :name, String
+    attribute :email, String
+    attribute :role, String
+
+    command "CreateUser" do
+      attribute :name, String
+      attribute :email, String
+      attribute :role, String
+    end
+
+    finder :by_email, :email
+    finder :by_role, :role
+    finder :by_name_and_role, :name, :role
+  end
+end
+```
+
+## Usage
+
+```ruby
+app = Hecks.boot(__dir__)
+
+User.create(name: "Alice", email: "alice@example.com", role: "admin")
+User.create(name: "Bob",   email: "bob@example.com",   role: "member")
+
+User.by_email("alice@example.com")
+# => [#<User name="Alice" ...>]
+
+User.by_role("member")
+# => [#<User name="Bob" ...>]
+
+User.by_name_and_role("Alice", "admin")
+# => [#<User name="Alice" ...>]
+
+User.by_name_and_role("Alice", "member")
+# => []
+```
+
+## How it works
+
+- **IR**: `finder :name, :param1, :param2` stores a `Finder` node on the aggregate
+- **Memory adapter**: auto-generates equality-match implementations filtering `@store.values`
+- **Port module**: generates `NotImplementedError` stubs so custom adapters know which methods to implement
+- **Runtime**: `FinderMethods.bind` defines singleton methods on the aggregate class that delegate to the repository
+
+## Custom adapters
+
+When writing a SQL or other adapter, include the generated port module and
+implement each finder method:
+
+```ruby
+class UserSqlRepository
+  include UsersDomain::Ports::UserRepository
+
+  def by_email(email)
+    db[:users].where(email: email).map { |row| hydrate(row) }
+  end
+end
+```

--- a/hecksties/lib/hecks/ports/queries.rb
+++ b/hecksties/lib/hecks/ports/queries.rb
@@ -31,6 +31,7 @@ module Hecks
       autoload :AdHocQueries,  "hecks/ports/queries/ad_hoc_queries"
       autoload :ScopeMethods,  "hecks/ports/queries/scope_methods"
       autoload :Operators,     "hecks/ports/queries/operators"
+      autoload :FinderMethods, "hecks/ports/queries/finder_methods"
 
       # Wires named scopes from the aggregate definition onto the class.
       #
@@ -43,6 +44,7 @@ module Hecks
       # @return [void]
       def self.bind(klass, aggregate)
         ScopeMethods.bind(klass, aggregate)
+        FinderMethods.bind(klass, aggregate)
       end
   end
 end

--- a/hecksties/lib/hecks/ports/queries/finder_methods.rb
+++ b/hecksties/lib/hecks/ports/queries/finder_methods.rb
@@ -1,0 +1,44 @@
+module Hecks
+  module Querying
+    # Hecks::Querying::FinderMethods
+    #
+    # Binds custom finder methods onto aggregate classes. Finders are declared
+    # in the domain DSL and represent named repository lookup methods that
+    # filter by equality on one or more attributes. Each finder becomes a
+    # singleton method on the aggregate class that delegates to the
+    # repository's finder implementation.
+    #
+    # == Usage
+    #
+    #   # In the domain DSL:
+    #   finder :by_email, :email
+    #   finder :by_status_and_priority, :status, :priority
+    #
+    #   # After binding:
+    #   FinderMethods.bind(UserClass, user_aggregate)
+    #   User.by_email("alice@example.com")         # => [User, ...]
+    #   User.by_status_and_priority("active", "high") # => [User, ...]
+    #
+    module FinderMethods
+      # Binds all finders from the aggregate definition as class methods.
+      #
+      # For each finder, defines a singleton method on the aggregate class
+      # that delegates to the repository's method of the same name.
+      #
+      # @param klass [Class] the aggregate class to receive finder methods;
+      #   must have +@__hecks_repo__+ set (done by AdHocQueries.bind)
+      # @param aggregate [Hecks::DomainModel::Structure::Aggregate] the aggregate
+      #   definition containing finder metadata
+      # @return [void]
+      def self.bind(klass, aggregate)
+        aggregate.finders.each do |finder|
+          repo = klass.instance_variable_get(:@__hecks_repo__)
+          finder_name = finder.name
+          klass.define_singleton_method(finder_name) do |*args|
+            repo.send(finder_name, *args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecksties/spec/ports/queries/finder_methods_spec.rb
+++ b/hecksties/spec/ports/queries/finder_methods_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Querying::FinderMethods do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :style, String
+        attribute :price, Float
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :style, String
+          attribute :price, Float
+        end
+
+        finder :by_style, :style
+        finder :by_name_and_style, :name, :style
+      end
+    end
+  end
+
+  before do
+    @app = Hecks.load(domain)
+
+    PizzasDomain::Pizza.create(name: "Margherita", style: "Classic", price: 12.0)
+    PizzasDomain::Pizza.create(name: "Pepperoni", style: "Spicy", price: 15.0)
+    PizzasDomain::Pizza.create(name: "Hawaiian", style: "Classic", price: 14.0)
+  end
+
+  describe "DSL definition" do
+    it "stores finders on the aggregate IR" do
+      agg = domain.aggregates.first
+      expect(agg.finders.size).to eq(2)
+      expect(agg.finders.map(&:name)).to eq([:by_style, :by_name_and_style])
+    end
+
+    it "records param names" do
+      agg = domain.aggregates.first
+      finder = agg.finders.find { |f| f.name == :by_name_and_style }
+      expect(finder.params).to eq([:name, :style])
+    end
+  end
+
+  describe "single-param finder" do
+    it "defines a class method on the aggregate" do
+      expect(PizzasDomain::Pizza).to respond_to(:by_style)
+    end
+
+    it "returns matching records" do
+      results = PizzasDomain::Pizza.by_style("Classic")
+      expect(results.map(&:name).sort).to eq(["Hawaiian", "Margherita"])
+    end
+
+    it "returns empty array when no matches" do
+      expect(PizzasDomain::Pizza.by_style("NonExistent")).to be_empty
+    end
+  end
+
+  describe "multi-param finder" do
+    it "filters by all params" do
+      results = PizzasDomain::Pizza.by_name_and_style("Margherita", "Classic")
+      expect(results.size).to eq(1)
+      expect(results.first.name).to eq("Margherita")
+    end
+
+    it "returns empty when one param mismatches" do
+      expect(PizzasDomain::Pizza.by_name_and_style("Margherita", "Spicy")).to be_empty
+    end
+  end
+
+  describe "DSL serialization" do
+    it "includes finders in serialized output" do
+      output = Hecks::DslSerializer.new(domain).serialize
+      expect(output).to include("finder :by_style, :style")
+      expect(output).to include("finder :by_name_and_style, :name, :style")
+    end
+  end
+
+  describe "aggregate rebuilder" do
+    it "preserves finders through rebuild" do
+      agg = domain.aggregates.first
+      builder = Hecks::DSL::AggregateRebuilder.from_aggregate(agg)
+      rebuilt = builder.build
+      expect(rebuilt.finders.size).to eq(2)
+      expect(rebuilt.finders.first.name).to eq(:by_style)
+      expect(rebuilt.finders.first.params).to eq([:style])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add custom finders DSL for aggregate repositories (HEC-62)

Add `finder :name, :param1, :param2` to the aggregate DSL. Finders are
named repository lookup methods that filter by equality on declared
attributes. Memory adapters auto-generate implementations; port modules
generate NotImplementedError stubs for custom adapters. FinderMethods.bind
wires finder class methods onto aggregate classes at boot time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)