### PR TITLE
HEC-70: Event versioning/upcasting

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -48,6 +48,15 @@
 - Define event subscribers with `on_event` for arbitrary side-effect code on events
 - Domain-level `on_event` subscribers for cross-aggregate reactions
 
+### Event Versioning & Upcasting
+- `schema_version` on explicit events: `event "CreatedPizza" do; schema_version 2; end` — tracks the current schema version in the domain IR
+- Domain-level `upcast` declarations: `upcast "CreatedPizza", from: 1, to: 2 do |data| ... end` — transforms stored event data between schema versions
+- EventUpcasterRegistry maps [event_type, version] pairs to transform procs
+- UpcasterEngine chains transforms sequentially (v1 -> v2 -> v3) to reach the current version
+- EventRecorder stores `schema_version` on every persisted event
+- EventRecorder applies upcasting transparently on read — `history` and `all_events` return current-version data
+- BuildEngine factory wires domain IR upcaster declarations into a registry and engine
+
 ### Queries & Scopes
 - Define named queries with `where`, `order`, `limit`, `offset` chainable DSL
 - Define named scopes as hash conditions or lambda predicates

--- a/bluebook/lib/hecks/domain_model/behavior.rb
+++ b/bluebook/lib/hecks/domain_model/behavior.rb
@@ -43,6 +43,7 @@ module Hecks
       autoload :ScheduledStep,  "hecks/domain_model/behavior/workflow_step"
       autoload :Saga,           "hecks/domain_model/behavior/saga"
       autoload :SagaStep,       "hecks/domain_model/behavior/saga_step"
+      autoload :UpcasterDeclaration, "hecks/domain_model/behavior/upcaster_declaration"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/behavior/domain_event.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/domain_event.rb
@@ -21,7 +21,7 @@ module Hecks
       # @return [String] PascalCase event name in past tense, e.g. "CreatedPizza"
       # @return [Array<Hecks::DomainModel::Structure::Attribute>] data attributes
       #   carried by the event, typically mirroring the originating command's attributes
-      attr_reader :name, :attributes, :references
+      attr_reader :name, :attributes, :references, :schema_version
 
       # Creates a new DomainEvent IR node.
       #
@@ -31,11 +31,13 @@ module Hecks
       #   attributes carried by this event. Defaults to an empty array.
       # @param references [Array<Hecks::DomainModel::Structure::Reference>] references
       #   carried by this event. Defaults to an empty array.
+      # @param schema_version [Integer] the current schema version for this event (default 1)
       # @return [DomainEvent]
-      def initialize(name:, attributes: [], references: [])
+      def initialize(name:, attributes: [], references: [], schema_version: 1)
         @name = Names.event_name(name)
         @attributes = attributes
         @references = references
+        @schema_version = schema_version
       end
     end
     end

--- a/bluebook/lib/hecks/domain_model/behavior/upcaster_declaration.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/upcaster_declaration.rb
@@ -1,0 +1,37 @@
+# = Hecks::DomainModel::Behavior::UpcasterDeclaration
+#
+# IR node representing a domain-level event upcaster declaration.
+# Captures the event type, source version, target version, and the
+# transform block that converts event data between versions.
+#
+#   decl = UpcasterDeclaration.new(
+#     event_type: "CreatedPizza", from: 1, to: 2,
+#     transform: ->(data) { data.merge("description" => "") }
+#   )
+#
+module Hecks
+  module DomainModel
+    module Behavior
+      class UpcasterDeclaration
+        # @return [String] the event type name
+        attr_reader :event_type
+
+        # @return [Integer] the source schema version
+        attr_reader :from
+
+        # @return [Integer] the target schema version
+        attr_reader :to
+
+        # @return [Proc] the transform block
+        attr_reader :transform
+
+        def initialize(event_type:, from:, to:, transform:)
+          @event_type = event_type
+          @from = from
+          @to = to
+          @transform = transform
+        end
+      end
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -74,6 +74,9 @@ module Hecks
       # @return [Array<DomainModel::SubscriberRegistration>] event subscriber registrations at the domain level
       attr_reader :event_subscribers
 
+      # @return [Array<DomainModel::Behavior::UpcasterDeclaration>] event upcaster declarations
+      attr_reader :upcasters
+
       # @return [String, nil] the filesystem path where this domain's source files live.
       #   Set after compilation or when loading from a gem. Used by generators to know
       #   where to write output files.
