### PR TITLE
HEC-73: Naming conventions analysis

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -333,6 +333,9 @@
 - Every validation error includes a structured `hint` field with a fix suggestion -- rendered as colored "Fix:" lines in the CLI, included in `ValidationError` exception messages, and accessible via `error.hint` / `error.to_h`
 - Implicit foreign key detection: warns when `_id String` should be `reference_to("Aggregate")`
 - Validator collects non-blocking warnings alongside blocking errors
+- Intention-revealing name analysis: warns on generic terms (Data, Info, Manager, Handler, Processor, etc.) in aggregate/VO/entity names
+- Event naming analysis: warns when domain event names are not past tense (e.g. `BakePizza` should be `BakedPizza`)
+- Attribute naming analysis: warns on vague suffixes (`_data`, `_info`), redundant aggregate prefixes (`pizza_name` on Pizza), and Hungarian-style type prefixes (`str_name`)
 
 ## Domain Interface Versioning
 - `hecks version_tag <version>` — snapshot current domain DSL to `db/hecks_versions/<version>.rb` with metadata header

--- a/bluebook/lib/hecks/validation_rules/naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming.rb
@@ -13,17 +13,23 @@ module Hecks
     # - +ComputedNameCollisions+ -- computed attribute names must not collide with regular attribute names
     # - +GlossaryTermViolations+ -- warns (or errors in strict mode) when names use banned glossary terms
     # - +SafeIdentifierNames+ -- rejects dangerous characters that could cause injection in generated Go/Ruby code
+    # - +IntentionRevealingNames+ -- warns on generic terms (Data, Manager, Handler, etc.)
+    # - +EventNaming+ -- warns when event names are not past tense
+    # - +AttributeNaming+ -- warns on _data/_info suffixes, redundant prefixes, type prefixes
     #
     # All rules are autoloaded and executed as part of +Hecks.validate+.
     #
     module Naming
