### PR TITLE
HEC-63: CQRS separate read/write models

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -107,7 +107,7 @@
 - `hecks_postgres` — PostgreSQL persistence
 - `hecks_mysql` — MySQL persistence
 - `hecks_mongodb` — MongoDB persistence; value objects embedded as nested documents (no join tables)
-- `hecks_cqrs` — named persistence connections for read/write separation
+- `hecks_cqrs` — named persistence connections for read/write separation; ReadModelStore port with `update`, `read`, `clear`; commands route to write repo, queries/scopes to read store; `runtime.enable_cqrs("Agg", read_repo: repo)` for programmatic activation; backward compatible single-adapter when no read store registered
 - `hecks_mongodb` — MongoDB document persistence via the mongo Ruby driver
 
 ### Server Extensions

--- a/docs/usage/cqrs.md
+++ b/docs/usage/cqrs.md
@@ -1,0 +1,87 @@
+# CQRS -- Command Query Responsibility Segregation
+
+Hecks supports separating write (command) and read (query) repositories.
+When CQRS is active, commands route to the write repository while queries,
+scopes, and read methods (`find`, `all`, `where`) route to a separate
+read store. When no read store is registered, everything uses a single
+adapter (backward compatible).
+
+## Programmatic Activation
+
+Enable CQRS for an aggregate after boot:
+
+```ruby
+domain = Hecks.domain "Catalog" do
+  aggregate "Product" do
+    attribute :name, String
+    attribute :price, Float
+
+    command "CreateProduct" do
+      attribute :name, String
+      attribute :price, Float
+    end
+  end
+end
+
+app = Hecks.load(domain)
+
+# Create a separate read-side adapter
+read_adapter = CatalogDomain::Adapters::ProductMemoryRepository.new
+app.enable_cqrs("Product", read_repo: read_adapter)
+
+# Commands write to the write repo
+Product.create(name: "Widget", price: 9.99)
+
+# Queries read from the read store (auto-synced via events)
+Product.all          # reads from read store
+Product.find(id)     # reads from read store
+Product.where(name: "Widget")  # reads from read store
+```
+
+## Extension Activation
+
+The `hecks_cqrs` extension auto-wires all aggregates when loaded:
+
+```ruby
+app = Hecks.load(domain)
+app.extend(:cqrs)
+```
+
+This creates a ReadModelStore for each aggregate and subscribes to
+all domain events for automatic synchronization.
+
+## ReadModelStore API
+
+```ruby
+require "hecks/ports/read_model_store"
+
+adapter = CatalogDomain::Adapters::ProductMemoryRepository.new
+store = Hecks::ReadModelStore.new(adapter: adapter)
+
+store.update(product)    # sync an aggregate into the read store
+store.read               # returns the underlying adapter
+store.read.all           # all records in the read store
+store.find(id)           # find by ID
+store.count              # record count
+store.clear              # wipe all data
+```
+
+## Inspecting CQRS Status
+
+```ruby
+app.cqrs?                 # => true if any aggregate has CQRS
+app.cqrs?("Product")      # => true if Product has CQRS
+app.read_store_for("Product")  # => the ReadModelStore instance
+```
+
+## How Auto-Sync Works
+
+When `enable_cqrs` or the CQRS extension is activated, the runtime
+subscribes to every aggregate event. On each event, the write repo
+is read and the read store is updated. This ensures eventual consistency
+between write and read sides.
+
+## Backward Compatibility
+
+When no read store is registered for an aggregate, all operations use
+the single repository adapter. No changes are needed for existing code.

--- a/hecksagon/lib/hecks/extensions/cqrs.rb
+++ b/hecksagon/lib/hecks/extensions/cqrs.rb
@@ -3,29 +3,27 @@ require "hecks"
 # HecksCqrs
 #
 # CQRS (Command Query Responsibility Segregation) support for Hecks domains.
-# Enables named persistence connections for read/write separation. Commands
-# route to the +:write+ connection, queries to the +:read+ connection.
-# Registers with the Hecks connection registry so domains can declare
-# multiple named adapters in their boot block.
+# Enables separate read and write repositories. Commands route to the write
+# repository, queries and scopes route to the read repository. When only a
+# single adapter is configured, behavior is unchanged (backward compatible).
 #
