### PR TITLE
HEC-83: Bounded context boundaries

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -333,6 +333,8 @@
 - Every validation error includes a structured `hint` field with a fix suggestion -- rendered as colored "Fix:" lines in the CLI, included in `ValidationError` exception messages, and accessible via `error.hint` / `error.to_h`
 - Implicit foreign key detection: warns when `_id String` should be `reference_to("Aggregate")`
 - Validator collects non-blocking warnings alongside blocking errors
+- Big Ball of Mud detection: reference density warning (>2.0), hub aggregate detection (>50% inbound), cycle detection via DFS
+- Fan-out warning: aggregates with 4+ outgoing references flagged for potential responsibility splitting
 
 ## Domain Interface Versioning
 - `hecks version_tag <version>` — snapshot current domain DSL to `db/hecks_versions/<version>.rb` with metadata header

--- a/bluebook/lib/hecks/domain/validator.rb
+++ b/bluebook/lib/hecks/domain/validator.rb
@@ -14,6 +14,8 @@ module Hecks
   # - NoBidirectionalReferences: no two aggregates referencing each other
   # - NoSelfReferences: aggregates must not reference themselves
   # - NoValueObjectReferences: value objects must not contain references
+  # - BoundaryAnalysis: warns about Big Ball of Mud (density, hubs, cycles)
+  # - FanOut: warns when an aggregate has too many outgoing references
   # - AggregatesHaveCommands: every aggregate must have at least one command
   # - CommandsHaveAttributes: structural check on command attributes
   # - ValidPolicyEvents: policy events must match existing events

--- a/bluebook/lib/hecks/validation_rules/references.rb
+++ b/bluebook/lib/hecks/validation_rules/references.rb
@@ -9,6 +9,9 @@ module Hecks
     # - +ValidReferences+ -- references must target existing aggregate roots (not value objects or entities)
     # - +NoBidirectionalReferences+ -- no mutual A->B and B->A references between aggregates
     # - +NoSelfReferences+ -- aggregates cannot reference themselves
+    # - +NoForeignKeyAttributes+ -- warns about _id attributes that should be reference_to
+    # - +BoundaryAnalysis+ -- warns about Big Ball of Mud (density, hubs, cycles)
+    # - +FanOut+ -- warns when an aggregate has too many outgoing references
     #
     # All rules are autoloaded and executed as part of +Hecks.validate+.
     #
@@ -16,7 +19,9 @@ module Hecks
       autoload :ValidReferences,           "hecks/validation_rules/references/valid_references"
       autoload :NoBidirectionalReferences, "hecks/validation_rules/references/no_bidirectional_references"
       autoload :NoSelfReferences,          "hecks/validation_rules/references/no_self_references"
-      autoload :NoForeignKeyAttributes,  "hecks/validation_rules/references/no_foreign_key_attributes"
+      autoload :NoForeignKeyAttributes,    "hecks/validation_rules/references/no_foreign_key_attributes"
+      autoload :BoundaryAnalysis,          "hecks/validation_rules/references/boundary_analysis"
+      autoload :FanOut,                    "hecks/validation_rules/references/fan_out"
     end
   end
 end

