### PR TITLE
HEC-78: Domain modules

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,6 +11,7 @@
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains
 - Domain version pinning and local path loading in configuration
+- Domain modules: `domain_module "Name" do ... end` groups related aggregates under a namespace for visualization and serialization. `domain.module_for("Aggregate")` looks up which module owns an aggregate. Mermaid diagrams render modules as subgraphs/namespaces. DSL serializer round-trips module groupings.
 
 ### Attributes & Types
 - Define typed attributes with String, Integer, Float, Boolean, JSON, Date, DateTime, etc.

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -15,10 +15,19 @@ module Hecks
     # @return [String] valid Ruby DSL source code
     def serialize
       lines = ["Hecks.domain \"#{@domain.name}\" do"]
-      @domain.aggregates.each_with_index do |agg, i|
-        lines << "" if i > 0
+      module_agg_names = @domain.modules.flat_map(&:aggregate_names)
+
+      @domain.modules.each_with_index do |mod, mi|
+        lines << "" if mi > 0
+        lines.concat(serialize_domain_module(mod))
+      end
+
+      ungrouped = @domain.aggregates.reject { |a| module_agg_names.include?(a.name) }
+      ungrouped.each_with_index do |agg, i|
+        lines << "" if i > 0 || @domain.modules.any?
         lines.concat(serialize_aggregate(agg))
       end
+
       @domain.policies.each { |pol| lines.concat(serialize_domain_policy(pol)) }
       lines << "end"
       lines.join("\n") + "\n"
@@ -26,22 +35,34 @@ module Hecks
 
     private
 
-    def serialize_aggregate(agg)
-      lines = ["  aggregate \"#{agg.name}\" do"]
-      lines.concat(serialize_attributes(agg.attributes, "    "))
-      lines.concat(serialize_references(agg.references, "    "))
-      lines.concat(serialize_value_objects(agg.value_objects))
-      lines.concat(serialize_entities(agg.entities))
-      lines.concat(serialize_validations(agg.validations))
-      lines.concat(serialize_invariants(agg.invariants, "    "))
-      lines.concat(serialize_scopes(agg.scopes))
-      lines.concat(serialize_computed_attributes(agg.computed_attributes))
-      lines.concat(serialize_queries(agg.queries))
-      lines.concat(serialize_specifications(agg.specifications))
-      lines.concat(serialize_commands(agg.commands))
-      lines.concat(serialize_policies(agg.policies))
-      lines.concat(serialize_subscribers(agg.subscribers))
+    def serialize_domain_module(mod)
+      aggs = @domain.aggregates.select { |a| mod.aggregate_names.include?(a.name) }
+      lines = ["  domain_module \"#{mod.name}\" do"]
+      aggs.each_with_index do |agg, i|
+        lines << "" if i > 0
+        lines.concat(serialize_aggregate(agg, indent: "    "))
+      end
       lines << "  end"
+      lines
+    end
+
+    def serialize_aggregate(agg, indent: "  ")
+      inner = indent + "  "
+      lines = ["#{indent}aggregate \"#{agg.name}\" do"]
+      lines.concat(serialize_attributes(agg.attributes, inner))
+      lines.concat(serialize_references(agg.references, inner))
+      lines.concat(serialize_value_objects(agg.value_objects, inner))
+      lines.concat(serialize_entities(agg.entities, inner))
+      lines.concat(serialize_validations(agg.validations, inner))
+      lines.concat(serialize_invariants(agg.invariants, inner))
+      lines.concat(serialize_scopes(agg.scopes, inner))
+      lines.concat(serialize_computed_attributes(agg.computed_attributes, inner))
+      lines.concat(serialize_queries(agg.queries, inner))
+      lines.concat(serialize_specifications(agg.specifications, inner))
+      lines.concat(serialize_commands(agg.commands, inner))
+      lines.concat(serialize_policies(agg.policies, inner))
+      lines.concat(serialize_subscribers(agg.subscribers, inner))
+      lines << "#{indent}end"
       lines
     end
 
@@ -49,26 +70,28 @@ module Hecks
       attrs.map { |a| "#{indent}attribute :#{a.name}, #{dsl_type(a)}" }
     end
 
-    def serialize_value_objects(vos)
+    def serialize_value_objects(vos, indent)
       vos.flat_map do |vo|