@@ -102,7 +105,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil, world_concerns: [])
+                     version: nil, world_concerns: [], upcasters: [])
         validate_version!(version)
         @name = name
         @version = version
@@ -119,6 +122,7 @@ module Hecks
         @custom_verbs = custom_verbs
         @tenancy = tenancy
         @event_subscribers = event_subscribers
+        @upcasters = upcasters
         @world_concerns = world_concerns.map(&:to_sym)
       end
 

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -66,6 +66,7 @@ module Hecks
         @tenancy = nil
         @event_subscribers = []
         @world_concerns = []
+        @upcasters = []
       end
 
       # Declare world concerns that this domain aspires to uphold.
@@ -158,6 +159,24 @@ module Hecks
       def on_event(event_name, &block)
         @event_subscribers << DomainModel::SubscriberRegistration.new(
           event_name: event_name.to_s, block: block
+        )
+      end
+
+      # Declare an event upcaster that transforms stored event data from
+      # one schema version to the next.
+      #
+      #   upcast "CreatedPizza", from: 1, to: 2 do |data|
+      #     data.merge("description" => data.delete("style") || "")
+      #   end
+      #
+      # @param event_type [String] the event type name
+      # @param from [Integer] source schema version
+      # @param to [Integer] target schema version
+      # @yield [data] transform block receiving the event data hash
+      # @return [void]
+      def upcast(event_type, from:, to:, &block)
+        @upcasters << DomainModel::Behavior::UpcasterDeclaration.new(
+          event_type: event_type.to_s, from: from, to: to, transform: block
         )
       end
 
@@ -280,7 +299,7 @@ module Hecks
           event_subscribers: @event_subscribers,
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
           glossary_strict: @glossary_strict || false,
-          world_concerns: @world_concerns
+          world_concerns: @world_concerns, upcasters: @upcasters
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/dsl/event_builder.rb
+++ b/bluebook/lib/hecks/dsl/event_builder.rb
@@ -16,12 +16,27 @@ module Hecks
       def initialize(name)
         @name = name
         @attributes = []
+        @schema_version = 1
+      end
+
+      # Set the schema version for this event.
+      #
+      #   event "PolicyExpired" do
+      #     schema_version 3
+      #     attribute :policy_id, String
+      #   end
+      #
+      # @param version [Integer] the current schema version
+      # @return [void]
+      def schema_version(version)
+        @schema_version = version
       end
 
       def build
         DomainModel::Behavior::DomainEvent.new(
           name: @name,
-          attributes: @attributes
+          attributes: @attributes,
+          schema_version: @schema_version
         )
       end
     end

--- a/docs/usage/event_versioning.md
+++ b/docs/usage/event_versioning.md
@@ -1,0 +1,107 @@
+# Event Versioning & Upcasting
+
+Domain events evolve over time. When an event's schema changes (fields added, renamed, or removed), old stored events need to be transformed to match the current schema. Hecks provides a built-in upcasting system for this.
+
+## Schema Version on Events
+
+Declare the current schema version on explicit events:
+
+```ruby
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :description, String
+
+    event "CreatedPizza" do
+      schema_version 2
+      attribute :name, String
+      attribute :description, String
+    end
+
+    command "CreatePizza" do
+      attribute :name, String
+      attribute :description, String
+    end
+  end
+end
+```
+
+Events default to `schema_version 1` when not declared.
+
+## Upcast Declarations
+
+Declare transforms at the domain level that convert stored event data from one version to the next:
+
+```ruby
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :description, String
+
+    event "CreatedPizza" do
+      schema_version 3
+      attribute :name, String
+      attribute :description, String
+      attribute :category, String
+    end
+
+    command "CreatePizza" do
+      attribute :name, String
+      attribute :description, String
+      attribute :category, String
+    end
+  end
+
+  # v1 had "style" instead of "description"
+  upcast "CreatedPizza", from: 1, to: 2 do |data|
+    data.merge("description" => data.delete("style") || "")
+  end
+
+  # v2 didn't have "category"
+  upcast "CreatedPizza", from: 2, to: 3 do |data|
+    data.merge("category" => "classic")
+  end
+end
+```
+
+Upcasters chain automatically: a v1 event gets transformed through v1->v2 then v2->v3.
+
+## Event Store Integration
+
+When using the SQL EventRecorder, pass an upcaster engine to enable transparent upcasting on reads:
+
+```ruby
+domain = Hecks.domain "Pizzas" do
+  # ... domain definition with upcast declarations ...
+end
+
+engine = Hecks::Events::BuildEngine.call(domain)
+recorder = Hecks::Persistence::EventRecorder.new(db,
+  upcaster_engine: engine,
+  domain: domain
+)
+
+# Old v1 events are automatically upcasted when reading:
+recorder.history("Pizza", "1")
+# => [{ event_type: "CreatedPizza", data: { "name" => "...", "description" => "...", "category" => "classic" }, schema_version: 3 }]
+```
+
+New events are stored with the current schema version. Old events are upcasted on read -- the stored data is never modified.
+
+## Standalone Usage
+
+You can also use the upcasting components directly:
+
+```ruby
+registry = Hecks::Events::UpcasterRegistry.new
+registry.register("CreatedPizza", from: 1, to: 2) do |data|
+  data.merge("description" => data.delete("style") || "")
+end
+
+engine = Hecks::Events::UpcasterEngine.new(registry)
+result = engine.upcast("CreatedPizza",
+  data: { "name" => "M", "style" => "Napoli" },
+  from_version: 1, to_version: 2
+)
+# => { "name" => "M", "description" => "Napoli" }
+```

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -144,6 +144,7 @@ module Hecks
   autoload :Application,       "hecks/runtime"
   # PortWiring is included directly in Runtime, no autoload needed
   autoload :AttachmentMethods, "hecks/runtime/attachment_methods"
