### PR TITLE
HEC-76: Aggregate classification

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,6 +11,7 @@
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains
 - Domain version pinning and local path loading in configuration
+- Strategic domain classification: `classification :core` / `:supporting` / `:generic` — defaults to `:supporting`, queryable via `core?`, `supporting?`, `generic?` on the domain IR, emitted by serializer
 
 ### Attributes & Types
 - Define typed attributes with String, Integer, Float, Boolean, JSON, Date, DateTime, etc.

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -15,6 +15,10 @@ module Hecks
     # @return [String] valid Ruby DSL source code
     def serialize
       lines = ["Hecks.domain \"#{@domain.name}\" do"]
+      if @domain.respond_to?(:classification) && @domain.classification &&
+         @domain.classification != :supporting
+        lines << "  classification :#{@domain.classification}"
+      end
       @domain.aggregates.each_with_index do |agg, i|
         lines << "" if i > 0
         lines.concat(serialize_aggregate(agg))

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -290,6 +290,7 @@ module Hecks
           domain.uses_kernels = @uses_kernels || []
           domain.anti_corruption_layers = @anti_corruption_layers || []
           domain.published_events = @published_events || []
+          domain.classification = @classification || :supporting
         end
         domain
       end

--- a/bluebook/spec/dsl/classification_spec.rb
+++ b/bluebook/spec/dsl/classification_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+
+RSpec.describe "Domain classification" do
+  describe "DSL" do
+    it "defaults to :supporting when not specified" do
+      domain = Hecks.domain("Notifications") do
+        aggregate("Email") { attribute :to, String; command("SendEmail") { attribute :to, String } }
+      end
+      expect(domain.classification).to eq(:supporting)
+      expect(domain.supporting?).to be true
+      expect(domain.core?).to be false
+      expect(domain.generic?).to be false
+    end
+
+    it "accepts :core classification" do
+      domain = Hecks.domain("Billing") do
+        classification :core
+        aggregate("Invoice") { attribute :amount, Float; command("CreateInvoice") { attribute :amount, Float } }
+      end
+      expect(domain.classification).to eq(:core)
+      expect(domain.core?).to be true
+      expect(domain.supporting?).to be false
+    end
+
+    it "accepts :supporting classification" do
+      domain = Hecks.domain("Reporting") do
+        classification :supporting
+        aggregate("Report") { attribute :title, String; command("CreateReport") { attribute :title, String } }
+      end
+      expect(domain.classification).to eq(:supporting)
+      expect(domain.supporting?).to be true
+    end
+
+    it "accepts :generic classification" do
+      domain = Hecks.domain("Auth") do
+        classification :generic
+        aggregate("User") { attribute :email, String; command("CreateUser") { attribute :email, String } }
+      end
+      expect(domain.classification).to eq(:generic)
+      expect(domain.generic?).to be true
+      expect(domain.core?).to be false
+      expect(domain.supporting?).to be false
+    end
+
+    it "rejects invalid classification values" do
+      expect {
+        Hecks.domain("Bad") do
+          classification :critical
+          aggregate("Thing") { attribute :name, String; command("CreateThing") { attribute :name, String } }
+        end
+      }.to raise_error(ArgumentError, /Invalid classification.*critical/)
+    end
+  end
+
+  describe "serializer" do
+    it "emits classification :core in DSL output" do
+      domain = Hecks.domain("Billing") do
+        classification :core
+        aggregate("Invoice") { attribute :amount, Float; command("CreateInvoice") { attribute :amount, Float } }
+      end
+      output = Hecks::DslSerializer.new(domain).serialize
+      expect(output).to include("classification :core")
+    end
+
+    it "omits classification when :supporting (the default)" do
+      domain = Hecks.domain("Notifications") do
+        aggregate("Email") { attribute :to, String; command("SendEmail") { attribute :to, String } }
+      end
+      output = Hecks::DslSerializer.new(domain).serialize
+      expect(output).not_to include("classification")
+    end
+
+    it "emits classification :generic in DSL output" do
+      domain = Hecks.domain("Auth") do
+        classification :generic
+        aggregate("User") { attribute :email, String; command("CreateUser") { attribute :email, String } }
+      end
+      output = Hecks::DslSerializer.new(domain).serialize
+      expect(output).to include("classification :generic")
+    end
+  end
+end