-# A domain has CQRS active when more than one named persist connection
-# exists in its connections hash. This module provides introspection
-# methods to check CQRS status and retrieve individual connection configs.
+# Activate CQRS by declaring named :write and :read persist connections:
 #
 #   CatsDomain.boot do
 #     persist_to :write, :sqlite
 #     persist_to :read, :sqlite, database: "read.db"
 #   end
 #
-#   # Access named connections:
-#   CatsDomain.connections[:persist][:write]
-#   # => { type: :sqlite }
-#   CatsDomain.connections[:persist][:read]
-#   # => { type: :sqlite, database: "read.db" }
+# Or programmatically after boot:
+#
+#   runtime.enable_cqrs("Pizza", read_repo: my_read_repo)
+#
+# The read store wraps the read adapter in a ReadModelStore, which auto-syncs
+# from command events on the event bus.
 #
 
 module HecksCqrs
-  VERSION = "2026.03.24.1"
+  VERSION = "2026.04.01.1"
 
   # Check whether a domain module has CQRS connections configured.
   # Returns true when more than one named persist connection exists,
@@ -55,9 +53,41 @@ module HecksCqrs
     persist = mod.connections[:persist]
     persist[name] if persist.is_a?(Hash)
   end
+
+  # Wires CQRS read/write separation onto a runtime.
+  #
+  # For each aggregate, creates a ReadModelStore backed by a fresh memory
+  # adapter, subscribes to all aggregate events to auto-sync the read store,
+  # and registers the read repository on the runtime for query routing.
+  #
+  # @param mod [Module] the domain module
+  # @param domain [Object] the domain IR
+  # @param runtime [Hecks::Runtime] the runtime to wire CQRS onto
+  # @return [void]
+  def self.call(mod, domain, runtime, **_kwargs)
+    require "hecks/ports/read_model_store"
+
+    domain.aggregates.each do |agg|
+      write_repo = runtime[agg.name]
+      adapter_class = mod::Adapters.const_get("#{agg.name}MemoryRepository")
+      read_adapter = adapter_class.new
+      read_store = Hecks::ReadModelStore.new(adapter: read_adapter)
+
+      # Auto-sync: on every aggregate event, copy the aggregate to the read store
+      agg.events.each do |event|
+        runtime.event_bus.subscribe(event.name) do |evt|
+          # Re-read from write repo and sync to read store
+          agg_class = mod.const_get(agg.name)
+          write_repo.all.each { |obj| read_store.update(obj) }
+        end
+      end
+
+      runtime.register_read_store(agg.name, read_store)
+    end
+  end
 end
 
-# Register with Hecks connection registry if available
+# Register with Hecks extension registry if available
 if defined?(Hecks) && Hecks.respond_to?(:extension_registry)
   Hecks.extension_registry[:cqrs] = HecksCqrs
 end