+  autoload :Events,            "hecks/events"
   autoload :EventBus,          "hecks/ports/event_bus/event_bus"
   # FilteredEventBus, CrossDomainQuery, CrossDomainView → hecks_multidomain
   autoload :Queue,             "hecks/ports/queue"

--- a/hecksties/lib/hecks/events.rb
+++ b/hecksties/lib/hecks/events.rb
@@ -1,0 +1,17 @@
+# = Hecks::Events
+#
+# Namespace for event versioning and upcasting infrastructure.
+# Provides a registry for mapping [event_type, version] to transform
+# procs, and an engine that chains transforms to upcast stored events
+# to their current schema version.
+#
+#   Hecks::Events::UpcasterRegistry.new
+#   Hecks::Events::UpcasterEngine.new(registry)
+#
+module Hecks
+  module Events
+    require_relative "events/upcaster_registry"
+    require_relative "events/upcaster_engine"
+    require_relative "events/build_engine"
+  end
+end

--- a/hecksties/lib/hecks/events/build_engine.rb
+++ b/hecksties/lib/hecks/events/build_engine.rb
@@ -1,0 +1,26 @@
+# = Hecks::Events::BuildEngine
+#
+# Factory method that builds an UpcasterEngine from a domain's
+# upcaster declarations. Reads the domain IR's upcasters array
+# and registers each transform in a fresh UpcasterRegistry.
+#
+#   engine = Hecks::Events::BuildEngine.call(domain)
+#   engine.upcast("CreatedPizza", data: old_data, from_version: 1, to_version: 2)
+#
+module Hecks
+  module Events
+    module BuildEngine
+      # Build an UpcasterEngine from the domain's upcaster declarations.
+      #
+      # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+      # @return [Hecks::Events::UpcasterEngine] a wired engine
+      def self.call(domain)
+        registry = UpcasterRegistry.new
+        (domain.upcasters || []).each do |decl|
+          registry.register(decl.event_type, from: decl.from, to: decl.to, &decl.transform)
+        end
+        UpcasterEngine.new(registry)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/events/upcaster_engine.rb
+++ b/hecksties/lib/hecks/events/upcaster_engine.rb
@@ -1,0 +1,47 @@
+# = Hecks::Events::UpcasterEngine
+#
+# Applies upcaster transforms from a stored schema version to the
+# current version. Chains transforms sequentially: v1 -> v2 -> v3.
+# Returns the original data unchanged if no transforms are needed.
+#
+#   engine = UpcasterEngine.new(registry)
+#   engine.upcast("CreatedPizza", data: { "name" => "M" }, from_version: 1, to_version: 3)
+#   # => { "name" => "M", "description" => "", "category" => "classic" }
+#
+module Hecks
+  module Events
+    class UpcasterEngine
+      # @param registry [UpcasterRegistry] the registry of transforms
+      def initialize(registry)
+        @registry = registry
+      end
+
+      # Apply all transforms needed to bring event data from one version to another.
+      #
+      # @param event_type [String] the event type name
+      # @param data [Hash] the stored event data hash
+      # @param from_version [Integer] the version the data was stored at
+      # @param to_version [Integer] the target version to upcast to
+      # @return [Hash] the upcasted data hash
+      # @raise [Hecks::Error] if a transform is missing for an intermediate version
+      def upcast(event_type, data:, from_version:, to_version:)
+        return data if from_version >= to_version
+
+        current_data = data.dup
+        current_version = from_version
+
+        while current_version < to_version
+          entry = @registry.lookup(event_type, current_version)
+          unless entry
+            raise Hecks::Error,
+              "Missing upcaster for #{event_type} from version #{current_version}"
+          end
+          current_data = entry[:transform].call(current_data)
+          current_version = entry[:to]
+        end
+
+        current_data
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/events/upcaster_registry.rb
+++ b/hecksties/lib/hecks/events/upcaster_registry.rb
@@ -1,0 +1,60 @@
+# = Hecks::Events::UpcasterRegistry
+#
+# Registry mapping [event_type, version] pairs to transform procs.
+# Each transform takes an event data hash at one version and returns
+# the data hash at the next version. Used by UpcasterEngine to chain
+# transforms from a stored version to the current schema version.
+#
+#   registry = UpcasterRegistry.new
+#   registry.register("CreatedPizza", from: 1, to: 2) do |data|
+#     data.merge("description" => data.delete("style") || "")
+#   end
+#   registry.lookup("CreatedPizza", 1)
+#   # => { to: 2, transform: #<Proc> }
+#
+module Hecks
+  module Events
+    class UpcasterRegistry
+      def initialize
+        @transforms = {}
+      end
+
+      # Register a transform from one version to the next.
+      #
+      # @param event_type [String] the event type name (e.g. "CreatedPizza")
+      # @param from [Integer] source schema version
+      # @param to [Integer] target schema version
+      # @yield [data] transform block receiving the event data hash
+      # @yieldreturn [Hash] the transformed data hash
+      # @return [void]
+      def register(event_type, from:, to:, &transform)
+        key = [event_type.to_s, from]
+        @transforms[key] = { to: to, transform: transform }
+      end
+
+      # Look up a transform for the given event type and version.
+      #
+      # @param event_type [String] the event type name
+      # @param version [Integer] the source schema version
+      # @return [Hash, nil] { to:, transform: } or nil if no transform registered
+      def lookup(event_type, version)
+        @transforms[[event_type.to_s, version]]
+      end
+
+      # Check if any transforms are registered for the given event type.
+      #
+      # @param event_type [String] the event type name
+      # @return [Boolean]
+      def any_for?(event_type)
+        @transforms.keys.any? { |type, _| type == event_type.to_s }
+      end
+
+      # Returns the number of registered transforms.
+      #
+      # @return [Integer]
+      def size
+        @transforms.size
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/ports/repository/event_recorder.rb
+++ b/hecksties/lib/hecks/ports/repository/event_recorder.rb
@@ -27,8 +27,14 @@ module Hecks
         # Ensures the +domain_events+ table exists, creating it if necessary.
         #
         # @param db [Sequel::Database] the Sequel database connection to store events in
