### PR TITLE
HEC-72: Pure function analysis

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,6 +23,7 @@
 - References hold live objects in memory — IDs are purely a persistence concern
 - Enum constraints: `attribute :category, String, enum: %w[low medium high]` — validated at runtime, dropdown in UI
 - Computed attributes: `computed :lot_size do; area / 43560.0; end` — derived values not stored in the database, shown in UI with "(computed)" hint, visible in `hecks inspect`, and available as MCP `add_computed` tool
+- Pure functions: `function :full_name do; "#{first} #{last}"; end` — side-effect-free methods on aggregates and value objects, generated as instance methods, serializer round-trip supported, name collision validation enforced
 
 ### Commands
 - Define commands with attributes, handlers, guards, read models, actors, and external system docs

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -36,6 +36,7 @@ module Hecks
       lines.concat(serialize_invariants(agg.invariants, "    "))
       lines.concat(serialize_scopes(agg.scopes))
       lines.concat(serialize_computed_attributes(agg.computed_attributes))
+      lines.concat(serialize_functions(agg.functions))
       lines.concat(serialize_queries(agg.queries))
       lines.concat(serialize_specifications(agg.specifications))
       lines.concat(serialize_commands(agg.commands))
@@ -54,6 +55,7 @@ module Hecks
         lines = ["", "    value_object \"#{vo.name}\" do"]
         lines.concat(serialize_attributes(vo.attributes, "      "))
         lines.concat(serialize_invariants(vo.invariants, "      "))
+        lines.concat(serialize_functions(vo.functions, "      "))
         lines << "    end"
       end
     end
@@ -83,6 +85,14 @@ module Hecks
       scopes.reject(&:callable?).flat_map do |s|
         formatted = s.conditions.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")
         ["", "    scope :#{s.name}, #{formatted}"]
+      end
+    end
+
+    def serialize_functions(fns, indent = "    ")
+      (fns || []).flat_map do |fn|
+        ["", "#{indent}function :#{fn.name} do",
+         "#{indent}  #{Hecks::Utils.block_source(fn.block)}",
+         "#{indent}end"]
       end
     end
 

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -57,6 +57,7 @@ module Hecks
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
       autoload :Reference,         "hecks/domain_model/structure/reference"
       autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
+      autoload :PureFunction,      "hecks/domain_model/structure/pure_function"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -72,6 +72,9 @@ module Hecks
       # @return [Array<ComputedAttribute>] derived attributes computed from other attributes
       attr_reader :computed_attributes
 
+      # @return [Array<PureFunction>] side-effect-free functions defined on this aggregate
+      attr_reader :functions
+
       # @return [Lifecycle, nil] optional state machine definition
       attr_reader :lifecycle
 
@@ -107,6 +110,7 @@ module Hecks
                      scopes: [], queries: [], subscribers: [],
                      specifications: [], references: [],
                      factories: [], computed_attributes: [],
+                     functions: [],
                      lifecycle: nil, metadata: {}, origin_domain: nil,
                      identity_fields: nil)
         @name = Names.aggregate_name(name)
@@ -125,6 +129,7 @@ module Hecks
         @references = references
         @factories = factories
         @computed_attributes = computed_attributes
+        @functions = functions
         @lifecycle = lifecycle
         @metadata = metadata
         @origin_domain = origin_domain

--- a/bluebook/lib/hecks/domain_model/structure/pure_function.rb
+++ b/bluebook/lib/hecks/domain_model/structure/pure_function.rb
@@ -1,0 +1,30 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::PureFunction
+    #
+    # A side-effect-free function defined on an aggregate or value object.
+    # Holds a name and a block whose body becomes a method on the generated
+    # class. Pure functions may only read attributes -- they must not mutate
+    # state, call commands, or emit events.
+    #
+    #   PureFunction.new(name: :full_name, block: proc { "#{first} #{last}" })
+    #
+    class PureFunction
+      # @return [Symbol] the name of this pure function
+      attr_reader :name
+
+      # @return [Proc] the block whose body computes the return value
+      attr_reader :block
+
+      # @param name [Symbol] function name
+      # @param block [Proc] computation block referencing attributes
+      def initialize(name:, block:)
+        @name = name
+        @block = block
+      end
+    end
+    end
+  end
+end