--- a/bluebook/lib/hecks/validation_rules/references/boundary_analysis.rb
+++ b/bluebook/lib/hecks/validation_rules/references/boundary_analysis.rb
@@ -1,0 +1,129 @@
+# Hecks::ValidationRules::References::BoundaryAnalysis
+#
+# Detects "Big Ball of Mud" anti-patterns by analyzing the reference graph
+# across aggregates. Three checks:
+#
+# 1. **Reference density** -- ratio of total references to aggregate count.
+#    A density above 2.0 suggests excessive coupling between boundaries.
+# 2. **Hub detection** -- any aggregate that is the target of more than 50%
+#    of all references is a hub, indicating a God Object smell.
+# 3. **Cycle detection** -- DFS-based detection of circular reference chains
+#    (A -> B -> C -> A). Cycles make it impossible to reason about boundaries.
+#
+# All findings are warnings (non-blocking), not errors.
+#
+#   rule = BoundaryAnalysis.new(domain)
+#   rule.errors   # => []
+#   rule.warnings # => ["Reference density 2.5 exceeds threshold ..."]
+#
+module Hecks
+  module ValidationRules
+    module References
+      class BoundaryAnalysis < BaseRule
+        DENSITY_THRESHOLD = 2.0
+        HUB_THRESHOLD     = 0.5
+
+        def errors
+          []
+        end
+
+        def warnings
+          return [] if @domain.aggregates.size < 2
+
+          graph = build_graph
+          results = []
+          results.concat(density_warnings(graph))
+          results.concat(hub_warnings(graph))
+          results.concat(cycle_warnings(graph))
+          results
+        end
+
+        private
+
+        def build_graph
+          graph = {}
+          @domain.aggregates.each do |agg|
+            targets = (agg.references || []).reject(&:domain).map { |r| r.type.to_s }
+            graph[agg.name] = targets
+          end
+          graph
+        end
+
+        def density_warnings(graph)
+          total_refs = graph.values.sum(&:size)
+          agg_count  = graph.size
+          density    = total_refs.to_f / agg_count
+
+          return [] unless density > DENSITY_THRESHOLD
+
+          ["Reference density #{format('%.1f', density)} exceeds threshold #{DENSITY_THRESHOLD} " \
+           "(#{total_refs} references across #{agg_count} aggregates). " \
+           "Consider splitting into separate bounded contexts."]
+        end
+
+        def hub_warnings(graph)
+          total_refs = graph.values.sum(&:size)
+          return [] if total_refs.zero?
+
+          inbound = Hash.new(0)
+          graph.each_value do |targets|
+            targets.each { |t| inbound[t] += 1 }
+          end
+
+          inbound.filter_map do |name, count|
+            pct = count.to_f / total_refs
+            next unless pct > HUB_THRESHOLD
+
+            "#{name} is a hub aggregate -- referenced by #{format('%.0f', pct * 100)}% " \
+            "of all references (#{count}/#{total_refs}). Consider extracting a shared kernel " \
+            "or anti-corruption layer."
+          end
+        end
+
+        def cycle_warnings(graph)
+          cycles = detect_cycles(graph)
+          cycles.map do |cycle|
+            path = cycle.join(" -> ") + " -> #{cycle.first}"
+            "Reference cycle detected: #{path}. " \
+            "Break the cycle with a domain event or policy instead of a direct reference."
+          end
+        end
+
+        def detect_cycles(graph)
+          visited  = {}
+          on_stack = {}
+          stack    = []
+          cycles   = []
+
+          graph.each_key do |node|
+            next if visited[node]
+            dfs(node, graph, visited, on_stack, stack, cycles)
+          end
+
+          cycles.map { |c| c.sort }.uniq
+        end
+
+        def dfs(node, graph, visited, on_stack, stack, cycles)
+          visited[node]  = true
+          on_stack[node] = true
+          stack.push(node)
+
+          (graph[node] || []).each do |neighbor|
+            next unless graph.key?(neighbor)
+
+            if on_stack[neighbor]
+              cycle_start = stack.index(neighbor)
+              cycles << stack[cycle_start..].dup
+            elsif !visited[neighbor]
+              dfs(neighbor, graph, visited, on_stack, stack, cycles)
+            end
+          end
+
+          stack.pop
+          on_stack[node] = false
+        end
+      end
+      Hecks.register_validation_rule(BoundaryAnalysis)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/references/fan_out.rb
+++ b/bluebook/lib/hecks/validation_rules/references/fan_out.rb
@@ -1,0 +1,36 @@
+# Hecks::ValidationRules::References::FanOut
+#
+# Warns when a single aggregate has too many outgoing references (fan-out).
+# An aggregate with 4 or more references is likely taking on too many
+# responsibilities and should be split into smaller aggregates.
+#
+# All findings are warnings (non-blocking), not errors.
+#
+#   rule = FanOut.new(domain)
+#   rule.errors   # => []
+#   rule.warnings # => ["Order has 5 outgoing references (threshold: 4) ..."]
+#
+module Hecks
+  module ValidationRules
+    module References
+      class FanOut < BaseRule
+        THRESHOLD = 4
+
+        def errors
+          []
+        end
+
+        def warnings
+          @domain.aggregates.filter_map do |agg|
+            refs = (agg.references || []).reject(&:domain)
+            next unless refs.size >= THRESHOLD
+
+            "#{agg.name} has #{refs.size} outgoing references (threshold: #{THRESHOLD}). " \
+            "This aggregate may have too many responsibilities -- consider splitting it."
+          end
+        end
+      end
+      Hecks.register_validation_rule(FanOut)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/references/boundary_analysis_spec.rb
+++ b/bluebook/spec/validation_rules/references/boundary_analysis_spec.rb
@@ -1,0 +1,140 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::References::BoundaryAnalysis do
+  def validate(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  def domain_with_refs(&block)
+    Hecks.domain("TestDomain", &block)
+  end
+
+  describe "reference density" do
+    it "warns when density exceeds 2.0" do
+      # 7 refs / 3 aggs = density 2.33
+      domain = domain_with_refs do
+        aggregate "Order" do
+          reference_to "Customer"
+          reference_to "Product"
+          command("PlaceOrder") { attribute :name, String }
+        end
+
+        aggregate "Customer" do
+          reference_to "Order"
+          reference_to "Product"
+          command("CreateCustomer") { attribute :name, String }
+        end
+
+        aggregate "Product" do
+          reference_to "Order"
+          reference_to "Customer"
+          reference_to "Order"
+          command("CreateProduct") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Reference density.*exceeds threshold/))
+    end
+
+    it "does not warn when density is low" do
+      domain = domain_with_refs do
+        aggregate "Order" do
+          reference_to "Customer"
+          command("PlaceOrder") { attribute :name, String }
+        end
+
+        aggregate "Customer" do
+          command("CreateCustomer") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      expect(warnings).not_to include(a_string_matching(/Reference density/))
+    end
+  end
+
+  describe "hub detection" do
+    it "warns when one aggregate receives >50% of all references" do
+      domain = domain_with_refs do
+        aggregate "Hub" do
+          command("CreateHub") { attribute :name, String }
+        end
+
+        aggregate "A" do
+          reference_to "Hub"
+          command("CreateA") { attribute :name, String }
+        end
+
+        aggregate "B" do
+          reference_to "Hub"
+          command("CreateB") { attribute :name, String }
+        end
+
+        aggregate "C" do
+          reference_to "Hub"
+          command("CreateC") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Hub is a hub aggregate/))
+    end
+  end
+
+  describe "cycle detection" do
+    it "warns when aggregates form a reference cycle" do
+      domain = domain_with_refs do
+        aggregate "A" do
+          reference_to "B"
+          command("CreateA") { attribute :name, String }
+        end
+
+        aggregate "B" do
+          reference_to "C"
+          command("CreateB") { attribute :name, String }
+        end
+
+        aggregate "C" do
+          reference_to "A"
+          command("CreateC") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      expect(warnings).to include(a_string_matching(/Reference cycle detected/))
+    end
+
+    it "does not warn for acyclic references" do
+      domain = domain_with_refs do
+        aggregate "Order" do
+          reference_to "Customer"
+          command("PlaceOrder") { attribute :name, String }
+        end
+
+        aggregate "Customer" do
+          command("CreateCustomer") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      expect(warnings).not_to include(a_string_matching(/Reference cycle/))
+    end
+  end
+
+  describe "single aggregate domain" do
+    it "produces no warnings" do
+      domain = domain_with_refs do
+        aggregate "Solo" do
+          command("CreateSolo") { attribute :name, String }
+        end
+      end
+
+      warnings = validate(domain)
+      boundary_warnings = warnings.select { |w| w.match?(/density|hub|cycle/i) }
+      expect(boundary_warnings).to be_empty
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/references/fan_out_spec.rb
+++ b/bluebook/spec/validation_rules/references/fan_out_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+RSpec.describe Hecks::ValidationRules::References::FanOut do
+  def validate(domain)
+    v = Hecks::Validator.new(domain)
+    v.valid?
+    v.warnings
+  end
+
+  it "warns when an aggregate has 4 or more references" do
+    domain = Hecks.domain "FanOutTest" do
+      aggregate "Order" do
+        reference_to "Customer"
+        reference_to "Product"
+        reference_to "Warehouse"
+        reference_to "ShippingMethod"
+        command("PlaceOrder") { attribute :name, String }
+      end
+
+      aggregate "Customer" do
+        command("CreateCustomer") { attribute :name, String }
+      end
+
+      aggregate "Product" do
+        command("CreateProduct") { attribute :name, String }
+      end
+
+      aggregate "Warehouse" do
+        command("CreateWarehouse") { attribute :name, String }
+      end
+
+      aggregate "ShippingMethod" do
+        command("CreateShippingMethod") { attribute :name, String }
+      end
+    end
+
+    warnings = validate(domain)
+    expect(warnings).to include(a_string_matching(/Order has 4 outgoing references/))
+  end
+
+  it "does not warn when below threshold" do
+    domain = Hecks.domain "SmallRefs" do
+      aggregate "Order" do
+        reference_to "Customer"
+        reference_to "Product"
+        command("PlaceOrder") { attribute :name, String }
+      end
+
+      aggregate "Customer" do
+        command("CreateCustomer") { attribute :name, String }
+      end
+
+      aggregate "Product" do
+        command("CreateProduct") { attribute :name, String }
+      end
+    end
+
+    warnings = validate(domain)
+    expect(warnings).not_to include(a_string_matching(/outgoing references/))
+  end
+end

