### PR TITLE
HEC-100: Versioned API contracts

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -340,9 +340,11 @@
 - `hecks diff --v1 <v1> --v2 <v2>` — diff two tagged version snapshots with breaking change classification
 - `hecks diff --v1 <v1>` — diff a tagged version against the working domain file
 - `hecks diff` — diff working domain against latest tagged version (falls back to build snapshot)
-- Breaking change classification: removed commands, removed attributes, removed aggregates marked as BREAKING
+- Breaking change classification: removed commands, removed attributes, removed aggregates, changed attribute types, renamed attributes, added required command attributes — all marked as BREAKING
 - Non-breaking changes: added commands, added attributes, added queries, added scopes
 - Auto-bump domain version on breaking changes: `hecks build` compares against the latest tagged snapshot and auto-bumps CalVer when breaking changes are detected
+- Versioned API contracts: `hecks contract_check --save` snapshots the public API surface (aggregates, attributes, command signatures) to `.hecks_api_contract.json`
+- `hecks contract_check` compares the current domain against the saved baseline and exits non-zero on unacknowledged breaking changes — suitable for CI pipelines
 
 ## Migrations & Schema Evolution
 - `DomainDiff` detects added/removed aggregates, attributes, VOs, entities, commands, policies, validations, invariants, queries, scopes, subscribers, specifications

--- a/docs/usage/api_contracts.md
+++ b/docs/usage/api_contracts.md
@@ -1,0 +1,74 @@
+# API Contracts
+
+Versioned API contracts let you detect breaking changes in your domain's
+public surface before they reach consumers. The contract captures aggregate
+names, attribute names and types, command signatures, and query names.
+
+## Save a baseline
+
+Snapshot the current domain API to `.hecks_api_contract.json`:
+
+```bash
+hecks contract_check --save
+# => API contract saved to .hecks_api_contract.json
+```
+
+The generated file is JSON and should be committed to version control.
+
+## Check for breaking changes
+
+Compare the current domain against the saved baseline:
+
+```bash
+hecks contract_check
+# => API contract: no changes detected.
+```
+
+When breaking changes exist, the command exits non-zero:
+
+```bash
+hecks contract_check
+# 2 API changes detected:
+#
+#   - attribute: Widget.color  <- BREAKING
+#   ~ type: Widget.name (String -> Integer)  <- BREAKING
+#
+# 2 breaking changes found!
+# Run `hecks contract_check --save` to acknowledge.
+```
+
+## Breaking change kinds
+
+The following changes are classified as breaking:
+
+| Kind | Example |
+|------|---------|
+| `remove_aggregate` | Deleting an entire aggregate |
+| `remove_attribute` | Removing a field from an aggregate |
+| `remove_command` | Removing a command |
+| `change_attribute_type` | Changing `:name` from `String` to `Integer` |
+| `rename_attribute` | Renaming `:color` to `:colour` |
+| `add_required_command_attribute` | Adding a new required field to a command |
+
+Non-breaking changes (added aggregates, added attributes, added commands)
+are reported but do not cause a non-zero exit.
+
+## CI integration
+
+Add to your CI pipeline to block deploys with unacknowledged API changes:
+
+```yaml
+# .github/workflows/ci.yml
+- name: API contract check
+  run: bundle exec hecks contract_check
+```
+
+## Acknowledging changes
+
+After reviewing breaking changes, update the baseline:
+
+```bash
+hecks contract_check --save
+git add .hecks_api_contract.json
+git commit -m "Acknowledge API contract changes"
+```

--- a/hecksties/lib/hecks/domain_versioning.rb
+++ b/hecksties/lib/hecks/domain_versioning.rb
@@ -10,6 +10,7 @@
 #
 require_relative "domain_versioning/breaking_classifier"
 require_relative "domain_versioning/breaking_bumper"
+require_relative "domain_versioning/api_contract"
 
 module Hecks
   module DomainVersioning

