### PR TITLE
HEC-69: Aggregate snapshots

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -635,6 +635,15 @@
 - Provides `validate_params` method and `validation_rules` on domain module
 - Wires into command bus as middleware
 
+### hecks_snapshots
+- Aggregate snapshot extension for event-sourced reconstitution
+- `MemorySnapshotStore` port: `save_snapshot(type, id, version:, state:)` and `load_snapshot(type, id)`
+- Auto-snapshot after N events per aggregate stream (configurable threshold, default 100)
+- DSL `apply` blocks on aggregates for event-driven reconstitution: `apply "CreatedPizza" do |agg, data| ... end`
+- `Reconstitution.reconstitute(klass, id, snapshot_store:, event_recorder:)` rebuilds from snapshot + filtered events
+- `app.extend(:snapshots, threshold: 50)` to wire at runtime
+- `Hecks.snapshot_store` accessor for the active store
+
 ## Go Domain Generation (hecks_go)
 
 ### Go Output from Same DSL

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -83,6 +83,10 @@ module Hecks
       #   an infrastructure decision made outside the domain IR.
       attr_reader :identity_fields
 
+      # @return [Hash{String => Proc}] event applier blocks for reconstituting
+      #   aggregate state from events. Keyed by event type name.
+      attr_reader :appliers
+
       # Creates a new Aggregate IR node.
       #
       # @param name [String] PascalCase name of the aggregate (e.g., "Pizza")
@@ -108,7 +112,7 @@ module Hecks
                      specifications: [], references: [],
                      factories: [], computed_attributes: [],
                      lifecycle: nil, metadata: {}, origin_domain: nil,
-                     identity_fields: nil)
+                     identity_fields: nil, appliers: {})
         @name = Names.aggregate_name(name)
         @attributes = attributes
         @value_objects = value_objects
@@ -129,6 +133,7 @@ module Hecks
         @metadata = metadata
         @origin_domain = origin_domain
         @identity_fields = identity_fields
+        @appliers = appliers
       end
 
       attr_reader :metadata, :origin_domain

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -82,6 +82,7 @@ module Hecks
         @identity_fields = nil
         @metadata = {}
         @facet_data = {}
+        @appliers = {}
         self.class.facet_registry.each do |facet_name, setup|
           @facet_data[facet_name] = []
           setup.call(self.class) unless self.class.method_defined?(facet_name)
@@ -190,7 +191,8 @@ module Hecks
           specifications: @specifications, computed_attributes: @computed_attributes,
           lifecycle: @lifecycle,
           metadata: @metadata, references: @references,
-          factories: @factories, identity_fields: @identity_fields
+          factories: @factories, identity_fields: @identity_fields,
+          appliers: @appliers
         )
       end
 

--- a/bluebook/lib/hecks/dsl/aggregate_builder/behavior_methods.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder/behavior_methods.rb
@@ -70,6 +70,18 @@ module Hecks
           @specifications << DomainModel::Behavior::Specification.new(name: name, block: block)
         end
 
+        # Register an apply block for reconstituting aggregate state from an event.
+        # Used by the snapshots extension to rebuild aggregates from event history.
+        #
+        # @param event_name [String] the event type name (e.g. "CreatedPizza")
+        # @yield [aggregate, event_data] receives current aggregate (or nil) and event data hash
+        # @yieldreturn [Object] the new/updated aggregate instance
+        # @return [void]
+        def apply(event_name, &block)
+          @appliers ||= {}
+          @appliers[event_name.to_s] = block
+        end
+
         private
 
         def generate_subscriber_name(event_name)