--- a/hecksties/lib/hecks/ports/read_model_store.rb
+++ b/hecksties/lib/hecks/ports/read_model_store.rb
@@ -1,0 +1,95 @@
+# Hecks::ReadModelStore
+#
+# Port for read-side storage in CQRS setups. A ReadModelStore wraps any
+# repository adapter and synchronizes it from write-side events. Provides
+# +update+, +read+, and +clear+ methods. When HecksCqrs is active, queries
+# and scopes are routed here while commands use the write repository.
+#
+#   store = ReadModelStore.new(adapter: PizzaMemoryRepository.new)
+#   store.update(pizza)          # sync an aggregate into the read store
+#   store.read.all               # delegates to the underlying adapter
+#   store.clear                  # wipe the read store
+#
+module Hecks
+  class ReadModelStore
+    # @return [Object] the underlying read-side repository adapter
+    attr_reader :adapter
+
+    # Creates a new ReadModelStore backed by the given adapter.
+    #
+    # @param adapter [Object] a repository adapter instance that responds to
+    #   +save+, +find+, +delete+, +all+, +count+, and optionally +query+
+    def initialize(adapter:)
+      @adapter = adapter
+    end
+
+    # Synchronizes an aggregate into the read store by saving it.
+    #
+    # @param aggregate [Object] the aggregate instance to persist on the read side
+    # @return [void]
+    def update(aggregate)
+      @adapter.save(aggregate)
+    end
+
+    # Returns the underlying adapter for direct query access.
+    # All read operations (find, all, where, query) go through this.
+    #
+    # @return [Object] the read-side repository adapter
+    def read
+      @adapter
+    end
+
+    # Wipes all data from the read store.
+    #
+    # @return [void]
+    def clear
+      @adapter.clear
+    end
+
+    # Delegates +find+ to the underlying adapter for convenience.
+    #
+    # @param id [String] the aggregate ID
+    # @return [Object, nil] the found aggregate or nil
+    def find(id)
+      @adapter.find(id)
+    end
+
+    # Delegates +all+ to the underlying adapter for convenience.
+    #
+    # @return [Array<Object>] all aggregates in the read store
+    def all
+      @adapter.all
+    end
+
+    # Delegates +count+ to the underlying adapter for convenience.
+    #
+    # @return [Integer] the number of aggregates in the read store
+    def count
+      @adapter.count
+    end
+
+    # Delegates +delete+ to the underlying adapter for convenience.
+    #
+    # @param id [String] the aggregate ID
+    # @return [void]
+    def delete(id)
+      @adapter.delete(id)
+    end
+
+    # Delegates +save+ to the underlying adapter for convenience.
+    #
+    # @param aggregate [Object] the aggregate to persist
+    # @return [void]
+    def save(aggregate)
+      @adapter.save(aggregate)
+    end
+
+    # Delegates +query+ to the underlying adapter if it responds to it.
+    #
+    # @param kwargs [Hash] query parameters (conditions, order, limit, etc.)
+    # @return [Array<Object>] matching aggregates
+    def query(**kwargs)
+      @adapter.query(**kwargs)
+    end
+  end
+end

--- a/hecksties/lib/hecks/ports/read_model_store/cqrs_read_binding.rb
+++ b/hecksties/lib/hecks/ports/read_model_store/cqrs_read_binding.rb
@@ -1,0 +1,33 @@
+# Hecks::CqrsReadBinding
+#
+# Rebinds class-level read methods (find, all, count, first, last) on an
+# aggregate class to use a read-side repository instead of the write repo.
+# Also rebinds where/find_by/order/limit/offset via AdHocQueries. Called
+# by PortSetup when CQRS is active for an aggregate.
+#
+#   CqrsReadBinding.bind(Pizza, read_repo)
+#   Pizza.all    # => reads from read_repo
+#   Pizza.find(1) # => reads from read_repo
+#   # But pizza.save still writes to the write repo
+#
+module Hecks
+  module CqrsReadBinding
+    # Rebinds read methods on the aggregate class to use the read repository.
+    #
+    # @param klass [Class] the aggregate class
+    # @param read_repo [Object] the read-side repository
+    # @return [void]
+    def self.bind(klass, read_repo)
+      klass.define_singleton_method(:find) { |id| read_repo.find(id) }
+      klass.define_singleton_method(:all) { read_repo.all }
+      klass.define_singleton_method(:count) { read_repo.count }
+      klass.define_singleton_method(:first) { all.first }
+      klass.define_singleton_method(:last) { all.last }
+
+      # Also set the repo reference used by ScopeMethods
+      klass.instance_variable_set(:@__hecks_read_repo__, read_repo)
+
+      Querying::AdHocQueries.bind(klass, read_repo)
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -91,6 +91,7 @@ module Hecks
         @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
         @event_bus = event_bus || EventBus.new
         @repositories = {}
+        @read_stores = {}
         @adapter_overrides = {}
         @async_handler = nil
         @runtime_options = {}
@@ -222,6 +223,65 @@ module Hecks
         name = aggregate_name.to_s
         @repositories[name] = repo
         wire_aggregate!(name)