--- a/bluebook/lib/hecks/domain_model/structure/value_object.rb
+++ b/bluebook/lib/hecks/domain_model/structure/value_object.rb
@@ -40,6 +40,9 @@ module Hecks
       #   Evaluated during construction; if any invariant fails, the object cannot be created.
       attr_reader :invariants
 
+      # @return [Array<PureFunction>] side-effect-free functions defined on this value object
+      attr_reader :functions
+
       # Creates a new ValueObject IR node.
       #
       # @param name [String] PascalCase name of the value object (e.g., "Address", "Money")
@@ -47,10 +50,11 @@ module Hecks
       # @param invariants [Array<Invariant>] business rules enforced at construction time
       #
       # @return [ValueObject] a new ValueObject instance
-      def initialize(name:, attributes: [], invariants: [])
+      def initialize(name:, attributes: [], invariants: [], functions: [])
         @name = name
         @attributes = attributes
         @invariants = invariants
+        @functions = functions
       end
     end
     end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -78,6 +78,7 @@ module Hecks
         @explicit_events = []
         @factories = []
         @computed_attributes = []
+        @functions = []
         @lifecycle = nil
         @identity_fields = nil
         @metadata = {}
@@ -97,6 +98,17 @@ module Hecks
       #
       def computed(name, &block)
         @computed_attributes << Structure::ComputedAttribute.new(name: name.to_sym, block: block)
+      end
+
+      # Declare a side-effect-free function. The block body becomes a method
+      # on the generated aggregate class. Functions may only read attributes.
+      #
+      #   function :full_address do
+      #     "#{street}, #{city} #{zip}"
+      #   end
+      #
+      def function(name, &block)
+        @functions << Structure::PureFunction.new(name: name.to_sym, block: block)
       end
 
       # Declare a natural key composed from attributes.
@@ -188,7 +200,7 @@ module Hecks
           scopes: @scopes, queries: @queries,
           subscribers: @subscribers,
           specifications: @specifications, computed_attributes: @computed_attributes,
-          lifecycle: @lifecycle,
+          functions: @functions, lifecycle: @lifecycle,
           metadata: @metadata, references: @references,
           factories: @factories, identity_fields: @identity_fields
         )

--- a/bluebook/lib/hecks/dsl/value_object_builder.rb
+++ b/bluebook/lib/hecks/dsl/value_object_builder.rb
@@ -37,6 +37,7 @@ module Hecks
         @name = name
         @attributes = []
         @invariants = []
+        @functions = []
       end
 
       # Define an invariant constraint on this value object.
@@ -49,6 +50,17 @@ module Hecks
       # @return [void]
       def invariant(message, &block)
         @invariants << Structure::Invariant.new(message: message, block: block)
+      end
+
+      # Declare a side-effect-free function on this value object. The block
+      # body becomes a method on the generated class.
+      #
+      #   function :display do
+      #     "#{street}, #{city}"
+      #   end
+      #
+      def function(name, &block)
+        @functions << Structure::PureFunction.new(name: name.to_sym, block: block)
       end
 
       # Implicit DSL: `name Type` → attribute
@@ -71,7 +83,8 @@ module Hecks
         Structure::ValueObject.new(
           name: @name,
           attributes: @attributes,
-          invariants: @invariants
+          invariants: @invariants,
+          functions: @functions
         )
       end
     end

--- a/bluebook/lib/hecks/generators/domain/aggregate_generator.rb
+++ b/bluebook/lib/hecks/generators/domain/aggregate_generator.rb
@@ -84,6 +84,15 @@ module Hecks
             lines << "    end"
           end
         end
+        unless (@aggregate.functions || []).empty?
+          lines << ""
+          lines << "    # Pure functions — side-effect-free"
+          @aggregate.functions.each do |fn|
+            lines << "    def #{fn.name}"
+            lines << "      #{Hecks::Utils.block_source(fn.block)}"
+            lines << "    end"
+          end
+        end
         if @aggregate.lifecycle
           lines << ""
           lines << "    # State predicates — see lifecycle.rb for full state machine"