--- a/docs/usage/snapshots.md
+++ b/docs/usage/snapshots.md
@@ -1,0 +1,124 @@
+# Aggregate Snapshots
+
+Aggregate snapshots speed up reconstitution in event-sourced domains by
+periodically saving a point-in-time copy of aggregate state. Instead of
+replaying every event from the beginning, reconstitution starts from the
+latest snapshot and only applies events that came after it.
+
+## Quick Start
+
+```ruby
+require "hecks/extensions/snapshots"
+
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+
+    command "CreatePizza" do
+      attribute :name, String
+    end
+
+    command "UpdatePizza" do
+      attribute :pizza, String
+      attribute :name, String
+    end
+
+    # Apply blocks define how to reconstitute from events
+    apply "CreatedPizza" do |_aggregate, data|
+      PizzasDomain::Pizza.new(id: data["aggregate_id"], name: data["name"])
+    end
+
+    apply "UpdatedPizza" do |aggregate, data|
+      PizzasDomain::Pizza.new(id: aggregate.id, name: data["name"] || aggregate.name)
+    end
+  end
+end
+
+app = Hecks.load(domain)
+app.extend(:snapshots, threshold: 50)  # snapshot every 50 events
+```
+
+## Snapshot Store
+
+The `MemorySnapshotStore` provides the port interface:
+
+```ruby
+store = Hecks::Snapshots::MemorySnapshotStore.new
+
+# Save a snapshot
+store.save_snapshot("Pizza", pizza_id, version: 50, state: { id: pizza_id, name: "Margherita" })
+
+# Load the latest snapshot
+snap = store.load_snapshot("Pizza", pizza_id)
+snap[:version]  # => 50
+snap[:state]    # => { id: "...", name: "Margherita" }
+snap[:taken_at] # => Time
+
+# Clear all snapshots
+store.clear
+```
+
+After wiring the extension, the store is available via `Hecks.snapshot_store`.
+
+## Reconstitution
+
+Rebuild an aggregate from snapshot + events:
+
+```ruby
+aggregate = Hecks::Snapshots::Reconstitution.reconstitute(
+  PizzasDomain::Pizza, pizza_id,
+  snapshot_store: Hecks.snapshot_store,
+  event_recorder: recorder
+)
+```
+
+The reconstitution flow:
+1. Load the latest snapshot for the aggregate (if any)
+2. Fetch events after the snapshot version
+3. Fold each event through the matching `apply` block
+4. Return the rebuilt aggregate
+
+## Auto-Snapshot
+
+The extension automatically snapshots after a configurable number of events
+per aggregate stream. Default threshold is 100.
+
+```ruby
+# Snapshot every 100 events (default)
+app.extend(:snapshots)
+
+# Snapshot every 20 events
+app.extend(:snapshots, threshold: 20)
+```
+
+## DSL: Apply Blocks
+
+Define `apply` blocks inside an aggregate to specify how each event type
+modifies aggregate state during reconstitution:
+
+```ruby
+aggregate "Order" do
+  attribute :status, String
+  attribute :total, Float
+
+  apply "PlacedOrder" do |_aggregate, data|
+    OrdersDomain::Order.new(
+      id: data["aggregate_id"],
+      status: "placed",
+      total: data["total"].to_f
+    )
+  end
+
+  apply "CompletedOrder" do |aggregate, data|
+    OrdersDomain::Order.new(
+      id: aggregate.id,
+      status: "completed",
+      total: aggregate.total
+    )
+  end
+end
+```
+
+The first argument is the current aggregate (nil for create events).
+The second argument is the event data as a Hash with string keys.
+The block must return a new aggregate instance.