+      end
+
+      # Registers a ReadModelStore for a named aggregate (CQRS read side).
+      # When registered, queries and scopes route to this store instead of
+      # the write repository.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param store [Hecks::ReadModelStore] the read model store
+      # @return [void]
+      def register_read_store(aggregate_name, store)
+        name = aggregate_name.to_s
+        @read_stores[name] = store
+        wire_aggregate!(name)
+      end
+
+      # Returns the read store for a named aggregate, or nil if CQRS is not
+      # active for that aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @return [Hecks::ReadModelStore, nil]
+      def read_store_for(aggregate_name)
+        @read_stores[aggregate_name.to_s]
+      end
+
+      # Programmatically enable CQRS for an aggregate with a custom read repo.
+      # Creates a ReadModelStore, subscribes to events for auto-sync, and
+      # re-wires the aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param read_repo [Object] the read-side repository adapter
+      # @return [Hecks::ReadModelStore] the created read model store
+      def enable_cqrs(aggregate_name, read_repo:)
+        require "hecks/ports/read_model_store"
+        name = aggregate_name.to_s
+        store = Hecks::ReadModelStore.new(adapter: read_repo)
+        write_repo = @repositories[name]
+
+        # Auto-sync on events
+        agg = @domain.aggregates.find { |a| a.name == name }
+        agg&.events&.each do |event|
+          @event_bus.subscribe(event.name) do |_evt|
+            write_repo.all.each { |obj| store.update(obj) }
+          end
+        end
+
+        register_read_store(name, store)
+        store
+      end
+
+      # Returns true if CQRS is active for the given aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @return [Boolean]
+      def cqrs?(aggregate_name = nil)
+        if aggregate_name
+          @read_stores.key?(aggregate_name.to_s)
+        else
+          @read_stores.any?
+        end
       end
 
       # Apply an extension to the live runtime without rebooting.

--- a/hecksties/lib/hecks/runtime/port_setup.rb
+++ b/hecksties/lib/hecks/runtime/port_setup.rb
@@ -54,16 +54,21 @@ module Hecks
       # @return [void]
       def wire_aggregate(agg)
         agg_class = @mod.const_get(domain_constant_name(agg.name))
-        repo = ownership_scoped_repo(agg, @repositories[agg.name])
+        write_repo = ownership_scoped_repo(agg, @repositories[agg.name])
+        query_repo = read_repo_for(agg.name) || write_repo
         defaults = build_defaults(agg)
 
-        Persistence.bind(agg_class, agg, repo)
-        Commands.bind(agg_class, agg, @command_bus, repo, defaults)
+        Persistence.bind(agg_class, agg, write_repo)
+        Commands.bind(agg_class, agg, @command_bus, write_repo, defaults)
         Querying.bind(agg_class, agg)
+        if cqrs_active?(agg.name)
+          require "hecks/ports/read_model_store/cqrs_read_binding"
+          CqrsReadBinding.bind(agg_class, query_repo)
+        end
         Introspection.bind(agg_class, agg)
-        Versioning.bind(agg_class, repo) if runtime_option?(agg.name, :versioned)
+        Versioning.bind(agg_class, repo_for_version(agg, write_repo)) if runtime_option?(agg.name, :versioned)
         AttachmentMethods.bind(agg_class) if runtime_option?(agg.name, :attachable)
-        wire_query_objects(agg, agg_class)
+        wire_query_objects(agg, agg_class, query_repo)
         GateEnforcer.new(gate_name: @gate_name, hecksagon: @hecksagon).enforce!(agg, agg_class)
       end
 
@@ -128,8 +133,34 @@ module Hecks
       # @param agg [Hecks::DomainModel::Aggregate] the aggregate definition
       # @param agg_class [Class] the runtime aggregate class to add query methods to
       # @return [void]
-      def wire_query_objects(agg, agg_class)
-        repo = @repositories[agg.name]
+      # Returns the read-side repo for an aggregate, or nil if no CQRS.
+      #
+      # @param name [String] aggregate name
+      # @return [Object, nil]
+      def read_repo_for(name)
+        store = @read_stores && @read_stores[name]
+        store&.adapter || store
+      end
+
+      # Returns true if a read store is registered for this aggregate.
+      #
+      # @param name [String] aggregate name
+      # @return [Boolean]
+      def cqrs_active?(name)
+        @read_stores && @read_stores.key?(name)
+      end
+
+      # Returns the appropriate repo for versioning (always write repo).
+      #
+      # @param agg [Object] aggregate definition
+      # @param write_repo [Object] the write repository
+      # @return [Object]
+      def repo_for_version(agg, write_repo)
+        write_repo
+      end
+
+      def wire_query_objects(agg, agg_class, query_repo = nil)
+        repo = query_repo || @repositories[agg.name]
         queries_mod = begin; agg_class.const_get(:Queries); rescue NameError; nil; end
 
         agg.queries.each do |query|

