### PR TITLE
HEC-82: Extension tracing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -130,6 +130,7 @@
 - `hecks_idempotency` — command deduplication by fingerprint
 - `hecks_transactions` — DB transaction wrapping when SQL adapter present
 - `hecks_retry` — exponential backoff for transient errors
+- `hecks_tracing` — distributed tracing with correlation IDs stamped on every domain event; auto-generates UUIDs, preserves pre-set trace IDs from upstream (e.g. HTTP headers via `Hecks.trace_id=`)
 
 ### Domain Connections DSL
 - `extend :sqlite` — declare persistence adapter

--- a/docs/usage/tracing.md
+++ b/docs/usage/tracing.md
@@ -1,0 +1,86 @@
+# Distributed Tracing
+
+The `:tracing` extension stamps a correlation ID (`@_trace_id`) on every
+domain event published through the event bus. This lets you correlate events
+across aggregates, services, and log systems.
+
+## Setup
+
+```ruby
+# In your Bluebook connections block:
+extend :tracing
+```
+
+Or boot manually:
+
+```ruby
+require "hecks/extensions/tracing"
+
+app = Hecks.boot(__dir__)
+Hecks.extension_registry[:tracing].call(PizzasDomain, domain, app)
+```
+
+## Auto-generated trace IDs
+
+When no trace ID is set on the thread, each event gets a fresh UUID:
+
+```ruby
+Pizza.create(name: "Margherita")
+event = app.event_bus.events.last
+event.instance_variable_get(:@_trace_id)
+# => "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+```
+
+## Propagating upstream trace IDs
+
+Set the trace ID before dispatching commands. This is typically done in
+Rack middleware or a controller before-action:
+
+```ruby
+# From an HTTP header:
+Hecks.trace_id = request.headers["X-Trace-Id"]
+Pizza.create(name: "Pepperoni")
+
+event = app.event_bus.events.last
+event.instance_variable_get(:@_trace_id)
+# => the same value from the header
+```
+
+## Scoped tracing with `with_trace`
+
+Use `with_trace` to scope a trace ID to a block. It auto-generates a UUID
+when called without an argument:
+
+```ruby
+Hecks.with_trace do |trace_id|
+  puts trace_id  # => "a1b2c3d4-..."
+  Pizza.create(name: "Hawaiian")
+end
+# trace_id is nil again here
+```
+
+Pass an explicit ID to propagate from upstream:
+
+```ruby
+Hecks.with_trace("upstream-trace-xyz") do |id|
+  Pizza.create(name: "BBQ Chicken")
+end
+```
+
+## Reading trace IDs from events
+
+Events carry the trace ID as an instance variable (not a formal attribute)
+so the event's constructor contract is unchanged:
+
+```ruby
+app.event_bus.events.each do |event|
+  trace = event.instance_variable_get(:@_trace_id)
+  puts "#{event.class.name.split('::').last} trace=#{trace}"
+end
+```
+
+## Thread safety
+
+Trace IDs are stored in `Thread.current[:hecks_trace_id]`, so each thread
+(or Fiber with thread-local storage) gets its own trace context. This is
+safe for multi-threaded servers like Puma.

--- a/hecksties/lib/hecks/extensions/tracing.rb
+++ b/hecksties/lib/hecks/extensions/tracing.rb
@@ -1,0 +1,31 @@
+# HecksTracing
+#
+# Distributed tracing extension for the Hecks event bus. Ensures every
+# domain event carries a trace ID for correlation. When a trace ID is
+# already set on the thread (e.g. propagated from an incoming HTTP header
+# via +Hecks.trace_id=+), events are stamped with that value. When no
+# trace ID is present, one is auto-generated per event.
+#
+# Usage:
+#   Hecks.boot(__dir__, extend: :tracing)
+#   Pizza.create(name: "Margherita")
+#   Hecks.event_bus.events.last.instance_variable_get(:@_trace_id)
+#   # => "a1b2c3d4-..."
+#
+#   # Propagate an incoming trace:
+#   Hecks.with_trace(request.headers["X-Trace-Id"]) do
+#     Pizza.create(name: "Pepperoni")
+#   end
+#
+require "securerandom"
+
+Hecks.describe_extension(:tracing,
+  description: "Distributed tracing — correlation IDs on every event",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :event_bus)
+
+Hecks.register_extension(:tracing) do |_domain_mod, _domain, runtime|
+  bus = Hecks.event_bus || runtime.event_bus
+  bus.instance_variable_set(:@auto_trace, true)
+end

--- a/hecksties/lib/hecks/ports/event_bus/event_bus.rb
+++ b/hecksties/lib/hecks/ports/event_bus/event_bus.rb
@@ -68,6 +68,7 @@ module Hecks
       #   a fully qualified name (the last segment is used for listener matching)
       # @return [void]
       def publish(event)
+        event = stamp_trace_id(event)
         @events << event
         event_name = Hecks::Utils.const_short_name(event)
         @listeners[event_name].each { |handler| handler.call(event) }
