### PR TITLE
HEC-98: Time travel debugging

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -215,6 +215,13 @@
 - Collection proxies for `list_of` attributes with `create`, `delete`, `each`, `count`
 - Automatic reference resolution with lazy loading from repository
 - Optional event sourcing with `EventRecorder` and `Aggregate.history(id)` replay
+- In-memory `EventStore` automatically records all published events with version numbers
+- Time travel: `app.as_of(timestamp).find("Pizza", id)` — reconstitutes aggregate state at a past point in time
+- Version replay: `app.at_version("Pizza", id, version: n)` — reconstitutes aggregate state at a specific event version
+- `app.reconstitute_at_version` alias for `at_version` for naming symmetry
+- `app.event_store` exposes the in-memory event store for direct stream queries
+- `event_store.read_stream_until(stream_id, timestamp:)` — filter events by time
+- `event_store.read_stream_to_version(stream_id, version:)` — filter events by version
 
 ## Querying
 - `where(field: value)` filtering on aggregates

--- a/docs/usage/time_travel.md
+++ b/docs/usage/time_travel.md
@@ -1,0 +1,109 @@
+# Time Travel — Replay Events to Point in Time
+
+Hecks automatically records every domain event published through the event bus
+into an in-memory `EventStore`. This enables replaying events to reconstruct
+aggregate state at any past point in time or at a specific version number.
+
+## Setup
+
+Time travel is built in — no extra configuration needed. Every `Hecks.load` or
+`Hecks.boot` call wires the event store automatically.
+
+```ruby
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :style, String
+
+    command "CreatePizza" do
+      attribute :name, String
+      attribute :style, String
+    end
+
+    command "RenamePizza" do
+      reference_to "Pizza"
+      attribute :name, String
+    end
+  end
+end
+
+app = Hecks.load(domain)
+```
+
+## Replay by Timestamp
+
+Use `app.as_of(timestamp)` to get a proxy that reconstitutes aggregates as they
+were at a given point in time:
+
+```ruby
+pizza = Pizza.create(name: "Original", style: "Classic")
+snapshot_time = Time.now
+
+# ... some time passes ...
+Pizza.rename(pizza: pizza.id, name: "Updated")
+
+# Travel back in time
+past_pizza = app.as_of(snapshot_time).find("Pizza", pizza.id)
+past_pizza.name  # => "Original"
+
+# Current state is unchanged
+Pizza.find(pizza.id).name  # => "Updated"
+```
+
+## Replay by Version
+
+Use `app.at_version` to reconstitute an aggregate at a specific event version:
+
+```ruby
+pizza = Pizza.create(name: "V1", style: "Classic")  # version 1
+Pizza.rename(pizza: pizza.id, name: "V2")            # version 2
+Pizza.rename(pizza: pizza.id, name: "V3")            # version 3
+
+v1 = app.at_version("Pizza", pizza.id, version: 1)
+v1.name  # => "V1"
+
+v2 = app.at_version("Pizza", pizza.id, version: 2)
+v2.name  # => "V2"
+```
+
+`reconstitute_at_version` is an alias for `at_version`:
+
+```ruby
+app.reconstitute_at_version("Pizza", pizza.id, version: 1)
+```
+
+## Direct EventStore Access
+
+The event store is available on the runtime for direct queries:
+
+```ruby
+store = app.event_store
+
+# All events in a stream
+store.read_stream("Pizza-#{pizza.id}")
+
+# Events up to a timestamp
+store.read_stream_until("Pizza-#{pizza.id}", timestamp: 1.hour.ago)
+
+# Events up to a version
+store.read_stream_to_version("Pizza-#{pizza.id}", version: 2)
+
+# Current version of a stream
+store.stream_version("Pizza-#{pizza.id}")  # => 3
+```
+
+Each record is a Hash with:
+- `:stream_id` — e.g. `"Pizza-abc123"`
+- `:version` — monotonically increasing integer per stream
+- `:event_type` — e.g. `"CreatedPizza"`
+- `:event` — the original domain event object
+- `:occurred_at` — the event's `Time` timestamp
+
+## How It Works
+
+1. Every domain event published on the event bus is automatically appended to
+   the in-memory `EventStore` via a global listener.
+2. Events are grouped into streams keyed by `"AggregateType-id"`.
+3. Each event gets an incrementing version number within its stream.
+4. `as_of` and `at_version` filter the stream, then replay events sequentially
+   to reconstruct the aggregate by applying event attributes cumulatively.

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -145,6 +145,7 @@ module Hecks
   # PortWiring is included directly in Runtime, no autoload needed
   autoload :AttachmentMethods, "hecks/runtime/attachment_methods"
   autoload :EventBus,          "hecks/ports/event_bus/event_bus"