--- a/hecksties/spec/extensions/cqrs_spec.rb
+++ b/hecksties/spec/extensions/cqrs_spec.rb
@@ -45,4 +45,110 @@ RSpec.describe HecksCqrs do
       expect(HecksCqrs.connection_for(mod, :read)).to be_nil
     end
   end
+
+  describe "CQRS read/write separation" do
+    let(:domain) do
+      Hecks.domain "CqrsTest" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "routes commands to write repo and queries to read store" do
+      app = Hecks.load(domain)
+
+      # Create via write side
+      CqrsTestDomain::Widget.create(name: "Sprocket")
+      expect(app["Widget"].all.size).to eq(1)
+
+      # Enable CQRS with a separate read repo
+      read_adapter = CqrsTestDomain::Adapters::WidgetMemoryRepository.new
+      app.enable_cqrs("Widget", read_repo: read_adapter)
+
+      # Read store starts empty
+      expect(app.read_store_for("Widget").count).to eq(0)
+
+      # Creating another widget syncs to read store via event
+      CqrsTestDomain::Widget.create(name: "Gadget")
+
+      # Write repo has both
+      expect(app["Widget"].all.size).to eq(2)
+
+      # Read store was synced by the event handler
+      expect(app.read_store_for("Widget").count).to eq(2)
+    end
+
+    it "rebinds class-level read methods to read store" do
+      app = Hecks.load(domain)
+
+      read_adapter = CqrsTestDomain::Adapters::WidgetMemoryRepository.new
+      app.enable_cqrs("Widget", read_repo: read_adapter)
+
+      # Write directly to the write repo
+      w = CqrsTestDomain::Widget.create(name: "Alpha")
+
+      # Class read methods (find, all, count) route to read store
+      # The read store was synced by the event auto-sync
+      expect(CqrsTestDomain::Widget.all.map(&:name)).to include("Alpha")
+      expect(CqrsTestDomain::Widget.count).to eq(1)
+      expect(CqrsTestDomain::Widget.find(w.id).name).to eq("Alpha")
+    end
+
+    it "reports cqrs? status" do
+      app = Hecks.load(domain)
+
+      expect(app.cqrs?).to be false
+      expect(app.cqrs?("Widget")).to be false
+
+      read_adapter = CqrsTestDomain::Adapters::WidgetMemoryRepository.new
+      app.enable_cqrs("Widget", read_repo: read_adapter)
+
+      expect(app.cqrs?).to be true
+      expect(app.cqrs?("Widget")).to be true
+    end
+
+    it "is backward compatible when no read store registered" do
+      app = Hecks.load(domain)
+
+      CqrsTestDomain::Widget.create(name: "Solo")
+      expect(CqrsTestDomain::Widget.all.size).to eq(1)
+      expect(CqrsTestDomain::Widget.find(CqrsTestDomain::Widget.first.id).name).to eq("Solo")
+      expect(app.cqrs?).to be false
+    end
+  end
+
+  describe "ReadModelStore" do
+    before { require "hecks/ports/read_model_store" }
+
+    let(:domain) do
+      Hecks.domain "RmTest" do
+        aggregate "Item" do
+          attribute :title, String
+          command "CreateItem" do
+            attribute :title, String
+          end
+        end
+      end
+    end
+
+    it "provides update, read, and clear" do
+      app = Hecks.load(domain)
+      adapter = RmTestDomain::Adapters::ItemMemoryRepository.new
+      store = Hecks::ReadModelStore.new(adapter: adapter)
+
+      item = RmTestDomain::Item.create(title: "Hello")
+      store.update(item)
+
+      expect(store.read.all.size).to eq(1)
+      expect(store.find(item.id).title).to eq("Hello")
+      expect(store.count).to eq(1)
+
+      store.clear
+      expect(store.count).to eq(0)
+    end
+  end
 end