-        lines = ["", "    value_object \"#{vo.name}\" do"]
-        lines.concat(serialize_attributes(vo.attributes, "      "))
-        lines.concat(serialize_invariants(vo.invariants, "      "))
-        lines << "    end"
+        inner = indent + "  "
+        lines = ["", "#{indent}value_object \"#{vo.name}\" do"]
+        lines.concat(serialize_attributes(vo.attributes, inner))
+        lines.concat(serialize_invariants(vo.invariants, inner))
+        lines << "#{indent}end"
       end
     end
 
-    def serialize_entities(entities)
+    def serialize_entities(entities, indent)
       entities.flat_map do |ent|
-        lines = ["", "    entity \"#{ent.name}\" do"]
-        lines.concat(serialize_attributes(ent.attributes, "      "))
-        lines.concat(serialize_invariants(ent.invariants, "      "))
-        lines << "    end"
+        inner = indent + "  "
+        lines = ["", "#{indent}entity \"#{ent.name}\" do"]
+        lines.concat(serialize_attributes(ent.attributes, inner))
+        lines.concat(serialize_invariants(ent.invariants, inner))
+        lines << "#{indent}end"
       end
     end
 
-    def serialize_validations(validations)
-      validations.map { |v| ["", "    validation :#{v.field}, #{v.rules.inspect}"] }.flatten
+    def serialize_validations(validations, indent)
+      validations.map { |v| ["", "#{indent}validation :#{v.field}, #{v.rules.inspect}"] }.flatten
     end
 
     def serialize_invariants(invariants, indent)
@@ -79,36 +102,39 @@ module Hecks
       end
     end
 
-    def serialize_scopes(scopes)
+    def serialize_scopes(scopes, indent)
       scopes.reject(&:callable?).flat_map do |s|
         formatted = s.conditions.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")
-        ["", "    scope :#{s.name}, #{formatted}"]
+        ["", "#{indent}scope :#{s.name}, #{formatted}"]
       end
     end
 
-    def serialize_queries(queries)
+    def serialize_queries(queries, indent)
+      inner = indent + "  "
       queries.flat_map do |q|
-        ["", "    query \"#{q.name}\" do",
-         "      #{Hecks::Utils.block_source(q.block)}",
-         "    end"]
+        ["", "#{indent}query \"#{q.name}\" do",
+         "#{inner}#{Hecks::Utils.block_source(q.block)}",
+         "#{indent}end"]
       end
     end
 
-    def serialize_computed_attributes(computed_attrs)
+    def serialize_computed_attributes(computed_attrs, indent)
+      inner = indent + "  "
       (computed_attrs || []).flat_map do |ca|
-        ["", "    computed :#{ca.name} do",
-         "      #{Hecks::Utils.block_source(ca.block)}",
-         "    end"]
+        ["", "#{indent}computed :#{ca.name} do",
+         "#{inner}#{Hecks::Utils.block_source(ca.block)}",
+         "#{indent}end"]
       end
     end
 
-    def serialize_specifications(specs)
+    def serialize_specifications(specs, indent)
+      inner = indent + "  "
       specs.flat_map do |spec|
         params = spec.block&.parameters&.map { |_, n| n.to_s } || []
         param_str = params.empty? ? "|object|" : "|#{params.join(", ")}|"
-        ["", "    specification \"#{spec.name}\" do #{param_str}",
-         "      #{Hecks::Utils.block_source(spec.block)}",
-         "    end"]
+        ["", "#{indent}specification \"#{spec.name}\" do #{param_str}",
+         "#{inner}#{Hecks::Utils.block_source(spec.block)}",
+         "#{indent}end"]
       end
     end
 
@@ -121,39 +147,42 @@ module Hecks
       end
     end
 
-    def serialize_commands(commands)
+    def serialize_commands(commands, indent)
+      inner = indent + "  "
       commands.flat_map do |cmd|
-        lines = ["", "    command \"#{cmd.name}\" do"]
+        lines = ["", "#{indent}command \"#{cmd.name}\" do"]
         if cmd.emits
           emits_names = Array(cmd.emits)
-          lines << "      emits #{emits_names.map { |n| "\"#{n}\"" }.join(", ")}"
+          lines << "#{inner}emits #{emits_names.map { |n| "\"#{n}\"" }.join(", ")}"
         end