--- a/hecksties/lib/hecks/domain_versioning/api_contract.rb
+++ b/hecksties/lib/hecks/domain_versioning/api_contract.rb
@@ -1,0 +1,176 @@
+# Hecks::DomainVersioning::ApiContract
+#
+# Serializes a domain's public API surface to a stable JSON representation.
+# The contract captures aggregate names, attribute names/types, command
+# signatures, and query names -- everything a consumer depends on.
+# Used by contract_check to detect unacknowledged breaking changes.
+#
+#   contract = ApiContract.serialize(domain)
+#   File.write(".hecks_api_contract.json", JSON.pretty_generate(contract))
+#
+#   changes = ApiContract.diff(old_contract, new_contract)
+#   # => [{ kind: :remove_attribute, aggregate: "Pizza", details: { name: :color } }, ...]
+#
+require "json"
+
+module Hecks
+  module DomainVersioning
+    module ApiContract
+      CONTRACT_FILE = ".hecks_api_contract.json"
+
+      # Serialize a domain's public API surface to a Hash suitable for JSON.
+      #
+      # @param domain [Hecks::DomainModel::Domain] the domain to serialize
+      # @return [Hash] JSON-serializable contract representation
+      def self.serialize(domain)
+        {
+          domain: domain.name,
+          version: domain.version,
+          aggregates: domain.aggregates.map { |agg| serialize_aggregate(agg) }
+        }
+      end
+
+      # Write the contract JSON file to disk.
+      #
+      # @param domain [Hecks::DomainModel::Domain] domain to snapshot
+      # @param base_dir [String] project root directory
+      # @return [String] path to the written file
+      def self.save(domain, base_dir: Dir.pwd)
+        path = File.join(base_dir, CONTRACT_FILE)
+        File.write(path, JSON.pretty_generate(serialize(domain)) + "\n")
+        path
+      end
+
+      # Load a previously saved contract from disk.
+      #
+      # @param base_dir [String] project root directory
+      # @return [Hash, nil] the contract hash, or nil if no file exists
+      def self.load(base_dir: Dir.pwd)
+        path = File.join(base_dir, CONTRACT_FILE)
+        return nil unless File.exist?(path)
+        JSON.parse(File.read(path), symbolize_names: true)
+      end
+
+      # Compare two contract hashes and return Change-like structs.
+      #
+      # @param old_contract [Hash] the baseline contract
+      # @param new_contract [Hash] the current contract
+      # @return [Array<Hecks::Migrations::DomainDiff::Change>] detected changes
+      def self.diff(old_contract, new_contract)
+        changes = []
+        old_aggs = index_by_name(old_contract[:aggregates] || [])
+        new_aggs = index_by_name(new_contract[:aggregates] || [])
+
+        changes.concat(diff_aggregates(old_aggs, new_aggs))
+        changes.concat(diff_existing_aggregates(old_aggs, new_aggs))
+        changes
+      end
+
+      # Serialize a single aggregate to a contract hash.
+      #
+      # @param agg [Hecks::DomainModel::Structure::Aggregate]
+      # @return [Hash]
+      def self.serialize_aggregate(agg)
+        {
+          name: agg.name,
+          attributes: agg.attributes.map { |a| { name: a.name.to_s, type: a.ruby_type } },
+          commands: agg.commands.map { |c| serialize_command(c) },
+          queries: (agg.queries || []).map(&:name)
+        }
+      end
+
+      # Serialize a single command to a contract hash.
+      #
+      # @param cmd [Hecks::DomainModel::Behavior::Command]
+      # @return [Hash]
+      def self.serialize_command(cmd)
+        {
+          name: cmd.name,
+          attributes: cmd.attributes.map { |a| { name: a.name.to_s, type: a.ruby_type } }
+        }
+      end
+
+      # --- private helpers ---
+
+      def self.index_by_name(list)
+        list.each_with_object({}) { |item, h| h[item[:name]] = item }
+      end
+
+      def self.diff_aggregates(old_aggs, new_aggs)
+        changes = []
+        (old_aggs.keys - new_aggs.keys).each do |name|
+          changes << make_change(:remove_aggregate, name, {})
+        end
+        (new_aggs.keys - old_aggs.keys).each do |name|
+          changes << make_change(:add_aggregate, name, {})
+        end
+        changes
+      end
+
+      def self.diff_existing_aggregates(old_aggs, new_aggs)
+        changes = []
+        (old_aggs.keys & new_aggs.keys).each do |name|
+          changes.concat(diff_attributes(name, old_aggs[name], new_aggs[name]))
+          changes.concat(diff_commands(name, old_aggs[name], new_aggs[name]))
+        end
+        changes
+      end
+
+      def self.diff_attributes(agg_name, old_agg, new_agg)
+        changes = []
+        old_attrs = index_by_name(old_agg[:attributes] || [])
+        new_attrs = index_by_name(new_agg[:attributes] || [])
+
+        (old_attrs.keys - new_attrs.keys).each do |attr_name|
+          changes << make_change(:remove_attribute, agg_name, { name: attr_name.to_sym })
+        end
+        (new_attrs.keys - old_attrs.keys).each do |attr_name|
+          a = new_attrs[attr_name]
+          changes << make_change(:add_attribute, agg_name, { name: attr_name.to_sym, type: a[:type] })
+        end
+        (old_attrs.keys & new_attrs.keys).each do |attr_name|
+          old_type = old_attrs[attr_name][:type]
+          new_type = new_attrs[attr_name][:type]
+          next if old_type == new_type
+          changes << make_change(:change_attribute_type, agg_name, {
+            name: attr_name.to_sym, old_type: old_type, new_type: new_type
+          })
+        end
+        changes
+      end
+
+      def self.diff_commands(agg_name, old_agg, new_agg)
+        changes = []
+        old_cmds = index_by_name(old_agg[:commands] || [])
+        new_cmds = index_by_name(new_agg[:commands] || [])
+
+        (old_cmds.keys - new_cmds.keys).each do |cmd_name|
+          changes << make_change(:remove_command, agg_name, { name: cmd_name })
+        end
+        (new_cmds.keys - old_cmds.keys).each do |cmd_name|
+          changes << make_change(:add_command, agg_name, { name: cmd_name })
+        end
+        (old_cmds.keys & new_cmds.keys).each do |cmd_name|
+          old_attr_names = (old_cmds[cmd_name][:attributes] || []).map { |a| a[:name] }
+          new_attr_names = (new_cmds[cmd_name][:attributes] || []).map { |a| a[:name] }
+          (new_attr_names - old_attr_names).each do |attr_name|
+            changes << make_change(:add_required_command_attribute, agg_name, {
+              command: cmd_name, name: attr_name.to_sym
+            })
+          end
+        end
+        changes
+      end
+
+      def self.make_change(kind, aggregate, details)
+        Hecks::Migrations::DomainDiff::Change.new(
+          kind: kind, context: nil, aggregate: aggregate, details: details
+        )
+      end
+
+      private_class_method :index_by_name, :diff_aggregates,
+                           :diff_existing_aggregates, :diff_attributes,
+                           :diff_commands, :make_change
+    end
+  end
+end