@@ -79,6 +80,28 @@ module Hecks
       # @return [void]
       def clear
         @events.clear
+      end
+
+      # Instance variable used to stamp the current trace ID onto published events.
+      TRACE_ATTR = :@_trace_id
+
+      private
+
+      # Stamps the current thread-local trace ID onto the event, if one is set.
+      #
+      # Uses an instance variable so the event's formal attribute contract is
+      # unchanged. Readers can access it via +event.instance_variable_get(:@_trace_id)+.
+      #
+      # @param event [Object] the domain event to stamp
+      # @return [void]
+      def stamp_trace_id(event)
+        tid = Hecks.trace_id
+        return event unless tid || @auto_trace
+
+        tid ||= SecureRandom.uuid
+        target = event.frozen? ? event.dup : event
+        target.instance_variable_set(TRACE_ATTR, tid)
+        target
       end
   end
 end

--- a/hecksties/lib/hecks/registries/thread_context.rb
+++ b/hecksties/lib/hecks/registries/thread_context.rb
@@ -1,8 +1,15 @@
 # Hecks::ThreadContextMethods
 #
-# Thread-local tenant and actor context.
+# Thread-local tenant, actor, and trace context.
+# Provides accessor pairs and +with_*+ scoping blocks for each context value.
 # Extracted from the Hecks module.
 #
+# Usage:
+#   Hecks.trace_id = "abc-123"
+#   Hecks.with_trace { |id| puts id }  # auto-generates UUID when nil
+#
+require "securerandom"
+
 module Hecks
   module ThreadContextMethods
     def tenant
@@ -51,6 +58,23 @@ module Hecks
       yield
     ensure
       Thread.current[:hecks_current_user] = old
+    end
+
+    def trace_id
+      Thread.current[:hecks_trace_id]
+    end
+
+    def trace_id=(id)
+      Thread.current[:hecks_trace_id] = id&.to_s
+    end
+
+    def with_trace(id = nil)
+      id ||= SecureRandom.uuid
+      old = Thread.current[:hecks_trace_id]
+      Thread.current[:hecks_trace_id] = id.to_s
+      yield id
+    ensure
+      Thread.current[:hecks_trace_id] = old
     end
   end
 end

--- a/hecksties/spec/extensions/tracing_spec.rb
+++ b/hecksties/spec/extensions/tracing_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require "hecks/extensions/tracing"
+
+RSpec.describe "Tracing extension" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  after { Hecks.trace_id = nil }
+
+  describe "auto-generated trace ID" do
+    it "assigns a UUID trace ID when none is set" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:tracing]&.call(
+        Object.const_get("PizzasDomain"), domain, app
+      )
+
+      PizzasDomain::Pizza.create(name: "Margherita")
+
+      event = app.event_bus.events.last
+      trace = event.instance_variable_get(:@_trace_id)
+      expect(trace).to match(/\A[0-9a-f\-]{36}\z/)
+    end
+
+    it "generates a different trace ID per command dispatch" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:tracing]&.call(
+        Object.const_get("PizzasDomain"), domain, app
+      )
+
+      PizzasDomain::Pizza.create(name: "A")
+      PizzasDomain::Pizza.create(name: "B")
+
+      traces = app.event_bus.events.map { |e| e.instance_variable_get(:@_trace_id) }
+      expect(traces.compact.size).to eq(2)
+      expect(traces[0]).not_to eq(traces[1])
+    end
+  end
+
+  describe "preserving pre-set trace ID" do
+    it "uses the existing trace ID when one is already set" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:tracing]&.call(
+        Object.const_get("PizzasDomain"), domain, app
+      )
+      Hecks.trace_id = "incoming-trace-abc"
+
+      PizzasDomain::Pizza.create(name: "Pepperoni")
+
+      event = app.event_bus.events.last
+      trace = event.instance_variable_get(:@_trace_id)
+      expect(trace).to eq("incoming-trace-abc")
+    end
+  end
+
+  describe "thread context" do
+    it "provides trace_id accessors" do
+      Hecks.trace_id = "test-123"
+      expect(Hecks.trace_id).to eq("test-123")
+    end
+
+    it "with_trace scopes trace ID and yields it" do
+      yielded = nil
+      Hecks.with_trace("scoped-id") { |id| yielded = id }
+      expect(yielded).to eq("scoped-id")
+      expect(Hecks.trace_id).to be_nil
+    end
+
+    it "with_trace auto-generates UUID when called without argument" do
+      yielded = nil
+      Hecks.with_trace { |id| yielded = id }
+      expect(yielded).to match(/\A[0-9a-f\-]{36}\z/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add distributed tracing extension with correlation IDs (HEC-82)

Extend ThreadContextMethods with trace_id, trace_id=, and with_trace
for thread-local trace context. EventBus stamps @_trace_id on every
published event when tracing is enabled. New :tracing driven extension
enables auto-generation of UUID trace IDs, while preserving pre-set
IDs propagated from upstream (e.g. HTTP headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)