-        lines.concat(serialize_attributes(cmd.attributes, "      "))
-        lines.concat(serialize_references(cmd.references, "      "))
-        cmd.read_models.each { |rm| lines << "      read_model \"#{rm.name}\"" }
-        cmd.external_systems.each { |ext| lines << "      external \"#{ext.name}\"" }
-        cmd.actors.each { |act| lines << "      actor \"#{act.name}\"" }
-        lines << "    end"
+        lines.concat(serialize_attributes(cmd.attributes, inner))
+        lines.concat(serialize_references(cmd.references, inner))
+        cmd.read_models.each { |rm| lines << "#{inner}read_model \"#{rm.name}\"" }
+        cmd.external_systems.each { |ext| lines << "#{inner}external \"#{ext.name}\"" }
+        cmd.actors.each { |act| lines << "#{inner}actor \"#{act.name}\"" }
+        lines << "#{indent}end"
       end
     end
 
-    def serialize_policies(policies)
+    def serialize_policies(policies, indent)
+      inner = indent + "  "
       policies.flat_map do |pol|
-        lines = ["", "    policy \"#{pol.name}\" do"]
-        lines << "      on \"#{pol.event_name}\""
-        lines << "      trigger \"#{pol.trigger_command}\""
-        lines << "      async true" if pol.async
-        lines << "      condition { |event| #{Hecks::Utils.block_source(pol.condition)} }" if pol.condition
-        lines << "    end"
+        lines = ["", "#{indent}policy \"#{pol.name}\" do"]
+        lines << "#{inner}on \"#{pol.event_name}\""
+        lines << "#{inner}trigger \"#{pol.trigger_command}\""
+        lines << "#{inner}async true" if pol.async
+        lines << "#{inner}condition { |event| #{Hecks::Utils.block_source(pol.condition)} }" if pol.condition
+        lines << "#{indent}end"
       end
     end
 
-    def serialize_subscribers(subscribers)
+    def serialize_subscribers(subscribers, indent)
+      inner = indent + "  "
       subscribers.flat_map do |sub|
         async_opt = sub.async ? ", async: true" : ""
-        lines = ["", "    on_event \"#{sub.event_name}\"#{async_opt} do |event|"]
-        lines << "      #{Hecks::Utils.block_source(sub.block)}" if sub.block
-        lines << "    end"
+        lines = ["", "#{indent}on_event \"#{sub.event_name}\"#{async_opt} do |event|"]
+        lines << "#{inner}#{Hecks::Utils.block_source(sub.block)}" if sub.block
+        lines << "#{indent}end"
       end
     end
 

--- a/bluebook/lib/hecks/domain/visualizer_parts/behavior_diagram.rb
+++ b/bluebook/lib/hecks/domain/visualizer_parts/behavior_diagram.rb
@@ -22,30 +22,46 @@ module Hecks
       def generate_behavior
         lines = ["flowchart LR"]
 
-        @domain.aggregates.each do |agg|
-          prefix = agg.name
-          lines << "    subgraph #{prefix}"
+        module_names = @domain.modules.flat_map(&:aggregate_names)
+        ungrouped = @domain.aggregates.reject { |a| module_names.include?(a.name) }
 
-          agg.commands.each_with_index do |cmd, i|
-            event = agg.events[i]
-            cmd_id = node_id(prefix, cmd.name)
-            lines << "        #{cmd_id}[#{cmd.name}]"
-
-            if event
-              evt_id = node_id(prefix, event.name)
-              lines << "        #{evt_id}([#{event.name}])"
-              lines << "        #{cmd_id} --> #{evt_id}"
-            end
-          end
-
+        @domain.modules.each do |mod|
+          aggs = @domain.aggregates.select { |a| mod.aggregate_names.include?(a.name) }
+          next if aggs.empty?
+          lines << "    subgraph #{mod.name}"
+          aggs.each { |agg| render_aggregate_subgraph(lines, agg, "        ") }
           lines << "    end"
         end
+
+        ungrouped.each { |agg| render_aggregate_subgraph(lines, agg, "    ") }
 
         policy_links(lines)
         lines.join("\n")
       end
 
       private