--- a/hecksties/lib/hecks/domain_versioning/breaking_classifier.rb
+++ b/hecksties/lib/hecks/domain_versioning/breaking_classifier.rb
@@ -17,6 +17,9 @@ module Hecks
         remove_command
         remove_value_object
         remove_entity
+        change_attribute_type
+        rename_attribute
+        add_required_command_attribute
       ].freeze
 
       NON_BREAKING_KINDS = %i[
@@ -84,6 +87,9 @@ module Hecks
         when :remove_index        then "- index: #{change.aggregate}"
         when :add_reference       then "+ reference: #{change.aggregate}"
         when :remove_reference    then "- reference: #{change.aggregate}"
+        when :change_attribute_type then "~ type: #{change.aggregate}.#{change.details[:name]} (#{change.details[:old_type]} -> #{change.details[:new_type]})"
+        when :rename_attribute     then "~ rename: #{change.aggregate}.#{change.details[:old_name]} -> #{change.details[:new_name]}"
+        when :add_required_command_attribute then "+ required: #{change.aggregate}.#{change.details[:command]}.#{change.details[:name]}"
         when :change_policy       then "~ policy: #{change.aggregate}.#{change.details[:name]}"
         else "#{change.kind}: #{change.aggregate} #{change.details}"
         end

--- a/hecksties/lib/hecks_cli/commands/contract_check.rb
+++ b/hecksties/lib/hecks_cli/commands/contract_check.rb
@@ -1,0 +1,58 @@
+# Hecks::CLI -- contract_check command
+#
+# Compares the current domain's public API surface against a saved
+# contract file. Exits non-zero when unacknowledged breaking changes
+# are detected. Use --save to update the baseline contract.
+#
+#   hecks contract_check
+#   hecks contract_check --save
+#
+Hecks::CLI.register_command(:contract_check, "Check for unacknowledged breaking API changes",
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" },
+    save:   { type: :boolean, default: false, desc: "Save current API as the baseline contract" }
+  }
+) do
+  domain = resolve_domain_option
+  next unless domain
+
+  contract_mod = Hecks::DomainVersioning::ApiContract
+
+  if options[:save]
+    path = contract_mod.save(domain, base_dir: Dir.pwd)
+    say "API contract saved to #{path}", :green
+    next
+  end
+
+  old_contract = contract_mod.load(base_dir: Dir.pwd)
+  unless old_contract
+    say "No baseline contract found. Run `hecks contract_check --save` first.", :yellow
+    exit 1
+  end
+
+  new_contract = contract_mod.serialize(domain)
+  changes = contract_mod.diff(old_contract, new_contract)
+
+  if changes.empty?
+    say "API contract: no changes detected.", :green
+    next
+  end
+
+  classified = Hecks::DomainVersioning::BreakingClassifier.classify(changes)
+  breaking = classified.select { |e| e[:breaking] }
+
+  say "#{changes.size} API change#{"s" if changes.size != 1} detected:", :yellow
+  say ""
+  classified.each do |entry|
+    suffix = entry[:breaking] ? "  <- BREAKING" : ""
+    color = entry[:breaking] ? :red : :green
+    say "  #{entry[:label]}#{suffix}", color
+  end
+
+  if breaking.any?
+    say ""
+    say "#{breaking.size} breaking change#{"s" if breaking.size != 1} found!", :red
+    say "Run `hecks contract_check --save` to acknowledge.", :yellow
+    exit 1
+  end
+end

