### PR TITLE
HEC-65: Optimistic concurrency

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,6 +32,7 @@
 - Events carry command attrs + all aggregate attrs by convention — policies can reference any field
 - Command `sets` declaration: `sets status: "approved"` — static field assignments
 - Define command `call` blocks in DSL for inline business logic (prototyping and play mode)
+- Optimistic concurrency control: add `attribute :expected_version, Integer` to a command — the lifecycle pipeline compares it against the persisted aggregate's version and raises `Hecks::ConcurrencyError` on mismatch, then bumps the version on success
 
 ### State Machines
 - Lifecycle DSL: `lifecycle :status, default: "draft" { transition "Approve" => "approved" }`

--- a/docs/usage/optimistic_concurrency.md
+++ b/docs/usage/optimistic_concurrency.md
@@ -1,0 +1,90 @@
+# Optimistic Concurrency
+
+Hecks supports optimistic concurrency control via version numbers on aggregates.
+When a command declares an `expected_version` attribute, the lifecycle pipeline
+checks it against the persisted aggregate's current version before persisting.
+On mismatch, a `Hecks::ConcurrencyError` is raised. On match, the aggregate
+version is bumped automatically.
+
+## Defining a versioned command
+
+Add `attribute :expected_version, Integer` to any update command:
+
+```ruby
+Hecks.domain "Documents" do
+  aggregate "Document" do
+    attribute :title, String
+    attribute :body, String
+
+    command "CreateDocument" do
+      attribute :title, String
+      attribute :body, String
+    end
+
+    command "EditDocument" do
+      reference_to "Document"
+      attribute :title, String
+      attribute :body, String
+      attribute :expected_version, Integer
+    end
+  end
+end
+```
+
+## Using optimistic concurrency
+
+```ruby
+app = Hecks.load(domain)
+
+# Create starts at version 0
+doc = DocumentsDomain::Document.create(title: "Draft", body: "...")
+doc.aggregate.version  # => 0
+
+# Edit with correct version succeeds and bumps
+result = DocumentsDomain::Document.edit(
+  document: doc.id,
+  title: "Final",
+  body: "...",
+  expected_version: 0
+)
+result.aggregate.version  # => 1
+
+# Edit with stale version raises
+begin
+  DocumentsDomain::Document.edit(
+    document: doc.id,
+    title: "Conflict",
+    body: "...",
+    expected_version: 0
+  )
+rescue Hecks::ConcurrencyError => e
+  e.expected_version  # => 0
+  e.actual_version    # => 1
+  e.aggregate_id      # => "abc-123..."
+  e.message           # => "Version mismatch on DocumentsDomain::Document: expected 0, got 1"
+end
+```
+
+## Opting out
+
+Commands that do not include `expected_version` skip the version check entirely.
+This preserves backward compatibility -- existing commands work unchanged.
+
+## Error structure
+
+`Hecks::ConcurrencyError` provides structured context for API responses:
+
+```ruby
+e.as_json
+# => { error: "ConcurrencyError", message: "...",
+#      expected_version: 0, actual_version: 1,
+#      aggregate_id: "abc-123..." }
+```
+
+## How it works
+
+1. Every aggregate starts at `version: 0`
+2. The `VersionCheckStep` runs between `CallStep` and `PostconditionStep`
+3. It looks up the persisted aggregate and compares versions
+4. On match, the new aggregate's version is set and bumped
+5. On mismatch, `Hecks::ConcurrencyError` is raised before persist

--- a/hecksties/lib/hecks/errors.rb
+++ b/hecksties/lib/hecks/errors.rb
@@ -223,6 +223,47 @@ module Hecks
   # Raised when a rate limit is exceeded for a command or query operation.
   class RateLimitExceeded < Error; end
 
