### PR TITLE
HEC-67: Process managers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -74,6 +74,14 @@
 - Steps declare success and failure transitions to other named commands
 - Compensations are rollback commands run in reverse order if the saga must unwind
 - Saga definitions stored in domain IR and available via `domain.sagas`
+- **Event-driven process managers**: `on "EventName", dispatch: "Command", from: "state", to: "next_state"` inside saga blocks
+- `ProcessManager` subscribes to event bus and transitions through states by dispatching commands
+- `SagaTransition` IR node: event trigger, command to dispatch, optional from-state guard, target state
+- State guards: transitions only fire when the instance is in the declared `from` state
+- `SagaStore#find_by_correlation(correlation_id)` looks up instances by correlation ID
+- `Saga#event_driven?` predicate distinguishes event-driven sagas from imperative step-based ones
+- Mixed sagas: combine imperative `step` entries with event-driven `on` transitions in one saga block
+- Full backward compatibility: imperative saga DSL (`step`, `compensate`) works unchanged
 
 ### Ubiquitous Language
 - `glossary { prefer "customer", not: ["user", "client"] }` — warn when banned terms appear in names across aggregates, commands, and events

--- a/bluebook/lib/hecks/domain_model/behavior.rb
+++ b/bluebook/lib/hecks/domain_model/behavior.rb
@@ -41,8 +41,9 @@ module Hecks
       autoload :CommandStep,    "hecks/domain_model/behavior/workflow_step"
       autoload :BranchStep,     "hecks/domain_model/behavior/workflow_step"
       autoload :ScheduledStep,  "hecks/domain_model/behavior/workflow_step"
-      autoload :Saga,           "hecks/domain_model/behavior/saga"
-      autoload :SagaStep,       "hecks/domain_model/behavior/saga_step"
+      autoload :Saga,             "hecks/domain_model/behavior/saga"
+      autoload :SagaStep,         "hecks/domain_model/behavior/saga_step"
+      autoload :SagaTransition,   "hecks/domain_model/behavior/saga_transition"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/behavior/saga.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/saga.rb
@@ -33,15 +33,20 @@ module Hecks
         # @return [String, nil] command to dispatch on timeout
         attr_reader :on_timeout
 
+        # @return [Array<SagaTransition>] event-driven transitions for process manager mode
+        attr_reader :transitions
+
         # Creates a new Saga IR node.
         #
         # @param name [String] the saga name
-        # @param steps [Array<SagaStep>] ordered steps
+        # @param steps [Array<SagaStep>] ordered imperative steps
+        # @param transitions [Array<SagaTransition>] event-driven transitions
         # @param timeout [String, nil] timeout duration
         # @param on_timeout [String, nil] timeout handler command
-        def initialize(name:, steps: [], timeout: nil, on_timeout: nil)
+        def initialize(name:, steps: [], transitions: [], timeout: nil, on_timeout: nil)
           @name = name.to_s
           @steps = steps
+          @transitions = transitions
           @timeout = timeout
           @on_timeout = on_timeout&.to_s
         end
@@ -51,6 +56,14 @@ module Hecks
         # @return [Boolean]
         def timed?
           !@timeout.nil?
+        end
+
+        # Whether this saga uses event-driven transitions (process manager mode)
+        # rather than imperative steps.
+        #
+        # @return [Boolean]
+        def event_driven?
+          !@transitions.empty?
         end
       end
     end