+  autoload :EventStore,        "hecks/ports/event_store"
   # FilteredEventBus, CrossDomainQuery, CrossDomainView → hecks_multidomain
   autoload :Queue,             "hecks/ports/queue"
   autoload :GateEnforcer,      "hecks/runtime/gate_enforcer"

--- a/hecksties/lib/hecks/ports/event_store.rb
+++ b/hecksties/lib/hecks/ports/event_store.rb
@@ -1,0 +1,90 @@
+# Hecks::EventStore
+#
+# In-memory event store that records domain events per aggregate stream.
+# Each event is stored with a stream ID, version number, and occurred_at
+# timestamp. Supports time-travel queries for replaying events up to a
+# point in time or a specific version.
+#
+# == Usage
+#
+#   store = Hecks::EventStore.new
+#   store.append("Pizza-42", event)
+#   store.read_stream("Pizza-42")           # => all events
+#   store.read_stream_until("Pizza-42", timestamp: cutoff)
+#   store.read_stream_to_version("Pizza-42", version: 3)
+#
+module Hecks
+  class EventStore
+    # @return [Array<Hash>] all stored event records across all streams
+    attr_reader :records
+
+    # Initializes an empty event store.
+    def initialize
+      @records = []
+      @stream_versions = Hash.new(0)
+    end
+
+    # Appends an event to the given stream. Assigns the next version number
+    # for that stream and captures the event's occurred_at timestamp.
+    #
+    # @param stream_id [String] the stream identifier (e.g. "Pizza-42")
+    # @param event [Object] domain event with +.occurred_at+ and +.class.name+
+    # @return [Hash] the stored event record
+    def append(stream_id, event)
+      @stream_versions[stream_id] += 1
+      record = {
+        stream_id: stream_id,
+        version: @stream_versions[stream_id],
+        event_type: Hecks::Utils.const_short_name(event),
+        event: event,
+        occurred_at: event.occurred_at
+      }
+      @records << record
+      record
+    end
+
+    # Returns all events in a stream ordered by version.
+    #
+    # @param stream_id [String] the stream identifier
+    # @return [Array<Hash>] event records ordered by version
+    def read_stream(stream_id)
+      @records
+        .select { |r| r[:stream_id] == stream_id }
+        .sort_by { |r| r[:version] }
+    end
+
+    # Returns events in a stream that occurred at or before the given timestamp.
+    #
+    # @param stream_id [String] the stream identifier
+    # @param timestamp [Time] the cutoff time (inclusive)
+    # @return [Array<Hash>] filtered event records ordered by version
+    def read_stream_until(stream_id, timestamp:)
+      read_stream(stream_id).select { |r| r[:occurred_at] <= timestamp }
+    end
+
+    # Returns events in a stream up to and including the given version.
+    #
+    # @param stream_id [String] the stream identifier
+    # @param version [Integer] the maximum version number (inclusive)
+    # @return [Array<Hash>] filtered event records ordered by version
+    def read_stream_to_version(stream_id, version:)
+      read_stream(stream_id).select { |r| r[:version] <= version }
+    end
+
+    # Returns the current version (highest version number) for a stream.
+    #
+    # @param stream_id [String] the stream identifier
+    # @return [Integer] the current version, or 0 if no events exist
+    def stream_version(stream_id)
+      @stream_versions[stream_id]
+    end
+
+    # Removes all stored events. Does not affect external listeners.
+    #
+    # @return [void]
+    def clear
+      @records.clear
+      @stream_versions.clear
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -13,6 +13,8 @@ require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
 require_relative "runtime/auth_coverage_check"
 require_relative "runtime/reference_authorizer_check"
+require_relative "runtime/time_travel"
+require_relative "runtime/as_of_proxy"
 
 module Hecks
   # Hecks::Runtime
@@ -63,6 +65,7 @@ module Hecks
       include AuthCoverageCheck
       include ReferenceCoverageCheck
       include SagaSetup
