### PR TITLE
HEC-101: Auto changelog generation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -343,6 +343,8 @@
 - Breaking change classification: removed commands, removed attributes, removed aggregates marked as BREAKING
 - Non-breaking changes: added commands, added attributes, added queries, added scopes
 - Auto-bump domain version on breaking changes: `hecks build` compares against the latest tagged snapshot and auto-bumps CalVer when breaking changes are detected
+- `hecks changelog` — generate a Markdown changelog from all tagged version snapshots, with Breaking Changes and Additions sections per version
+- `hecks changelog --output DOMAIN_CHANGELOG.md` — write the changelog to a file instead of stdout
 
 ## Migrations & Schema Evolution
 - `DomainDiff` detects added/removed aggregates, attributes, VOs, entities, commands, policies, validations, invariants, queries, scopes, subscribers, specifications

--- a/docs/usage/changelog.md
+++ b/docs/usage/changelog.md
@@ -1,0 +1,74 @@
+# Domain Changelog Generation
+
+Generate a Markdown changelog from tagged domain version snapshots. The changelog diffs consecutive version pairs, classifies changes as breaking or non-breaking, and renders structured output.
+
+## Prerequisites
+
+Tag at least two domain versions to see diffs between them:
+
+```bash
+# Tag initial version
+hecks version_tag 1.0.0
+
+# Make domain changes, then tag again
+hecks version_tag 2.0.0
+```
+
+## Usage
+
+### Print to stdout
+
+```bash
+hecks changelog
+```
+
+Output:
+
+```markdown
+# Domain Changelog
+
+## 2.0.0 (2026-02-01)
+
+### Breaking Changes
+
+- - attribute: Widget.color
+
+### Additions
+
+- + aggregate: Gadget
+- + attribute: Widget.size (String)
+
+## 1.0.0 (2026-01-01)
+
+Initial release.
+```
+
+### Write to file
+
+```bash
+hecks changelog --output DOMAIN_CHANGELOG.md
+```
+
+## How it works
+
+1. Loads all version snapshots from `db/hecks_versions/`
+2. Diffs each consecutive pair using `DomainDiff`
+3. Classifies changes via `BreakingClassifier` (removed aggregates, attributes, commands = breaking; additions = non-breaking)
+4. Renders Markdown with version headers, Breaking Changes section, and Additions section
+
+## Programmatic API
+
+```ruby
+# Generate structured changelog data
+sections = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: Dir.pwd)
+
+sections.each do |section|
+  puts "#{section[:version]} (#{section[:tagged_at]})"
+  section[:breaking].each { |c| puts "  BREAKING: #{c[:label]}" }
+  section[:additions].each { |c| puts "  Added: #{c[:label]}" }
+end
+
+# Render to Markdown
+markdown = Hecks::DomainVersioning::ChangelogRenderer.render(sections)
+File.write("DOMAIN_CHANGELOG.md", markdown)
+```

--- a/hecksties/lib/hecks/domain_versioning.rb
+++ b/hecksties/lib/hecks/domain_versioning.rb
@@ -10,6 +10,8 @@
 #
 require_relative "domain_versioning/breaking_classifier"
 require_relative "domain_versioning/breaking_bumper"
+require_relative "domain_versioning/changelog_generator"
+require_relative "domain_versioning/changelog_renderer"
 
 module Hecks
   module DomainVersioning