--- a/hecksties/lib/hecks/extensions/snapshots.rb
+++ b/hecksties/lib/hecks/extensions/snapshots.rb
@@ -1,0 +1,70 @@
+# HecksSnapshots
+#
+# Aggregate snapshot extension for event-sourced domains. Provides a snapshot
+# store port (save_snapshot, load_snapshot), memory-backed implementation,
+# aggregate reconstitution from snapshot + events, and automatic snapshotting
+# after a configurable number of events (default 100).
+#
+# Usage:
+#   require "hecks/extensions/snapshots"
+#
+#   app = Hecks.load(domain)
+#   app.extend(:snapshots)
+#
+#   # Or with custom threshold:
+#   app.extend(:snapshots, threshold: 50)
+#
+#   # Reconstitute from snapshot + events:
+#   Hecks.snapshot_store.load_snapshot("Pizza", pizza_id)
+#
+require_relative "snapshots/memory_snapshot_store"
+require_relative "snapshots/reconstitution"
+require_relative "snapshots/auto_snapshot"
+
+module Hecks
+  module Snapshots
+    # Registers DSL `apply` blocks on an aggregate class.
+    #
+    # @param klass [Class] the aggregate class
+    # @param event_name [String] the event type name (e.g., "CreatedPizza")
+    # @param block [Proc] a block receiving (aggregate, event_data) and returning new aggregate
+    # @return [void]
+    def self.register_applier(klass, event_name, &block)
+      appliers = klass.instance_variable_get(:@__hecks_appliers__) || {}
+      appliers[event_name] = block
+      klass.instance_variable_set(:@__hecks_appliers__, appliers)
+    end
+  end
+end
+
+# Extension registration: describe and register with Hecks runtime.
+Hecks.describe_extension(:snapshots,
+  description: "Aggregate snapshots for event-sourced reconstitution",
+  adapter_type: :driven,
+  config: { threshold: { default: 100, type: Integer } },
+  wires_to: :event_bus)
+
+Hecks.register_extension(:snapshots) do |domain_mod, domain, runtime, **opts|
+  threshold = opts.fetch(:threshold, 100)
+  store = Hecks::Snapshots::MemorySnapshotStore.new
+
+  Hecks.instance_variable_set(:@_snapshot_store, store)
+  Hecks.define_singleton_method(:snapshot_store) { @_snapshot_store }
+
+  resolver = ->(agg_type, agg_id) {
+    domain.aggregates.each do |agg|
+      next unless agg.name == agg_type
+      klass_name = "#{domain_mod}::#{agg.name}"
+      klass = Object.const_get(klass_name) rescue nil
+      return klass.find(agg_id) if klass&.respond_to?(:find)
+    end
+    nil
+  }
+
+  Hecks::Snapshots::AutoSnapshot.new(
+    snapshot_store: store,
+    event_bus: runtime.event_bus,
+    threshold: threshold,
+    aggregate_resolver: resolver
+  )
+end