+
+      # Render an aggregate's commands and events as a Mermaid subgraph.
+      #
+      # @param lines [Array<String>] the diagram lines array
+      # @param agg [Aggregate] the aggregate to render
+      # @param indent [String] leading whitespace for the subgraph keyword
+      # @return [void]
+      def render_aggregate_subgraph(lines, agg, indent)
+        prefix = agg.name
+        lines << "#{indent}subgraph #{prefix}"
+        agg.commands.each_with_index do |cmd, i|
+          event = agg.events[i]
+          cmd_id = node_id(prefix, cmd.name)
+          lines << "#{indent}    #{cmd_id}[#{cmd.name}]"
+          if event
+            evt_id = node_id(prefix, event.name)
+            lines << "#{indent}    #{evt_id}([#{event.name}])"
+            lines << "#{indent}    #{cmd_id} --> #{evt_id}"
+          end
+        end
+        lines << "#{indent}end"
+      end
 
       # Add dotted-line policy links to the diagram. Each policy connects
       # an event node to a command node with a labeled edge showing the

--- a/bluebook/lib/hecks/domain/visualizer_parts/structure_diagram.rb
+++ b/bluebook/lib/hecks/domain/visualizer_parts/structure_diagram.rb
@@ -23,32 +23,9 @@ module Hecks
       def generate_structure
         lines = ["classDiagram"]
 
-        @domain.aggregates.each do |agg|
-          lines << "    class #{agg.name} {"
-          agg.attributes.each do |attr|
-            lines << "        #{attribute_label(attr)}"
-          end
-          lines << "    }"
-
-          agg.value_objects.each do |vo|
-            lines << "    class #{vo.name} {"
-            vo.attributes.each do |attr|
-              lines << "        #{attribute_label(attr)}"
-            end
-            lines << "    }"
-            lines << "    #{agg.name} *-- #{vo.name}"
-          end
-
-          agg.entities.each do |ent|
-            lines << "    class #{ent.name} {"
-            lines << "        +id : UUID"
-            ent.attributes.each do |attr|
-              lines << "        #{attribute_label(attr)}"
-            end
-            lines << "    }"
-            lines << "    #{agg.name} *-- #{ent.name}"
-          end
-        end
+        grouped, ungrouped = partition_by_module
+        grouped.each { |mod, aggs| render_module_subgraph(lines, mod, aggs) }
+        ungrouped.each { |agg| render_aggregate_class(lines, agg, "    ") }
 
         references(lines)
         lines.join("\n")
@@ -56,10 +33,59 @@ module Hecks
 
       private
 
+      # Partition aggregates into module-grouped and ungrouped sets.
+      #
+      # @return [Array(Array, Array)] [grouped_pairs, ungrouped_aggs]
+      def partition_by_module
+        module_names = @domain.modules.flat_map(&:aggregate_names)
+        ungrouped = @domain.aggregates.reject { |a| module_names.include?(a.name) }
+        grouped = @domain.modules.map do |mod|
+          aggs = @domain.aggregates.select { |a| mod.aggregate_names.include?(a.name) }
+          [mod, aggs]
+        end
+        [grouped, ungrouped]
+      end
+
+      # Render a namespace subgraph wrapping module aggregates.
+      #
+      # @param lines [Array<String>] the diagram lines array
+      # @param mod [DomainModule] the module IR node
+      # @param aggs [Array<Aggregate>] aggregates in this module
+      # @return [void]
+      def render_module_subgraph(lines, mod, aggs)
+        lines << "    namespace #{mod.name} {"
+        aggs.each { |agg| render_aggregate_class(lines, agg, "        ") }
+        lines << "    }"
+      end
+
+      # Render a single aggregate and its children as Mermaid classes.
+      #
+      # @param lines [Array<String>] the diagram lines array
+      # @param agg [Aggregate] the aggregate to render
+      # @param indent [String] leading whitespace
+      # @return [void]
+      def render_aggregate_class(lines, agg, indent)
+        lines << "#{indent}class #{agg.name} {"
+        agg.attributes.each { |attr| lines << "#{indent}    #{attribute_label(attr)}" }
+        lines << "#{indent}}"
+
+        agg.value_objects.each do |vo|
+          lines << "#{indent}class #{vo.name} {"
+          vo.attributes.each { |attr| lines << "#{indent}    #{attribute_label(attr)}" }
+          lines << "#{indent}}"
+          lines << "#{indent}#{agg.name} *-- #{vo.name}"
+        end
+
+        agg.entities.each do |ent|
+          lines << "#{indent}class #{ent.name} {"
+          lines << "#{indent}    +id : UUID"
+          ent.attributes.each { |attr| lines << "#{indent}    #{attribute_label(attr)}" }
+          lines << "#{indent}}"
+          lines << "#{indent}#{agg.name} *-- #{ent.name}"
+        end
+      end
+
       # Format an attribute for display in a Mermaid class diagram.