--- a/docs/usage/domain_classification.md
+++ b/docs/usage/domain_classification.md
@@ -1,0 +1,67 @@
+# Domain Classification
+
+Classify domains as **core**, **supporting**, or **generic** using the
+`classification` DSL keyword. This follows the strategic DDD pattern for
+distinguishing where to invest the most design effort.
+
+## DSL
+
+```ruby
+Hecks.domain "Billing" do
+  classification :core
+
+  aggregate "Invoice" do
+    attribute :amount, Float
+    command("CreateInvoice") { attribute :amount, Float }
+  end
+end
+```
+
+Valid values: `:core`, `:supporting`, `:generic`. Defaults to `:supporting`
+when omitted.
+
+## Querying
+
+```ruby
+domain = Hecks.domain("Billing") { classification :core; ... }
+
+domain.classification  # => :core
+domain.core?           # => true
+domain.supporting?     # => false
+domain.generic?        # => false
+```
+
+## Serializer
+
+The `DslSerializer` emits the classification when it differs from the default:
+
+```ruby
+Hecks::DslSerializer.new(domain).serialize
+# => 'Hecks.domain "Billing" do\n  classification :core\n  ...'
+```
+
+`:supporting` is omitted from serialized output since it is the default.
+
+## Example
+
+```ruby
+require "hecks"
+
+billing = Hecks.domain "Billing" do
+  classification :core
+  aggregate("Invoice") { attribute :amount, Float; command("CreateInvoice") { attribute :amount, Float } }
+end
+
+notifications = Hecks.domain "Notifications" do
+  classification :generic
+  aggregate("Email") { attribute :to, String; command("SendEmail") { attribute :to, String } }
+end
+
+reporting = Hecks.domain "Reporting" do
+  aggregate("Report") { attribute :title, String; command("CreateReport") { attribute :title, String } }
+end
+
+puts "#{billing.name}: #{billing.classification}"        # Billing: core
+puts "#{notifications.name}: #{notifications.classification}" # Notifications: generic
+puts "#{reporting.name}: #{reporting.classification}"     # Reporting: supporting
+```

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -36,6 +36,21 @@ The version is accessible on the domain IR (`domain.version`), the loaded
 module (`BankingDomain.version`), the generated gemspec, and the Go server
 comment header. See [Domain Versioning](domain_version.md) for details.
 
+### Domain classification
+
+Classify a domain as `:core`, `:supporting`, or `:generic` to express its
+strategic importance. Defaults to `:supporting` when omitted.
+
+```ruby
+Hecks.domain "Billing" do
+  classification :core
+  # ...
+end
+```
+
+Query with `domain.classification`, `domain.core?`, `domain.supporting?`,
+`domain.generic?`. See [Domain Classification](domain_classification.md).
+
 ### Domain-level methods
 
 At the domain level you can declare aggregates, cross-aggregate policies, services, read models, workflows, actors, tenancy, and glossary rules:

--- a/hecksagon/lib/hecksagon.rb
+++ b/hecksagon/lib/hecksagon.rb
@@ -34,4 +34,17 @@ module Hecksagon
   autoload :AclBuilder,       "hecksagon/acl_builder"
   autoload :AdapterRegistry,  "hecksagon/adapter_registry"
   autoload :ContractValidator, "hecksagon/contract_validator"