--- a/bluebook/lib/hecks/generators/domain/value_object_generator.rb
+++ b/bluebook/lib/hecks/generators/domain/value_object_generator.rb
@@ -104,6 +104,15 @@ module Hecks
           lines << "        [self.class, #{@vo.attributes.map(&:name).join(", ")}].hash"
         end
         lines << "      end"
+        unless (@vo.functions || []).empty?
+          lines << ""
+          lines << "      # Pure functions — side-effect-free"
+          @vo.functions.each do |fn|
+            lines << "      def #{fn.name}"
+            lines << "        #{Hecks::Utils.block_source(fn.block)}"
+            lines << "      end"
+          end
+        end
         lines << ""
         lines << "      private"
         lines << ""

--- a/bluebook/lib/hecks/validation_rules/naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming.rb
@@ -11,6 +11,7 @@ module Hecks
     # - +UniqueAggregateNames+ -- no duplicate aggregate names within a domain
     # - +ReservedNames+ -- rejects Ruby keywords as attribute names and invalid aggregate constants
     # - +ComputedNameCollisions+ -- computed attribute names must not collide with regular attribute names
+    # - +FunctionNameCollisions+ -- pure function names must not collide with attributes or computed attributes
     # - +GlossaryTermViolations+ -- warns (or errors in strict mode) when names use banned glossary terms
     # - +SafeIdentifierNames+ -- rejects dangerous characters that could cause injection in generated Go/Ruby code
     #
@@ -22,6 +23,7 @@ module Hecks
       autoload :UniqueAggregateNames,   "hecks/validation_rules/naming/unique_aggregate_names"
       autoload :ReservedNames,          "hecks/validation_rules/naming/reserved_names"
       autoload :ComputedNameCollisions, "hecks/validation_rules/naming/computed_name_collisions"
+      autoload :FunctionNameCollisions, "hecks/validation_rules/naming/function_name_collisions"
       autoload :GlossaryTermViolations, "hecks/validation_rules/naming/glossary_term_violations"
       autoload :SafeIdentifierNames,    "hecks/validation_rules/naming/safe_identifier_names"
     end

--- a/bluebook/lib/hecks/validation_rules/naming/function_name_collisions.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/function_name_collisions.rb
@@ -1,0 +1,40 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::FunctionNameCollisions
+    #
+    # Validates that pure function names do not collide with regular
+    # attribute or computed attribute names on the same aggregate.
+    # Such collisions would generate a method that shadows an accessor.
+    #
+    # Part of the ValidationRules::Naming group -- run by +Hecks.validate+.
+    #
+    #   rule = FunctionNameCollisions.new(domain)
+    #   rule.errors  # => ["Pizza: function 'name' collides with a regular attribute"]
+    #
+    class FunctionNameCollisions < BaseRule
+      # Checks all aggregates for name collisions between functions and attributes.
+      #
+      # @return [Array<String>] error messages for each collision found
+      def errors
+        result = []
+        @domain.aggregates.each do |agg|
+          attr_names = agg.attributes.map(&:name).map(&:to_sym)
+          computed_names = (agg.computed_attributes || []).map(&:name).map(&:to_sym)
+          taken = attr_names + computed_names
+
+          (agg.functions || []).each do |fn|
+            if taken.include?(fn.name.to_sym)
+              result << error("#{agg.name}: function '#{fn.name}' collides with an attribute or computed attribute",
+                hint: "Rename the function to avoid the collision")
+            end
+          end
+        end
+        result
+      end
+    end
+    Hecks.register_validation_rule(FunctionNameCollisions)
+    end
+  end
+end

