### PR TITLE
HEC-95: Performance benchmarks

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -434,6 +434,7 @@
 - `hecks migrations` — schema migration management
 - `hecks interview` — conversational onboarding that walks through domain definition interactively (name, aggregates, attributes, commands) and writes a Bluebook file
 - `hecks docs update` — sync doc headers and READMEs
+- `hecks benchmark` — run build, load, and dispatch benchmarks with monotonic timing; stores JSON results in `tmp/benchmarks/` and warns on 20% regressions; `--suite build|load|dispatch` for single suite; `--iterations N`; `--json` for machine output
 - All commands accept `--domain` flag consistently
 - `--format json` on `validate`, `inspect`, and `tree` commands for Studio/tooling consumption
 

--- a/docs/usage/benchmarks.md
+++ b/docs/usage/benchmarks.md
@@ -1,0 +1,83 @@
+# Benchmarks
+
+Measure build, load, and dispatch performance of your Hecks domain.
+
+## CLI Usage
+
+Run from a directory containing a Bluebook file:
+
+```bash
+# Run all three suites (build, load, dispatch) with 10 iterations each
+hecks benchmark
+
+# Run only the build benchmark with 20 iterations
+hecks benchmark --suite build --iterations 20
+
+# Output results as JSON
+hecks benchmark --json
+```
+
+## Output
+
+```
+Running build benchmark (10 iterations)...
+Running load benchmark (10 iterations)...
+Running dispatch benchmark (10 iterations)...
+
+Build:
+  min:    32.15ms
+  median: 34.82ms
+  max:    41.07ms
+
+Load:
+  min:    8.21ms
+  median: 9.44ms
+  max:    12.30ms
+
+Dispatch:
+  min:    0.31ms
+  median: 0.38ms
+  max:    0.52ms
+
+Results saved to tmp/benchmarks/benchmark_20260401_120000.json
+```
+
+## Regression Detection
+
+Results are saved as JSON in `tmp/benchmarks/`. On each run, the tool
+compares the current median against the previous run. If any suite
+regresses by more than 20%, a warning is printed:
+
+```
+REGRESSIONS DETECTED:
+  build: 34.82ms -> 45.10ms (+29.5%)
+```
+
+## Programmatic API
+
+```ruby
+require "hecks/benchmarks"
+
+# Run all suites
+results = Hecks::Benchmarks.run_all(domain_dir: ".", iterations: 10)
+results[:build][:median]  # => 0.03482
+
+# Run a single suite
+timing = Hecks::Benchmarks::BuildBenchmark.run(domain_dir: ".", iterations: 5)
+timing[:min]    # => 0.03215
+timing[:median] # => 0.03482
+timing[:max]    # => 0.04107
+
+# Store and check regressions
+store = Hecks::Benchmarks::ResultStore.new
+store.save(results)
+regressions = store.check_regressions(results)
+```
+
+## Suites
+
+| Suite      | What it measures                                      |
+|------------|-------------------------------------------------------|
+| `build`    | Time to generate a domain gem from Bluebook            |
+| `load`     | Time to parse Bluebook and wire a runtime (in-memory)  |
+| `dispatch` | Time to dispatch a single command through the bus      |

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -28,6 +28,7 @@ require "bluebook"
 require "hecksagon"
 require_relative "hecks/deprecations"
 require_relative "hecks/stats"
+require_relative "hecks/benchmarks"
 require "hecks/runtime/boot"
 require "hecks/workshop"
 