--- a/hecksties/lib/hecks/extensions/snapshots/auto_snapshot.rb
+++ b/hecksties/lib/hecks/extensions/snapshots/auto_snapshot.rb
@@ -1,0 +1,117 @@
+# Hecks::Snapshots::AutoSnapshot
+#
+# Event bus listener that automatically takes a snapshot of an aggregate
+# after every N events. Configurable threshold (default 100). Subscribes
+# to the event bus via `on_any` and tracks event counts per aggregate
+# stream. When the threshold is reached, serializes the current aggregate
+# state and saves it to the snapshot store.
+#
+# Usage:
+#   auto = Hecks::Snapshots::AutoSnapshot.new(
+#     snapshot_store: store,
+#     event_bus: bus,
+#     threshold: 50,
+#     aggregate_resolver: ->(type, id) { klass.find(id) }
+#   )
+#
+module Hecks
+  module Snapshots
+    class AutoSnapshot
+      # @return [Integer] the event count threshold that triggers a snapshot
+      attr_reader :threshold
+
+      # Creates an auto-snapshot listener and subscribes to the event bus.
+      #
+      # @param snapshot_store [MemorySnapshotStore] where to save snapshots
+      # @param event_bus [Hecks::EventBus] the event bus to listen on
+      # @param threshold [Integer] number of events between snapshots (default 100)
+      # @param aggregate_resolver [Proc] callable(type, id) that returns the aggregate
+      def initialize(snapshot_store:, event_bus:, threshold: 100, aggregate_resolver:)
+        @snapshot_store = snapshot_store
+        @threshold = threshold
+        @aggregate_resolver = aggregate_resolver
+        @event_counts = Hash.new(0)
+        event_bus.on_any { |event| check_and_snapshot(event) }
+      end
+
+      private
+
+      # Checks if the event count for this stream has reached the threshold,
+      # and if so, takes a snapshot.
+      #
+      # @param event [Object] the domain event
+      # @return [void]
+      def check_and_snapshot(event)
+        agg_type, agg_id = extract_stream_info(event)
+        return unless agg_type && agg_id
+
+        key = "#{agg_type}-#{agg_id}"
+        @event_counts[key] += 1
+
+        return unless @event_counts[key] >= @threshold
+
+        take_snapshot(agg_type, agg_id, @event_counts[key])
+        @event_counts[key] = 0
+      end
+
+      # Extracts the aggregate type and ID from a domain event.
+      #
+      # @param event [Object] the domain event
+      # @return [Array(String, String)] [aggregate_type, aggregate_id]
+      def extract_stream_info(event)
+        agg_id = event.respond_to?(:aggregate_id) ? event.aggregate_id : event.respond_to?(:id) ? event.id : nil
+        return [nil, nil] unless agg_id
+
+        event_name = Hecks::Utils.const_short_name(event)
+        agg_type = infer_aggregate_type(event_name)
+        [agg_type, agg_id]
+      end
+
+      # Infers the aggregate type from an event class name by looking at the
+      # module hierarchy (e.g., PizzasDomain::Pizza::Events::CreatedPizza -> Pizza).
+      #
+      # @param event_name [String] the short event class name
+      # @return [String] the aggregate type name
+      def infer_aggregate_type(event_name)
+        event_name
+          .gsub(/^(Created|Updated|Deleted|Placed|Approved|Rejected|Completed)/, "")
+      end
+
+      # Saves a snapshot of the aggregate's current state.
+      #
+      # @param agg_type [String] the aggregate type
+      # @param agg_id [String, Integer] the aggregate ID
+      # @param version [Integer] the event count (used as version)
+      # @return [void]
+      def take_snapshot(agg_type, agg_id, version)
+        aggregate = @aggregate_resolver.call(agg_type, agg_id)
+        return unless aggregate
+
+        state = serialize_aggregate(aggregate)
+        @snapshot_store.save_snapshot(agg_type, agg_id, version: version, state: state)
+      end
+
+      # Serializes an aggregate to a hash of its attributes.
+      #
+      # @param aggregate [Object] the aggregate instance
+      # @return [Hash] the serialized state
+      def serialize_aggregate(aggregate)
+        if aggregate.class.respond_to?(:hecks_attributes)
+          attrs = { id: aggregate.id }
+          aggregate.class.hecks_attributes.each do |attr|
+            attrs[attr.name.to_sym] = aggregate.send(attr.name)
+          end
+          attrs
+        else
+          params = aggregate.class.instance_method(:initialize).parameters
+          attrs = { id: aggregate.id }
+          params.each do |_, name|
+            next unless name && name != :id
+            attrs[name] = aggregate.send(name) if aggregate.respond_to?(name)
+          end
+          attrs
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/snapshots/memory_snapshot_store.rb
+++ b/hecksties/lib/hecks/extensions/snapshots/memory_snapshot_store.rb
@@ -1,0 +1,71 @@
+# Hecks::Snapshots::MemorySnapshotStore
+#
+# In-memory snapshot store for aggregate state. Stores snapshots keyed by
+# aggregate type and ID, with a version number corresponding to the event
+# stream position at the time of the snapshot.
+#
+# Each snapshot is a Hash with :aggregate_type, :aggregate_id, :version,
+# :state (the serialized attribute hash), and :taken_at timestamp.
+#
+# Usage:
+#   store = Hecks::Snapshots::MemorySnapshotStore.new
+#   store.save_snapshot("Pizza", "abc-123", version: 50, state: { name: "Margherita" })
+#   snap = store.load_snapshot("Pizza", "abc-123")
+#   snap[:version]  # => 50
+#   snap[:state]    # => { name: "Margherita" }
+#
+module Hecks
+  module Snapshots
+    class MemorySnapshotStore
+      def initialize
+        @store = {}
+      end
+
+      # Saves a snapshot of an aggregate's state at a given event version.
+      #
+      # @param aggregate_type [String] the aggregate type name (e.g., "Pizza")
+      # @param aggregate_id [String, Integer] the aggregate instance ID
+      # @param version [Integer] the event stream version this snapshot represents
+      # @param state [Hash] the serialized aggregate attributes
+      # @return [Hash] the stored snapshot
+      def save_snapshot(aggregate_type, aggregate_id, version:, state:)
+        key = snapshot_key(aggregate_type, aggregate_id)
+        snapshot = {
+          aggregate_type: aggregate_type,
+          aggregate_id: aggregate_id,
+          version: version,
+          state: state,
+          taken_at: Time.now
+        }
+        @store[key] = snapshot
+      end
+
+      # Loads the most recent snapshot for an aggregate instance.
+      #
+      # @param aggregate_type [String] the aggregate type name
+      # @param aggregate_id [String, Integer] the aggregate instance ID
+      # @return [Hash, nil] the snapshot hash, or nil if none exists
+      def load_snapshot(aggregate_type, aggregate_id)
+        @store[snapshot_key(aggregate_type, aggregate_id)]
+      end
+
+      # Removes all stored snapshots.
+      #
+      # @return [void]
+      def clear
+        @store.clear
+      end
+
+      private
+
+      # Builds the storage key for a given aggregate.
+      #
+      # @param aggregate_type [String] the aggregate type name
+      # @param aggregate_id [String, Integer] the aggregate instance ID
+      # @return [String] the composite key
+      def snapshot_key(aggregate_type, aggregate_id)
+        "#{aggregate_type}-#{aggregate_id}"
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/snapshots/reconstitution.rb
+++ b/hecksties/lib/hecks/extensions/snapshots/reconstitution.rb
@@ -1,0 +1,77 @@
+# Hecks::Snapshots::Reconstitution
+#
+# Rebuilds an aggregate from a snapshot plus subsequent events. Uses the
+# aggregate class's registered `apply` blocks to fold each event onto
+# the reconstituted state.
+#
+# The reconstitution flow:
+#   1. Load the latest snapshot (or start from a blank state)
+#   2. Fetch events after the snapshot version
+#   3. Fold each event through the aggregate's `apply` block
+#   4. Return the rebuilt aggregate instance
+#
+# Usage:
+#   aggregate = Hecks::Snapshots::Reconstitution.reconstitute(
+#     Pizza, "abc-123",
+#     snapshot_store: store,
+#     event_history: events_after_version
+#   )
+#
+module Hecks
+  module Snapshots
+    module Reconstitution
+      # Rebuilds an aggregate from snapshot + events.
+      #
+      # @param klass [Class] the aggregate class (e.g., Pizza)
+      # @param aggregate_id [String, Integer] the aggregate instance ID
+      # @param snapshot_store [MemorySnapshotStore] the snapshot store
+      # @param event_recorder [Object] object responding to #history(type, id)
+      # @return [Object, nil] the reconstituted aggregate, or nil if no history
+      def self.reconstitute(klass, aggregate_id, snapshot_store:, event_recorder:)
+        agg_type = klass.name.split("::").last
+        snapshot = snapshot_store.load_snapshot(agg_type, aggregate_id)
+        appliers = klass.instance_variable_get(:@__hecks_appliers__) || {}
+
+        if snapshot
+          aggregate = klass.new(**symbolize_keys(snapshot[:state]))
+          events = events_after(event_recorder, agg_type, aggregate_id, snapshot[:version])
+        else
+          all_events = event_recorder.history(agg_type, aggregate_id)
+          return nil if all_events.empty?
+          aggregate = nil
+          events = all_events
+        end
+
+        events.each do |event_hash|
+          event_name = event_hash[:event_type]
+          applier = appliers[event_name]
+          next unless applier
+          aggregate = applier.call(aggregate, event_hash[:data])
+        end
+
+        aggregate
+      end
+
+      # Fetches events after a given version from the event recorder.
+      #
+      # @param recorder [Object] event recorder with #history method
+      # @param agg_type [String] aggregate type name
+      # @param agg_id [String, Integer] aggregate ID
+      # @param after_version [Integer] only return events with version > this
+      # @return [Array<Hash>] filtered event hashes
+      def self.events_after(recorder, agg_type, agg_id, after_version)
+        recorder.history(agg_type, agg_id).select { |e| e[:version] > after_version }
+      end
+
+      # Converts string keys to symbols for aggregate construction.
+      #
+      # @param hash [Hash] the hash to convert
+      # @return [Hash] hash with symbol keys
+      def self.symbolize_keys(hash)
+        hash.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+      end
+
+      private_class_method :events_after, :symbolize_keys
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/port_setup.rb
+++ b/hecksties/lib/hecks/runtime/port_setup.rb
@@ -61,6 +61,7 @@ module Hecks
         Commands.bind(agg_class, agg, @command_bus, repo, defaults)
         Querying.bind(agg_class, agg)
         Introspection.bind(agg_class, agg)
