### PR TITLE
HEC-77: Shared kernel types

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -10,6 +10,7 @@
 - Define value objects as immutable nested types within aggregates
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains
+- Shared Kernel — `shared_kernel` + `expose_types` in provider domain, `uses_kernel "Name"` in consumer domain; value objects/entities become aliased in the consumer namespace via `SharedKernelRegistry`; auto-exposes all VOs and entities when no explicit types given
 - Domain version pinning and local path loading in configuration
 
 ### Attributes & Types

--- a/bluebook/lib/hecks/domain/in_memory_loader.rb
+++ b/bluebook/lib/hecks/domain/in_memory_loader.rb
@@ -15,6 +15,8 @@ module Hecks
       gem = domain.gem_name
       load_src(module_shell(mod, domain.version), "#{gem}.rb")
 
+      install_kernel_aliases(domain, mod)
+
       domain.aggregates.each do |agg|
         safe = domain_constant_name(agg.name)
         snake = domain_snake_name(safe)
@@ -77,6 +79,38 @@ module Hecks
     end
 
     def self.gen(klass, obj, **opts) = klass.new(obj, **opts).generate
+
+    # Creates class aliases in the consumer domain for types from shared kernels.
+    # When a domain declares `uses_kernel "Pricing"`, any types exposed by Pricing
+    # (e.g., Money) become available as `ConsumerDomain::Money`.
+    def self.install_kernel_aliases(domain, mod)
+      return unless defined?(Hecksagon::SharedKernelRegistry)
+      kernels = domain.respond_to?(:uses_kernels) ? (domain.uses_kernels || []) : []
+      kernels.each do |kernel_name|
+        types = Hecksagon::SharedKernelRegistry.types_for(kernel_name)
+        kernel_mod = domain_module_name(kernel_name)
+        types.each do |type_name|
+          src = resolve_kernel_type(kernel_mod, type_name)
+          next unless src
+          load_src("module #{mod}; #{type_name} = #{src}; end", "#{domain.gem_name}/kernel_alias_#{type_name.downcase}.rb")
+        end
+      end
+    end
+
+    # Searches aggregate namespaces in the kernel domain for the named type.
+    def self.resolve_kernel_type(kernel_mod, type_name)
+      return nil unless Object.const_defined?(kernel_mod)
+      km = Object.const_get(kernel_mod)
+      # Check directly on the kernel module first
+      return "#{kernel_mod}::#{type_name}" if km.const_defined?(type_name, false)
+      # Check nested under each aggregate
+      km.constants.each do |c|
+        sub = km.const_get(c)
+        next unless sub.is_a?(Class) || sub.is_a?(Module)
+        return "#{kernel_mod}::#{c}::#{type_name}" if sub.const_defined?(type_name, false)
+      end
+      nil
+    end
 
     def self.load_src(source, virtual_path)
       RubyVM::InstructionSequence.compile(source, virtual_path).eval

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -287,9 +287,17 @@ module Hecks
           domain.driving_ports = @driving_ports || []
           domain.driven_ports = @driven_ports || []
           domain.shared_kernel = @shared_kernel || false
+          domain.shared_kernel_types = @shared_kernel_types || []
           domain.uses_kernels = @uses_kernels || []
           domain.anti_corruption_layers = @anti_corruption_layers || []
           domain.published_events = @published_events || []
+          if domain.shared_kernel? && defined?(Hecksagon::SharedKernelRegistry)
+            types = domain.shared_kernel_types
+            if types.empty?
+              types = domain.aggregates.flat_map { |a| a.value_objects.map(&:name) + a.entities.map(&:name) }
+            end
+            Hecksagon::SharedKernelRegistry.register(domain.name, types)
+          end
         end
         domain
       end