-        def initialize(db)
+        # @param upcaster_engine [Hecks::Events::UpcasterEngine, nil] optional engine
+        #   for upcasting stored events to their current schema version
+        # @param domain [Hecks::DomainModel::Structure::Domain, nil] optional domain IR
+        #   for resolving current event schema versions
+        def initialize(db, upcaster_engine: nil, domain: nil)
           @db = db
+          @upcaster_engine = upcaster_engine
+          @domain = domain
           ensure_table
         end
 
@@ -47,12 +53,15 @@ module Hecks
           stream_id = "#{aggregate_type}-#{aggregate_id}"
           version = next_version(stream_id)
 
+          event_type = Hecks::Utils.const_short_name(event)
+
           @db[:domain_events].insert(
             stream_id: stream_id,
-            event_type: Hecks::Utils.const_short_name(event),
+            event_type: event_type,
             data: serialize_event(event),
             occurred_at: event.occurred_at.iso8601,
-            version: version
+            version: version,
+            schema_version: current_schema_version(event_type)
           )
         end
 
@@ -119,13 +128,34 @@ module Hecks
         # @return [Hash] a normalized event hash with +:stream_id+, +:event_type+,
         #   +:data+ (parsed JSON), +:occurred_at+, and +:version+
         def deserialize_row(row)