+      include TimeTravel
 
       # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to
       attr_reader :domain
@@ -72,6 +75,9 @@ module Hecks
 
       # @return [Hecks::Commands::CommandBus] the command bus that dispatches commands through middleware
       attr_reader :command_bus
+
+      # @return [Hecks::EventStore] the in-memory event store for time-travel queries
+      attr_reader :event_store
 
       # Boots the runtime: wires repositories, policies, subscribers, and the command bus.
       # Evaluates an optional configuration block in the context of the runtime instance,
@@ -90,6 +96,7 @@ module Hecks
         @mod = Object.const_get(@mod_name)
         @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
         @event_bus = event_bus || EventBus.new
+        @event_store = EventStore.new
         @repositories = {}
         @adapter_overrides = {}
         @async_handler = nil
@@ -107,6 +114,7 @@ module Hecks
         ServiceSetup.bind(@domain, @mod, @command_bus)
         setup_workflows
         setup_sagas
+        wire_event_store
         hoist_constants
       end
 
@@ -275,6 +283,22 @@ module Hecks
           domain: @domain,
           event_bus: @event_bus
         )
+      end
+
+      # Subscribes a global listener on the event bus that appends every
+      # published event to the in-memory EventStore. Derives the stream ID
+      # from the event's class namespace and aggregate_id attribute.
+      #
+      # @return [void]
+      def wire_event_store
+        store = @event_store
+        @event_bus.on_any do |event|
+          agg_type = event.class.name&.split("::")&.[](-3)
+          agg_id = event.respond_to?(:aggregate_id) ? event.aggregate_id : nil
+          if agg_type && agg_id
+            store.append("#{agg_type}-#{agg_id}", event)
+          end
+        end
       end
 
       def trace_reactive_chain(command_name)