-      # List attributes show as +Type[] name+, references show as
-      # +String name+ (since they store IDs), and scalars show as
-      # +Type name+.
       #
       # @param attr [Hecks::DomainModel::Attribute] the attribute to format
       # @return [String] Mermaid-formatted attribute line (e.g., "+String name")
@@ -71,9 +97,7 @@ module Hecks
         end
       end
 
-      # Add cross-aggregate reference arrows to the diagram. Scans all
-      # aggregates for declared references and draws a directed
-      # association to the referenced aggregate.
+      # Add cross-aggregate reference arrows to the diagram.
       #
       # @param lines [Array<String>] the diagram lines array to append to
       # @return [void]

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -57,6 +57,7 @@ module Hecks
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
       autoload :Reference,         "hecks/domain_model/structure/reference"
       autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
+      autoload :DomainModule,      "hecks/domain_model/structure/domain_module"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -64,7 +64,7 @@ module Hecks
       # @return [Boolean] true if glossary violations are treated as errors instead of warnings
       attr_reader :glossary_strict
 
-      # @return [Array<Hash>] logical module groupings within this domain
+      # @return [Array<DomainModule>] logical module groupings within this domain
       attr_reader :modules
 
       # @return [Array<Symbol>] declared world concerns for this domain
@@ -115,7 +115,7 @@ module Hecks
         @sagas = sagas
         @glossary_rules = glossary_rules
         @glossary_strict = glossary_strict
-        @modules = modules
+        @modules = modules.map { |m| coerce_module(m) }
         @custom_verbs = custom_verbs
         @tenancy = tenancy
         @event_subscribers = event_subscribers
@@ -254,7 +254,20 @@ module Hecks
         aggregates.find { |a| a.commands.any? { |c| c.name == command_name.to_s } }
       end
 
+      # Find the module that contains an aggregate by name.
+      #
+      # @param aggregate_name [String] the aggregate name to look up
+      # @return [DomainModule, nil] the module containing that aggregate, or nil
+      def module_for(aggregate_name)
+        modules.find { |m| m.aggregate_names.include?(aggregate_name.to_s) }
+      end
+
       private
+
+      def coerce_module(m)
+        return m if m.is_a?(DomainModule)
+        DomainModule.new(name: m[:name], aggregate_names: m[:aggregates] || [])
+      end
 
       def validate_version!(v)
         return if v.nil?

--- a/bluebook/lib/hecks/domain_model/structure/domain_module.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain_module.rb
@@ -1,0 +1,33 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::DomainModule
+    #
+    # A logical namespace grouping within a domain. Groups related aggregates
+    # under a named module for visualization and serialization. Aggregates
+    # still live flat on the Domain; the module is a categorization overlay.
+    #
+    #   mod = DomainModule.new(name: "Fulfillment", aggregate_names: ["Order", "Shipment"])
+    #   mod.name             # => "Fulfillment"
+    #   mod.aggregate_names  # => ["Order", "Shipment"]
+    #
+    class DomainModule
+      # @return [String] the module name (e.g., "Fulfillment", "PolicyManagement")
+      attr_reader :name
+
+      # @return [Array<String>] names of aggregates belonging to this module
+      attr_reader :aggregate_names
+
+      # Creates a new DomainModule IR node.
+      #
+      # @param name [String] the module name
+      # @param aggregate_names [Array<String>] the aggregate names in this module
+      def initialize(name:, aggregate_names: [])
+        @name = name
+        @aggregate_names = aggregate_names
+      end
+    end
+    end
+  end
+end