+          data = JSON.parse(row[:data] || "{}")
+          stored_version = row[:schema_version] || 1
+          event_type = row[:event_type]
+          target_version = current_schema_version(event_type)
+
+          if @upcaster_engine && stored_version < target_version
+            data = @upcaster_engine.upcast(
+              event_type, data: data,
+              from_version: stored_version, to_version: target_version
+            )
+          end
+
           {
             stream_id: row[:stream_id],
-            event_type: row[:event_type],
-            data: JSON.parse(row[:data] || "{}"),
+            event_type: event_type,
+            data: data,
             occurred_at: row[:occurred_at],
-            version: row[:version]
+            version: row[:version],
+            schema_version: target_version
           }
+        end
+
+        # Returns the current schema version for an event type by looking
+        # it up in the domain IR. Defaults to 1 if no domain is set.
+        def current_schema_version(event_type)
+          return 1 unless @domain
+          event_ir = @domain.all_events.find { |e| e.name == event_type }
+          event_ir&.schema_version || 1
         end
 
         # Creates the +domain_events+ table if it does not already exist.
@@ -149,6 +179,7 @@ module Hecks
             String :data, text: true
             String :occurred_at
             Integer :version
+            Integer :schema_version, default: 1
             index :stream_id
           end
         end

--- a/hecksties/spec/events/event_recorder_upcasting_spec.rb
+++ b/hecksties/spec/events/event_recorder_upcasting_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+require "sequel"
+
+RSpec.describe "EventRecorder with upcasting" do
+  let(:domain) do
+    Hecks.domain "PizzaUpcast" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :description, String
+
+        event "CreatedPizza" do
+          schema_version 2
+          attribute :name, String
+          attribute :description, String
+        end
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :description, String
+        end
+      end
+
+      upcast "CreatedPizza", from: 1, to: 2 do |data|
+        data.merge("description" => data.delete("style") || "unknown")
+      end
+    end
+  end
+
+  let(:db) { Sequel.sqlite }
+  let(:engine) { Hecks::Events::BuildEngine.call(domain) }
+  let(:recorder) { Hecks::Persistence::EventRecorder.new(db, upcaster_engine: engine, domain: domain) }
+
+  # Ensure the recorder (and table) exist before inserting raw data
+  before { recorder }
+
+  it "upcasts old events on read" do
+    db[:domain_events].insert(
+      stream_id: "Pizza-1",
+      event_type: "CreatedPizza",
+      data: '{"name":"Margherita","style":"Napoli"}',
+      occurred_at: Time.now.iso8601,
+      version: 1,
+      schema_version: 1
+    )
+
+    history = recorder.history("Pizza", "1")
+    expect(history.size).to eq(1)
+    expect(history.first[:data]["description"]).to eq("Napoli")
+    expect(history.first[:data]).not_to have_key("style")
+    expect(history.first[:schema_version]).to eq(2)
+  end
+
+  it "leaves current-version events unchanged" do
+    db[:domain_events].insert(
+      stream_id: "Pizza-2",
+      event_type: "CreatedPizza",
+      data: '{"name":"Pepperoni","description":"Spicy"}',
+      occurred_at: Time.now.iso8601,
+      version: 1,
+      schema_version: 2
+    )
+
+    history = recorder.history("Pizza", "2")
+    expect(history.first[:data]["description"]).to eq("Spicy")
+  end
+
+  it "upcasts events in all_events" do
+    db[:domain_events].insert(
+      stream_id: "Pizza-1",
+      event_type: "CreatedPizza",
+      data: '{"name":"M","style":"Classic"}',
+      occurred_at: Time.now.iso8601,
+      version: 1,
+      schema_version: 1
+    )
+
+    events = recorder.all_events
+    expect(events.first[:data]["description"]).to eq("Classic")
+  end
+end