+  # Raised when a command's +expected_version+ does not match the aggregate's
+  # current +version+. Indicates a concurrent modification -- retry the command
+  # after re-reading the aggregate.
+  #
+  #   raise Hecks::ConcurrencyError.new(
+  #     "Version mismatch: expected 2, got 3",
+  #     expected_version: 2, actual_version: 3, aggregate_id: "abc-123"
+  #   )
+  class ConcurrencyError < Error
+    # @return [Integer, nil] the version the caller expected
+    attr_reader :expected_version
+
+    # @return [Integer, nil] the version currently on the aggregate
+    attr_reader :actual_version
+
+    # @return [String, nil] the aggregate ID involved in the conflict
+    attr_reader :aggregate_id
+
+    # @param message [String] human-readable error message
+    # @param expected_version [Integer, nil] the version the caller expected
+    # @param actual_version [Integer, nil] the current aggregate version
+    # @param aggregate_id [String, nil] the aggregate ID
+    def initialize(message = nil, expected_version: nil, actual_version: nil, aggregate_id: nil)
+      @expected_version = expected_version
+      @actual_version = actual_version
+      @aggregate_id = aggregate_id
+      super(message)
+    end
+
+    # Returns structured error data with version conflict context.
+    #
+    # @return [Hash] error data with version details
+    def as_json
+      h = super
+      h[:expected_version] = expected_version if expected_version
+      h[:actual_version] = actual_version if actual_version
+      h[:aggregate_id] = aggregate_id.to_s if aggregate_id
+      h
+    end
+  end
+
   # Raised when a generator attempts to write a file outside the designated
   # output directory. Prevents path traversal attacks where user-controlled
   # domain names or aggregate names contain +../+ segments, absolute paths,

--- a/hecksties/lib/hecks/mixins/command.rb
+++ b/hecksties/lib/hecks/mixins/command.rb
@@ -1,6 +1,7 @@
 require_relative "command/lifecycle_steps"
 require_relative "command/reference_validation"
 require_relative "command/validation"
+require_relative "command/versioning"
 require_relative "command/dispatch"
 
 module Hecks
@@ -58,6 +59,7 @@ module Hecks
       base.attr_reader :aggregate, :event, :events
       base.include(ReferenceValidation)
       base.include(Validation)
+      base.include(Versioning)
       base.include(Dispatch)
     end
 

--- a/hecksties/lib/hecks/mixins/command/lifecycle_steps.rb
+++ b/hecksties/lib/hecks/mixins/command/lifecycle_steps.rb
@@ -39,6 +39,11 @@ module Hecks
         cmd
       }
 