--- a/bluebook/spec/dsl/pure_function_spec.rb
+++ b/bluebook/spec/dsl/pure_function_spec.rb
@@ -1,0 +1,210 @@
+require "spec_helper"
+
+RSpec.describe "pure functions" do
+  describe "DSL parsing" do
+    it "parses function keyword on aggregates and builds IR" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :first, String
+          attribute :last, String
+          function :full_name do
+            "#{first} #{last}"
+          end
+          command("CreatePerson") { attribute :first, String; attribute :last, String }
+        end
+      end
+
+      agg = domain.aggregates.first
+      expect(agg.functions.size).to eq(1)
+
+      fn = agg.functions.first
+      expect(fn.name).to eq(:full_name)
+      expect(fn.block).to be_a(Proc)
+    end
+
+    it "parses function keyword on value objects" do
+      domain = Hecks.domain("Shipping") do
+        aggregate("Shipment") do
+          attribute :status, String
+          value_object "Address" do
+            attribute :street, String
+            attribute :city, String
+            function :display do
+              "#{street}, #{city}"
+            end
+          end
+          command("CreateShipment") { attribute :status, String }
+        end
+      end
+
+      vo = domain.aggregates.first.value_objects.first
+      expect(vo.functions.size).to eq(1)
+      expect(vo.functions.first.name).to eq(:display)
+    end
+
+    it "supports multiple functions on one aggregate" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :first, String
+          attribute :last, String
+          function(:full_name) { "#{first} #{last}" }
+          function(:initials) { "#{first[0]}#{last[0]}" }
+          command("CreatePerson") { attribute :first, String }
+        end
+      end
+
+      expect(domain.aggregates.first.functions.size).to eq(2)
+    end
+  end
+
+  describe "Ruby code generation" do
+    it "generates function methods on aggregate class" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :first, String
+          attribute :last, String
+          function :full_name do
+            "#{first} #{last}"
+          end
+          command("CreatePerson") { attribute :first, String }
+        end
+      end
+
+      gen = Hecks::Generators::Domain::AggregateGenerator.new(
+        domain.aggregates.first, domain_module: "ContactsDomain"
+      )
+      code = gen.generate
+
+      expect(code).to include("def full_name")
+      expect(code).to include("# Pure functions")
+    end
+
+    it "generates function methods on value object class" do
+      domain = Hecks.domain("Shipping") do
+        aggregate("Shipment") do
+          attribute :status, String
+          value_object "Address" do
+            attribute :street, String
+            attribute :city, String
+            function :display do
+              "#{street}, #{city}"
+            end
+          end
+          command("CreateShipment") { attribute :status, String }
+        end
+      end
+
+      vo = domain.aggregates.first.value_objects.first
+      gen = Hecks::Generators::Domain::ValueObjectGenerator.new(
+        vo, domain_module: "ShippingDomain", aggregate_name: "Shipment"
+      )
+      code = gen.generate
+
+      expect(code).to include("def display")
+      expect(code).to include("# Pure functions")
+    end
+  end
+
+  describe "serializer round-trip" do
+    it "serializes and restores aggregate functions" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :first, String
+          function :full_name do
+            "#{first} #{last}"
+          end
+          command("CreatePerson") { attribute :first, String }
+        end
+      end
+
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).to include("function :full_name do")
+
+      restored = eval(source)
+      fn = restored.aggregates.first.functions.first
+      expect(fn.name).to eq(:full_name)
+    end
+
+    it "serializes and restores value object functions" do
+      domain = Hecks.domain("Shipping") do
+        aggregate("Shipment") do
+          attribute :status, String
+          value_object "Address" do
+            attribute :street, String
+            function :display do
+              "#{street}, #{city}"
+            end
+          end
+          command("CreateShipment") { attribute :status, String }
+        end
+      end
+
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).to include("function :display do")
+
+      restored = eval(source)
+      vo = restored.aggregates.first.value_objects.first
+      expect(vo.functions.first.name).to eq(:display)
+    end
+  end
+
+  describe "validation" do
+    it "detects function name collision with regular attribute" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :name, String
+          function(:name) { "oops" }
+          command("CreatePerson") { attribute :name, String }
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      expect(validator.errors).to include(
+        "Person: function 'name' collides with an attribute or computed attribute"
+      )
+    end
+
+    it "detects function name collision with computed attribute" do
+      domain = Hecks.domain("Contacts") do
+        aggregate("Person") do
+          attribute :first, String
+          computed(:display) { first }
+          function(:display) { first }
+          command("CreatePerson") { attribute :first, String }
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      expect(validator.errors).to include(
+        "Person: function 'display' collides with an attribute or computed attribute"
+      )
+    end
+  end
+
+  describe "defaults" do
+    it "defaults functions to empty array on aggregates" do
+      domain = Hecks.domain("Simple") do
+        aggregate("Thing") do
+          attribute :name, String
+          command("CreateThing") { attribute :name, String }
+        end
+      end
+
+      expect(domain.aggregates.first.functions).to eq([])
+    end
+
+    it "defaults functions to empty array on value objects" do
+      domain = Hecks.domain("Simple") do
+        aggregate("Thing") do
+          attribute :name, String
+          value_object("Tag") { attribute :label, String }
+          command("CreateThing") { attribute :name, String }
+        end
+      end
+
+      expect(domain.aggregates.first.value_objects.first.functions).to eq([])
+    end
+  end
+end

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -585,6 +585,48 @@ Computed attribute names can't collide with regular attribute names (the validat
 
 ---
 