--- a/hecksties/lib/hecks/domain_versioning/changelog_generator.rb
+++ b/hecksties/lib/hecks/domain_versioning/changelog_generator.rb
@@ -1,0 +1,89 @@
+# Hecks::DomainVersioning::ChangelogGenerator
+#
+# Loads version snapshots from db/hecks_versions/, diffs consecutive
+# pairs, and classifies each change as breaking or non-breaking.
+# Returns structured data ready for rendering.
+#
+#   sections = ChangelogGenerator.call(base_dir: Dir.pwd)
+#   sections.each do |section|
+#     puts "#{section[:version]} (#{section[:tagged_at]})"
+#     section[:breaking].each { |c| puts "  BREAKING: #{c[:label]}" }
+#     section[:additions].each { |c| puts "  Added: #{c[:label]}" }
+#   end
+#
+module Hecks
+  module DomainVersioning
+    module ChangelogGenerator
+      # Generate changelog sections from all tagged version snapshots.
+      #
+      # Each section represents one version and contains classified changes
+      # relative to its predecessor. The first version gets an "Initial release"
+      # marker.
+      #
+      # @param base_dir [String] project root directory
+      # @return [Array<Hash>] newest-first, each with :version, :tagged_at,
+      #   :breaking, :additions keys
+      def self.call(base_dir: Dir.pwd)
+        entries = DomainVersioning.log(base_dir: base_dir)
+        return [] if entries.empty?
+
+        # entries are newest-first; we need consecutive pairs (newer, older)
+        entries.each_with_index.map do |entry, i|
+          older = entries[i + 1]
+          build_section(entry, older)
+        end
+      end
+
+      # Build a single changelog section by diffing two version snapshots.
+      #
+      # @param entry [Hash] the newer version entry
+      # @param older [Hash, nil] the older version entry (nil for first)
+      # @return [Hash] with :version, :tagged_at, :breaking, :additions
+      def self.build_section(entry, older)
+        unless older
+          return {
+            version: entry[:version],
+            tagged_at: entry[:tagged_at],
+            breaking: [],
+            additions: [],
+            initial: true
+          }
+        end
+
+        old_domain = load_snapshot(older[:path])
+        new_domain = load_snapshot(entry[:path])
+
+        unless old_domain && new_domain
+          return {
+            version: entry[:version],
+            tagged_at: entry[:tagged_at],
+            breaking: [],
+            additions: [],
+            initial: false
+          }
+        end
+
+        changes = Hecks::Migrations::DomainDiff.call(old_domain, new_domain)
+        classified = BreakingClassifier.classify(changes)
+
+        {
+          version: entry[:version],
+          tagged_at: entry[:tagged_at],
+          breaking: classified.select { |c| c[:breaking] },
+          additions: classified.reject { |c| c[:breaking] },
+          initial: false
+        }
+      end
+
+      # Load a domain from a snapshot file.
+      #
+      # @param path [String] snapshot file path
+      # @return [Hecks::DomainModel::Domain, nil]
+      def self.load_snapshot(path)
+        return nil unless File.exist?(path)
+        Kernel.load(path)
+        Hecks.last_domain
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/domain_versioning/changelog_renderer.rb
+++ b/hecksties/lib/hecks/domain_versioning/changelog_renderer.rb
@@ -1,0 +1,67 @@
+# Hecks::DomainVersioning::ChangelogRenderer
+#
+# Renders changelog sections (from ChangelogGenerator) into Markdown.
+# Each version gets a header, optional Breaking Changes section,
+# and an Additions section.
+#
+#   sections = ChangelogGenerator.call(base_dir: Dir.pwd)
+#   markdown = ChangelogRenderer.render(sections)
+#   File.write("DOMAIN_CHANGELOG.md", markdown)
+#
+module Hecks
+  module DomainVersioning
+    module ChangelogRenderer
+      # Render changelog sections to Markdown string.
+      #
+      # @param sections [Array<Hash>] from ChangelogGenerator.call
+      # @return [String] Markdown-formatted changelog
+      def self.render(sections)
+        lines = ["# Domain Changelog", ""]
+
+        sections.each do |section|
+          lines << render_section(section)
+        end
+
+        lines.join("\n")
+      end
+
+      # Render a single version section.
+      #
+      # @param section [Hash] with :version, :tagged_at, :breaking, :additions, :initial
+      # @return [String] Markdown for this section
+      def self.render_section(section)
+        out = []
+        date_suffix = section[:tagged_at] ? " (#{section[:tagged_at]})" : ""
+        out << "## #{section[:version]}#{date_suffix}"
+        out << ""
+
+        if section[:initial]
+          out << "Initial release."
+          out << ""
+          return out.join("\n")
+        end
+
+        if section[:breaking].any?
+          out << "### Breaking Changes"
+          out << ""
+          section[:breaking].each { |c| out << "- #{c[:label]}" }
+          out << ""
+        end
+
+        if section[:additions].any?
+          out << "### Additions"
+          out << ""
+          section[:additions].each { |c| out << "- #{c[:label]}" }
+          out << ""
+        end
+
+        if section[:breaking].empty? && section[:additions].empty?
+          out << "No changes."
+          out << ""
+        end
+
+        out.join("\n")
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/changelog.rb
+++ b/hecksties/lib/hecks_cli/commands/changelog.rb
@@ -1,0 +1,30 @@
+# Hecks::CLI changelog command
+#
+# Generates a Markdown changelog from tagged domain version snapshots.
+# Diffs consecutive version pairs, classifies changes as breaking or
+# additions, and renders structured Markdown output.
+#
+#   hecks changelog              # Print changelog to stdout
+#   hecks changelog --output DOMAIN_CHANGELOG.md  # Write to file
+#
+Hecks::CLI.register_command(:changelog, "Generate domain changelog from version snapshots",
+  options: {
+    output: { type: :string, desc: "Write changelog to file instead of stdout" }
+  }
+) do
+  sections = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: Dir.pwd)
+
+  if sections.empty?
+    say "No versions tagged yet. Run `hecks version_tag <version>` to tag one.", :yellow
+    next
+  end
+
+  markdown = Hecks::DomainVersioning::ChangelogRenderer.render(sections)
+
+  if options[:output]
+    File.write(options[:output], markdown)
+    say "Changelog written to #{options[:output]}", :green
+  else
+    say markdown
+  end
+end