+        wire_appliers(agg_class, agg)
         Versioning.bind(agg_class, repo) if runtime_option?(agg.name, :versioned)
         AttachmentMethods.bind(agg_class) if runtime_option?(agg.name, :attachable)
         wire_query_objects(agg, agg_class)
@@ -114,6 +115,19 @@ module Hecks
       # @return [Boolean]
       def runtime_option?(aggregate_name, option)
         (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
+      end
+
+      # Registers apply blocks from the aggregate IR onto the aggregate class.
+      # These are used by the snapshots extension for reconstitution.
+      #
+      # @param agg_class [Class] the aggregate class
+      # @param agg [Hecks::DomainModel::Structure::Aggregate] the aggregate definition
+      # @return [void]
+      def wire_appliers(agg_class, agg)
+        return unless agg.respond_to?(:appliers) && agg.appliers&.any?
+        appliers = agg_class.instance_variable_get(:@__hecks_appliers__) || {}
+        agg.appliers.each { |event_name, block| appliers[event_name.to_s] = block }
+        agg_class.instance_variable_set(:@__hecks_appliers__, appliers)
       end
 
       # Wires DSL-defined query objects as class methods on the aggregate class.

--- a/hecksties/spec/extensions/snapshots_spec.rb
+++ b/hecksties/spec/extensions/snapshots_spec.rb
@@ -1,0 +1,190 @@
+require "spec_helper"
+require "hecks/extensions/snapshots"
+
+RSpec.describe "Aggregate Snapshots" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :description, String
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :description, String
+        end
+
+        command "UpdatePizza" do
+          attribute :pizza, String
+          attribute :name, String
+          attribute :description, String
+        end
+
+        apply "CreatedPizza" do |_aggregate, data|
+          PizzasDomain::Pizza.new(
+            id: data["aggregate_id"],
+            name: data["name"],
+            description: data["description"]
+          )
+        end
+
+        apply "UpdatedPizza" do |aggregate, data|
+          PizzasDomain::Pizza.new(
+            id: aggregate.id,
+            name: data["name"] || aggregate.name,
+            description: data["description"] || aggregate.description
+          )
+        end
+      end
+    end
+  end
+
+  describe Hecks::Snapshots::MemorySnapshotStore do
+    let(:store) { described_class.new }
+
+    it "saves and loads a snapshot" do
+      store.save_snapshot("Pizza", "abc-123", version: 5, state: { name: "Margherita" })
+      snap = store.load_snapshot("Pizza", "abc-123")
+
+      expect(snap[:aggregate_type]).to eq("Pizza")
+      expect(snap[:aggregate_id]).to eq("abc-123")
+      expect(snap[:version]).to eq(5)
+      expect(snap[:state]).to eq({ name: "Margherita" })
+      expect(snap[:taken_at]).to be_a(Time)
+    end
+
+    it "returns nil for missing snapshot" do
+      expect(store.load_snapshot("Pizza", "nonexistent")).to be_nil
+    end
+
+    it "overwrites previous snapshot for same aggregate" do
+      store.save_snapshot("Pizza", "abc", version: 1, state: { name: "V1" })
+      store.save_snapshot("Pizza", "abc", version: 5, state: { name: "V5" })
+
+      snap = store.load_snapshot("Pizza", "abc")
+      expect(snap[:version]).to eq(5)
+      expect(snap[:state][:name]).to eq("V5")
+    end
+
+    it "clears all snapshots" do
+      store.save_snapshot("Pizza", "1", version: 1, state: {})
+      store.save_snapshot("Pizza", "2", version: 1, state: {})
+      store.clear
+      expect(store.load_snapshot("Pizza", "1")).to be_nil
+      expect(store.load_snapshot("Pizza", "2")).to be_nil
+    end
+  end
+
+  describe Hecks::Snapshots::Reconstitution do
+    it "reconstitutes from full event history without snapshot" do
+      app = Hecks.load(domain)
+      pizza = PizzasDomain::Pizza.create(name: "Margherita", description: "Classic")
+
+      store = Hecks::Snapshots::MemorySnapshotStore.new
+      recorder = MockEventRecorder.new([
+        { event_type: "CreatedPizza", data: { "aggregate_id" => pizza.id, "name" => "Margherita", "description" => "Classic" }, version: 1 }
+      ])
+
+      result = described_class.reconstitute(
+        PizzasDomain::Pizza, pizza.id,
+        snapshot_store: store,
+        event_recorder: recorder
+      )
+
+      expect(result.name).to eq("Margherita")
+      expect(result.description).to eq("Classic")
+    end
+
+    it "reconstitutes from snapshot plus subsequent events" do
+      app = Hecks.load(domain)
+
+      store = Hecks::Snapshots::MemorySnapshotStore.new
+      store.save_snapshot("Pizza", "abc-123", version: 5, state: {
+        id: "abc-123", name: "Margherita", description: "Classic"
+      })
+
+      recorder = MockEventRecorder.new([
+        { event_type: "CreatedPizza", data: { "aggregate_id" => "abc-123", "name" => "Margherita", "description" => "Classic" }, version: 1 },
+        { event_type: "UpdatedPizza", data: { "name" => "Supreme", "description" => "Loaded" }, version: 6 }
+      ])
+
+      result = described_class.reconstitute(
+        PizzasDomain::Pizza, "abc-123",
+        snapshot_store: store,
+        event_recorder: recorder
+      )
+
+      expect(result.name).to eq("Supreme")
+      expect(result.description).to eq("Loaded")
+    end
+
+    it "returns nil when no events exist" do
+      app = Hecks.load(domain)
+      store = Hecks::Snapshots::MemorySnapshotStore.new
+      recorder = MockEventRecorder.new([])
+
+      result = described_class.reconstitute(
+        PizzasDomain::Pizza, "nonexistent",
+        snapshot_store: store,
+        event_recorder: recorder
+      )
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe "DSL apply blocks" do
+    it "registers appliers on the aggregate class at boot" do
+      app = Hecks.load(domain)
+      appliers = PizzasDomain::Pizza.instance_variable_get(:@__hecks_appliers__)
+
+      expect(appliers).to be_a(Hash)
+      expect(appliers.keys).to include("CreatedPizza", "UpdatedPizza")
+    end
+  end
+
+  describe "extension registration" do
+    it "wires snapshot store and auto-snapshot on extend" do
+      app = Hecks.load(domain)
+      app.extend(:snapshots, threshold: 3)
+
+      expect(Hecks.snapshot_store).to be_a(Hecks::Snapshots::MemorySnapshotStore)
+    end
+
+    it "takes auto-snapshot after threshold events across streams" do
+      app = Hecks.load(domain)
+
+      store = Hecks::Snapshots::MemorySnapshotStore.new
+      Hecks.instance_variable_set(:@_snapshot_store, store)
+      Hecks.define_singleton_method(:snapshot_store) { @_snapshot_store }
+
+      # Manually wire with a low threshold
+      resolver = ->(agg_type, agg_id) {
+        PizzasDomain::Pizza.find(agg_id) if agg_type == "Pizza"
+      }
+
+      Hecks::Snapshots::AutoSnapshot.new(
+        snapshot_store: store,
+        event_bus: app.event_bus,
+        threshold: 1,
+        aggregate_resolver: resolver
+      )
+
+      pizza = PizzasDomain::Pizza.create(name: "Margherita", description: "Classic")
+
+      snap = store.load_snapshot("Pizza", pizza.id)
+      expect(snap).not_to be_nil
+      expect(snap[:state][:name]).to eq("Margherita")
+    end
+  end
+end
+
+# Minimal mock event recorder for reconstitution tests
+class MockEventRecorder
+  def initialize(events)
+    @events = events
+  end
+
+  def history(_type, _id)
+    @events
+  end
+end


### PR DESCRIPTION
## Summary
feat: HEC-69 aggregate snapshots extension

SnapshotStore port (save_snapshot, load_snapshot) with memory
implementation, DSL apply blocks for event-driven reconstitution,
auto-snapshot after configurable N events per stream (default 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)