-      autoload :CommandNaming,          "hecks/validation_rules/naming/command_naming"
-      autoload :NameCollisions,         "hecks/validation_rules/naming/name_collisions"
-      autoload :UniqueAggregateNames,   "hecks/validation_rules/naming/unique_aggregate_names"
-      autoload :ReservedNames,          "hecks/validation_rules/naming/reserved_names"
-      autoload :ComputedNameCollisions, "hecks/validation_rules/naming/computed_name_collisions"
-      autoload :GlossaryTermViolations, "hecks/validation_rules/naming/glossary_term_violations"
-      autoload :SafeIdentifierNames,    "hecks/validation_rules/naming/safe_identifier_names"
+      autoload :CommandNaming,           "hecks/validation_rules/naming/command_naming"
+      autoload :NameCollisions,          "hecks/validation_rules/naming/name_collisions"
+      autoload :UniqueAggregateNames,    "hecks/validation_rules/naming/unique_aggregate_names"
+      autoload :ReservedNames,           "hecks/validation_rules/naming/reserved_names"
+      autoload :ComputedNameCollisions,  "hecks/validation_rules/naming/computed_name_collisions"
+      autoload :GlossaryTermViolations,  "hecks/validation_rules/naming/glossary_term_violations"
+      autoload :SafeIdentifierNames,     "hecks/validation_rules/naming/safe_identifier_names"
+      autoload :IntentionRevealingNames, "hecks/validation_rules/naming/intention_revealing_names"
+      autoload :EventNaming,             "hecks/validation_rules/naming/event_naming"
+      autoload :AttributeNaming,         "hecks/validation_rules/naming/attribute_naming"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/naming/attribute_naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/attribute_naming.rb
@@ -1,0 +1,115 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::AttributeNaming
+    #
+    # Warns about attribute names that leak implementation or carry redundant
+    # prefixes. Catches three patterns:
+    #
+    # 1. Suffixes like +_data+ or +_info+ (e.g. +order_data+) -- vague,
+    #    prefer the domain concept itself
+    # 2. Redundant aggregate-name prefixes (e.g. +pizza_name+ on Pizza) --
+    #    the aggregate context already provides the namespace
+    # 3. Hungarian-style type prefixes (e.g. +str_name+, +int_count+) --
+    #    types are declared explicitly in the DSL
+    #
+    # This is a warning-only rule: it does not block compilation.
+    #
+    # == Usage
+    #
+    #   domain = Hecks.domain("Pizzas") do
+    #     aggregate("Pizza") do
+    #       attribute :pizza_name, String
+    #       attribute :toppings_data, String
+    #       command("CreatePizza") { attribute :name, String }
+    #     end
+    #   end
+    #
+    #   rule = AttributeNaming.new(domain)
+    #   rule.warnings
+    #   # => ["Attribute 'pizza_name' on Pizza has redundant prefix 'pizza_' ..."]
+    #
+    class AttributeNaming < BaseRule
+      VAGUE_SUFFIXES = %w[_data _info _details _stuff _object _record].freeze
+      TYPE_PREFIXES  = %w[str_ int_ bool_ arr_ lst_ hash_ obj_ num_ flt_].freeze
+
+      # No errors -- this rule only produces warnings.
+      #
+      # @return [Array] always empty
+      def errors
+        []
+      end
+
+      # Returns warnings for attributes with vague suffixes, redundant
+      # aggregate prefixes, or Hungarian-style type prefixes.
+      #
+      # @return [Array<ValidationMessage>] warning messages
+      def warnings
+        result = []
+        @domain.aggregates.each do |agg|
+          check_attrs(agg, agg.name, agg.attributes, result)
+          agg.value_objects.each { |vo| check_attrs(agg, vo.name, vo.attributes, result) }
+          agg.entities.each      { |ent| check_attrs(agg, ent.name, ent.attributes, result) }
+        end
+        result
+      end
+
+      private
+
+      # Checks a set of attributes for naming smells.
+      #
+      # @param agg [Aggregate] the owning aggregate (for context)
+      # @param owner_name [String] the immediate owner name (aggregate/VO/entity)
+      # @param attributes [Array<Attribute>] the attributes to check
+      # @param result [Array<ValidationMessage>] collects warnings
+      def check_attrs(agg, owner_name, attributes, result)
+        prefix = "#{owner_name.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}_"
+        attributes.each do |attr|
+          name = attr.name.to_s
+          result.concat(check_vague_suffix(name, owner_name))
+          result.concat(check_redundant_prefix(name, owner_name, prefix))
+          result.concat(check_type_prefix(name, owner_name))
+        end
+      end
+
+      # @return [Array<ValidationMessage>] warning if name ends with a vague suffix
+      def check_vague_suffix(name, owner)
+        VAGUE_SUFFIXES.each do |suffix|
+          next unless name.end_with?(suffix)
+          clean = name.chomp(suffix)
+          return [error(
+            "Attribute '#{name}' on #{owner} has vague suffix '#{suffix}'",
+            hint: "Rename to '#{clean}' or a more specific domain term"
+          )]
+        end
+        []
+      end
+
+      # @return [Array<ValidationMessage>] warning if name starts with aggregate prefix
+      def check_redundant_prefix(name, owner, prefix)
+        return [] unless name.start_with?(prefix) && name.length > prefix.length
+        clean = name.sub(/\A#{Regexp.escape(prefix)}/, "")
+        [error(
+          "Attribute '#{name}' on #{owner} has redundant prefix '#{prefix}'",
+          hint: "Rename to '#{clean}' -- the #{owner} context already provides the namespace"
+        )]
+      end
+
+      # @return [Array<ValidationMessage>] warning if name starts with a type prefix
+      def check_type_prefix(name, owner)
+        TYPE_PREFIXES.each do |tp|
+          next unless name.start_with?(tp) && name.length > tp.length
+          clean = name.sub(/\A#{Regexp.escape(tp)}/, "")
+          return [error(
+            "Attribute '#{name}' on #{owner} has Hungarian-style type prefix '#{tp}'",
+            hint: "Rename to '#{clean}' -- types are declared explicitly in the DSL"
+          )]
+        end
+        []
+      end
+    end
+    Hecks.register_validation_rule(AttributeNaming)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/naming/event_naming.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/event_naming.rb
@@ -1,0 +1,79 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::EventNaming
+    #
+    # Warns when domain event names do not follow past-tense convention.
+    # In DDD, events describe something that already happened, so names
+    # like "CreatedPizza" and "ApprovedOrder" are correct, while
+    # "CreatePizza" or "ApprovingOrder" are not.
+    #
+    # Detection: checks that the first PascalCase word ends in "ed", "en",
+    # "nt" (sent), "un" (begun), or "id" (paid). This catches the vast
+    # majority of English past-tense verb forms.
+    #
+    # This is a warning-only rule: it does not block compilation.
+    #
+    # == Usage
+    #
+    #   domain = Hecks.domain("Pizzas") do
+    #     aggregate("Pizza") do
+    #       attribute :name, String
+    #       command("CreatePizza") { attribute :name, String }
+    #       event("BakePizza")
+    #     end
+    #   end
+    #
+    #   rule = EventNaming.new(domain)
+    #   rule.warnings
+    #   # => ["Event 'BakePizza' in Pizza does not appear to be past tense ..."]
+    #
+    class EventNaming < BaseRule
+      PAST_TENSE_SUFFIXES = /(?:ed|en|nt|un|id)\z/i
+
+      # No errors -- this rule only produces warnings.
+      #
+      # @return [Array] always empty
+      def errors
+        []
+      end
+
+      # Returns warnings for events whose first word does not look like
+      # past tense.
+      #
+      # @return [Array<ValidationMessage>] warning messages
+      def warnings
+        result = []
+        @domain.aggregates.each do |agg|
+          agg.events.each do |evt|
+            first_word = evt.name.split(/(?=[A-Z])/).first
+            next if first_word.match?(PAST_TENSE_SUFFIXES)
+
+            result << error(
+              "Event '#{evt.name}' in #{agg.name} does not appear to be past tense",
+              hint: "Rename to past tense, e.g. '#{suggest_past_tense(first_word, evt.name)}'"
+            )
+          end
+        end
+        result
+      end
+
+      private
+
+      # Suggests a past-tense version of the event name by appending "ed"
+      # to the first word (or "d" if it ends with "e").
+      #
+      # @param first_word [String] the verb portion of the event name
+      # @param full_name [String] the full PascalCase event name
+      # @return [String] a suggested past-tense event name
+      def suggest_past_tense(first_word, full_name)
+        suffix = full_name.sub(/\A#{Regexp.escape(first_word)}/, "")
+        past = first_word.end_with?("e") ? "#{first_word}d" : "#{first_word}ed"
+        "#{past}#{suffix}"
+      end
+    end
+    Hecks.register_validation_rule(EventNaming)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/naming/intention_revealing_names.rb
+++ b/bluebook/lib/hecks/validation_rules/naming/intention_revealing_names.rb
@@ -1,0 +1,77 @@
+module Hecks
+  module ValidationRules
+    module Naming
+
+    # Hecks::ValidationRules::Naming::IntentionRevealingNames
+    #
+    # Warns when aggregate, value object, or entity names use generic terms
+    # that hide domain intent. Names like "Data", "Info", "Manager", and
+    # "Handler" are code smells in DDD -- they reveal implementation rather
+    # than domain meaning.
+    #
+    # This is a warning-only rule: it does not block compilation.
+    #
+    # == Usage
+    #
+    #   domain = Hecks.domain("Pizzas") do
+    #     aggregate("OrderManager") do
+    #       attribute :name, String
+    #       command("CreateOrderManager") { attribute :name, String }
+    #     end
+    #   end
+    #
+    #   rule = IntentionRevealingNames.new(domain)
+    #   rule.warnings
+    #   # => ["Aggregate 'OrderManager' uses generic term 'Manager' ..."]
+    #
+    class IntentionRevealingNames < BaseRule
+      GENERIC_TERMS = %w[
+        Data Info Manager Handler Processor Helper Util Utils
+        Service Object Base Item Record Entry Wrapper Container
+      ].freeze
+
+      GENERIC_PATTERN = /(?:^|(?<=[a-z]))(?:#{GENERIC_TERMS.join("|")})(?=[A-Z]|\z)/
+
+      # No errors -- this rule only produces warnings.
+      #
+      # @return [Array] always empty
+      def errors
+        []
+      end
+
+      # Returns warnings for aggregates, value objects, and entities whose
+      # names contain generic, non-intention-revealing terms.
+      #
+      # @return [Array<ValidationMessage>] warning messages
+      def warnings
+        result = []
+        @domain.aggregates.each do |agg|
+          result.concat(check_name("Aggregate", agg.name))
+          agg.value_objects.each { |vo| result.concat(check_name("ValueObject", vo.name)) }
+          agg.entities.each      { |ent| result.concat(check_name("Entity", ent.name)) }
+        end
+        result
+      end
+
+      private
+
+      # Scans a PascalCase name for generic terms and returns a warning
+      # for each match found.
+      #
+      # @param kind [String] human-readable label (e.g. "Aggregate")
+      # @param name [String] the PascalCase name to check
+      # @return [Array<ValidationMessage>] warnings for this name
+      def check_name(kind, name)
+        matches = name.scan(GENERIC_PATTERN)
+        matches.map do |term|
+          error(
+            "#{kind} '#{name}' uses generic term '#{term}' -- prefer a domain-specific name",
+            hint: "Replace '#{term}' with a term from your ubiquitous language"
+          )
+        end
+      end
+    end
+    Hecks.register_validation_rule(IntentionRevealingNames)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/naming/attribute_naming_spec.rb
+++ b/bluebook/spec/validation_rules/naming/attribute_naming_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::Naming::AttributeNaming do
+  def build_domain(attr_name, agg_name: "Pizza")
+    Hecks.domain("Pizzas") do
+      aggregate(agg_name) do
+        attribute attr_name, String
+        command("Create#{agg_name}") { attribute :name, String }
+      end
+    end
+  end
+
+  def warnings_for(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  describe "vague suffixes" do
+    %w[order_data toppings_info customer_details].each do |name|
+      it "warns about '#{name}'" do
+        ws = warnings_for(build_domain(name.to_sym))
+        expect(ws.any? { |w| w.include?(name) && w.include?("vague suffix") }).to be true
+      end
+    end
+  end
+
+  describe "redundant aggregate prefix" do
+    it "warns about 'pizza_name' on Pizza" do
+      ws = warnings_for(build_domain(:pizza_name))
+      expect(ws.any? { |w| w.include?("pizza_name") && w.include?("redundant prefix") }).to be true
+    end
+  end
+
+  describe "Hungarian-style type prefix" do
+    it "warns about 'str_name'" do
+      ws = warnings_for(build_domain(:str_name))
+      expect(ws.any? { |w| w.include?("str_name") && w.include?("Hungarian") }).to be true
+    end
+  end
+
+  describe "clean attribute names" do
+    %w[name status description].each do |name|
+      it "does not warn about '#{name}'" do
+        ws = warnings_for(build_domain(name.to_sym))
+        naming_ws = ws.select { |w| w.include?("vague suffix") || w.include?("redundant prefix") || w.include?("Hungarian") }
+        expect(naming_ws).to be_empty
+      end
+    end
+  end
+
+  describe "does not produce errors" do
+    it "returns no errors for bad attribute names" do
+      domain = build_domain(:order_data)
+      v = Hecks::Validator.new(domain)
+      valid = v.valid?
+      expect(valid).to be true
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/naming/event_naming_spec.rb
+++ b/bluebook/spec/validation_rules/naming/event_naming_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::Naming::EventNaming do
+  def build_domain_with_event(event_name)
+    Hecks.domain("Pizzas") do
+      aggregate("Pizza") do
+        attribute :name, String
+        command("CreatePizza") { attribute :name, String }
+        event(event_name)
+      end
+    end
+  end
+
+  def warnings_for(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  describe "non-past-tense events" do
+    %w[BakePizza ApprovingOrder].each do |name|
+      it "warns about '#{name}'" do
+        ws = warnings_for(build_domain_with_event(name))
+        expect(ws.any? { |w| w.include?(name) && w.include?("past tense") }).to be true
+      end
+    end
+  end
+
+  describe "past-tense events" do
+    %w[CreatedPizza ApprovedOrder SentNotification PaidInvoice].each do |name|
+      it "does not warn about '#{name}'" do
+        ws = warnings_for(build_domain_with_event(name))
+        expect(ws.select { |w| w.include?("past tense") }).to be_empty
+      end
+    end
+  end
+
+  describe "does not produce errors" do
+    it "returns no errors for non-past-tense events" do
+      domain = build_domain_with_event("BakePizza")
+      v = Hecks::Validator.new(domain)
+      valid = v.valid?
+      expect(valid).to be true
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/naming/intention_revealing_names_spec.rb
+++ b/bluebook/spec/validation_rules/naming/intention_revealing_names_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::Naming::IntentionRevealingNames do
+  def build_domain(agg_name)
+    Hecks.domain("Pizzas") do
+      aggregate(agg_name) do
+        attribute :name, String
+        command("Create#{agg_name}") { attribute :name, String }
+      end
+    end
+  end
+
+  def warnings_for(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  describe "generic aggregate names" do
+    %w[OrderManager PaymentHandler DataProcessor].each do |name|
+      it "warns about '#{name}'" do
+        ws = warnings_for(build_domain(name))
+        expect(ws.any? { |w| w.include?(name) && w.include?("generic") }).to be true
+      end
+    end
+  end
+
+  describe "clean aggregate names" do
+    %w[Pizza Order Payment].each do |name|
+      it "does not warn about '#{name}'" do
+        ws = warnings_for(build_domain(name))
+        expect(ws.select { |w| w.include?("generic") }).to be_empty
+      end
+    end
+  end
+
+  describe "does not produce errors" do
+    it "returns no errors for generic names" do
+      domain = build_domain("OrderManager")
+      v = Hecks::Validator.new(domain)
+      valid = v.valid?
+      expect(valid).to be true
+    end
+  end
+end

--- a/docs/usage/naming_analysis.md
+++ b/docs/usage/naming_analysis.md
@@ -1,0 +1,92 @@
+# Naming Analysis
+
+Hecks includes three naming analysis rules that produce non-blocking warnings
+during validation. They help enforce intention-revealing, DDD-idiomatic names
+throughout your domain model.
+
+## Intention-Revealing Names
+
+Warns when aggregate, value object, or entity names contain generic terms that
+hide domain intent.
+
+**Flagged terms:** Data, Info, Manager, Handler, Processor, Helper, Util, Utils,
+Service, Object, Base, Item, Record, Entry, Wrapper, Container
+
+```ruby
+Hecks.domain "Orders" do
+  aggregate "OrderManager" do          # warning: generic term 'Manager'
+    attribute :name, String
+    command("CreateOrderManager") { attribute :name, String }
+  end
+end
+```
+
+Fix: rename to a domain-specific concept like `Order`, `Fulfillment`, or
+`Dispatcher`.
+
+## Event Naming (Past Tense)
+
+Warns when domain event names do not follow past-tense convention. Events
+describe something that already happened.
+
+```ruby
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command("CreatePizza") { attribute :name, String }
+    event "BakePizza"                  # warning: not past tense
+  end
+end
+```
+
+Fix: rename to `BakedPizza`. The rule checks for common English past-tense
+endings (`-ed`, `-en`, `-nt`, `-un`, `-id`).
+
+## Attribute Naming
+
+Warns on three attribute naming patterns:
+
+### Vague suffixes
+
+Suffixes like `_data`, `_info`, `_details` add no meaning:
+
+```ruby
+attribute :order_data, String          # warning: vague suffix '_data'
+```
+
+Fix: rename to `order` or a more specific term like `order_summary`.
+
+### Redundant aggregate prefix
+
+The aggregate name already provides context:
+
+```ruby
+aggregate "Pizza" do
+  attribute :pizza_name, String        # warning: redundant prefix 'pizza_'
+end
+```
+
+Fix: rename to `name`.
+
+### Hungarian-style type prefix
+
+Types are declared explicitly in the DSL:
+
+```ruby
+attribute :str_name, String            # warning: Hungarian prefix 'str_'
+```
+
+Fix: rename to `name`.
+
+## Running the analysis
+
+All three rules run automatically during `hecks validate` and `hecks build`.
+Warnings appear in the CLI output but do not block compilation.
+
+```sh
+hecks validate
+# Warnings:
+#   Aggregate 'OrderManager' uses generic term 'Manager' -- prefer a domain-specific name
+#   Event 'BakePizza' in Pizza does not appear to be past tense
+#   Attribute 'pizza_name' on Pizza has redundant prefix 'pizza_'
+```


### PR DESCRIPTION
## Summary
feat: add intention-revealing naming analysis validation rules (HEC-73)

Three new warning-only validation rules for naming analysis:
- IntentionRevealingNames: flags generic terms (Data, Manager, Handler, etc.)
- EventNaming: flags event names not in past tense
- AttributeNaming: flags _data/_info suffixes, redundant prefixes, type prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)