--- a/hecksties/spec/ports/read_model_store/cqrs_read_binding_spec.rb
+++ b/hecksties/spec/ports/read_model_store/cqrs_read_binding_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "hecks/ports/read_model_store"
+require "hecks/ports/read_model_store/cqrs_read_binding"
+
+RSpec.describe Hecks::CqrsReadBinding do
+  let(:domain) do
+    Hecks.domain "CrbTest" do
+      aggregate "Gadget" do
+        attribute :label, String
+        command "CreateGadget" do
+          attribute :label, String
+        end
+      end
+    end
+  end
+
+  it "rebinds find, all, count to the read repo" do
+    app = Hecks.load(domain)
+
+    read_adapter = CrbTestDomain::Adapters::GadgetMemoryRepository.new
+    described_class.bind(CrbTestDomain::Gadget, read_adapter)
+
+    # Write to the write repo directly
+    gadget = CrbTestDomain::Gadget.create(label: "Whirligig")
+
+    # The write repo has data but the read adapter is empty
+    expect(read_adapter.all).to be_empty
+    expect(app["Gadget"].all.size).to eq(1)
+
+    # Reads route to the empty read adapter
+    expect(CrbTestDomain::Gadget.all).to be_empty
+    expect(CrbTestDomain::Gadget.count).to eq(0)
+
+    # Sync to read adapter
+    read_adapter.save(gadget)
+
+    # Now reads see it
+    expect(CrbTestDomain::Gadget.all.size).to eq(1)
+    expect(CrbTestDomain::Gadget.find(gadget.id).label).to eq("Whirligig")
+  end
+
+  it "binds where and find_by via AdHocQueries" do
+    app = Hecks.load(domain)
+
+    read_adapter = CrbTestDomain::Adapters::GadgetMemoryRepository.new
+    described_class.bind(CrbTestDomain::Gadget, read_adapter)
+
+    gadget = CrbTestDomain::Gadget.create(label: "Doodad")
+    read_adapter.save(gadget)
+
+    expect(CrbTestDomain::Gadget.where(label: "Doodad").count).to eq(1)
+    expect(CrbTestDomain::Gadget.find_by(label: "Doodad").label).to eq("Doodad")
+  end
+end

--- a/hecksties/spec/ports/read_model_store_spec.rb
+++ b/hecksties/spec/ports/read_model_store_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+require "hecks/ports/read_model_store"
+
+RSpec.describe Hecks::ReadModelStore do
+  let(:domain) do
+    Hecks.domain "RmsTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:app) { Hecks.load(domain) }
+  let(:adapter) { app; RmsTestDomain::Adapters::WidgetMemoryRepository.new }
+  let(:store) { described_class.new(adapter: adapter) }
+
+  before { app }
+
+  it "exposes the underlying adapter via #read" do
+    expect(store.read).to eq(adapter)
+  end
+
+  it "saves an aggregate via #update" do
+    widget = RmsTestDomain::Widget.create(name: "Bolt")
+    store.update(widget)
+    expect(store.count).to eq(1)
+  end
+
+  it "finds by id" do
+    widget = RmsTestDomain::Widget.create(name: "Nut")
+    store.update(widget)
+    expect(store.find(widget.id).name).to eq("Nut")
+  end
+
+  it "clears all data" do
+    widget = RmsTestDomain::Widget.create(name: "Screw")
+    store.update(widget)
+    store.clear
+    expect(store.count).to eq(0)
+  end
+
+  it "delegates all to adapter" do
+    w1 = RmsTestDomain::Widget.create(name: "A")
+    w2 = RmsTestDomain::Widget.create(name: "B")
+    store.update(w1)
+    store.update(w2)
+    expect(store.all.size).to eq(2)
+  end
+
+  it "delegates delete to adapter" do
+    widget = RmsTestDomain::Widget.create(name: "Gone")
+    store.update(widget)
+    store.delete(widget.id)
+    expect(store.count).to eq(0)
+  end
+end


### PR DESCRIPTION
## Summary
test(cqrs): add dedicated specs for ReadModelStore and CqrsReadBinding


feat(cqrs): separate write and read models with ReadModelStore port

HEC-63: Add CQRS read/write separation to Hecks. ReadModelStore port
at hecksties/lib/hecks/ports/read_model_store.rb with update, read,
clear. CqrsReadBinding rebinds class-level read methods (find, all,
where) to the read store. Runtime gains enable_cqrs, register_read_store,
read_store_for, and cqrs? methods. PortSetup routes commands to write
repo and queries/scopes to read repo when CQRS is active. Backward
compatible -- single adapter when no read store is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)