### PR TITLE
HEC-97: Contract testing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -743,6 +743,13 @@
 - Fetches `/_events` from both, normalizes to event name lists, asserts equality
 - Run explicitly: `bundle exec rspec hecksties/spec/cross_target_parity_spec.rb --tag parity`
 
+### Contract Testing
+- `Hecks::ContractTesting` module with shared RSpec examples for repository adapter compliance
+- `include_examples "hecks repository contract"` exercises find, save, delete, all, count, query, clear
+- Adapter and factory provided as lambdas -- works with any adapter (memory, SQL, filesystem, MongoDB)
+- `Hecks::ContractTesting.generate_specs(domain, output_dir:)` auto-generates contract specs per aggregate
+- Generated specs include full domain DSL so they run standalone
+
 ### Rails Smoke Test
 - `hecksties/spec/rails_smoke_spec.rb` — tagged `:slow`, excluded from default run
 - Boots `examples/pizzas_rails` as a real subprocess against a free port

--- a/docs/usage/contract_testing.md
+++ b/docs/usage/contract_testing.md
@@ -1,0 +1,81 @@
+# Contract Testing
+
+Verify that any repository adapter conforms to the Hecks repository interface.
+
+## Quick Start
+
+```ruby
+require "hecks/contract_testing"
+
+RSpec.describe "Pizza memory adapter" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  include_examples "hecks repository contract",
+    adapter: -> { PizzasDomain::Adapters::PizzaMemoryRepository.new },
+    factory: -> { PizzasDomain::Pizza.new(name: "Margherita") }
+end
+```
+
+## What It Tests
+
+The shared examples exercise the full repository interface:
+
+| Method | Assertions |
+|--------|-----------|
+| `save` + `find` | Persists and retrieves by ID; overwrites on duplicate |
+| `find` | Returns `nil` for unknown ID |
+| `delete` | Removes entity; no-op for unknown ID |
+| `all` | Returns all entities; empty array when empty |
+| `count` | Returns count; 0 when empty |
+| `query` | Filters by conditions; supports limit and offset |
+| `clear` | Removes all entities |
+
+## Auto-Generate Specs
+
+Generate contract specs for every aggregate in a domain:
+
+```ruby
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+
+Hecks::ContractTesting.generate_specs(domain, output_dir: "spec/contracts")
+# => ["spec/contracts/pizza_repository_contract_spec.rb"]
+```
+
+Each generated file is standalone and includes the full domain DSL block,
+so it can run without your app's boot sequence.
+
+## Testing a Custom Adapter
+
+```ruby
+require "hecks/contract_testing"
+
+RSpec.describe MySqlAdapter do
+  before(:all) { setup_test_database }
+  after(:all) { teardown_test_database }
+
+  include_examples "hecks repository contract",
+    adapter: -> { MySqlAdapter.new(connection: test_conn, table: "pizzas") },
+    factory: -> { PizzasDomain::Pizza.new(name: "Test") }
+end
+```
+
+Any adapter that passes all shared examples is guaranteed to work with
+the Hecks runtime.

--- a/hecksties/lib/hecks/contract_testing.rb
+++ b/hecksties/lib/hecks/contract_testing.rb
@@ -1,0 +1,43 @@
+# = Hecks::ContractTesting
+#
+# Test harness for verifying that repository adapters conform to the
+# Hecks repository interface contract. Provides shared RSpec examples
+# that exercise find, save, delete, all, count, query, and clear --
+# ensuring any adapter (memory, SQL, filesystem, MongoDB, etc.) behaves
+# identically.
+#
+# Also includes a spec generator that writes contract specs for every
+# aggregate in a domain, so adapter authors get compliance tests for free.
+#
+# == Usage (manual)
+#
+#   require "hecks/contract_testing"
+#
+#   RSpec.describe MyAdapter do
+#     include_examples "hecks repository contract",
+#       adapter: -> { MyAdapter.new },
+#       factory: -> { MyDomain::Pizza.new(name: "Test") }
+#   end
+#
+# == Usage (auto-generate)
+#
+#   Hecks::ContractTesting.generate_specs(domain, output_dir: "spec/contracts")
+#
+require_relative "contract_testing/repository_contract"
+require_relative "contract_testing/spec_generator"
+
+module Hecks
+  module ContractTesting
+    # Generates contract spec files for every aggregate in a domain.
+    #
+    # Delegates to SpecGenerator to produce one spec file per aggregate,
+    # each including the shared "hecks repository contract" examples.
+    #
+    # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+    # @param output_dir [String] directory to write spec files into
+    # @return [Array<String>] list of generated file paths
+    def self.generate_specs(domain, output_dir:)
+      SpecGenerator.new(domain, output_dir: output_dir).generate
+    end
+  end
+end