--- a/hecksties/lib/hecks/runtime/as_of_proxy.rb
+++ b/hecksties/lib/hecks/runtime/as_of_proxy.rb
@@ -1,0 +1,42 @@
+# Hecks::Runtime::AsOfProxy
+#
+# A lightweight proxy returned by +Runtime#as_of(timestamp)+. Scopes
+# all +find+ calls to reconstitute aggregate state as of the given
+# point in time by replaying events from the EventStore.
+#
+# == Usage
+#
+#   snapshot = app.as_of(1.hour.ago)
+#   pizza = snapshot.find("Pizza", pizza_id)
+#   pizza.name  # => the name at that point in time
+#
+module Hecks
+  class Runtime
+    class AsOfProxy
+      # Creates a new proxy scoped to a timestamp.
+      #
+      # @param runtime [Hecks::Runtime] the runtime to query against
+      # @param timestamp [Time] the point in time to replay events to
+      def initialize(runtime, timestamp)
+        @runtime = runtime
+        @timestamp = timestamp
+      end
+
+      # Reconstitutes an aggregate as of the scoped timestamp.
+      #
+      # @param aggregate_type [String] the aggregate name (e.g. "Pizza")
+      # @param id [String] the aggregate instance ID
+      # @return [Object, nil] the reconstructed aggregate, or nil if no events
+      def find(aggregate_type, id)
+        @runtime.reconstitute_at(aggregate_type, id, timestamp: @timestamp)
+      end
+
+      # Returns a readable summary of this proxy.
+      #
+      # @return [String]
+      def inspect
+        "#<Hecks::Runtime::AsOfProxy as_of=#{@timestamp.iso8601}>"
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/time_travel.rb
+++ b/hecksties/lib/hecks/runtime/time_travel.rb
@@ -1,0 +1,99 @@
+# Hecks::Runtime::TimeTravel
+#
+# Mixin for Runtime that enables event replay to reconstruct aggregate
+# state at a past point in time or version. Works with the in-memory
+# EventStore to filter events, then applies them sequentially to build
+# the aggregate.
+#
+# == Usage
+#
+#   app.as_of(1.hour.ago).find("Pizza", pizza_id)
+#   app.at_version("Pizza", pizza_id, version: 3)
+#
+module Hecks
+  class Runtime
+    module TimeTravel
+      # Returns an AsOfProxy scoped to the given timestamp. The proxy
+      # delegates find calls to reconstitute_at.
+      #
+      # @param timestamp [Time] the point in time to replay to
+      # @return [Hecks::Runtime::AsOfProxy] a proxy that answers find queries
+      def as_of(timestamp)
+        AsOfProxy.new(self, timestamp)
+      end
+
+      # Reconstitutes an aggregate by replaying events up to the given version.
+      #
+      # @param aggregate_type [String] the aggregate name (e.g. "Pizza")
+      # @param id [String] the aggregate instance ID
+      # @param version [Integer] the version to replay up to
+      # @return [Object, nil] the reconstructed aggregate, or nil if no events
+      def at_version(aggregate_type, id, version:)
+        stream_id = "#{aggregate_type}-#{id}"
+        records = event_store.read_stream_to_version(stream_id, version: version)
+        reconstitute_from_records(aggregate_type, id, records)
+      end
+
+      # Reconstitutes an aggregate by replaying events up to the given timestamp.
+      #
+      # @param aggregate_type [String] the aggregate name (e.g. "Pizza")
+      # @param id [String] the aggregate instance ID
+      # @param timestamp [Time] the cutoff time
+      # @return [Object, nil] the reconstructed aggregate, or nil if no events
+      def reconstitute_at(aggregate_type, id, timestamp:)
+        stream_id = "#{aggregate_type}-#{id}"
+        records = event_store.read_stream_until(stream_id, timestamp: timestamp)
+        reconstitute_from_records(aggregate_type, id, records)
+      end
+
+      # Reconstitutes an aggregate by replaying events up to a version number.
+      # Alias that delegates to at_version for naming symmetry.
+      #
+      # @param aggregate_type [String] the aggregate name (e.g. "Pizza")
+      # @param id [String] the aggregate instance ID
+      # @param version [Integer] the version to replay up to
+      # @return [Object, nil] the reconstructed aggregate, or nil if no events
+      def reconstitute_at_version(aggregate_type, id, version:)
+        at_version(aggregate_type, id, version: version)
+      end
+
+      private
+
+      # Builds an aggregate from a sequence of event records by extracting
+      # attribute values from each event and applying them cumulatively.
+      #
+      # @param aggregate_type [String] the aggregate name
+      # @param id [String] the aggregate ID
+      # @param records [Array<Hash>] the event records to replay
+      # @return [Object, nil] the reconstructed aggregate, or nil if no records
+      def reconstitute_from_records(aggregate_type, id, records)
+        return nil if records.empty?
+
+        agg_class = resolve_aggregate_class(aggregate_type)
+        return nil unless agg_class
+
+        attr_names = Persistence::RepositoryMethods.attr_names(agg_class).map(&:to_sym)
+        attrs = {}
+
+        records.each do |record|
+          event = record[:event]
+          attr_names.each do |name|
+            attrs[name] = event.send(name) if event.respond_to?(name)
+          end
+        end
+
+        agg_class.new(id: id, **attrs)
+      end
+
+      # Resolves the Ruby class for a given aggregate type name.
+      #
+      # @param aggregate_type [String] the aggregate name (e.g. "Pizza")
+      # @return [Class, nil] the aggregate class, or nil if not found
+      def resolve_aggregate_class(aggregate_type)
+        @mod.const_get(aggregate_type)
+      rescue NameError
+        nil
+      end
+    end
+  end
+end