+
+  # Post-load injection: include StrategicDSL into DomainBuilder after both
+  # bluebook and hecksagon are loaded (bluebook defines DomainBuilder first,
+  # hecksagon loads second, so the `if defined?` guard in the class body fires
+  # too early).
+  def self.inject_strategic_dsl!
+    return unless defined?(Hecks::DSL::DomainBuilder)
+    return if Hecks::DSL::DomainBuilder.include?(StrategicDSL)
+
+    Hecks::DSL::DomainBuilder.include(StrategicDSL)
+  end
 end
+
+Hecksagon.inject_strategic_dsl!

--- a/hecksagon/lib/hecksagon/domain_mixin.rb
+++ b/hecksagon/lib/hecksagon/domain_mixin.rb
@@ -2,16 +2,37 @@ module Hecksagon
 
   # Hecksagon::DomainMixin
   #
-  # Extends Domain IR objects with hexagonal accessors.
-  # Applied automatically when heksagons is loaded.
+  # Extends Domain IR objects with hexagonal accessors: ports, shared kernels,
+  # anti-corruption layers, published events, and domain classification.
+  #
+  #   domain.classification  # => :core
+  #   domain.core?           # => true
+  #   domain.supporting?     # => false
+  #   domain.generic?        # => false
   #
   module DomainMixin
     attr_accessor :driving_ports, :driven_ports,
                   :shared_kernel, :uses_kernels,
-                  :anti_corruption_layers, :published_events
+                  :anti_corruption_layers, :published_events,
+                  :classification
 
     def shared_kernel?
       @shared_kernel == true
+    end
+
+    # @return [Boolean] true if this domain is classified as core
+    def core?
+      @classification == :core
+    end
+
+    # @return [Boolean] true if this domain is classified as supporting
+    def supporting?
+      @classification == :supporting
+    end
+
+    # @return [Boolean] true if this domain is classified as generic
+    def generic?
+      @classification == :generic
     end
   end
 end

--- a/hecksagon/lib/hecksagon/strategic_dsl.rb
+++ b/hecksagon/lib/hecksagon/strategic_dsl.rb
@@ -3,9 +3,16 @@ module Hecksagon
   # Hecksagon::StrategicDSL
   #
   # Mixin for domain builders. Adds strategic hexagonal patterns:
-  # shared kernels, anti-corruption layers, published events.
+  # shared kernels, anti-corruption layers, published events,
+  # and domain classification (core, supporting, generic).
+  #
+  #   Hecks.domain "Billing" do
+  #     classification :core
+  #   end
   #
   module StrategicDSL
+    VALID_CLASSIFICATIONS = %i[core supporting generic].freeze
+
     def self.included(base)
       base.class_eval do
         def init_strategic
@@ -13,8 +20,26 @@ module Hecksagon
           @uses_kernels ||= []
           @anti_corruption_layers ||= []
           @published_events ||= []
+          @classification ||= :supporting
         end
       end
+    end
+
+    # Declare the strategic classification for this domain.
+    # Valid values: :core, :supporting, :generic. Defaults to :supporting.
+    #
+    #   classification :core
+    #
+    # @param value [Symbol] one of :core, :supporting, :generic
+    # @raise [ArgumentError] if the value is not a valid classification
+    def classification(value)
+      value = value.to_sym
+      unless VALID_CLASSIFICATIONS.include?(value)
+        raise ArgumentError,
+              "Invalid classification #{value.inspect}. Must be one of: #{VALID_CLASSIFICATIONS.join(", ")}"
+      end
+      init_strategic
+      @classification = value
     end
 
     def shared_kernel


### PR DESCRIPTION
## Summary
feat: add domain classification DSL (core/supporting/generic)

HEC-76: Add strategic domain classification to the DSL. Domains can
declare `classification :core`, `:supporting`, or `:generic` (defaults
to `:supporting`). Queryable via `domain.core?`, `domain.supporting?`,
`domain.generic?`. Serializer emits non-default classifications. Also
fixes StrategicDSL injection into DomainBuilder via post-load hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)