### PR TITLE
HEC-96: Property-based testing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -750,6 +750,13 @@
 - Validates 422 on invalid params via ActiveModel validations
 - Run explicitly: `bundle exec rspec hecksties/spec/rails_smoke_spec.rb --tag slow`
 
+### Property-Based Testing
+- `require "hecks/test_helper/property_testing"` — no external gems needed
+- `TypeGenerators` — per-type random value generators with configurable seed for reproducibility
+- `AggregateGenerator` — generates N random valid attribute hashes from aggregate IR metadata
+- `DomainFuzzer` — generates random data, executes create commands via runtime, produces a pass/fail report
+- RSpec integration: `property_test` helper for per-attribute assertions, `survive_fuzz_testing` matcher for full-domain fuzz runs
+
 ## Examples
 - Pizzas domain: plain Ruby app with commands, queries, collection proxies, event history
 - Pizzas static Ruby: generated standalone Ruby project with HTTP server, UI, roles, filesystem persistence

--- a/docs/usage/property_testing.md
+++ b/docs/usage/property_testing.md
@@ -1,0 +1,126 @@
+# Property-Based Testing
+
+Generate random valid data from your domain IR and fuzz-test your aggregates.
+No external gems required.
+
+## Setup
+
+```ruby
+# spec_helper.rb or wherever you need it
+require "hecks/test_helper/property_testing"
+```
+
+## Type Generators
+
+Generate random values for any Hecks attribute type:
+
+```ruby
+gen = Hecks::TestHelper::PropertyTesting::TypeGenerators.new(seed: 42)
+
+gen.generate(String)    # => "prop_kxqz"
+gen.generate(Integer)   # => 847
+gen.generate(Float)     # => 312.45
+gen.generate(Date)      # => #<Date: 2026-06-15>
+gen.generate(DateTime)  # => #<DateTime: 2026-06-15T10:30:00>
+gen.generate(JSON)      # => { "beta" => 73 }
+gen.generate("Pizza")   # => "a1b2c3d4-e5f6-..." (reference UUID)
+```
+
+Same seed produces the same sequence every time.
+
+## Aggregate Generator
+
+Generate N random attribute hashes from an aggregate's IR:
+
+```ruby
+domain = Hecks.domain("Pizzas") do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :style, String
+    attribute :price, Float
+  end
+end
+
+pizza_agg = domain.aggregates.first
+gen = Hecks::TestHelper::PropertyTesting::AggregateGenerator.new(pizza_agg, seed: 42)
+
+gen.generate(3)
+# => [
+#   { name: "prop_abc", style: "prop_def", price: 123.45 },
+#   { name: "prop_ghi", style: "prop_jkl", price: 678.90 },
+#   { name: "prop_mno", style: "prop_pqr", price: 234.56 }
+# ]
+
+# Generate for a specific command
+gen.generate_for_command("CreatePizza", 5)
+```
+
+## Domain Fuzzer
+
+Fuzz-test an entire domain by running random data through create commands:
+
+```ruby
+domain = Hecks.domain("Pizzas") { ... }
+runtime = Hecks.load(domain)
+
+fuzzer = Hecks::TestHelper::PropertyTesting::DomainFuzzer.new(domain, runtime, seed: 42)
+report = fuzzer.run(iterations: 50)
+
+report.passed?          # => true
+report.summary          # => "100/100 passed across 2 aggregate(s)"
+report.failures         # => [] (empty when all pass)
+report.failure_details  # => ["Pizza#CreatePizza: TypeError -- ..."]
+report.seed             # => 42 (for reproducing failures)
+```
+
+## RSpec Integration
+
+### property_test helper
+
+Run assertions against N random attribute hashes:
+
+```ruby
+RSpec.describe "Pizza properties" do
+  include Hecks::TestHelper::PropertyTesting::RSpecHelpers
+
+  let(:domain) { Hecks.domain("Pizzas") { ... } }
+  let(:pizza_agg) { domain.aggregates.first }
+
+  it "always generates string names" do
+    property_test(pizza_agg, count: 100, seed: 42) do |attrs|
+      expect(attrs[:name]).to be_a(String)
+      expect(attrs[:name].length).to be > 0
+    end
+  end
+end
+```
+
+### survive_fuzz_testing matcher
+
+Assert that a domain survives N iterations of random input:
+
+```ruby
+RSpec.describe "Domain fuzz test" do
+  let(:domain) { Hecks.domain("Pizzas") { ... } }
+  let(:runtime) { Hecks.load(domain) }
+
+  it "survives fuzz testing" do
+    expect([domain, runtime]).to survive_fuzz_testing(iterations: 50, seed: 42)
+  end
+end
+```
+
+On failure, the matcher prints the seed and all failure details so you can
+reproduce the exact sequence.
+
+## Reproducibility
+
+Every generator accepts a `seed:` parameter. When a test fails, note the seed
+from the output and pass it back to reproduce the exact same random sequence:
+
+```ruby
+# Failure output: "Fuzz testing failed (seed: 12345):"
+# Reproduce:
+fuzzer = DomainFuzzer.new(domain, runtime, seed: 12345)
+report = fuzzer.run(iterations: 50)
+```