--- a/hecksties/lib/hecks/benchmarks.rb
+++ b/hecksties/lib/hecks/benchmarks.rb
@@ -1,0 +1,32 @@
+# Hecks::Benchmarks
+#
+# Entry point for the benchmark subsystem. Measures build, load, and
+# dispatch performance with monotonic timing and regression detection.
+#
+#   Hecks::Benchmarks.run_all(domain_dir: "examples/pizzas")
+#
+module Hecks
+  module Benchmarks
+    autoload :Timer,             "hecks/benchmarks/timer"
+    autoload :BuildBenchmark,    "hecks/benchmarks/build_benchmark"
+    autoload :LoadBenchmark,     "hecks/benchmarks/load_benchmark"
+    autoload :DispatchBenchmark, "hecks/benchmarks/dispatch_benchmark"
+    autoload :ResultStore,       "hecks/benchmarks/result_store"
+
+    SUITES = %i[build load dispatch].freeze
+
+    # Run all benchmark suites and return combined results.
+    #
+    # @param domain_dir [String] path to a directory with a Bluebook
+    # @param iterations [Integer] number of iterations per suite
+    # @return [Hash] keyed by suite name
+    def self.run_all(domain_dir:, iterations: 10)
+      results = {}
+      SUITES.each do |suite|
+        klass = const_get("#{suite.capitalize}Benchmark")
+        results[suite] = klass.run(domain_dir: domain_dir, iterations: iterations)
+      end
+      results
+    end
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/build_benchmark.rb
+++ b/hecksties/lib/hecks/benchmarks/build_benchmark.rb
@@ -1,0 +1,33 @@
+# Hecks::Benchmarks::BuildBenchmark
+#
+# Measures the time to build a domain gem from a Bluebook file.
+# Uses the default :ruby target and writes to a temp directory.
+#
+#   result = Hecks::Benchmarks::BuildBenchmark.run(domain_dir: "examples/pizzas")
+#   result[:median] # => 0.045
+#
+require "tmpdir"
+
+module Hecks
+  module Benchmarks
+    class BuildBenchmark
+      # @param domain_dir [String] directory containing a Bluebook
+      # @param iterations [Integer] number of timed runs
+      # @return [Hash] timing stats from Timer
+      def self.run(domain_dir:, iterations: 10)
+        bluebook = Dir[File.join(domain_dir, "*Bluebook")].first
+        raise "No Bluebook found in #{domain_dir}" unless bluebook
+
+        Kernel.load(bluebook)
+        domain = Hecks.last_domain
+        domain.source_path = bluebook
+
+        Timer.measure(iterations: iterations) do
+          Dir.mktmpdir do |tmp|
+            Hecks.build(domain, output_dir: tmp)
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/commands/benchmark.rb
+++ b/hecksties/lib/hecks/benchmarks/commands/benchmark.rb
@@ -1,0 +1,65 @@
+# Hecks Benchmark CLI Command
+#
+# Registers the `hecks benchmark` command. Runs build, load, and
+# dispatch benchmarks against the current domain, stores results,
+# and warns on regressions.
+#
+#   hecks benchmark
+#   hecks benchmark --iterations 20
+#   hecks benchmark --suite build
+#
+Hecks::CLI.register_command(:benchmark, "Run performance benchmarks",
+  options: {
+    iterations: { type: :numeric, default: 10, desc: "Iterations per suite" },
+    suite:      { type: :string,  desc: "Run a single suite: build, load, or dispatch" },
+    json:       { type: :boolean, desc: "Output results as JSON" }
+  }
+) do
+  require "hecks/benchmarks"
+
+  fmt = ->(seconds) { "%.2fms" % (seconds * 1000) }
+  domain_dir = Dir.pwd
+  bluebook = Dir[File.join(domain_dir, "*Bluebook")].first
+  unless bluebook
+    say "No Bluebook found in #{domain_dir}", :red
+    next
+  end
+
+  iterations = options[:iterations] || 10
+  suites = options[:suite] ? [options[:suite].to_sym] : Hecks::Benchmarks::SUITES
+
+  results = {}
+  suites.each do |suite|
+    klass = Hecks::Benchmarks.const_get("#{suite.capitalize}Benchmark")
+    say "Running #{suite} benchmark (#{iterations} iterations)..."
+    results[suite] = klass.run(domain_dir: domain_dir, iterations: iterations)
+  end
+
+  store = Hecks::Benchmarks::ResultStore.new
+  regressions = store.check_regressions(results)
+  saved_path = store.save(results)
+
+  if options[:json]
+    require "json"
+    puts JSON.pretty_generate(results.transform_values { |v| v.except(:times) })
+  else
+    results.each do |suite, timing|
+      say ""
+      say "#{suite.to_s.capitalize}:", :bold
+      say "  min:    #{fmt.call(timing[:min])}"
+      say "  median: #{fmt.call(timing[:median])}"
+      say "  max:    #{fmt.call(timing[:max])}"
+    end
+    say ""
+    say "Results saved to #{saved_path}", :green
+  end
+
+  next if regressions.empty?
+
+  say ""
+  say "REGRESSIONS DETECTED:", :red
+  regressions.each do |r|
+    say "  #{r[:suite]}: #{fmt.call(r[:previous_median])} -> " \
+        "#{fmt.call(r[:current_median])} (+#{r[:pct_change]}%)", :red
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/dispatch_benchmark.rb
+++ b/hecksties/lib/hecks/benchmarks/dispatch_benchmark.rb
@@ -1,0 +1,52 @@
+# Hecks::Benchmarks::DispatchBenchmark
+#
+# Measures the time to dispatch commands through a booted runtime.
+# Loads the domain once, then times N create-command dispatches.
+#
+#   result = Hecks::Benchmarks::DispatchBenchmark.run(domain_dir: "examples/pizzas")
+#   result[:median] # => 0.0004
+#
+module Hecks
+  module Benchmarks
+    class DispatchBenchmark
+      # @param domain_dir [String] directory containing a Bluebook
+      # @param iterations [Integer] number of timed runs
+      # @return [Hash] timing stats from Timer
+      def self.run(domain_dir:, iterations: 10)
+        bluebook = Dir[File.join(domain_dir, "*Bluebook")].first
+        raise "No Bluebook found in #{domain_dir}" unless bluebook
+
+        Kernel.load(bluebook)
+        domain = Hecks.last_domain
+        domain.source_path = bluebook
+        runtime = Hecks.load(domain, force: true)
+
+        aggregate = domain.aggregates.first
+        command = aggregate.commands.first
+        attrs = build_sample_attrs(command)
+
+        Timer.measure(iterations: iterations) do
+          runtime.run(command.name, **attrs)
+        end
+      end
+
+      # Build minimal sample attributes for a command.
+      # Strings get "bench", Integers get 1, Booleans get true, etc.
+      def self.build_sample_attrs(command)
+        command.attributes.each_with_object({}) do |attr, hash|
+          hash[attr.name.to_sym] = sample_value(attr)
+        end
+      end
+
+      def self.sample_value(attr)
+        case attr.type.to_s
+        when /Integer/i then 1
+        when /Float/i   then 1.0
+        when /Boolean/i then true
+        when /Date/i    then Date.today.to_s
+        else                 "bench_#{attr.name}"
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/load_benchmark.rb
+++ b/hecksties/lib/hecks/benchmarks/load_benchmark.rb
@@ -1,0 +1,28 @@
+# Hecks::Benchmarks::LoadBenchmark
+#
+# Measures the time to load a domain from a Bluebook and wire a
+# runtime with in-memory adapters (no persistence).
+#
+#   result = Hecks::Benchmarks::LoadBenchmark.run(domain_dir: "examples/pizzas")
+#   result[:median] # => 0.012
+#
+module Hecks
+  module Benchmarks
+    class LoadBenchmark
+      # @param domain_dir [String] directory containing a Bluebook
+      # @param iterations [Integer] number of timed runs
+      # @return [Hash] timing stats from Timer
+      def self.run(domain_dir:, iterations: 10)
+        bluebook = Dir[File.join(domain_dir, "*Bluebook")].first
+        raise "No Bluebook found in #{domain_dir}" unless bluebook
+
+        Timer.measure(iterations: iterations) do
+          Kernel.load(bluebook)
+          domain = Hecks.last_domain
+          domain.source_path = bluebook
+          Hecks.load(domain, force: true)
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/result_store.rb
+++ b/hecksties/lib/hecks/benchmarks/result_store.rb
@@ -1,0 +1,78 @@
+# Hecks::Benchmarks::ResultStore
+#
+# Persists benchmark results as JSON in tmp/benchmarks/ and detects
+# regressions by comparing median times against the previous run.
+# A 20% increase in median time triggers a regression warning.
+#
+#   store = Hecks::Benchmarks::ResultStore.new
+#   store.save(results)
+#   store.check_regressions(results) # => [{ suite: :build, ... }]
+#
+require "json"
+require "fileutils"
+
+module Hecks
+  module Benchmarks
+    class ResultStore
+      REGRESSION_THRESHOLD = 0.20
+      DEFAULT_DIR = "tmp/benchmarks"
+
+      attr_reader :dir
+
+      def initialize(dir: DEFAULT_DIR)
+        @dir = dir
+      end
+
+      # Save results to a timestamped JSON file.
+      #
+      # @param results [Hash] suite => timing hash
+      # @return [String] path to saved file
+      def save(results)
+        FileUtils.mkdir_p(dir)
+        filename = "benchmark_#{Time.now.strftime('%Y%m%d_%H%M%S')}.json"
+        path = File.join(dir, filename)
+        payload = results.transform_values { |v| v.except(:times) }
+        File.write(path, JSON.pretty_generate(payload))
+        path
+      end
+
+      # Load the most recent saved result.
+      #
+      # @return [Hash, nil] parsed results or nil if none exist
+      def latest
+        files = Dir[File.join(dir, "benchmark_*.json")].sort
+        return nil if files.empty?
+
+        JSON.parse(File.read(files.last), symbolize_names: true)
+      end
+
+      # Compare current results against the previous run.
+      # Returns an array of regression hashes for any suite whose
+      # median increased by more than REGRESSION_THRESHOLD (20%).
+      #
+      # @param current [Hash] suite => timing hash
+      # @return [Array<Hash>] regressions found
+      def check_regressions(current)
+        previous = latest
+        return [] unless previous
+
+        regressions = []
+        current.each do |suite, timing|
+          prev = previous[suite]
+          next unless prev && prev[:median]
+
+          pct_change = (timing[:median] - prev[:median]) / prev[:median]
+          next unless pct_change > REGRESSION_THRESHOLD
+
+          regressions << {
+            suite: suite,
+            previous_median: prev[:median],
+            current_median: timing[:median],
+            pct_change: (pct_change * 100).round(1)
+          }
+        end
+        regressions
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/benchmarks/timer.rb
+++ b/hecksties/lib/hecks/benchmarks/timer.rb
@@ -1,0 +1,32 @@
+# Hecks::Benchmarks::Timer
+#
+# Monotonic-clock timer that runs a block N times and computes
+# min, median, and max durations in seconds.
+#
+#   result = Hecks::Benchmarks::Timer.measure(iterations: 10) { some_work }
+#   result[:median] # => 0.0032
+#
+module Hecks
+  module Benchmarks
+    class Timer
+      # Run a block N times and return timing statistics.
+      #
+      # @param iterations [Integer] number of runs
+      # @yield the block to benchmark
+      # @return [Hash] :min, :median, :max, :times (all in seconds)
+      def self.measure(iterations: 10)
+        times = Array.new(iterations) do
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          yield
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        end
+
+        sorted = times.sort
+        mid = iterations / 2
+        median = iterations.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
+
+        { min: sorted.first, median: median, max: sorted.last, times: times }
+      end
+    end
+  end
+end