--- a/bluebook/lib/hecks/domain_model/behavior/saga_transition.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/saga_transition.rb
@@ -1,0 +1,57 @@
+# Hecks::DomainModel::Behavior::SagaTransition
+#
+# Intermediate representation of an event-driven transition in a saga
+# (process manager). Each transition reacts to a named event and
+# dispatches a command, optionally moving the saga to a new state.
+#
+# Part of the DomainModel IR layer. Built by SagaBuilder in the DSL,
+# consumed by ProcessManager at runtime to drive event-based state
+# machines.
+#
+#   transition = SagaTransition.new(
+#     event: "PaymentReceived",
+#     command: "ShipOrder",
+#     from: "awaiting_payment",
+#     to: "shipping"
+#   )
+#   transition.guarded?  # => true (has a from state)
+#
+module Hecks
+  module DomainModel
+    module Behavior
+      class SagaTransition
+        # @return [String] event name that triggers this transition
+        attr_reader :event
+
+        # @return [String] command to dispatch when event fires
+        attr_reader :command
+
+        # @return [String, nil] required current state (nil = any state)
+        attr_reader :from
+
+        # @return [String] target state after transition
+        attr_reader :to
+
+        # Creates a new SagaTransition IR node.
+        #
+        # @param event [String] the triggering event name
+        # @param command [String] the command to dispatch
+        # @param from [String, nil] required source state
+        # @param to [String] target state after transition
+        def initialize(event:, command:, from: nil, to:)
+          @event = event.to_s
+          @command = command.to_s
+          @from = from&.to_s
+          @to = to.to_s
+        end
+
+        # Whether this transition requires a specific source state.
+        #
+        # @return [Boolean]
+        def guarded?
+          !@from.nil?
+        end
+      end
+    end
+  end
+end

--- a/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder/strategic_builders.rb
@@ -71,6 +71,7 @@ module Hecks
         def initialize(name)
           @name = name
           @steps = []
+          @transitions = []
           @timeout = nil
           @on_timeout = nil
         end
@@ -87,12 +88,22 @@ module Hecks
           end
         end
 
+        # Event-driven transition for process manager mode.
+        #
+        #   on "PaymentReceived", dispatch: "ShipOrder",
+        #      from: "awaiting_payment", to: "shipping"
+        def on(event, dispatch:, from: nil, to:)
+          @transitions << DomainModel::Behavior::SagaTransition.new(
+            event: event, command: dispatch, from: from, to: to
+          )
+        end
+
         def timeout(duration)   = (@timeout = duration)
         def on_timeout(command)  = (@on_timeout = command)
 
         def build
           DomainModel::Behavior::Saga.new(
-            name: @name, steps: @steps,
+            name: @name, steps: @steps, transitions: @transitions,
             timeout: @timeout, on_timeout: @on_timeout
           )
         end

--- a/docs/usage/process_managers.md
+++ b/docs/usage/process_managers.md
@@ -1,0 +1,113 @@
+# Process Managers (Event-Driven Sagas)
+
+Process managers are event-driven state machines that subscribe to the event bus,
+transition through named states, and dispatch commands in response to domain events.
+
+## DSL
+
+Use `on` inside a `saga` block to define event-driven transitions:
+
+```ruby
+domain = Hecks.domain "OrderManagement" do
+  aggregate "Order" do
+    attribute :item, String
+    attribute :correlation_id, String
+
+    command "PlaceOrder" do
+      attribute :item, String
+      attribute :correlation_id, String
+    end
+
+    command "ShipOrder" do
+      attribute :item, String
+      attribute :correlation_id, String
+    end
+
+    command "CompleteOrder" do
+      attribute :item, String
+      attribute :correlation_id, String
+    end
+  end
+
+  saga "OrderProcess" do
+    on "OrderPlaced",
+      dispatch: "ShipOrder",
+      from: "started",
+      to: "shipping"
+
+    on "OrderShipped",
+      dispatch: "CompleteOrder",
+      from: "shipping",
+      to: "completed"
+  end
+end
+```
+
+## Starting a Process Manager
+
+```ruby
+app = Hecks.load(domain)
+
+# Start a process manager instance (state begins at "started")
+instance = OrderManagementDomain.start_order_process(
+  correlation_id: "order-42",
+  item: "Widget"
+)
+instance[:state]          # => "started"
+instance[:correlation_id] # => "order-42"
+```
+
+## Event-Driven Transitions
+
+When a matching event is published on the bus, the process manager:
+1. Finds the instance by `correlation_id` on the event
+2. Checks the `from:` state guard (if present)
+3. Dispatches the declared command
+4. Advances the instance to the `to:` state
+
+Events must respond to `correlation_id` (method or hash key).
+
+## State Guards
+
+Transitions only fire when the instance is in the declared `from` state:
+
+```ruby
+on "OrderShipped",
+  dispatch: "CompleteOrder",
+  from: "shipping",    # Only fires when state == "shipping"
+  to: "completed"
+```
+
+## SagaStore Correlation Lookup
+
+```ruby
+store = Hecks::SagaStore.new
+store.save("pm_abc", { correlation_id: "order-42", state: "shipping" })
+store.find_by_correlation("order-42")  # => the instance hash
+```
+
+## Mixing Imperative Steps and Event-Driven Transitions
+
+A single saga can combine both styles:
+
+```ruby
+saga "TicketProcess" do
+  step "CreateTicket", on_success: "TicketCreated"
+
+  on "TicketCreated",
+    dispatch: "AssignTicket",
+    from: "started",
+    to: "assigned"
+end
+```
+
+## Backward Compatibility
+
+Existing imperative sagas with `step`/`compensate` continue to work unchanged.
+The `event_driven?` predicate on the Saga IR tells you which mode is in use:
+
+```ruby
+domain.sagas.first.event_driven?  # true if transitions present
+domain.sagas.first.steps           # imperative steps (may be empty)
+domain.sagas.first.transitions     # event-driven transitions (may be empty)
+```

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -155,6 +155,7 @@ module Hecks
   autoload :Versioning,        "hecks/runtime/versioning"
   autoload :ViewBinding,       "hecks/runtime/view_binding"
   autoload :WorkflowExecutor,  "hecks/runtime/workflow_executor"