--- a/hecksties/lib/hecks/test_helper/property_testing.rb
+++ b/hecksties/lib/hecks/test_helper/property_testing.rb
@@ -1,0 +1,26 @@
+# = Hecks::TestHelper::PropertyTesting
+#
+# Property-based testing toolkit for Hecks domains. Generates random valid
+# data from domain IR metadata and runs fuzz tests against booted runtimes.
+# No external gems required.
+#
+#   require "hecks/test_helper/property_testing"
+#
+#   gen = Hecks::TestHelper::PropertyTesting::AggregateGenerator.new(pizza_agg)
+#   gen.generate(10).each { |attrs| puts attrs.inspect }
+#
+#   fuzzer = Hecks::TestHelper::PropertyTesting::DomainFuzzer.new(domain, runtime)
+#   report = fuzzer.run(iterations: 50)
+#   puts report.summary
+#
+require_relative "property_testing/type_generators"
+require_relative "property_testing/aggregate_generator"
+require_relative "property_testing/domain_fuzzer"
+require_relative "property_testing/rspec_integration"
+
+module Hecks
+  module TestHelper
+    module PropertyTesting
+    end
+  end
+end

--- a/hecksties/lib/hecks/test_helper/property_testing/aggregate_generator.rb
+++ b/hecksties/lib/hecks/test_helper/property_testing/aggregate_generator.rb
@@ -1,0 +1,72 @@
+# = Hecks::TestHelper::PropertyTesting::AggregateGenerator
+#
+# Generates N random valid attribute hashes for an aggregate root. Uses
+# TypeGenerators to produce type-appropriate values for each attribute.
+# Useful for fuzz testing, bulk creation tests, and property assertions.
+#
+#   domain = Hecks.domain("Pizzas") { aggregate("Pizza") { attribute :name, String } }
+#   gen = AggregateGenerator.new(domain.aggregates.first, seed: 42)
+#   gen.generate(5)  # => [{ name: "prop_abc" }, { name: "prop_xyz" }, ...]
+#
+module Hecks
+  module TestHelper
+    module PropertyTesting
+      class AggregateGenerator
+        attr_reader :aggregate, :type_generators
+
+        # @param aggregate [Hecks::DomainModel::Structure::Aggregate] the aggregate IR
+        # @param seed [Integer, nil] random seed for reproducibility
+        def initialize(aggregate, seed: nil)
+          @aggregate = aggregate
+          @type_generators = TypeGenerators.new(seed: seed)
+        end
+
+        # @return [Integer] the seed used by the underlying type generator
+        def seed
+          @type_generators.seed
+        end
+
+        # Generate N random attribute hashes for the aggregate.
+        #
+        # @param count [Integer] number of hashes to generate
+        # @return [Array<Hash{Symbol => Object}>] random attribute hashes
+        def generate(count)
+          Array.new(count) { generate_one }
+        end
+
+        # Generate a single random attribute hash.
+        #
+        # @return [Hash{Symbol => Object}] a single random attribute hash
+        def generate_one
+          result = {}
+          @aggregate.attributes.each do |attr|
+            result[attr.name] = @type_generators.generate_for_attribute(attr)
+          end
+          result
+        end
+
+        # Generate attribute hashes for a specific command on this aggregate.
+        #
+        # @param command_name [String] the command name
+        # @param count [Integer] number of hashes to generate
+        # @return [Array<Hash{Symbol => Object}>] random command attribute hashes
+        def generate_for_command(command_name, count)
+          cmd = @aggregate.commands.find { |c| c.name == command_name }
+          raise ArgumentError, "Unknown command: #{command_name}" unless cmd
+
+          Array.new(count) { build_command_hash(cmd) }
+        end
+
+        private
+
+        def build_command_hash(command)
+          result = {}
+          command.attributes.each do |attr|
+            result[attr.name] = @type_generators.generate_for_attribute(attr)
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/test_helper/property_testing/domain_fuzzer.rb
+++ b/hecksties/lib/hecks/test_helper/property_testing/domain_fuzzer.rb
@@ -1,0 +1,126 @@
+# = Hecks::TestHelper::PropertyTesting::DomainFuzzer
+#
+# Generates random data for every aggregate in a domain, executes create
+# commands against a booted runtime, and reports successes and failures.
+# Designed for smoke-testing domain models with random inputs.
+#
+#   domain = Hecks.domain("Pizzas") { ... }
+#   runtime = Hecks.load(domain)
+#   report = DomainFuzzer.new(domain, runtime).run(iterations: 20)
+#   report.passed?        # => true
+#   report.summary        # => "20/20 passed across 2 aggregates"
+#
+module Hecks
+  module TestHelper
+    module PropertyTesting
+      class DomainFuzzer
+        attr_reader :domain, :runtime
+
+        # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+        # @param runtime [Hecks::Runtime] a booted runtime with memory adapters
+        # @param seed [Integer, nil] random seed for reproducibility
+        def initialize(domain, runtime, seed: nil)
+          @domain = domain
+          @runtime = runtime
+          @seed = seed
+        end
+
+        # Run the fuzzer against all aggregates.
+        #
+        # @param iterations [Integer] number of random instances per aggregate
+        # @return [FuzzReport] the test report
+        def run(iterations: 10)
+          results = []
+          @domain.aggregates.each do |agg|
+            results.concat(fuzz_aggregate(agg, iterations))
+          end
+          FuzzReport.new(results: results, seed: @seed)
+        end
+
+        private
+
+        def fuzz_aggregate(aggregate, iterations)
+          gen = AggregateGenerator.new(aggregate, seed: @seed)
+          create_cmd = find_create_command(aggregate)
+          return [] unless create_cmd
+
+          gen.generate_for_command(create_cmd.name, iterations).map do |attrs|
+            fuzz_one(aggregate, create_cmd, attrs)
+          end
+        end
+
+        def fuzz_one(aggregate, command, attrs)
+          @runtime.run(command.name, **attrs)
+          FuzzResult.new(
+            aggregate: aggregate.name,
+            command: command.name,
+            attributes: attrs,
+            success: true
+          )
+        rescue StandardError => e
+          FuzzResult.new(
+            aggregate: aggregate.name,
+            command: command.name,
+            attributes: attrs,
+            success: false,
+            error: e
+          )
+        end
+
+        def find_create_command(aggregate)
+          aggregate.commands.find { |c| c.name.start_with?("Create") }
+        end
+      end
+
+      # Immutable result of a single fuzz attempt.
+      class FuzzResult
+        attr_reader :aggregate, :command, :attributes, :error
+
+        def initialize(aggregate:, command:, attributes:, success:, error: nil)
+          @aggregate = aggregate
+          @command = command
+          @attributes = attributes
+          @success = success
+          @error = error
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      # Summary report from a full fuzz run.
+      class FuzzReport
+        attr_reader :results, :seed
+
+        def initialize(results:, seed:)
+          @results = results
+          @seed = seed
+        end
+
+        def passed?
+          @results.all?(&:success?)
+        end
+
+        def failures
+          @results.reject(&:success?)
+        end
+
+        def successes
+          @results.select(&:success?)
+        end
+
+        def summary
+          aggs = @results.map(&:aggregate).uniq
+          "#{successes.size}/#{@results.size} passed across #{aggs.size} aggregate(s)"
+        end
+
+        def failure_details
+          failures.map do |f|
+            "#{f.aggregate}##{f.command}: #{f.error.class} — #{f.error.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/test_helper/property_testing/rspec_integration.rb
+++ b/hecksties/lib/hecks/test_helper/property_testing/rspec_integration.rb
@@ -1,0 +1,75 @@
+# = Hecks::TestHelper::PropertyTesting::RSpecIntegration
+#
+# RSpec matchers and helpers for property-based testing. Provides
+# `survive_fuzz_testing` matcher and `property_test` helper method
+# for concise property assertions in specs.
+#
+#   RSpec.describe "Pizza domain" do
+#     include Hecks::TestHelper::PropertyTesting::RSpecHelpers
+#
+#     it "survives fuzz testing" do
+#       expect(domain_with_runtime).to survive_fuzz_testing(iterations: 50)
+#     end
+#
+#     it "always produces valid names" do
+#       property_test(aggregate, count: 20) do |attrs|
+#         expect(attrs[:name]).to be_a(String)
+#       end
+#     end
+#   end
+#
+module Hecks
+  module TestHelper
+    module PropertyTesting
+      module RSpecHelpers
+        # Run a property assertion against N random attribute hashes.
+        #
+        # @param aggregate [Hecks::DomainModel::Structure::Aggregate] the aggregate IR
+        # @param count [Integer] number of random samples
+        # @param seed [Integer, nil] random seed
+        # @yield [Hash] each generated attribute hash
+        def property_test(aggregate, count: 20, seed: nil, &block)
+          gen = AggregateGenerator.new(aggregate, seed: seed)
+          gen.generate(count).each(&block)
+        end
+      end
+
+      # RSpec matcher: expect(domain_with_runtime).to survive_fuzz_testing
+      class SurviveFuzzTestingMatcher
+        def initialize(iterations:, seed:)
+          @iterations = iterations
+          @seed = seed
+        end
+
+        def matches?(domain_runtime_pair)
+          domain, runtime = domain_runtime_pair
+          fuzzer = DomainFuzzer.new(domain, runtime, seed: @seed)
+          @report = fuzzer.run(iterations: @iterations)
+          @report.passed?
+        end
+
+        def failure_message
+          lines = ["Fuzz testing failed (seed: #{@report.seed}):"]
+          lines.concat(@report.failure_details.map { |d| "  - #{d}" })
+          lines.join("\n")
+        end
+
+        def description
+          "survive #{@iterations} iterations of fuzz testing"
+        end
+      end
+    end
+  end
+end
+
+if defined?(RSpec)
+  RSpec::Matchers.define :survive_fuzz_testing do |iterations: 10, seed: nil|
+    matcher = Hecks::TestHelper::PropertyTesting::SurviveFuzzTestingMatcher.new(
+      iterations: iterations, seed: seed
+    )
+
+    match { |actual| matcher.matches?(actual) }
+    failure_message { matcher.failure_message }
+    description { matcher.description }
+  end
+end