--- a/hecksties/spec/benchmarks/benchmarks_spec.rb
+++ b/hecksties/spec/benchmarks/benchmarks_spec.rb
@@ -1,0 +1,51 @@
+require "hecks"
+require "hecks/benchmarks"
+
+RSpec.describe Hecks::Benchmarks, :slow do
+  let(:pizzas_dir) { File.expand_path("../../../examples/pizzas", __dir__) }
+
+  describe "BuildBenchmark" do
+    it "measures domain build time" do
+      result = Hecks::Benchmarks::BuildBenchmark.run(
+        domain_dir: pizzas_dir, iterations: 2
+      )
+
+      expect(result[:min]).to be > 0
+      expect(result[:median]).to be > 0
+      expect(result[:times].length).to eq(2)
+    end
+  end
+
+  describe "LoadBenchmark" do
+    it "measures domain load time" do
+      result = Hecks::Benchmarks::LoadBenchmark.run(
+        domain_dir: pizzas_dir, iterations: 2
+      )
+
+      expect(result[:min]).to be > 0
+      expect(result[:median]).to be > 0
+    end
+  end
+
+  describe "DispatchBenchmark" do
+    it "measures command dispatch time" do
+      result = Hecks::Benchmarks::DispatchBenchmark.run(
+        domain_dir: pizzas_dir, iterations: 2
+      )
+
+      expect(result[:min]).to be > 0
+      expect(result[:median]).to be > 0
+    end
+  end
+
+  describe ".run_all" do
+    it "runs all suites and returns combined results" do
+      results = described_class.run_all(domain_dir: pizzas_dir, iterations: 2)
+
+      expect(results.keys).to contain_exactly(:build, :load, :dispatch)
+      results.each_value do |timing|
+        expect(timing[:median]).to be > 0
+      end
+    end
+  end
+end