--- a/bluebook/spec/domain_model/domain_module_spec.rb
+++ b/bluebook/spec/domain_model/domain_module_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+
+RSpec.describe Hecks::DomainModel::Structure::DomainModule do
+  subject(:mod) do
+    described_class.new(name: "Fulfillment", aggregate_names: ["Order", "Shipment"])
+  end
+
+  it "stores the module name" do
+    expect(mod.name).to eq("Fulfillment")
+  end
+
+  it "stores aggregate names" do
+    expect(mod.aggregate_names).to eq(["Order", "Shipment"])
+  end
+
+  it "defaults aggregate_names to empty array" do
+    m = described_class.new(name: "Empty")
+    expect(m.aggregate_names).to eq([])
+  end
+end
+
+RSpec.describe "Domain#module_for" do
+  let(:domain) do
+    Hecks.domain "ECommerce" do
+      domain_module "Catalog" do
+        aggregate("Product") { attribute :name, String; command("CreateProduct") { attribute :name, String } }
+      end
+
+      domain_module "Fulfillment" do
+        aggregate("Order") { attribute :qty, Integer; command("PlaceOrder") { attribute :qty, Integer } }
+        aggregate("Shipment") { attribute :tracking, String; command("CreateShipment") { attribute :tracking, String } }
+      end
+
+      aggregate("Review") { attribute :body, String; command("CreateReview") { attribute :body, String } }
+    end
+  end
+
+  it "returns the module containing the aggregate" do
+    mod = domain.module_for("Product")
+    expect(mod).not_to be_nil
+    expect(mod.name).to eq("Catalog")
+  end
+
+  it "finds aggregates in multi-aggregate modules" do
+    expect(domain.module_for("Order").name).to eq("Fulfillment")
+    expect(domain.module_for("Shipment").name).to eq("Fulfillment")
+  end
+
+  it "returns nil for ungrouped aggregates" do
+    expect(domain.module_for("Review")).to be_nil
+  end
+
+  it "returns nil for unknown aggregates" do
+    expect(domain.module_for("NonExistent")).to be_nil
+  end
+
+  it "stores modules as DomainModule IR nodes" do
+    domain.modules.each do |m|
+      expect(m).to be_a(Hecks::DomainModel::Structure::DomainModule)
+    end
+  end
+
+  it "all aggregates are flat on the domain regardless of module" do
+    expect(domain.aggregates.map(&:name)).to contain_exactly("Product", "Order", "Shipment", "Review")
+  end
+end
+
+RSpec.describe "Visualizer with domain_modules" do
+  let(:domain) do
+    Hecks.domain "Shop" do
+      domain_module "Catalog" do
+        aggregate("Product") do
+          attribute :name, String
+          command("CreateProduct") { attribute :name, String }
+        end
+      end
+
+      domain_module "Sales" do
+        aggregate("Order") do
+          attribute :qty, Integer
+          reference_to "Product"
+          command("PlaceOrder") { attribute :qty, Integer }
+        end
+      end
+
+      aggregate("Review") do
+        attribute :body, String
+        command("CreateReview") { attribute :body, String }
+      end
+    end
+  end
+
+  let(:mermaid) { Hecks::DomainVisualizer.new(domain).generate }
+
+  describe "structure diagram" do
+    it "wraps module aggregates in namespace blocks" do
+      expect(mermaid).to include("namespace Catalog {")
+      expect(mermaid).to include("namespace Sales {")
+    end
+
+    it "renders ungrouped aggregates outside namespaces" do
+      expect(mermaid).to include("class Review {")
+    end
+
+    it "still shows cross-module references" do
+      expect(mermaid).to include("Order --> Product : product")
+    end
+  end
+
+  describe "behavior diagram" do
+    it "wraps module aggregates in module subgraphs" do
+      expect(mermaid).to include("subgraph Catalog")
+      expect(mermaid).to include("subgraph Sales")
+    end
+
+    it "nests aggregate subgraphs inside module subgraphs" do
+      expect(mermaid).to include("subgraph Product")
+      expect(mermaid).to include("subgraph Order")
+    end
+
+    it "renders ungrouped aggregate subgraphs at top level" do
+      expect(mermaid).to include("subgraph Review")
+    end
+  end
+end
+
+RSpec.describe "DslSerializer with domain_modules" do
+  let(:domain) do
+    Hecks.domain "Shop" do
+      domain_module "Catalog" do
+        aggregate("Product") { attribute :name, String; command("CreateProduct") { attribute :name, String } }
+      end
+
+      aggregate("Review") { attribute :body, String; command("CreateReview") { attribute :body, String } }
+    end
+  end
+
+  let(:source) { Hecks::DslSerializer.new(domain).serialize }
+
+  it "emits domain_module blocks" do
+    expect(source).to include('domain_module "Catalog" do')
+  end
+
+  it "nests aggregates inside module blocks" do
+    expect(source).to include('domain_module "Catalog" do')
+    expect(source).to include('aggregate "Product" do')
+  end
+
+  it "emits ungrouped aggregates outside module blocks" do
+    expect(source).to include('aggregate "Review" do')
+  end
+
+  it "round-trips through eval" do
+    restored = eval(source)
+    expect(restored.modules.size).to eq(1)
+    expect(restored.modules.first.name).to eq("Catalog")
+    expect(restored.modules.first.aggregate_names).to eq(["Product"])
+    expect(restored.aggregates.map(&:name)).to contain_exactly("Product", "Review")
+  end
+end