--- a/hecksties/lib/hecks/test_helper/property_testing/type_generators.rb
+++ b/hecksties/lib/hecks/test_helper/property_testing/type_generators.rb
@@ -1,0 +1,114 @@
+# = Hecks::TestHelper::PropertyTesting::TypeGenerators
+#
+# Per-type random value generators for property-based testing. Each Hecks
+# attribute type (String, Integer, Float, Date, etc.) has a corresponding
+# generator that produces random valid values. Handles list_of and
+# reference_to attributes. Seed is configurable for reproducibility.
+#
+#   gen = TypeGenerators.new(seed: 42)
+#   gen.generate(String)              # => "prop_kxqz"
+#   gen.generate(Integer)             # => 847
+#   gen.generate_for_attribute(attr)  # handles list/reference types
+#
+module Hecks
+  module TestHelper
+    module PropertyTesting
+      class TypeGenerators
+        attr_reader :rng
+
+        # @param seed [Integer, nil] random seed for reproducibility
+        def initialize(seed: nil)
+          @seed = seed || Random.new_seed
+          @rng = Random.new(@seed)
+        end
+
+        # @return [Integer] the seed used by this generator
+        def seed
+          @seed
+        end
+
+        # Generate a random value for a given type class.
+        #
+        # @param type [Class, String] the attribute type
+        # @return [Object] a random value of the appropriate type
+        def generate(type)
+          type_key = type.is_a?(Class) ? type.name : type.to_s
+
+          case type_key
+          when "String"   then generate_string
+          when "Integer"  then generate_integer
+          when "Float"    then generate_float
+          when "Date"     then generate_date
+          when "DateTime" then generate_datetime
+          when "JSON"     then generate_json
+          else
+            type.is_a?(String) ? generate_reference_id : generate_string
+          end
+        end
+
+        # Generate a value appropriate for an Attribute IR node, handling
+        # list_of and reference_to patterns.
+        #
+        # @param attribute [Hecks::DomainModel::Structure::Attribute] the attribute
+        # @return [Object] a random valid value
+        def generate_for_attribute(attribute)
+          if attribute.list?
+            generate_list(attribute.type)
+          elsif attribute.enum
+            attribute.enum.sample(random: @rng)
+          else
+            generate(attribute.type)
+          end
+        end
+
+        private
+
+        def generate_string
+          len = @rng.rand(3..12)
+          chars = ("a".."z").to_a
+          "prop_" + Array.new(len) { chars[@rng.rand(chars.size)] }.join
+        end
+
+        def generate_integer
+          @rng.rand(1..10_000)
+        end
+
+        def generate_float
+          (@rng.rand * 1000).round(2)
+        end
+
+        def generate_date
+          days_offset = @rng.rand(-365..365)
+          Date.today + days_offset
+        end
+
+        def generate_datetime
+          days_offset = @rng.rand(-365..365)
+          DateTime.now + days_offset
+        end
+
+        def generate_json
+          keys = %w[alpha beta gamma delta]
+          key = keys[@rng.rand(keys.size)]
+          { key => @rng.rand(1..100) }
+        end
+
+        def generate_reference_id
+          format(
+            "%08x-%04x-%04x-%04x-%012x",
+            @rng.rand(0xFFFFFFFF),
+            @rng.rand(0xFFFF),
+            @rng.rand(0xFFFF),
+            @rng.rand(0xFFFF),
+            @rng.rand(0xFFFFFFFFFFFF)
+          )
+        end
+
+        def generate_list(element_type)
+          count = @rng.rand(0..5)
+          Array.new(count) { generate(element_type) }
+        end
+      end
+    end
+  end
+end