--- a/hecksties/lib/hecks/contract_testing/repository_contract.rb
+++ b/hecksties/lib/hecks/contract_testing/repository_contract.rb
@@ -1,0 +1,132 @@
+# = Hecks::ContractTesting::RepositoryContract
+#
+# Shared RSpec examples that verify a repository adapter implements the
+# full Hecks repository interface: find, save, delete, all, count,
+# query, and clear. Any adapter that passes these examples is guaranteed
+# to work with the Hecks runtime.
+#
+# == Usage
+#
+#   RSpec.describe MyAdapter do
+#     include_examples "hecks repository contract",
+#       adapter: -> { MyAdapter.new },
+#       factory: -> { MyDomain::Pizza.new(name: "Margherita") }
+#   end
+#
+module Hecks
+  module ContractTesting
+    module RepositoryContract
+      def self.register!
+        RSpec.shared_examples "hecks repository contract" do |adapter:, factory:|
+          let(:repo) { adapter.call }
+          let(:entity) { factory.call }
+
+          after { repo.clear }
+
+          describe "#save and #find" do
+            it "persists and retrieves an entity by id" do
+              repo.save(entity)
+              found = repo.find(entity.id)
+              expect(found).not_to be_nil
+              expect(found.id).to eq(entity.id)
+            end
+
+            it "overwrites on duplicate save" do
+              repo.save(entity)
+              repo.save(entity)
+              expect(repo.count).to eq(1)
+            end
+          end
+
+          describe "#find" do
+            it "returns nil for unknown id" do
+              expect(repo.find("nonexistent-id")).to be_nil
+            end
+          end
+
+          describe "#delete" do
+            it "removes a persisted entity" do
+              repo.save(entity)
+              repo.delete(entity.id)
+              expect(repo.find(entity.id)).to be_nil
+            end
+
+            it "is a no-op for unknown id" do
+              expect { repo.delete("nonexistent-id") }.not_to raise_error
+            end
+          end
+
+          describe "#all" do
+            it "returns all persisted entities" do
+              e1 = factory.call
+              e2 = factory.call
+              repo.save(e1)
+              repo.save(e2)
+              ids = repo.all.map(&:id)
+              expect(ids).to contain_exactly(e1.id, e2.id)
+            end
+
+            it "returns empty array when empty" do
+              expect(repo.all).to eq([])
+            end
+          end
+
+          describe "#count" do
+            it "returns the number of persisted entities" do
+              repo.save(factory.call)
+              repo.save(factory.call)
+              expect(repo.count).to eq(2)
+            end
+
+            it "returns 0 when empty" do
+              expect(repo.count).to eq(0)
+            end
+          end
+
+          describe "#query" do
+            it "filters by conditions" do
+              e1 = factory.call
+              e2 = factory.call
+              repo.save(e1)
+              repo.save(e2)
+              results = repo.query(conditions: { id: e1.id })
+              expect(results.size).to eq(1)
+              expect(results.first.id).to eq(e1.id)
+            end
+
+            it "supports limit" do
+              3.times { repo.save(factory.call) }
+              results = repo.query(limit: 2)
+              expect(results.size).to eq(2)
+            end
+
+            it "supports offset" do
+              3.times { repo.save(factory.call) }
+              all_results = repo.query
+              offset_results = repo.query(offset: 1)
+              expect(offset_results.size).to eq(2)
+            end
+
+            it "returns all when no filters given" do
+              repo.save(factory.call)
+              repo.save(factory.call)
+              expect(repo.query.size).to eq(2)
+            end
+          end
+
+          describe "#clear" do
+            it "removes all entities" do
+              repo.save(factory.call)
+              repo.save(factory.call)
+              repo.clear
+              expect(repo.count).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+# Auto-register when loaded under RSpec
+Hecks::ContractTesting::RepositoryContract.register! if defined?(RSpec)