+## Pure Functions
+
+Pure functions are side-effect-free methods on aggregates or value objects. They may only read attributes — no state mutation, no commands, no events.
+
+```ruby
+aggregate "Person" do
+  attribute :first, String
+  attribute :last, String
+
+  function :full_name do
+    "#{first} #{last}"
+  end
+
+  command "CreatePerson" do
+    attribute :first, String
+    attribute :last, String
+  end
+end
+```
+
+Value objects support them too:
+
+```ruby
+value_object "Address" do
+  attribute :street, String
+  attribute :city, String
+
+  function :display do
+    "#{street}, #{city}"
+  end
+end
+```
+
+Function names can't collide with regular or computed attribute names. The generated class gets a plain instance method:
+
+```ruby
+person = Person.create(first: "Alice", last: "Smith")
+person.full_name # => "Alice Smith"
+```
+
+---
+
 ## Lifecycle
 
 A lifecycle is a state machine on a single attribute. It declares which commands trigger which state transitions, and optionally constrains which source states are valid. The runtime enforces these transitions — trying to publish an archived post raises an error.

--- a/docs/usage/pure_functions.md
+++ b/docs/usage/pure_functions.md
@@ -1,0 +1,96 @@
+# Pure Functions
+
+Side-effect-free functions on aggregates and value objects.
+
+## On Aggregates
+
+```ruby
+Hecks.domain "Contacts" do
+  aggregate "Person" do
+    attribute :first, String
+    attribute :last, String
+
+    function :full_name do
+      "#{first} #{last}"
+    end
+
+    function :initials do
+      "#{first[0]}#{last[0]}"
+    end
+
+    command "CreatePerson" do
+      attribute :first, String
+      attribute :last, String
+    end
+  end
+end
+```
+
+Generated output:
+
+```ruby
+class Person
+  include Hecks::Model
+
+  attribute :first
+  attribute :last
+
+  # Pure functions -- side-effect-free
+  def full_name
+    "#{first} #{last}"
+  end
+
+  def initials
+    "#{first[0]}#{last[0]}"
+  end
+end
+```
+
+## On Value Objects
+
+```ruby
+value_object "Address" do
+  attribute :street, String
+  attribute :city, String
+  attribute :zip, String
+
+  function :display do
+    "#{street}, #{city} #{zip}"
+  end
+end
+```
+
+Generated output:
+
+```ruby
+class Address
+  attr_reader :street, :city, :zip
+
+  # Pure functions -- side-effect-free
+  def display
+    "#{street}, #{city} #{zip}"
+  end
+end
+```
+
+## Serializer Round-Trip
+
+Functions survive serialization and deserialization:
+
+```ruby
+domain = Hecks.domain("Contacts") { ... }
+source = Hecks::DslSerializer.new(domain).serialize
+restored = eval(source)
+restored.aggregates.first.functions.first.name  # => :full_name
+```
+
+## Validation
+
+Function names must not collide with regular or computed attributes:
+
+```ruby
+aggregate "Person" do
+  attribute :name, String
+  function(:name) { "oops" }  # => validation error
+end
+```


### PR DESCRIPTION
## Summary
docs: add pure functions to DSL reference


feat: add pure functions on aggregates and value objects (HEC-72)

New `function` DSL keyword for side-effect-free methods on both
aggregates and value objects. IR node PureFunction, generators emit
methods, serializer round-trips, and validation catches name collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)