--- a/hecksties/spec/property_testing_spec.rb
+++ b/hecksties/spec/property_testing_spec.rb
@@ -1,0 +1,154 @@
+require_relative "../spec_helper"
+require "hecks/test_helper/property_testing"
+
+RSpec.describe Hecks::TestHelper::PropertyTesting do
+  let(:domain) { BootedDomains.pizzas }
+  let(:pizza_agg) { domain.aggregates.find { |a| a.name == "Pizza" } }
+  let(:order_agg) { domain.aggregates.find { |a| a.name == "Order" } }
+
+  describe Hecks::TestHelper::PropertyTesting::TypeGenerators do
+    subject(:gen) { described_class.new(seed: 42) }
+
+    it "generates strings" do
+      val = gen.generate(String)
+      expect(val).to be_a(String)
+      expect(val).to start_with("prop_")
+    end
+
+    it "generates integers" do
+      val = gen.generate(Integer)
+      expect(val).to be_a(Integer)
+      expect(val).to be_between(1, 10_000)
+    end
+
+    it "generates floats" do
+      val = gen.generate(Float)
+      expect(val).to be_a(Float)
+    end
+
+    it "generates dates" do
+      val = gen.generate(Date)
+      expect(val).to be_a(Date)
+    end
+
+    it "generates datetimes" do
+      val = gen.generate(DateTime)
+      expect(val).to be_a(DateTime)
+    end
+
+    it "generates JSON hashes" do
+      val = gen.generate(JSON)
+      expect(val).to be_a(Hash)
+    end
+
+    it "generates reference UUIDs for unknown string types" do
+      val = gen.generate("Pizza")
+      expect(val).to be_a(String)
+      expect(val).to match(/\A[0-9a-f]{8}-/)
+    end
+
+    it "is reproducible with the same seed" do
+      gen1 = described_class.new(seed: 99)
+      gen2 = described_class.new(seed: 99)
+      5.times do
+        expect(gen1.generate(String)).to eq(gen2.generate(String))
+      end
+    end
+
+    it "generates for list attributes" do
+      list_attr = pizza_agg.attributes.find { |a| a.list? }
+      next skip("no list attribute found") unless list_attr
+
+      val = gen.generate_for_attribute(list_attr)
+      expect(val).to be_an(Array)
+    end
+
+    it "generates for enum attributes" do
+      enum_attr = Hecks::DomainModel::Structure::Attribute.new(
+        name: :status, type: String, enum: %w[active inactive]
+      )
+      val = gen.generate_for_attribute(enum_attr)
+      expect(%w[active inactive]).to include(val)
+    end
+  end
+
+  describe Hecks::TestHelper::PropertyTesting::AggregateGenerator do
+    subject(:gen) { described_class.new(pizza_agg, seed: 42) }
+
+    it "generates N attribute hashes" do
+      hashes = gen.generate(5)
+      expect(hashes.size).to eq(5)
+      hashes.each do |h|
+        expect(h).to be_a(Hash)
+        expect(h).to have_key(:name)
+      end
+    end
+
+    it "generates a single hash" do
+      h = gen.generate_one
+      expect(h).to be_a(Hash)
+      expect(h[:name]).to be_a(String)
+    end
+
+    it "generates for a specific command" do
+      hashes = gen.generate_for_command("CreatePizza", 3)
+      expect(hashes.size).to eq(3)
+      hashes.each do |h|
+        expect(h).to have_key(:name)
+        expect(h).to have_key(:style)
+      end
+    end
+
+    it "raises on unknown command" do
+      expect { gen.generate_for_command("Nonexistent", 1) }
+        .to raise_error(ArgumentError, /Unknown command/)
+    end
+
+    it "is reproducible" do
+      gen1 = described_class.new(pizza_agg, seed: 77)
+      gen2 = described_class.new(pizza_agg, seed: 77)
+      expect(gen1.generate(3)).to eq(gen2.generate(3))
+    end
+
+    it "exposes the seed" do
+      expect(gen.seed).to eq(42)
+    end
+  end
+
+  describe Hecks::TestHelper::PropertyTesting::DomainFuzzer do
+    let(:runtime) { Hecks.load(domain) }
+
+    it "runs fuzz tests and produces a report" do
+      fuzzer = described_class.new(domain, runtime, seed: 42)
+      report = fuzzer.run(iterations: 5)
+
+      expect(report).to be_a(Hecks::TestHelper::PropertyTesting::FuzzReport)
+      expect(report.results).not_to be_empty
+      expect(report.summary).to match(/\d+\/\d+ passed/)
+    end
+
+    it "reports seed for reproducibility" do
+      fuzzer = described_class.new(domain, runtime, seed: 123)
+      report = fuzzer.run(iterations: 2)
+      expect(report.seed).to eq(123)
+    end
+  end
+
+  describe "RSpec integration" do
+    include Hecks::TestHelper::PropertyTesting::RSpecHelpers
+
+    it "provides property_test helper" do
+      tested = 0
+      property_test(pizza_agg, count: 10, seed: 42) do |attrs|
+        expect(attrs[:name]).to be_a(String)
+        tested += 1
+      end
+      expect(tested).to eq(10)
+    end
+
+    it "provides survive_fuzz_testing matcher" do
+      runtime = Hecks.load(domain)
+      expect([domain, runtime]).to survive_fuzz_testing(iterations: 5, seed: 42)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add property-based testing for Hecks domains (HEC-96)

Type-aware random generators, aggregate fuzzers, and RSpec integration
for testing domains with random valid data. No external gems required.
Seed-based reproducibility for debugging failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)