+  autoload :ProcessManager,    "hecks/runtime/process_manager"
 
   # = Hecks::HTTP
   #

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -8,6 +8,8 @@ require_relative "runtime/workflow_setup"
 require_relative "runtime/saga_store"
 require_relative "runtime/saga_runner"
 require_relative "runtime/saga_setup"
+require_relative "runtime/process_manager"
+require_relative "runtime/process_manager_setup"
 require_relative "runtime/constant_hoisting"
 require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
@@ -63,6 +65,7 @@ module Hecks
       include AuthCoverageCheck
       include ReferenceCoverageCheck
       include SagaSetup
+      include ProcessManagerSetup
 
       # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to
       attr_reader :domain
@@ -107,6 +110,7 @@ module Hecks
         ServiceSetup.bind(@domain, @mod, @command_bus)
         setup_workflows
         setup_sagas
+        setup_process_managers
         hoist_constants
       end
 

--- a/hecksties/lib/hecks/runtime/process_manager.rb
+++ b/hecksties/lib/hecks/runtime/process_manager.rb
@@ -1,0 +1,113 @@
+# Hecks::ProcessManager
+#
+# Event-driven state machine that subscribes to the event bus and
+# transitions through states by dispatching commands. Unlike SagaRunner
+# which executes steps imperatively, ProcessManager reacts to domain
+# events and advances a saga instance through declared transitions.
+#
+# Each transition declares: an event trigger, a command to dispatch,
+# an optional source state guard, and a target state.
+#
+#   pm = ProcessManager.new(saga_def, command_bus, store, event_bus)
+#   pm.wire!
+#   # Now events on the bus drive the state machine automatically.
+#   pm.start(correlation_id: "order-42", item: "Widget")
+#
+module Hecks
+  class ProcessManager
+    # @return [Hecks::DomainModel::Behavior::Saga] the saga definition
+    attr_reader :saga
+
+    # Creates a new process manager for the given saga definition.
+    #
+    # @param saga [Hecks::DomainModel::Behavior::Saga] saga IR with transitions
+    # @param command_bus [Hecks::Commands::CommandBus] for dispatching commands
+    # @param store [Hecks::SagaStore] for persisting saga state
+    # @param event_bus [Hecks::EventBus] for subscribing to domain events
+    def initialize(saga, command_bus, store, event_bus)
+      @saga = saga
+      @command_bus = command_bus
+      @store = store
+      @event_bus = event_bus
+    end
+
+    # Subscribes to the event bus for each transition's trigger event.
+    # Must be called once at boot time.
+    #
+    # @return [void]
+    def wire!
+      @saga.transitions.each do |transition|
+        @event_bus.subscribe(transition.event) do |event|
+          handle_event(transition, event)
+        end
+      end
+    end
+
+    # Start a new process manager instance. Persists initial state and
+    # returns the instance hash.
+    #
+    # @param correlation_id [String, nil] optional correlation ID (auto-generated if nil)
+    # @param attrs [Hash] keyword arguments stored on the instance
+    # @return [Hash] the initial process manager instance state
+    def start(correlation_id: nil, **attrs)
+      cid = correlation_id || generate_id
+      instance = new_instance(cid, attrs)
+      @store.save(cid, instance)
+      instance
+    end
+
+    private
+
+    def generate_id
+      "pm_#{SecureRandom.hex(8)}"
+    end
+
+    def new_instance(correlation_id, attrs)
+      {
+        saga_id: correlation_id,
+        correlation_id: correlation_id,
+        saga_name: @saga.name,
+        state: "started",
+        attrs: attrs,
+        completed_transitions: [],
+        error: nil
+      }
+    end
+
+    def handle_event(transition, event)
+      instance = find_instance(event)
+      return unless instance
+      return unless state_matches?(instance, transition)
+
+      begin
+        @command_bus.dispatch(transition.command, **instance[:attrs])
+        instance[:state] = transition.to
+        instance[:completed_transitions] << transition.event
+        @store.save(instance[:saga_id], instance)
+      rescue => e
+        instance[:state] = "failed"
+        instance[:error] = "#{transition.command}: #{e.message}"
+        @store.save(instance[:saga_id], instance)
+      end
+    end
+
+    def find_instance(event)
+      cid = extract_correlation_id(event)
+      return nil unless cid
+      @store.find_by_correlation(cid)
+    end
+
+    def extract_correlation_id(event)
+      if event.respond_to?(:correlation_id)
+        event.correlation_id
+      elsif event.respond_to?(:[])
+        event[:correlation_id]
+      end
+    end
+
+    def state_matches?(instance, transition)
+      return true unless transition.guarded?
+      instance[:state] == transition.from
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/process_manager_setup.rb
+++ b/hecksties/lib/hecks/runtime/process_manager_setup.rb
@@ -1,0 +1,43 @@
+# Hecks::Runtime::ProcessManagerSetup
+#
+# Mixin that wires event-driven saga definitions (those with transitions)
+# as ProcessManager instances on the event bus at boot time. Each
+# event-driven saga gets a ProcessManager that subscribes to events
+# and a start method on the domain module.
+#
+#   class Runtime
+#     include ProcessManagerSetup
+#   end
+#
+module Hecks
+  class Runtime
+    module ProcessManagerSetup
+      include HecksTemplating::NamingHelpers
+      private
+
+      # Wires all event-driven sagas as ProcessManager instances.
+      # Creates a start_<saga_name> method that initializes a process
+      # manager instance and wires event subscriptions on the bus.
+      #
+      # @return [void]
+      def setup_process_managers
+        return unless @domain.respond_to?(:sagas)
+
+        event_driven = @domain.sagas.select(&:event_driven?)
+        return if event_driven.empty?
+
+        @saga_store ||= SagaStore.new
+
+        event_driven.each do |saga|
+          pm = ProcessManager.new(saga, @command_bus, @saga_store, @event_bus)
+          pm.wire!
+          method_name = :"start_#{domain_snake_name(saga.name)}"
+
+          @mod.define_singleton_method(method_name) do |**attrs|
+            pm.start(**attrs)
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/saga_store.rb
+++ b/hecksties/lib/hecks/runtime/saga_store.rb
@@ -41,6 +41,21 @@ module Hecks
       @instances.delete(saga_id.to_s)
     end
 