--- a/hecksties/spec/events/event_versioning_spec.rb
+++ b/hecksties/spec/events/event_versioning_spec.rb
@@ -1,0 +1,141 @@
+require "spec_helper"
+
+RSpec.describe "Event versioning and upcasting" do
+  describe "schema_version on DomainEvent IR" do
+    it "defaults to 1" do
+      domain = Hecks.domain "VersionDefault" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      event = domain.aggregates.first.events.first
+      expect(event.schema_version).to eq(1)
+    end
+
+    it "accepts an explicit schema_version on an event" do
+      domain = Hecks.domain "VersionExplicit" do
+        aggregate "Widget" do
+          attribute :name, String
+
+          event "WidgetArchived" do
+            schema_version 3
+            attribute :widget_id, String
+          end
+        end
+      end
+
+      event = domain.aggregates.first.events.find { |e| e.name == "WidgetArchived" }
+      expect(event.schema_version).to eq(3)
+    end
+  end
+
+  describe "upcast DSL at domain level" do
+    it "stores upcaster declarations on the domain IR" do
+      domain = Hecks.domain "UpcastDSL" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+
+        upcast "CreatedWidget", from: 1, to: 2 do |data|
+          data.merge("color" => "default")
+        end
+      end
+
+      expect(domain.upcasters.size).to eq(1)
+      decl = domain.upcasters.first
+      expect(decl.event_type).to eq("CreatedWidget")
+      expect(decl.from).to eq(1)
+      expect(decl.to).to eq(2)
+      expect(decl.transform).to be_a(Proc)
+    end
+  end
+
+  describe Hecks::Events::UpcasterRegistry do
+    subject(:registry) { described_class.new }
+
+    it "registers and looks up transforms" do
+      registry.register("CreatedWidget", from: 1, to: 2) { |d| d.merge("v2" => true) }
+
+      entry = registry.lookup("CreatedWidget", 1)
+      expect(entry[:to]).to eq(2)
+      expect(entry[:transform].call({})).to eq({ "v2" => true })
+    end
+
+    it "returns nil for missing transforms" do
+      expect(registry.lookup("CreatedWidget", 99)).to be_nil
+    end
+
+    it "reports any_for?" do
+      registry.register("CreatedWidget", from: 1, to: 2) { |d| d }
+      expect(registry.any_for?("CreatedWidget")).to be true
+      expect(registry.any_for?("Unknown")).to be false
+    end
+  end
+
+  describe Hecks::Events::UpcasterEngine do
+    let(:registry) { Hecks::Events::UpcasterRegistry.new }
+    subject(:engine) { described_class.new(registry) }
+
+    before do
+      registry.register("CreatedWidget", from: 1, to: 2) do |data|
+        data.merge("color" => "default")
+      end
+      registry.register("CreatedWidget", from: 2, to: 3) do |data|
+        data.merge("size" => "medium")
+      end
+    end
+
+    it "chains transforms from v1 to v3" do
+      result = engine.upcast("CreatedWidget",
+        data: { "name" => "W" }, from_version: 1, to_version: 3)
+      expect(result).to eq({ "name" => "W", "color" => "default", "size" => "medium" })
+    end
+
+    it "applies a single step from v2 to v3" do
+      result = engine.upcast("CreatedWidget",
+        data: { "name" => "W", "color" => "blue" }, from_version: 2, to_version: 3)
+      expect(result).to eq({ "name" => "W", "color" => "blue", "size" => "medium" })
+    end
+
+    it "returns data unchanged when already at target version" do
+      data = { "name" => "W" }
+      result = engine.upcast("CreatedWidget", data: data, from_version: 3, to_version: 3)
+      expect(result).to eq(data)
+    end
+
+    it "raises when a transform is missing" do
+      expect {
+        engine.upcast("CreatedWidget", data: {}, from_version: 5, to_version: 6)
+      }.to raise_error(Hecks::Error, /Missing upcaster/)
+    end
+  end
+
+  describe Hecks::Events::BuildEngine do
+    it "builds an engine from domain upcaster declarations" do
+      domain = Hecks.domain "BuildEngineTest" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+
+        upcast "CreatedWidget", from: 1, to: 2 do |data|
+          data.merge("added" => true)
+        end
+      end
+
+      engine = Hecks::Events::BuildEngine.call(domain)
+      result = engine.upcast("CreatedWidget",
+        data: { "name" => "W" }, from_version: 1, to_version: 2)
+      expect(result).to eq({ "name" => "W", "added" => true })
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: domain event versioning and upcasting (HEC-70)

Add schema_version to domain events and an upcasting pipeline that
transforms stored event data from old versions to the current schema.

- DomainEvent IR gains schema_version (default 1)
- EventBuilder DSL: `schema_version N` inside event blocks
- UpcasterRegistry maps [event_type, version] to transform procs
- UpcasterEngine chains transforms sequentially (v1 -> v2 -> v3)
- Domain-level `upcast "EventName", from:, to:` DSL declarations
- EventRecorder stores schema_version, applies upcasting on reads
- BuildEngine factory wires domain IR upcasters into engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)