--- a/docs/usage/boundary_analysis.md
+++ b/docs/usage/boundary_analysis.md
@@ -1,0 +1,80 @@
+# Boundary Analysis (Big Ball of Mud Detection)
+
+Hecks automatically warns when your domain model shows signs of the
+"Big Ball of Mud" anti-pattern -- excessive coupling between aggregates
+that erodes bounded context boundaries.
+
+## What gets checked
+
+### Reference Density (threshold: 2.0)
+
+The ratio of total cross-aggregate references to the number of aggregates.
+A density above 2.0 means every aggregate averages more than two outgoing
+references, suggesting the domain is over-connected.
+
+### Hub Detection (threshold: 50%)
+
+Any aggregate that receives more than 50% of all inbound references is
+flagged as a hub. Hubs often become "God Objects" that every other
+aggregate depends on.
+
+### Cycle Detection (DFS)
+
+Circular reference chains like A -> B -> C -> A are detected using
+depth-first search. Cycles make it impossible to reason about aggregate
+boundaries and ownership.
+
+### Fan-Out (threshold: 4)
+
+Any single aggregate with 4 or more outgoing references is flagged.
+High fan-out suggests the aggregate has too many responsibilities.
+
+## Example
+
+```ruby
+Hecks.domain "Ecommerce" do
+  aggregate "Order" do
+    reference_to "Customer"
+    reference_to "Product"
+    reference_to "Warehouse"
+    reference_to "ShippingMethod"
+    command("PlaceOrder") { attribute :name, String }
+  end
+
+  aggregate "Customer" do
+    reference_to "Order"
+    reference_to "Product"
+    command("CreateCustomer") { attribute :name, String }
+  end
+
+  aggregate "Product" do
+    reference_to "Warehouse"
+    command("CreateProduct") { attribute :name, String }
+  end
+
+  aggregate "Warehouse" do
+    command("CreateWarehouse") { attribute :name, String }
+  end
+
+  aggregate "ShippingMethod" do
+    command("CreateShippingMethod") { attribute :name, String }
+  end
+end
+```
+
+Running `hecks build` will show warnings like:
+
+```
+WARNING: Order has 4 outgoing references (threshold: 4). This aggregate may have too many responsibilities -- consider splitting it.
+WARNING: Reference cycle detected: Customer -> Order -> Customer. Break the cycle with a domain event or policy instead of a direct reference.
+```
+
+## How to fix
+
+- **High density**: Split the domain into separate bounded contexts
+- **Hub aggregates**: Extract a shared kernel or anti-corruption layer
+- **Cycles**: Replace one direction with a domain event or policy
+- **High fan-out**: Split the aggregate into smaller, focused aggregates
+
+All boundary analysis findings are **warnings** (non-blocking). Your domain
+will still compile and build, but the warnings highlight structural risks.


### PR DESCRIPTION
## Summary
feat: add Big Ball of Mud detection for boundary analysis (HEC-83)

Add warning-only validation rules that detect structural anti-patterns
in the domain reference graph: reference density >2.0, hub aggregates
receiving >50% of references, circular reference chains via DFS, and
fan-out of 4+ outgoing references per aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)