--- a/hecksties/spec/benchmarks/result_store_spec.rb
+++ b/hecksties/spec/benchmarks/result_store_spec.rb
@@ -1,0 +1,65 @@
+require "hecks"
+require "hecks/benchmarks"
+require "tmpdir"
+
+RSpec.describe Hecks::Benchmarks::ResultStore do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:store)  { described_class.new(dir: tmpdir) }
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def sample_results(build_median: 0.05, load_median: 0.01, dispatch_median: 0.001)
+    {
+      build:    { min: build_median * 0.9, median: build_median, max: build_median * 1.1, times: [build_median] },
+      load:     { min: load_median * 0.9, median: load_median, max: load_median * 1.1, times: [load_median] },
+      dispatch: { min: dispatch_median * 0.9, median: dispatch_median, max: dispatch_median * 1.1, times: [dispatch_median] }
+    }
+  end
+
+  it "saves results to a JSON file" do
+    path = store.save(sample_results)
+
+    expect(File.exist?(path)).to be true
+    data = JSON.parse(File.read(path), symbolize_names: true)
+    expect(data[:build][:median]).to eq(0.05)
+    expect(data[:build]).not_to have_key(:times)
+  end
+
+  it "loads the latest result" do
+    store.save(sample_results(build_median: 0.04))
+    sleep 0.01
+    store.save(sample_results(build_median: 0.05))
+
+    latest = store.latest
+    expect(latest[:build][:median]).to eq(0.05)
+  end
+
+  it "returns nil when no previous results exist" do
+    expect(store.latest).to be_nil
+  end
+
+  it "detects regressions above 20% threshold" do
+    store.save(sample_results(build_median: 0.05))
+
+    regressed = sample_results(build_median: 0.07)
+    regressions = store.check_regressions(regressed)
+
+    expect(regressions.length).to eq(1)
+    expect(regressions.first[:suite]).to eq(:build)
+    expect(regressions.first[:pct_change]).to eq(40.0)
+  end
+
+  it "reports no regressions when within threshold" do
+    store.save(sample_results(build_median: 0.05))
+
+    stable = sample_results(build_median: 0.055)
+    regressions = store.check_regressions(stable)
+
+    expect(regressions).to be_empty
+  end
+
+  it "returns empty regressions when no previous run exists" do
+    regressions = store.check_regressions(sample_results)
+    expect(regressions).to be_empty
+  end
+end

--- a/hecksties/spec/benchmarks/timer_spec.rb
+++ b/hecksties/spec/benchmarks/timer_spec.rb
@@ -1,0 +1,25 @@
+require "hecks"
+require "hecks/benchmarks"
+
+RSpec.describe Hecks::Benchmarks::Timer do
+  it "runs the block N times and returns min/median/max" do
+    counter = 0
+    result = described_class.measure(iterations: 5) { counter += 1 }
+
+    expect(counter).to eq(5)
+    expect(result).to have_key(:min)
+    expect(result).to have_key(:median)
+    expect(result).to have_key(:max)
+    expect(result).to have_key(:times)
+    expect(result[:times].length).to eq(5)
+    expect(result[:min]).to be <= result[:median]
+    expect(result[:median]).to be <= result[:max]
+  end
+
+  it "handles even iteration counts for median" do
+    result = described_class.measure(iterations: 4) { nil }
+
+    expect(result[:times].length).to eq(4)
+    expect(result[:median]).to be_a(Float)
+  end
+end


### PR DESCRIPTION
## Summary
feat: add benchmark subsystem with CLI command (HEC-95)

Adds `hecks benchmark` to measure build, load, and dispatch performance
with monotonic timing, JSON result storage, and 20% regression detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)