--- a/docs/usage/shared_kernel.md
+++ b/docs/usage/shared_kernel.md
@@ -1,0 +1,97 @@
+# Shared Kernel — Common Types Across Bounded Contexts
+
+Share value objects and entities between bounded contexts without duplicating definitions.
+
+## Provider domain: declare shared kernel
+
+```ruby
+pricing = Hecks.domain "Pricing" do
+  shared_kernel
+  expose_types "Money", "Currency"
+
+  aggregate "Rate" do
+    attribute :amount, Integer
+
+    value_object "Money" do
+      attribute :cents, Integer
+      attribute :currency, String
+    end
+
+    value_object "Currency" do
+      attribute :code, String
+      attribute :symbol, String
+    end
+
+    command "CreateRate" do
+      attribute :amount, Integer
+    end
+  end
+end
+```
+
+## Consumer domain: use the kernel
+
+```ruby
+orders = Hecks.domain "Orders" do
+  uses_kernel "Pricing"
+
+  aggregate "Order" do
+    attribute :customer_name, String
+    attribute :total_cents, Integer
+
+    command "PlaceOrder" do
+      attribute :customer_name, String
+      attribute :total_cents, Integer
+    end
+  end
+end
+```
+
+## Boot both and use shared types
+
+```ruby
+Hecks.load(pricing)
+Hecks.load(orders)
+
+# The shared type is aliased into the consumer namespace
+money = OrdersDomain::Money.new(cents: 999, currency: "USD")
+money.cents     # => 999
+money.currency  # => "USD"
+
+# It's the same class as the provider's
+OrdersDomain::Money == PricingDomain::Rate::Money  # => true
+```
+
+## Auto-expose (no explicit types)
+
+When `expose_types` is omitted, all value objects and entities from the
+kernel domain are automatically exposed:
+
+```ruby
+common = Hecks.domain "Common" do
+  shared_kernel  # no expose_types -- exposes everything
+
+  aggregate "Shared" do
+    value_object "Address" do
+      attribute :street, String
+      attribute :city, String
+    end
+
+    value_object "PhoneNumber" do
+      attribute :digits, String
+    end
+
+    command "CreateShared" do
+      attribute :label, String
+    end
+  end
+end
+```
+
+## Registry API
+
+```ruby
+Hecksagon::SharedKernelRegistry.kernel?("Pricing")     # => true
+Hecksagon::SharedKernelRegistry.types_for("Pricing")    # => ["Money", "Currency"]
+Hecksagon::SharedKernelRegistry.all                     # => ["Pricing"]
+```

--- a/hecksagon/lib/hecksagon.rb
+++ b/hecksagon/lib/hecksagon.rb
@@ -34,4 +34,16 @@ module Hecksagon
   autoload :AclBuilder,       "hecksagon/acl_builder"
   autoload :AdapterRegistry,  "hecksagon/adapter_registry"
   autoload :ContractValidator, "hecksagon/contract_validator"
+  autoload :SharedKernelRegistry, "hecksagon/shared_kernel_registry"
+
+  # Patch DomainBuilder with strategic/extension DSL methods when both
+  # hecksagon and bluebook are loaded (order-independent).
+  def self.patch_domain_builder!
+    return unless defined?(Hecks::DSL::DomainBuilder)
+    builder = Hecks::DSL::DomainBuilder
+    builder.include(StrategicDSL) unless builder.include?(StrategicDSL)
+    builder.include(ExtensionsDSL) unless builder.include?(ExtensionsDSL)
+  end
+
+  patch_domain_builder!
 end

--- a/hecksagon/lib/hecksagon/domain_mixin.rb
+++ b/hecksagon/lib/hecksagon/domain_mixin.rb
@@ -7,7 +7,7 @@ module Hecksagon
   #
   module DomainMixin
     attr_accessor :driving_ports, :driven_ports,
-                  :shared_kernel, :uses_kernels,
+                  :shared_kernel, :shared_kernel_types, :uses_kernels,
                   :anti_corruption_layers, :published_events
 
     def shared_kernel?

--- a/hecksagon/lib/hecksagon/shared_kernel_registry.rb
+++ b/hecksagon/lib/hecksagon/shared_kernel_registry.rb
@@ -1,0 +1,58 @@
+# Hecksagon::SharedKernelRegistry
+#
+# Global registry mapping domain names to types they expose as a shared
+# kernel. When a domain declares `shared_kernel` in its Bluebook, its
+# value objects and entities become available to consumer domains that
+# declare `uses_kernel "DomainName"`.
+#
+# Consumer domains get class aliases in their namespace so they can
+# reference shared types without fully qualifying the source domain.
+#
+#   SharedKernelRegistry.register("Pricing", ["Money", "Currency"])
+#   SharedKernelRegistry.types_for("Pricing")  # => ["Money", "Currency"]
+#   SharedKernelRegistry.kernel?("Pricing")     # => true
+#
+module Hecksagon
+  module SharedKernelRegistry
+    @kernels = {}
+
+    # Register a domain as a shared kernel with the types it exposes.
+    #
+    # @param domain_name [String] the domain name (e.g., "Pricing")
+    # @param types [Array<String>] type names exposed (e.g., ["Money", "Currency"])
+    # @return [void]
+    def self.register(domain_name, types)
+      @kernels[domain_name.to_s] = types.map(&:to_s)
+    end
+
+    # Returns the type names exposed by a shared kernel domain.
+    #
+    # @param domain_name [String] the domain name
+    # @return [Array<String>] exposed type names, empty if not registered
+    def self.types_for(domain_name)
+      @kernels.fetch(domain_name.to_s, [])
+    end
+
+    # Whether a domain is registered as a shared kernel.
+    #
+    # @param domain_name [String] the domain name
+    # @return [Boolean]
+    def self.kernel?(domain_name)
+      @kernels.key?(domain_name.to_s)
+    end
+
+    # All registered shared kernel domain names.
+    #
+    # @return [Array<String>]
+    def self.all
+      @kernels.keys
+    end
+
+    # Clear all registrations. Used in tests for isolation.
+    #
+    # @return [void]
+    def self.clear!
+      @kernels.clear
+    end
+  end
+end