--- a/hecksties/spec/cli/commands/contract_check_spec.rb
+++ b/hecksties/spec/cli/commands/contract_check_spec.rb
@@ -1,0 +1,102 @@
+# contract_check_spec.rb — HEC-100
+#
+# Specs for the hecks contract_check CLI command.
+#
+require "spec_helper"
+require "hecks_cli"
+require "tmpdir"
+
+RSpec.describe "hecks contract_check" do
+  before { allow($stdout).to receive(:puts) }
+
+  it "exits non-zero when no baseline contract exists" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+        expect { cli.contract_check }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+    end
+  end
+
+  it "passes when domain matches saved contract" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        messages = []
+        allow(cli).to receive(:say) { |msg, *| messages << msg }
+
+        # Save baseline
+        allow(cli).to receive(:options).and_return({ "save" => true, "domain" => nil })
+        cli.contract_check
+
+        # Check against same domain
+        allow(cli).to receive(:options).and_return({ "save" => false, "domain" => nil })
+        cli.contract_check
+
+        expect(messages.join("\n")).to include("no changes")
+      end
+    end
+  end
+
+  it "exits non-zero on breaking changes" do
+    Dir.mktmpdir do |dir|
+      # Save baseline with color attribute
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            attribute :color, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+        allow(cli).to receive(:options).and_return({ "save" => true, "domain" => nil })
+        cli.contract_check
+      end
+
+      # Remove color attribute (breaking change)
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+        allow(cli).to receive(:options).and_return({ "save" => false, "domain" => nil })
+        expect { cli.contract_check }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+    end
+  end
+end

--- a/hecksties/spec/domain_versioning/api_contract_spec.rb
+++ b/hecksties/spec/domain_versioning/api_contract_spec.rb
@@ -1,0 +1,130 @@
+# api_contract_spec.rb — HEC-100
+#
+# Specs for API contract serialization and diffing.
+#
+require "spec_helper"
+require "json"
+require "tmpdir"
+
+RSpec.describe Hecks::DomainVersioning::ApiContract do
+  let(:domain) do
+    Hecks.domain "Test" do
+      aggregate "Widget" do
+        attribute :name, String
+        attribute :color, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  describe ".serialize" do
+    it "captures aggregate names and attributes" do
+      contract = described_class.serialize(domain)
+      expect(contract[:domain]).to eq("Test")
+      agg = contract[:aggregates].first
+      expect(agg[:name]).to eq("Widget")
+      expect(agg[:attributes].map { |a| a[:name] }).to include("name", "color")
+    end
+
+    it "captures command signatures" do
+      contract = described_class.serialize(domain)
+      cmd = contract[:aggregates].first[:commands].first
+      expect(cmd[:name]).to eq("CreateWidget")
+      expect(cmd[:attributes].first[:name]).to eq("name")
+    end
+  end
+
+  describe ".save and .load" do
+    it "round-trips through JSON on disk" do
+      Dir.mktmpdir do |dir|
+        described_class.save(domain, base_dir: dir)
+        loaded = described_class.load(base_dir: dir)
+        expect(loaded[:domain]).to eq("Test")
+        expect(loaded[:aggregates].first[:name]).to eq("Widget")
+      end
+    end
+
+    it "returns nil when no contract file exists" do
+      Dir.mktmpdir do |dir|
+        expect(described_class.load(base_dir: dir)).to be_nil
+      end
+    end
+  end
+
+  describe ".diff" do
+    let(:old_contract) { described_class.serialize(domain) }
+
+    it "detects removed attributes as breaking" do
+      new_domain = Hecks.domain("Test") do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+      new_contract = described_class.serialize(new_domain)
+      changes = described_class.diff(old_contract, new_contract)
+      kinds = changes.map(&:kind)
+      expect(kinds).to include(:remove_attribute)
+    end
+
+    it "detects changed attribute types" do
+      new_domain = Hecks.domain("Test") do
+        aggregate "Widget" do
+          attribute :name, Integer
+          attribute :color, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+      new_contract = described_class.serialize(new_domain)
+      changes = described_class.diff(old_contract, new_contract)
+      type_change = changes.find { |c| c.kind == :change_attribute_type }
+      expect(type_change).not_to be_nil
+      expect(type_change.details[:old_type]).to eq("String")
+      expect(type_change.details[:new_type]).to eq("Integer")
+    end
+
+    it "detects added required command attributes" do
+      new_domain = Hecks.domain("Test") do
+        aggregate "Widget" do
+          attribute :name, String
+          attribute :color, String
+          command "CreateWidget" do
+            attribute :name, String
+            attribute :color, String
+          end
+        end
+      end
+      new_contract = described_class.serialize(new_domain)
+      changes = described_class.diff(old_contract, new_contract)
+      req = changes.find { |c| c.kind == :add_required_command_attribute }
+      expect(req).not_to be_nil
+      expect(req.details[:command]).to eq("CreateWidget")
+      expect(req.details[:name]).to eq(:color)
+    end
+
+    it "detects removed aggregates" do
+      new_domain = Hecks.domain("Test") do
+        aggregate "Gadget" do
+          attribute :label, String
+          command "CreateGadget" do
+            attribute :label, String
+          end
+        end
+      end
+      new_contract = described_class.serialize(new_domain)
+      changes = described_class.diff(old_contract, new_contract)
+      expect(changes.map(&:kind)).to include(:remove_aggregate)
+    end
+
+    it "returns empty when contracts match" do
+      changes = described_class.diff(old_contract, old_contract)
+      expect(changes).to be_empty
+    end
+  end
+end