--- a/hecksties/lib/hecks/contract_testing/spec_generator.rb
+++ b/hecksties/lib/hecks/contract_testing/spec_generator.rb
@@ -1,0 +1,102 @@
+# = Hecks::ContractTesting::SpecGenerator
+#
+# Generates contract spec files for every aggregate in a domain.
+# Each spec file includes the shared "hecks repository contract"
+# examples, pre-wired with the domain's memory adapter and a factory
+# lambda that constructs a valid aggregate instance.
+#
+# == Usage
+#
+#   gen = Hecks::ContractTesting::SpecGenerator.new(domain, output_dir: "spec/contracts")
+#   paths = gen.generate  # => ["spec/contracts/pizza_repository_contract_spec.rb", ...]
+#
+module Hecks
+  module ContractTesting
+    class SpecGenerator
+      include HecksTemplating::NamingHelpers
+
+      # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+      # @param output_dir [String] directory to write spec files into
+      def initialize(domain, output_dir:)
+        @domain = domain
+        @output_dir = output_dir
+      end
+
+      # Generates one contract spec file per aggregate.
+      #
+      # @return [Array<String>] absolute paths of written files
+      def generate
+        FileUtils.mkdir_p(@output_dir)
+        @domain.aggregates.map { |agg| write_spec(agg) }
+      end
+
+      private
+
+      def write_spec(aggregate)
+        safe = domain_constant_name(aggregate.name)
+        snake = domain_snake_name(safe)
+        mod = domain_constant_name(@domain.name) + "Domain"
+        path = File.join(@output_dir, "#{snake}_repository_contract_spec.rb")
+
+        attrs = aggregate.attributes.map do |attr|
+          "#{attr.name}: #{sample_value(attr.type)}"
+        end.join(", ")
+
+        content = spec_template(mod, safe, attrs)
+        File.write(path, content)
+        path
+      end
+
+      def spec_template(mod, aggregate, attrs)
+        <<~RUBY
+          require "hecks"
+          require "hecks/contract_testing"
+
+          RSpec.describe "#{aggregate} repository contract" do
+            let(:domain) do
+              Hecks.domain "#{@domain.name}" do
+          #{domain_block_body}
+              end
+            end
+
+            before { @app = Hecks.load(domain) }
+
+            include_examples "hecks repository contract",
+              adapter: -> { #{mod}::Adapters::#{aggregate}MemoryRepository.new },
+              factory: -> { #{mod}::#{aggregate}.new(#{attrs}) }
+          end
+        RUBY
+      end
+
+      def domain_block_body
+        @domain.aggregates.map do |agg|
+          lines = []
+          lines << "      aggregate \"#{agg.name}\" do"
+          agg.attributes.each do |attr|
+            lines << "        attribute :#{attr.name}, #{attr.type}"
+          end
+          agg.commands.each do |cmd|
+            lines << "        command \"#{cmd.name}\" do"
+            cmd.attributes.each do |attr|
+              lines << "          attribute :#{attr.name}, #{attr.type}"
+            end
+            lines << "        end"
+          end
+          lines << "      end"
+          lines.join("\n")
+        end.join("\n")
+      end
+
+      def sample_value(type)
+        case type.to_s
+        when "Integer" then "1"
+        when "Float"   then "1.0"
+        when "Boolean" then "true"
+        when "Date"    then "Date.today"
+        when "DateTime" then "DateTime.now"
+        else '"test"'
+        end
+      end
+    end
+  end
+end

--- a/hecksties/spec/contract_testing/repository_contract_spec.rb
+++ b/hecksties/spec/contract_testing/repository_contract_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "hecks/contract_testing"
+
+RSpec.describe Hecks::ContractTesting::RepositoryContract do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+
+        command "CreatePizza" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  describe ".register!" do
+    it "registers the shared example group" do
+      groups = RSpec.world.shared_example_group_registry
+        .send(:shared_example_groups)[:main]
+      expect(groups).to have_key("hecks repository contract")
+    end
+  end
+
+  include_examples "hecks repository contract",
+    adapter: -> { PizzasDomain::Adapters::PizzaMemoryRepository.new },
+    factory: -> { PizzasDomain::Pizza.new(name: "Test") }
+end

--- a/hecksties/spec/contract_testing/spec_generator_spec.rb
+++ b/hecksties/spec/contract_testing/spec_generator_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "hecks/contract_testing"
+require "tmpdir"
+
+RSpec.describe Hecks::ContractTesting::SpecGenerator do
+  let(:domain) do
+    Hecks.domain "Orders" do
+      aggregate "Order" do
+        attribute :total, Integer
+        attribute :status, String
+
+        command "PlaceOrder" do
+          attribute :total, Integer
+          attribute :status, String
+        end
+      end
+
+      aggregate "Item" do
+        attribute :name, String
+
+        command "CreateItem" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  it "generates one spec file per aggregate" do
+    Dir.mktmpdir do |dir|
+      paths = described_class.new(domain, output_dir: dir).generate
+      expect(paths.size).to eq(2)
+      basenames = paths.map { |p| File.basename(p) }.sort
+      expect(basenames).to eq([
+        "item_repository_contract_spec.rb",
+        "order_repository_contract_spec.rb"
+      ])
+    end
+  end
+
+  it "uses correct type sample values in generated specs" do
+    Dir.mktmpdir do |dir|
+      paths = described_class.new(domain, output_dir: dir).generate
+      order_spec = File.read(paths.find { |p| p.include?("order") })
+      expect(order_spec).to include("total: 1")
+      expect(order_spec).to include('status: "test"')
+    end
+  end
+
+  it "includes the shared examples reference" do
+    Dir.mktmpdir do |dir|
+      paths = described_class.new(domain, output_dir: dir).generate
+      paths.each do |path|
+        content = File.read(path)
+        expect(content).to include('include_examples "hecks repository contract"')
+      end
+    end
+  end
+end

--- a/hecksties/spec/contract_testing_spec.rb
+++ b/hecksties/spec/contract_testing_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "hecks/contract_testing"
+require "tmpdir"
+
+RSpec.describe Hecks::ContractTesting do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :style, String
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :style, String
+        end
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  describe "shared examples" do
+    include_examples "hecks repository contract",
+      adapter: -> { PizzasDomain::Adapters::PizzaMemoryRepository.new },
+      factory: -> { PizzasDomain::Pizza.new(name: "Margherita", style: "Classic") }
+  end
+
+  describe ".generate_specs" do
+    it "writes a contract spec file per aggregate" do
+      Dir.mktmpdir do |dir|
+        paths = Hecks::ContractTesting.generate_specs(domain, output_dir: dir)
+        expect(paths.size).to eq(1)
+        expect(File.basename(paths.first)).to eq("pizza_repository_contract_spec.rb")
+        content = File.read(paths.first)
+        expect(content).to include("hecks repository contract")
+        expect(content).to include("PizzasDomain::Adapters::PizzaMemoryRepository")
+        expect(content).to include("PizzasDomain::Pizza.new")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
test: add dedicated specs for repository_contract and spec_generator


feat: add contract testing for repository adapters (HEC-97)

Shared RSpec examples verify find, save, delete, all, count, query, and
clear on any adapter. Auto-generate contract specs per aggregate with
Hecks::ContractTesting.generate_specs(domain, output_dir:).

🤖 Generated with [Claude Code](https://claude.com/claude-code)