--- a/hecksagon/lib/hecksagon/strategic_dsl.rb
+++ b/hecksagon/lib/hecksagon/strategic_dsl.rb
@@ -10,6 +10,7 @@ module Hecksagon
       base.class_eval do
         def init_strategic
           @shared_kernel ||= false
+          @shared_kernel_types ||= []
           @uses_kernels ||= []
           @anti_corruption_layers ||= []
           @published_events ||= []
@@ -20,6 +21,17 @@ module Hecksagon
     def shared_kernel
       init_strategic
       @shared_kernel = true
+    end
+
+    # Declare which types this shared kernel exposes to consumers.
+    # Only meaningful when `shared_kernel` is also declared.
+    #
+    #   shared_kernel
+    #   expose_types "Money", "Currency"
+    #
+    def expose_types(*types)
+      init_strategic
+      @shared_kernel_types.concat(types.map(&:to_s))
     end
 
     def uses_kernel(name)

--- a/hecksagon/spec/hecksagon/shared_kernel_registry_spec.rb
+++ b/hecksagon/spec/hecksagon/shared_kernel_registry_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe Hecksagon::SharedKernelRegistry do
+  before { described_class.clear! }
+  after  { described_class.clear! }
+
+  describe ".register and .types_for" do
+    it "stores and retrieves types for a domain" do
+      described_class.register("Pricing", ["Money", "Currency"])
+      expect(described_class.types_for("Pricing")).to eq(["Money", "Currency"])
+    end
+
+    it "returns empty array for unregistered domain" do
+      expect(described_class.types_for("Unknown")).to eq([])
+    end
+  end
+
+  describe ".kernel?" do
+    it "returns true for registered domains" do
+      described_class.register("Pricing", ["Money"])
+      expect(described_class.kernel?("Pricing")).to be true
+    end
+
+    it "returns false for unregistered domains" do
+      expect(described_class.kernel?("Pricing")).to be false
+    end
+  end
+
+  describe ".all" do
+    it "returns all registered domain names" do
+      described_class.register("Pricing", ["Money"])
+      described_class.register("Common", ["Address"])
+      expect(described_class.all).to contain_exactly("Pricing", "Common")
+    end
+  end
+
+  describe ".clear!" do
+    it "removes all registrations" do
+      described_class.register("Pricing", ["Money"])
+      described_class.clear!
+      expect(described_class.all).to be_empty
+    end
+  end
+end

--- a/hecksties/spec/shared_kernel_spec.rb
+++ b/hecksties/spec/shared_kernel_spec.rb
@@ -95,10 +95,8 @@ RSpec.describe "Shared Kernel" do
   end
 
   describe "auto-expose when no explicit types given" do
-    before(:all) do
-      Hecksagon::SharedKernelRegistry.clear!
-
-      @common = Hecks.domain "Common" do
+    it "exposes all value objects and entities when no explicit types" do
+      common = Hecks.domain "Common" do
         shared_kernel
 
         aggregate "Shared" do
@@ -119,10 +117,7 @@ RSpec.describe "Shared Kernel" do
         end
       end
 
-      Hecks.load(@common, force: true)
-    end
-
-    it "exposes all value objects and entities when no explicit types" do
+      Hecks.load(common, force: true)
       types = Hecksagon::SharedKernelRegistry.types_for("Common")
       expect(types).to include("Address", "PhoneNumber")
     end