--- a/docs/usage/domain_modules.md
+++ b/docs/usage/domain_modules.md
@@ -1,0 +1,122 @@
+# Domain Modules
+
+Group related aggregates under named modules within a domain. Modules are
+a logical namespace overlay -- aggregates still live flat on `domain.aggregates`,
+but the module grouping drives Mermaid diagram layout and DSL serialization.
+
+## DSL
+
+```ruby
+Hecks.domain "ECommerce" do
+  domain_module "Catalog" do
+    aggregate "Product" do
+      attribute :name, String
+      command("CreateProduct") { attribute :name, String }
+    end
+  end
+
+  domain_module "Fulfillment" do
+    aggregate "Order" do
+      attribute :qty, Integer
+      reference_to "Product"
+      command("PlaceOrder") { attribute :qty, Integer }
+    end
+
+    aggregate "Shipment" do
+      attribute :tracking, String
+      command("CreateShipment") { attribute :tracking, String }
+    end
+  end
+
+  # Aggregates outside any module are ungrouped
+  aggregate "Review" do
+    attribute :body, String
+    command("CreateReview") { attribute :body, String }
+  end
+end
+```
+
+## Querying modules
+
+```ruby
+domain = Hecks.domain "ECommerce" do ... end
+
+domain.modules
+# => [#<DomainModule name="Catalog" ...>, #<DomainModule name="Fulfillment" ...>]
+
+domain.module_for("Order")
+# => #<DomainModule name="Fulfillment" aggregate_names=["Order", "Shipment"]>
+
+domain.module_for("Review")
+# => nil  (ungrouped)
+```
+
+## Visualization
+
+Modules appear as Mermaid `namespace` blocks in the structure diagram and
+nested `subgraph` blocks in the behavior diagram:
+
+```ruby
+puts domain.to_mermaid
+```
+
+Structure output (classDiagram):
+
+```mermaid
+classDiagram
+    namespace Catalog {
+        class Product {
+            +String name
+        }
+    }
+    namespace Fulfillment {
+        class Order {
+            +Integer qty
+        }
+        class Shipment {
+            +String tracking
+        }
+    }
+    class Review {
+        +String body
+    }
+    Order --> Product : product
+```
+
+Behavior output (flowchart LR):
+
+```mermaid
+flowchart LR
+    subgraph Catalog
+        subgraph Product
+            Product_CreateProduct[CreateProduct]
+            Product_CreatedProduct([CreatedProduct])
+            Product_CreateProduct --> Product_CreatedProduct
+        end
+    end
+    subgraph Fulfillment
+        subgraph Order
+            Order_PlaceOrder[PlaceOrder]
+            Order_PlacedOrder([PlacedOrder])
+            Order_PlaceOrder --> Order_PlacedOrder
+        end
+        subgraph Shipment
+            Shipment_CreateShipment[CreateShipment]
+            Shipment_CreatedShipment([CreatedShipment])
+            Shipment_CreateShipment --> Shipment_CreatedShipment
+        end
+    end
+    subgraph Review
+        Review_CreateReview[CreateReview]
+        Review_CreatedReview([CreatedReview])
+        Review_CreateReview --> Review_CreatedReview
+    end
+```
+
+## Serialization round-trip
+
+```ruby
+source = Hecks::DslSerializer.new(domain).serialize
+restored = eval(source)
+restored.modules.first.name  # => "Catalog"
+```


### PR DESCRIPTION
## Summary
feat: promote domain_module to proper IR node with module_for lookup

Replaces hash-based module storage with DomainModule IR node (name,
aggregate_names). Adds Domain#module_for(agg) for reverse lookup.
Visualizer renders modules as Mermaid namespace/subgraph blocks.
Serializer emits domain_module blocks and round-trips through eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)