+      VersionCheckStep = ->(cmd) {
+        cmd.send(:check_version)
+        cmd
+      }
+
       PostconditionStep = ->(cmd) {
         before = cmd.send(:find_existing_for_postcondition)
         cmd.send(:check_postconditions, before, cmd.aggregate)
@@ -62,12 +67,12 @@ module Hecks
 
       PIPELINE = [
         GuardStep, HandlerStep, PreconditionStep, ValidateReferencesStep, CallStep,
-        PostconditionStep, PersistStep, EmitStep, RecordStep
+        VersionCheckStep, PostconditionStep, PersistStep, EmitStep, RecordStep
       ].freeze
 
       DRY_RUN_PIPELINE = [
         GuardStep, HandlerStep, PreconditionStep, ValidateReferencesStep, CallStep,
-        PostconditionStep
+        VersionCheckStep, PostconditionStep
       ].freeze
     end
   end

--- a/hecksties/lib/hecks/mixins/command/versioning.rb
+++ b/hecksties/lib/hecks/mixins/command/versioning.rb
@@ -1,0 +1,95 @@
+# Hecks::Command::Versioning
+#
+# Optimistic concurrency control for commands. When a command includes an
+# +expected_version+ attribute, the VersionCheckStep compares it against the
+# aggregate's current version after +#call+ returns. On mismatch, raises
+# +Hecks::ConcurrencyError+. On success, bumps the aggregate version.
+#
+# Commands that do not supply +expected_version+ (nil) skip the check entirely,
+# preserving backward compatibility.
+#
+# == Usage
+#
+#   cmd = UpdatePizza.call(pizza_id: id, name: "New Name", expected_version: 1)
+#   cmd.aggregate.version  # => 2
+#
+module Hecks
+  module Command
+    module Versioning
+      # Checks expected_version against the persisted aggregate's current version.
+      # If the command instance does not respond to +expected_version+ or the value
+      # is nil, the check is skipped (opt-in concurrency control).
+      #
+      # Looks up the existing aggregate in the repository to read its version,
+      # since +#call+ may construct a brand-new object that starts at version 0.
+      # On match, bumps the version on the aggregate returned by +#call+.
+      #
+      # @return [void]
+      # @raise [Hecks::ConcurrencyError] when versions do not match
+      def check_version
+        return unless respond_to?(:expected_version, true)
+
+        expected = expected_version
+        return if expected.nil?
+
+        agg = self.aggregate
+        return unless agg&.respond_to?(:version)
+
+        existing = find_persisted_for_version_check
+        actual = existing ? existing.version : 0
+
+        unless expected == actual
+          raise Hecks::ConcurrencyError.new(
+            "Version mismatch on #{agg.class.name}: expected #{expected}, got #{actual}",
+            expected_version: expected,
+            actual_version: actual,
+            aggregate_id: agg.id
+          )
+        end
+
+        agg.instance_variable_set(:@version, actual)
+        agg.bump_version!
+      end
+
+      private
+
+      # Finds the persisted aggregate by checking self-referencing references
+      # first (from +reference_to+), then falling back to instance variables
+      # ending in +_id+.
+      #
+      # @return [Object, nil] the persisted aggregate or nil
+      def find_persisted_for_version_check
+        id_val = resolve_self_ref_id || resolve_id_ivar
+        return nil unless id_val
+
+        repository&.find(id_val) rescue nil
+      end
+
+      # Resolves the aggregate ID from a self-referencing +reference_to+ field.
+      #
+      # @return [String, nil] the aggregate ID or nil
+      def resolve_self_ref_id
+        meta = self.class.reference_meta
+        return nil unless meta&.any?
+
+        agg_name = Hecks::Conventions::Names
+                     .aggregate_module_from_command(self.class.name)
+                     .split("::").last
+
+        ref = meta.find { |r| r.type == agg_name }
+        return nil unless ref
+
+        val = respond_to?(ref.name, true) ? send(ref.name) : nil
+        val.respond_to?(:id) ? val.id : val
+      end
+
+      # Falls back to scanning instance variables ending in +_id+.
+      #
+      # @return [String, nil] the aggregate ID or nil
+      def resolve_id_ivar
+        ivar = instance_variables.find { |v| v.to_s.end_with?("_id") }
+        ivar ? instance_variable_get(ivar) : nil
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/mixins/model.rb
+++ b/hecksties/lib/hecks/mixins/model.rb
@@ -52,7 +52,7 @@ module Hecks
     # @return [void]
     def self.included(base)
       base.extend(ClassMethods)
-      base.attr_reader :id, :created_at, :updated_at
+      base.attr_reader :id, :created_at, :updated_at, :version
       create_submodule(base, :Commands)
       create_submodule(base, :Events)
       create_submodule(base, :Queries)
@@ -96,8 +96,9 @@ module Hecks
       # @return [void]
       def rebuild_initializer
         attrs = @hecks_attributes.dup
-        define_method(:initialize) do |id: nil, **kwargs|
+        define_method(:initialize) do |id: nil, version: 0, **kwargs|
           @id = id || SecureRandom.uuid
+          @version = version
           @_pristine = {}
           attrs.each do |attr|
             val = kwargs.fetch(attr.name, attr.default)
@@ -137,6 +138,14 @@ module Hecks
     # @return [void]
     def stamp_updated!
       @updated_at = Time.now
+    end
+
+    # Increments the aggregate version by one. Called by the versioning step
+    # in the command lifecycle after the version check passes.
+    #
+    # @return [Integer] the new version number
+    def bump_version!
+      @version += 1
     end
 
     # Returns true if both objects are the same type and share the same id.

--- a/hecksties/spec/mixins/command/versioning_spec.rb
+++ b/hecksties/spec/mixins/command/versioning_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+RSpec.describe "Optimistic concurrency — version check on commands" do
+  before(:all) do
+    @domain = Hecks.domain "VersionCheckTest" do
+      aggregate "Document" do
+        attribute :title, String
+
+        command "CreateDocument" do
+          attribute :title, String
+        end
+
+        command "RenameDocument" do
+          reference_to "Document"
+          attribute :title, String
+          attribute :expected_version, Integer
+        end
+
+        command "UpdateDocument" do
+          reference_to "Document"
+          attribute :title, String
+        end
+      end
+    end
+
+    @app = Hecks.load(@domain, force: true)
+  end
+
+  it "new aggregates start at version 0" do
+    doc = VersionCheckTestDomain::Document.create(title: "Draft")
+    expect(doc.aggregate.version).to eq(0)
+  end
+
+  it "bumps version when expected_version matches" do
+    doc = VersionCheckTestDomain::Document.create(title: "Draft")
+    result = VersionCheckTestDomain::Document.rename(
+      document: doc.id, title: "Final", expected_version: 0
+    )
+    expect(result.aggregate.version).to eq(1)
+  end
+
+  it "raises ConcurrencyError when expected_version mismatches" do
+    doc = VersionCheckTestDomain::Document.create(title: "Draft")
+    # First rename bumps to version 1
+    VersionCheckTestDomain::Document.rename(
+      document: doc.id, title: "v1", expected_version: 0
+    )
+    # Second rename with stale version 0 should fail
+    expect {
+      VersionCheckTestDomain::Document.rename(
+        document: doc.id, title: "v2", expected_version: 0
+      )
+    }.to raise_error(Hecks::ConcurrencyError, /expected 0, got 1/)
+  end
+
+  it "skips version check when expected_version is not on the command" do
+    doc = VersionCheckTestDomain::Document.create(title: "Draft")
+    result = VersionCheckTestDomain::Document.update(
+      document: doc.id, title: "Updated"
+    )
+    expect(result.aggregate).not_to be_nil
+    expect(result.aggregate.version).to eq(0)
+  end
+
+  it "ConcurrencyError includes structured context" do
+    doc = VersionCheckTestDomain::Document.create(title: "Draft")
+    VersionCheckTestDomain::Document.rename(
+      document: doc.id, title: "v1", expected_version: 0
+    )
+
+    begin
+      VersionCheckTestDomain::Document.rename(
+        document: doc.id, title: "v2", expected_version: 0
+      )
+    rescue Hecks::ConcurrencyError => e
+      expect(e.expected_version).to eq(0)
+      expect(e.actual_version).to eq(1)
+      expect(e.aggregate_id).to eq(doc.id)
+      json = e.as_json
+      expect(json[:expected_version]).to eq(0)
+      expect(json[:actual_version]).to eq(1)
+    end
+  end
+
+  it "successive bumps increment version correctly" do
+    doc = VersionCheckTestDomain::Document.create(title: "v0")
+    VersionCheckTestDomain::Document.rename(
+      document: doc.id, title: "v1", expected_version: 0
+    )
+    result = VersionCheckTestDomain::Document.rename(
+      document: doc.id, title: "v2", expected_version: 1
+    )
+    expect(result.aggregate.version).to eq(2)
+  end
+end


### PR DESCRIPTION
## Summary
feat: optimistic concurrency via version numbers on aggregates (HEC-65)

Add expected_version attribute to commands for opt-in concurrency control.
The VersionCheckStep compares expected_version against the persisted
aggregate's version and raises ConcurrencyError on mismatch, bumping
the version on success. Aggregates start at version 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)