--- a/hecksties/spec/shared_kernel_spec.rb
+++ b/hecksties/spec/shared_kernel_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+
+RSpec.describe "Shared Kernel" do
+  before(:all) do
+    Hecksagon::SharedKernelRegistry.clear!
+
+    @pricing = Hecks.domain "Pricing" do
+      shared_kernel
+      expose_types "Money"
+
+      aggregate "Rate" do
+        attribute :amount, Integer
+        attribute :currency, String
+
+        value_object "Money" do
+          attribute :cents, Integer
+          attribute :currency, String
+        end
+
+        command "CreateRate" do
+          attribute :amount, Integer
+          attribute :currency, String
+        end
+      end
+    end
+
+    @orders = Hecks.domain "Orders" do
+      uses_kernel "Pricing"
+
+      aggregate "Order" do
+        attribute :customer_name, String
+        attribute :total_cents, Integer
+
+        command "PlaceOrder" do
+          attribute :customer_name, String
+          attribute :total_cents, Integer
+        end
+      end
+    end
+
+    @pricing_rt = Hecks.load(@pricing, force: true)
+    @orders_rt = Hecks.load(@orders, force: true)
+  end
+
+  after(:all) do
+    Hecksagon::SharedKernelRegistry.clear!
+  end
+
+  describe "SharedKernelRegistry" do
+    it "registers a domain as shared kernel on build" do
+      expect(Hecksagon::SharedKernelRegistry.kernel?("Pricing")).to be true
+    end
+
+    it "stores exposed type names" do
+      expect(Hecksagon::SharedKernelRegistry.types_for("Pricing")).to eq(["Money"])
+    end
+
+    it "returns empty for non-kernel domains" do
+      expect(Hecksagon::SharedKernelRegistry.types_for("Orders")).to eq([])
+    end
+
+    it "does not register consumer domains as kernels" do
+      expect(Hecksagon::SharedKernelRegistry.kernel?("Orders")).to be false
+    end
+  end
+
+  describe "Domain IR" do
+    it "marks kernel domain as shared_kernel" do
+      expect(@pricing.shared_kernel?).to be true
+    end
+
+    it "records exposed types on the domain" do
+      expect(@pricing.shared_kernel_types).to eq(["Money"])
+    end
+
+    it "records uses_kernels on the consumer domain" do
+      expect(@orders.uses_kernels).to eq(["Pricing"])
+    end
+  end
+
+  describe "InMemoryLoader kernel aliases" do
+    it "creates alias for Money in the consumer domain module" do
+      expect(OrdersDomain.const_defined?(:Money)).to be true
+    end
+
+    it "aliases to the source domain type" do
+      expect(OrdersDomain::Money).to eq(PricingDomain::Rate::Money)
+    end
+
+    it "allows constructing the shared type via the alias" do
+      money = OrdersDomain::Money.new(cents: 999, currency: "USD")
+      expect(money.cents).to eq(999)
+      expect(money.currency).to eq("USD")
+    end
+  end
+
+  describe "auto-expose when no explicit types given" do
+    before(:all) do
+      Hecksagon::SharedKernelRegistry.clear!
+
+      @common = Hecks.domain "Common" do
+        shared_kernel
+
+        aggregate "Shared" do
+          attribute :label, String
+
+          value_object "Address" do
+            attribute :street, String
+            attribute :city, String
+          end
+
+          value_object "PhoneNumber" do
+            attribute :digits, String
+          end
+
+          command "CreateShared" do
+            attribute :label, String
+          end
+        end
+      end
+
+      Hecks.load(@common, force: true)
+    end
+
+    it "exposes all value objects and entities when no explicit types" do
+      types = Hecksagon::SharedKernelRegistry.types_for("Common")
+      expect(types).to include("Address", "PhoneNumber")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
test: add unit spec for SharedKernelRegistry, fix test isolation

Adds focused unit spec at hecksagon/spec/hecksagon/shared_kernel_registry_spec.rb.
Fixes auto-expose test to avoid clearing registry in a nested before(:all)
which caused order-dependent failures in randomized runs.

feat: shared kernel — common types across bounded contexts

Provider domains declare `shared_kernel` + `expose_types` to register
value objects/entities in SharedKernelRegistry. Consumer domains declare
`uses_kernel "Name"` to get class aliases installed by InMemoryLoader.
Auto-exposes all VOs/entities when no explicit types given. Also fixes
StrategicDSL inclusion in DomainBuilder via Hecksagon.patch_domain_builder!
to handle load-order independence between bluebook and hecksagon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)