+    # Find a saga instance by correlation ID. Searches instance attrs for
+    # a matching :correlation_id value, or falls back to saga_id lookup.
+    #
+    # @param correlation_id [String] the correlation identifier
+    # @return [Hash, nil] the saga state, or nil if not found
+    def find_by_correlation(correlation_id)
+      key = correlation_id.to_s
+      return @instances[key] if @instances.key?(key)
+
+      @instances.values.find do |inst|
+        inst.dig(:attrs, :correlation_id).to_s == key ||
+          inst[:correlation_id].to_s == key
+      end
+    end
+
     # Remove all stored saga instances.
     #
     # @return [void]

--- a/hecksties/spec/process_manager_spec.rb
+++ b/hecksties/spec/process_manager_spec.rb
@@ -1,0 +1,220 @@
+require "spec_helper"
+
+RSpec.describe "Process Manager (HEC-67)" do
+  let(:domain) do
+    Hecks.domain "ProcessManagerTest" do
+      aggregate "Order" do
+        attribute :item, String
+        attribute :status, String
+        attribute :correlation_id, String
+
+        command "PlaceOrder" do
+          attribute :item, String
+          attribute :correlation_id, String
+        end
+
+        command "ShipOrder" do
+          attribute :item, String
+          attribute :correlation_id, String
+        end
+
+        command "CompleteOrder" do
+          attribute :item, String
+          attribute :correlation_id, String
+        end
+      end
+
+      saga "OrderProcess" do
+        on "OrderPlaced",
+          dispatch: "ShipOrder",
+          from: "started",
+          to: "shipping"
+
+        on "OrderShipped",
+          dispatch: "CompleteOrder",
+          from: "shipping",
+          to: "completed"
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  describe "DSL and IR" do
+    it "registers event-driven transitions in the saga IR" do
+      saga = domain.sagas.first
+      expect(saga.transitions.size).to eq(2)
+      expect(saga.event_driven?).to be true
+      expect(saga.steps).to be_empty
+    end
+
+    it "builds transition IR with all attributes" do
+      t = domain.sagas.first.transitions.first
+      expect(t).to be_a(Hecks::DomainModel::Behavior::SagaTransition)
+      expect(t.event).to eq("OrderPlaced")
+      expect(t.command).to eq("ShipOrder")
+      expect(t.from).to eq("started")
+      expect(t.to).to eq("shipping")
+      expect(t.guarded?).to be true
+    end
+  end
+
+  describe "runtime wiring" do
+    it "exposes start_<saga_name> method on the domain module" do
+      expect(ProcessManagerTestDomain).to respond_to(:start_order_process)
+    end
+
+    it "starts a process manager instance with initial state" do
+      result = ProcessManagerTestDomain.start_order_process(
+        correlation_id: "order-1", item: "Widget"
+      )
+      expect(result[:state]).to eq("started")
+      expect(result[:correlation_id]).to eq("order-1")
+      expect(result[:saga_name]).to eq("OrderProcess")
+    end
+  end
+
+  describe "event-driven transitions" do
+    it "transitions state when matching event fires" do
+      instance = ProcessManagerTestDomain.start_order_process(
+        correlation_id: "order-2", item: "Gadget"
+      )
+
+      # Simulate the OrderPlaced event
+      event = Struct.new(:correlation_id, keyword_init: true)
+        .new(correlation_id: "order-2")
+      @app.event_bus.publish(event)
+
+      # Allow the class to match "OrderPlaced" by naming
+      # Instead, use a proper event class
+      order_placed = Class.new do
+        attr_reader :correlation_id
+        def initialize(cid); @correlation_id = cid; end
+        def self.name; "ProcessManagerTestDomain::Order::OrderPlaced"; end
+      end
+
+      @app.event_bus.publish(order_placed.new("order-2"))
+
+      store = @app.instance_variable_get(:@saga_store)
+      updated = store.find_by_correlation("order-2")
+      expect(updated[:state]).to eq("shipping")
+      expect(updated[:completed_transitions]).to include("OrderPlaced")
+    end
+
+    it "guards transitions by from-state" do
+      ProcessManagerTestDomain.start_order_process(
+        correlation_id: "order-3", item: "Gizmo"
+      )
+
+      # Publish OrderShipped when state is "started" (wrong state)
+      order_shipped = Class.new do
+        attr_reader :correlation_id
+        def initialize(cid); @correlation_id = cid; end
+        def self.name; "ProcessManagerTestDomain::Order::OrderShipped"; end
+      end
+
+      @app.event_bus.publish(order_shipped.new("order-3"))
+
+      store = @app.instance_variable_get(:@saga_store)
+      instance = store.find_by_correlation("order-3")
+      # Should still be "started" because OrderShipped requires from: "shipping"
+      expect(instance[:state]).to eq("started")
+    end
+  end
+
+  describe "SagaStore#find_by_correlation" do
+    it "finds by correlation_id in instance metadata" do
+      store = Hecks::SagaStore.new
+      store.save("pm_abc", {
+        saga_id: "pm_abc",
+        correlation_id: "corr-99",
+        attrs: { item: "X" }
+      })
+      found = store.find_by_correlation("corr-99")
+      expect(found[:saga_id]).to eq("pm_abc")
+    end
+
+    it "finds by correlation_id in attrs" do
+      store = Hecks::SagaStore.new
+      store.save("pm_def", {
+        saga_id: "pm_def",
+        attrs: { correlation_id: "corr-77" }
+      })
+      found = store.find_by_correlation("corr-77")
+      expect(found[:saga_id]).to eq("pm_def")
+    end
+
+    it "returns nil when not found" do
+      store = Hecks::SagaStore.new
+      expect(store.find_by_correlation("nonexistent")).to be_nil
+    end
+  end
+
+  describe "backward compatibility" do
+    let(:imperative_domain) do
+      Hecks.domain "ImperativeSagaCompat" do
+        aggregate "Task" do
+          attribute :name, String
+          command "DoStep" do
+            attribute :name, String
+          end
+        end
+
+        saga "SimpleFlow" do
+          step "DoStep", on_success: "StepDone"
+        end
+      end
+    end
+
+    before { @compat_app = Hecks.load(imperative_domain) }
+
+    it "still supports imperative step-based sagas" do
+      saga = imperative_domain.sagas.first
+      expect(saga.event_driven?).to be false
+      expect(saga.steps.size).to eq(1)
+    end
+
+    it "wires imperative sagas as start_ methods" do
+      result = ImperativeSagaCompatDomain.start_simple_flow(name: "test")
+      expect(result[:state]).to eq(:completed)
+    end
+  end
+
+  describe "mixed saga with both steps and transitions" do
+    let(:mixed_domain) do
+      Hecks.domain "MixedSagaTest" do
+        aggregate "Ticket" do
+          attribute :title, String
+          attribute :correlation_id, String
+
+          command "CreateTicket" do
+            attribute :title, String
+            attribute :correlation_id, String
+          end
+
+          command "AssignTicket" do
+            attribute :title, String
+            attribute :correlation_id, String
+          end
+        end
+
+        saga "TicketProcess" do
+          step "CreateTicket", on_success: "TicketCreated"
+
+          on "TicketCreated",
+            dispatch: "AssignTicket",
+            from: "started",
+            to: "assigned"
+        end
+      end
+    end
+
+    it "has both steps and transitions" do
+      d = mixed_domain
+      saga = d.sagas.first
+      expect(saga.steps.size).to eq(1)
+      expect(saga.transitions.size).to eq(1)
+      expect(saga.event_driven?).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat(HEC-67): event-driven process managers for sagas

Add ProcessManager that subscribes to the event bus and transitions
saga instances through named states by dispatching commands. Extends
the saga DSL with `on` transitions alongside existing imperative steps.

- SagaTransition IR node: event, command, from-state guard, to-state
- ProcessManager: event-driven state machine wired at boot
- SagaStore#find_by_correlation for correlation-based instance lookup
- Saga#event_driven? predicate for distinguishing modes
- Full backward compat with imperative step-based sagas

🤖 Generated with [Claude Code](https://claude.com/claude-code)