--- a/hecksties/spec/runtime/time_travel_spec.rb
+++ b/hecksties/spec/runtime/time_travel_spec.rb
@@ -1,0 +1,145 @@
+require "spec_helper"
+
+RSpec.describe "Time Travel" do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :style, String
+
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :style, String
+        end
+
+        command "RenamePizza" do
+          reference_to "Pizza"
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let!(:app) { Hecks.load(domain) }
+
+  describe Hecks::EventStore do
+    let(:store) { Hecks::EventStore.new }
+
+    let(:event1) do
+      PizzasDomain::Pizza::Events::CreatedPizza.new(
+        aggregate_id: "pizza-1", name: "Margherita", style: "Classic"
+      )
+    end
+
+    let(:event2) do
+      PizzasDomain::Pizza::Events::RenamedPizza.new(
+        aggregate_id: "pizza-1", name: "Pepperoni"
+      )
+    end
+
+    it "appends events with incrementing versions" do
+      store.append("Pizza-pizza-1", event1)
+      store.append("Pizza-pizza-1", event2)
+
+      records = store.read_stream("Pizza-pizza-1")
+      expect(records.size).to eq(2)
+      expect(records[0][:version]).to eq(1)
+      expect(records[1][:version]).to eq(2)
+    end
+
+    it "reads stream up to a version" do
+      store.append("Pizza-pizza-1", event1)
+      store.append("Pizza-pizza-1", event2)
+
+      records = store.read_stream_to_version("Pizza-pizza-1", version: 1)
+      expect(records.size).to eq(1)
+      expect(records.first[:event_type]).to eq("CreatedPizza")
+    end
+
+    it "reads stream until a timestamp" do
+      store.append("Pizza-pizza-1", event1)
+      cutoff = Time.now + 0.001
+      sleep 0.002
+      e2 = PizzasDomain::Pizza::Events::RenamedPizza.new(
+        aggregate_id: "pizza-1", name: "Pepperoni"
+      )
+      store.append("Pizza-pizza-1", e2)
+
+      records = store.read_stream_until("Pizza-pizza-1", timestamp: cutoff)
+      expect(records.size).to eq(1)
+    end
+
+    it "reports stream version" do
+      expect(store.stream_version("Pizza-pizza-1")).to eq(0)
+      store.append("Pizza-pizza-1", event1)
+      expect(store.stream_version("Pizza-pizza-1")).to eq(1)
+    end
+
+    it "clears all records" do
+      store.append("Pizza-pizza-1", event1)
+      store.clear
+      expect(store.records).to be_empty
+    end
+  end
+
+  describe "Runtime#event_store" do
+    it "exposes the event store" do
+      expect(app.event_store).to be_a(Hecks::EventStore)
+    end
+
+    it "automatically records events when commands execute" do
+      pizza = PizzasDomain::Pizza.create(name: "Margherita", style: "Classic")
+      records = app.event_store.read_stream("Pizza-#{pizza.id}")
+      expect(records.size).to eq(1)
+      expect(records.first[:event_type]).to eq("CreatedPizza")
+    end
+  end
+
+  describe "Runtime#as_of" do
+    it "reconstitutes aggregate at a past point in time" do
+      pizza = PizzasDomain::Pizza.create(name: "Original", style: "Classic")
+      snapshot_time = Time.now + 0.001
+      sleep 0.002
+      PizzasDomain::Pizza.rename(pizza: pizza.id, name: "Updated")
+
+      past_pizza = app.as_of(snapshot_time).find("Pizza", pizza.id)
+      expect(past_pizza.name).to eq("Original")
+    end
+
+    it "returns nil when no events exist before timestamp" do
+      result = app.as_of(Time.now - 3600).find("Pizza", "nonexistent")
+      expect(result).to be_nil
+    end
+
+    it "has a readable inspect" do
+      proxy = app.as_of(Time.now)
+      expect(proxy.inspect).to include("AsOfProxy")
+    end
+  end
+
+  describe "Runtime#at_version" do
+    it "reconstitutes aggregate at a specific version" do
+      pizza = PizzasDomain::Pizza.create(name: "V1", style: "Classic")
+      PizzasDomain::Pizza.rename(pizza: pizza.id, name: "V2")
+
+      v1_pizza = app.at_version("Pizza", pizza.id, version: 1)
+      expect(v1_pizza.name).to eq("V1")
+
+      v2_pizza = app.at_version("Pizza", pizza.id, version: 2)
+      expect(v2_pizza.name).to eq("V2")
+    end
+
+    it "returns nil for version 0" do
+      result = app.at_version("Pizza", "missing", version: 0)
+      expect(result).to be_nil
+    end
+  end
+
+  describe "Runtime#reconstitute_at_version" do
+    it "is an alias for at_version" do
+      pizza = PizzasDomain::Pizza.create(name: "Test", style: "NY")
+      v1 = app.reconstitute_at_version("Pizza", pizza.id, version: 1)
+      expect(v1.name).to eq("Test")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add time travel — replay events to point in time

Add in-memory EventStore with read_stream_until(timestamp:) and
read_stream_to_version(version:) queries. Wire it into Runtime via
event bus global listener so every published event is automatically
recorded with stream IDs and incrementing version numbers.

Runtime API: app.as_of(time).find(type, id) reconstitutes aggregate
state at a past timestamp. app.at_version(type, id, version:) does
the same for a specific event version. Both replay events sequentially
to build the aggregate from its event history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)