--- a/hecksties/spec/domain_versioning/breaking_classifier_spec.rb
+++ b/hecksties/spec/domain_versioning/breaking_classifier_spec.rb
@@ -1,0 +1,61 @@
+# breaking_classifier_spec.rb — HEC-100
+#
+# Specs for new breaking change kinds: change_attribute_type,
+# rename_attribute, add_required_command_attribute.
+#
+require "spec_helper"
+
+RSpec.describe Hecks::DomainVersioning::BreakingClassifier do
+  Change = Hecks::Migrations::DomainDiff::Change
+
+  describe ".breaking?" do
+    it "classifies :change_attribute_type as breaking" do
+      change = Change.new(kind: :change_attribute_type, context: nil, aggregate: "Widget",
+                          details: { name: :color, old_type: "String", new_type: "Integer" })
+      expect(described_class.breaking?(change)).to be true
+    end
+
+    it "classifies :rename_attribute as breaking" do
+      change = Change.new(kind: :rename_attribute, context: nil, aggregate: "Widget",
+                          details: { old_name: :color, new_name: :colour })
+      expect(described_class.breaking?(change)).to be true
+    end
+
+    it "classifies :add_required_command_attribute as breaking" do
+      change = Change.new(kind: :add_required_command_attribute, context: nil, aggregate: "Widget",
+                          details: { command: "CreateWidget", name: :priority })
+      expect(described_class.breaking?(change)).to be true
+    end
+
+    it "classifies :add_attribute as non-breaking" do
+      change = Change.new(kind: :add_attribute, context: nil, aggregate: "Widget",
+                          details: { name: :tags, type: "String" })
+      expect(described_class.breaking?(change)).to be false
+    end
+  end
+
+  describe ".format_label" do
+    it "formats change_attribute_type" do
+      change = Change.new(kind: :change_attribute_type, context: nil, aggregate: "Widget",
+                          details: { name: :color, old_type: "String", new_type: "Integer" })
+      label = described_class.format_label(change)
+      expect(label).to include("Widget.color")
+      expect(label).to include("String -> Integer")
+    end
+
+    it "formats rename_attribute" do
+      change = Change.new(kind: :rename_attribute, context: nil, aggregate: "Widget",
+                          details: { old_name: :color, new_name: :colour })
+      label = described_class.format_label(change)
+      expect(label).to include("color -> colour")
+    end
+
+    it "formats add_required_command_attribute" do
+      change = Change.new(kind: :add_required_command_attribute, context: nil, aggregate: "Widget",
+                          details: { command: "CreateWidget", name: :priority })
+      label = described_class.format_label(change)
+      expect(label).to include("CreateWidget")
+      expect(label).to include("priority")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: versioned API contracts with breaking change detection (HEC-100)

Add contract_check CLI command that serializes the domain's public API
surface to JSON and exits non-zero on unacknowledged breaking changes.
Extend breaking_classifier with change_attribute_type, rename_attribute,
and add_required_command_attribute as new breaking change kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)