--- a/hecksties/spec/domain_versioning/changelog_spec.rb
+++ b/hecksties/spec/domain_versioning/changelog_spec.rb
@@ -1,0 +1,207 @@
+require "spec_helper"
+require "hecks_cli"
+
+RSpec.describe "domain changelog generation" do
+  before { allow($stdout).to receive(:puts) }
+
+  def write_snapshot(dir, version, date, dsl_content)
+    versions_dir = File.join(dir, "db/hecks_versions")
+    FileUtils.mkdir_p(versions_dir)
+    header = "# Hecks domain snapshot\n# version: #{version}\n# tagged_at: #{date}\n"
+    File.write(File.join(versions_dir, "#{version}.rb"), header + dsl_content)
+  end
+
+  describe Hecks::DomainVersioning::ChangelogGenerator do
+    it "returns empty array when no versions exist" do
+      Dir.mktmpdir do |dir|
+        result = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: dir)
+        expect(result).to eq([])
+      end
+    end
+
+    it "marks the first version as initial" do
+      Dir.mktmpdir do |dir|
+        write_snapshot(dir, "1.0.0", "2026-01-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        sections = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: dir)
+        expect(sections.size).to eq(1)
+        expect(sections.first[:version]).to eq("1.0.0")
+        expect(sections.first[:initial]).to be true
+      end
+    end
+
+    it "classifies additions and breaking changes between versions" do
+      Dir.mktmpdir do |dir|
+        write_snapshot(dir, "1.0.0", "2026-01-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        write_snapshot(dir, "2.0.0", "2026-02-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              attribute :color, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+            aggregate "Gadget" do
+              attribute :label, String
+              command "CreateGadget" do
+                attribute :label, String
+              end
+            end
+          end
+        RUBY
+
+        sections = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: dir)
+        expect(sections.size).to eq(2)
+
+        newest = sections.first
+        expect(newest[:version]).to eq("2.0.0")
+        expect(newest[:initial]).to be false
+        expect(newest[:additions].size).to be >= 2
+        expect(newest[:breaking]).to be_empty
+      end
+    end
+
+    it "detects breaking changes when attributes are removed" do
+      Dir.mktmpdir do |dir|
+        write_snapshot(dir, "1.0.0", "2026-01-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              attribute :color, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        write_snapshot(dir, "2.0.0", "2026-02-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        sections = Hecks::DomainVersioning::ChangelogGenerator.call(base_dir: dir)
+        newest = sections.first
+        expect(newest[:breaking].size).to eq(1)
+        expect(newest[:breaking].first[:label]).to include("attribute")
+      end
+    end
+  end
+
+  describe Hecks::DomainVersioning::ChangelogRenderer do
+    it "renders markdown with version headers and sections" do
+      sections = [
+        { version: "2.0.0", tagged_at: "2026-02-01", initial: false,
+          breaking: [{ label: "- attribute: Widget.color" }],
+          additions: [{ label: "+ aggregate: Gadget" }] },
+        { version: "1.0.0", tagged_at: "2026-01-01", initial: true,
+          breaking: [], additions: [] }
+      ]
+
+      md = Hecks::DomainVersioning::ChangelogRenderer.render(sections)
+      expect(md).to include("# Domain Changelog")
+      expect(md).to include("## 2.0.0 (2026-02-01)")
+      expect(md).to include("### Breaking Changes")
+      expect(md).to include("- - attribute: Widget.color")
+      expect(md).to include("### Additions")
+      expect(md).to include("- + aggregate: Gadget")
+      expect(md).to include("## 1.0.0 (2026-01-01)")
+      expect(md).to include("Initial release.")
+    end
+
+    it "renders no-changes section when both lists are empty" do
+      sections = [
+        { version: "1.1.0", tagged_at: "2026-03-01", initial: false,
+          breaking: [], additions: [] }
+      ]
+
+      md = Hecks::DomainVersioning::ChangelogRenderer.render(sections)
+      expect(md).to include("No changes.")
+    end
+  end
+
+  describe "hecks changelog CLI command" do
+    it "prints changelog to stdout" do
+      Dir.mktmpdir do |dir|
+        write_snapshot(dir, "1.0.0", "2026-01-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        Dir.chdir(dir) do
+          cli = Hecks::CLI.new
+          messages = []
+          allow(cli).to receive(:say) { |msg, color| messages << [msg, color] }
+
+          cli.changelog
+
+          text = messages.map(&:first).join("\n")
+          expect(text).to include("# Domain Changelog")
+          expect(text).to include("## 1.0.0")
+          expect(text).to include("Initial release.")
+        end
+      end
+    end
+
+    it "writes changelog to file with --output" do
+      Dir.mktmpdir do |dir|
+        write_snapshot(dir, "1.0.0", "2026-01-01", <<~RUBY)
+          Hecks.domain "Test" do
+            aggregate "Widget" do
+              attribute :name, String
+              command "CreateWidget" do
+                attribute :name, String
+              end
+            end
+          end
+        RUBY
+
+        Dir.chdir(dir) do
+          cli = Hecks::CLI.new([], output: "DOMAIN_CHANGELOG.md")
+          messages = []
+          allow(cli).to receive(:say) { |msg, color| messages << [msg, color] }
+
+          cli.changelog
+
+          path = File.join(dir, "DOMAIN_CHANGELOG.md")
+          expect(File.exist?(path)).to be true
+          content = File.read(path)
+          expect(content).to include("# Domain Changelog")
+          expect(content).to include("## 1.0.0")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat(cli): add domain changelog generation from version snapshots

HEC-101: New `hecks changelog` command loads all tagged version snapshots
from db/hecks_versions/, diffs consecutive pairs via DomainDiff, classifies
changes as breaking or non-breaking, and renders structured Markdown with
version headers, Breaking Changes section, and Additions section.
Supports --output flag to write to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)