### PR TITLE
HEC-103: AI domain review

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -506,6 +506,17 @@
 - `add_lifecycle` and `add_transition` tools for state machine building via MCP
 - `add_attribute` tool for adding individual attributes to existing aggregates
 - All tool output uses `capture_output` to show the same terse feedback as the REPL
+- `review_domain` MCP tool runs an AI-powered DDD review returning structured findings with severity, category, and recommendations
+
+### AI Domain Review
+- `hecks review` CLI command runs an AI-powered DDD review of any domain model
+- Reviews aggregate boundaries, command design, value objects, naming, references, policies, and missing patterns
+- Structured findings with severity levels: critical, warning, suggestion
+- Each finding includes target element, category, message, and concrete recommendation
+- Overall score (1-10) with summary assessment
+- Degrades gracefully without `ANTHROPIC_API_KEY` — returns a stub review instead of crashing
+- JSON output format via `--format json` for tooling integration
+- Configurable model via `--model` option
 
 ### Command Bus Port (HTTP Adapter Boundary)
 - `Hecks::HTTP::CommandBusPort` — explicit port between HTTP routes and the domain

--- a/docs/usage/ai_review.md
+++ b/docs/usage/ai_review.md
@@ -1,0 +1,102 @@
+# AI Domain Review
+
+AI-powered DDD review of a Hecks domain model. Evaluates aggregate boundaries,
+command design, value objects, naming, references, policies, and missing patterns.
+
+## Prerequisites
+
+Set your Anthropic API key:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Without an API key the command degrades gracefully, returning a stub review
+with score 0 and a message to configure the key.
+
+## CLI Usage
+
+Review the domain in the current directory:
+
+```bash
+hecks review
+```
+
+Review a specific domain:
+
+```bash
+hecks review --domain path/to/my_domain
+```
+
+JSON output for tooling:
+
+```bash
+hecks review --format json
+```
+
+Use a different model:
+
+```bash
+hecks review --model claude-sonnet-4-20250514
+```
+
+### Example Output
+
+```
+Reviewing domain: Pizzas...
+
+Score: 7/10
+Solid domain model with minor naming improvements needed.
+
+  [SUGGESTION] Pizza (value_objects)
+    Consider extracting Topping as a value object with validation.
+    => Add a Topping value object with name and amount attributes.
+
+  [WARNING] Order (boundaries)
+    Order aggregate references Pizza directly -- consider using an ID reference.
+    => Use reference_to(Pizza) to keep aggregate boundaries clean.
+```
+
+## MCP Tool
+
+The `review_domain` tool is available in the MCP server:
+
+```
+Tool: review_domain
+Input: {} (no parameters -- reviews the current session domain)
+Output: JSON with overall_score, summary, and findings array
+```
+
+## Ruby API
+
+```ruby
+require "hecks_ai"
+
+domain = Hecks.last_domain
+review = Hecks::AI::DomainReviewer.new(domain).call
+
+puts review[:overall_score]  # => 7
+puts review[:summary]        # => "Solid domain model..."
+
+review[:findings].each do |f|
+  puts "[#{f[:severity]}] #{f[:target]}: #{f[:message]}"
+end
+```
+
+## Severity Levels
+
+| Level      | Meaning                                                  |
+|------------|----------------------------------------------------------|
+| critical   | Violates a core DDD principle, will cause problems       |
+| warning    | Suboptimal but functional, fix before model grows        |
+| suggestion | Nice-to-have improvement for clarity or expressiveness   |
+
+## Review Categories
+
+- **boundaries** -- aggregate consistency boundaries
+- **commands** -- command naming and design
+- **value_objects** -- primitive obsession, missing VOs
+- **naming** -- ubiquitous language consistency
+- **references** -- cross-aggregate coupling
+- **policies** -- missing or misconfigured policies
+- **missing_patterns** -- lifecycles, specs, services

--- a/hecks_ai/lib/hecks_ai.rb
+++ b/hecks_ai/lib/hecks_ai.rb
@@ -18,10 +18,13 @@ module Hecks
     autoload :TypeResolver,     "hecks_ai/type_resolver"
     autoload :LlmClient,        "hecks_ai/llm_client"
     autoload :DomainBuilder,    "hecks_ai/domain_builder"
+    autoload :DomainReviewer,   "hecks_ai/domain_reviewer"
 
     module Prompts
-      autoload :DomainGeneration, "hecks_ai/prompts/domain_generation"
-      autoload :DomainToolSchema, "hecks_ai/prompts/domain_tool_schema"
+      autoload :DomainGeneration,      "hecks_ai/prompts/domain_generation"
+      autoload :DomainToolSchema,      "hecks_ai/prompts/domain_tool_schema"
+      autoload :DomainReview,          "hecks_ai/prompts/domain_review"
+      autoload :DomainReviewToolSchema, "hecks_ai/prompts/domain_review_tool_schema"
     end
   end
 end

--- a/hecks_ai/lib/hecks_ai/commands/review.rb
+++ b/hecks_ai/lib/hecks_ai/commands/review.rb
@@ -1,0 +1,76 @@
+# Hecks::AI::Commands::Review
+#
+# CLI command: run an AI-powered DDD review of a domain model.
+# Reads ANTHROPIC_API_KEY from ENV, serializes the domain IR, sends to the LLM,
+# and prints structured findings. Degrades gracefully without an API key.
+#
+#   hecks review                         # review the local Bluebook domain
+#   hecks review --domain path/to/domain # explicit domain path
+#   hecks review --format json           # raw JSON output for tooling
+#
+Hecks::CLI.register_command(:review, "AI-powered DDD review of a domain model",
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" },
+    format: { type: :string, desc: "Output format: text (default) or json" },
+    model:  { type: :string, desc: "Anthropic model (default: claude-opus-4-5)" }
+  }
+) do
+  require "hecks_ai"
+  require_relative "../domain_reviewer"
+  require_relative "../prompts/domain_review"
+  require_relative "../domain_serializer"
+
+  domain = resolve_domain_option
+  next unless domain
+
+  reviewer_opts = {}
+  reviewer_opts[:model] = options[:model] if options[:model]
+
+  say "Reviewing domain: #{domain.name}..."
+
+  review = Hecks::AI::DomainReviewer.new(domain, **reviewer_opts).call
+
+  if options[:format] == "json"
+    require "json"
+    say JSON.pretty_generate(review)
+    next
+  end
+
+  print_review(review)
+end
+
+def print_review(review)
+  score   = review[:overall_score] || review["overall_score"] || 0
+  summary = review[:summary]       || review["summary"] || ""
+  findings = review[:findings]     || review["findings"] || []
+
+  say ""
+  color = score >= 7 ? :green : score >= 4 ? :yellow : :red
+  say "Score: #{score}/10", color
+  say summary
+  say ""
+
+  if findings.empty?
+    say "No findings.", :green
+    return
+  end
+
+  findings.each do |f|
+    sev = f[:severity] || f["severity"]
+    sev_color = case sev
+    when "critical" then :red
+    when "warning"  then :yellow
+    else :cyan
+    end
+
+    target = f[:target]         || f["target"]
+    cat    = f[:category]       || f["category"]
+    msg    = f[:message]        || f["message"]
+    rec    = f[:recommendation] || f["recommendation"]
+
+    say "  [#{sev.upcase}] #{target} (#{cat})", sev_color
+    say "    #{msg}"
+    say "    => #{rec}", :white
+    say ""
+  end
+end

--- a/hecks_ai/lib/hecks_ai/domain_reviewer.rb
+++ b/hecks_ai/lib/hecks_ai/domain_reviewer.rb
@@ -1,0 +1,104 @@
+# Hecks::AI::DomainReviewer
+#
+# Sends a serialized Domain IR to the Anthropic LLM and returns structured
+# DDD review findings. Uses tool_use to force structured output matching the
+# review schema -- no free-form text, no parsing failures.
+#
+# Gracefully degrades when ANTHROPIC_API_KEY is not set, returning a stub
+# review that tells the user to configure their API key.
+#
+#   domain = Hecks.last_domain
+#   review = Hecks::AI::DomainReviewer.new(domain).call
+#   review[:overall_score]  # => 7
+#   review[:findings]       # => [{ target: "Order", severity: "warning", ... }]
+#
+module Hecks
+  module AI
+    class DomainReviewer
+      require "net/http"
+      require "uri"
+      require "json"
+
+      API_URL    = "https://api.anthropic.com/v1/messages"
+      MODEL      = "claude-opus-4-5"
+      MAX_TOKENS = 4096
+
+      # @param domain [Hecks::DomainModel::Structure::Domain] the domain to review
+      # @param api_key [String, nil] Anthropic API key (defaults to ENV)
+      # @param model [String] model ID override
+      def initialize(domain, api_key: ENV["ANTHROPIC_API_KEY"], model: MODEL)
+        @domain  = domain
+        @api_key = api_key
+        @model   = model
+      end
+
+      # Performs the review. Returns a Hash with :overall_score, :summary, :findings.
+      # Degrades gracefully without an API key.
+      #
+      # @return [Hash] structured review result
+      def call
+        return unavailable_review unless @api_key && !@api_key.strip.empty?
+
+        body     = build_request
+        response = post(body)
+        extract_tool_result(response)
+      end
+
+      private
+
+      def serialize_domain
+        require_relative "domain_serializer"
+        Hecks::MCP::DomainSerializer.call(@domain)
+      end
+
+      def build_request
+        {
+          model: @model,
+          max_tokens: MAX_TOKENS,
+          system: Hecks::AI::Prompts::DomainReview::SYSTEM_PROMPT,
+          tools: [Hecks::AI::Prompts::DomainReview::TOOL_SCHEMA],
+          tool_choice: { type: "tool", name: "review_domain" },
+          messages: [
+            { role: "user", content: "Review this domain model:\n\n#{JSON.generate(serialize_domain)}" }
+          ]
+        }
+      end
+
+      def post(body)
+        uri  = URI.parse(API_URL)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Post.new(uri.path)
+        request["x-api-key"]        = @api_key
+        request["anthropic-version"] = "2023-06-01"
+        request["content-type"]      = "application/json"
+        request.body = JSON.generate(body)
+
+        response = http.request(request)
+        raise "Anthropic API error #{response.code}: #{response.body}" unless response.code == "200"
+
+        JSON.parse(response.body, symbolize_names: true)
+      end
+
+      def extract_tool_result(response)
+        content  = response[:content] || []
+        tool_use = content.find { |block| block[:type] == "tool_use" }
+        raise "No tool_use block in response" unless tool_use
+
+        input = tool_use[:input]
+        raise "Empty tool input in response" unless input
+
+        input
+      end
+
+      def unavailable_review
+        {
+          overall_score: 0,
+          summary: "AI review unavailable -- set ANTHROPIC_API_KEY to enable.",
+          findings: []
+        }
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/inspect_tools.rb
+++ b/hecks_ai/lib/hecks_ai/inspect_tools.rb
@@ -13,6 +13,7 @@ module Hecks
     #   - +list_aggregates+  -- comma-separated list of aggregate names
     #   - +preview_code+     -- generated Ruby source code for an aggregate (or all)
     #   - +show_dsl+         -- the raw Hecks DSL source that defines the domain
+    #   - +review_domain+    -- AI-powered DDD review with structured findings
     #
     # All tools require an active session (enforced via +ctx.ensure_session!+).
     #
@@ -59,6 +60,19 @@ module Hecks
         ) do |_|
           ctx.ensure_session!
           ctx.workshop.to_dsl
+        end
+
+        server.define_tool(
+          name: "review_domain",
+          description: "AI-powered DDD review of the current domain model. Returns structured findings with severity, category, and recommendations. Requires ANTHROPIC_API_KEY.",
+          input_schema: { type: "object", properties: {} }
+        ) do |_|
+          ctx.ensure_session!
+          require_relative "domain_reviewer"
+          require_relative "prompts/domain_review"
+          domain = ctx.workshop.to_domain
+          review = Hecks::AI::DomainReviewer.new(domain).call
+          JSON.generate(review)
         end
       end
     end

--- a/hecks_ai/lib/hecks_ai/prompts/domain_review.rb
+++ b/hecks_ai/lib/hecks_ai/prompts/domain_review.rb
@@ -1,0 +1,56 @@
+# Hecks::AI::Prompts::DomainReview
+#
+# System prompt and tool schema for AI domain review. Instructs the LLM
+# to evaluate a domain model against DDD best practices and return
+# structured findings via tool_use.
+#
+# Used by DomainReviewer to build the Anthropic Messages API request.
+#
+#   Hecks::AI::Prompts::DomainReview::SYSTEM_PROMPT  # => String
+#   Hecks::AI::Prompts::DomainReview::TOOL_SCHEMA    # => Hash
+#
+require_relative "domain_review_tool_schema"
+
+module Hecks
+  module AI
+    module Prompts
+      module DomainReview
+        SYSTEM_PROMPT = <<~PROMPT
+          You are an expert Domain-Driven Design reviewer. Given a serialized domain
+          model (aggregates, commands, queries, policies, validations, value objects,
+          entities, services), you evaluate it against DDD best practices and return
+          structured findings.
+
+          Review criteria:
+          1. Aggregate boundaries — each aggregate should be a true consistency
+             boundary. Look for aggregates that are too large (god aggregates) or
+             too small (anemic). Flag missing invariants.
+          2. Command design — commands should follow Verb+Noun naming
+             (e.g. CreateOrder, CancelShipment). Flag commands with unclear intent
+             or missing validations.
+          3. Value objects — immutable types with equality by value. Flag primitives
+             that should be value objects (e.g. bare String for email, address, money).
+          4. Naming — ubiquitous language consistency. Flag generic names
+             (e.g. "Item", "Data", "Info") that don't express domain concepts.
+          5. References — cross-aggregate references should be intentional.
+             Flag bidirectional references or tight coupling between aggregates.
+          6. Policies — reactive policies should have clear event triggers.
+             Flag missing policies for common domain rules.
+          7. Missing patterns — suggest lifecycle state machines, specifications,
+             or domain services where the model would benefit.
+
+          Severity levels:
+          - critical: violates a core DDD principle, will cause problems at scale
+          - warning: suboptimal but functional, should address before the model grows
+          - suggestion: nice-to-have improvement for clarity or expressiveness
+
+          For each finding, provide the aggregate or element it applies to,
+          the category, severity, a clear message, and a concrete recommendation.
+          Also provide an overall_score (1-10) and a brief summary.
+        PROMPT
+
+        TOOL_SCHEMA = Hecks::AI::Prompts::DomainReviewToolSchema::SCHEMA
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/prompts/domain_review_tool_schema.rb
+++ b/hecks_ai/lib/hecks_ai/prompts/domain_review_tool_schema.rb
@@ -1,0 +1,42 @@
+# Hecks::AI::Prompts::DomainReviewToolSchema
+#
+# Anthropic tool_use schema for the review_domain tool. Defines the JSON
+# structure the LLM must return when reviewing a domain model.
+#
+# Separated from DomainReview to keep file sizes within limits.
+#
+#   Hecks::AI::Prompts::DomainReviewToolSchema::SCHEMA  # => Hash
+#
+module Hecks
+  module AI
+    module Prompts
+      module DomainReviewToolSchema
+        FINDING_ITEM = {
+          type: "object",
+          required: %w[target category severity message recommendation],
+          properties: {
+            target:         { type: "string", description: "Aggregate or element name this applies to" },
+            category:       { type: "string", description: "Review category: boundaries, commands, value_objects, naming, references, policies, missing_patterns" },
+            severity:       { type: "string", enum: %w[critical warning suggestion] },
+            message:        { type: "string", description: "Clear description of the finding" },
+            recommendation: { type: "string", description: "Concrete action to resolve the finding" }
+          }
+        }.freeze
+
+        SCHEMA = {
+          name: "review_domain",
+          description: "Return structured DDD review findings for a domain model",
+          input_schema: {
+            type: "object",
+            required: %w[overall_score summary findings],
+            properties: {
+              overall_score: { type: "integer", description: "Overall domain quality score from 1 (poor) to 10 (excellent)" },
+              summary:       { type: "string",  description: "Brief overall assessment of the domain model" },
+              findings:      { type: "array",   items: FINDING_ITEM }
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/hecks_ai/spec/domain_reviewer_spec.rb
+++ b/hecks_ai/spec/domain_reviewer_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::DomainReviewer do
+  let(:domain) do
+    Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+        attribute :description, String
+        validation :name, presence: true
+        command "CreatePizza" do
+          attribute :name, String
+          attribute :description, String
+        end
+      end
+    end
+  end
+
+  describe "#call" do
+    context "without an API key" do
+      subject(:reviewer) { described_class.new(domain, api_key: nil) }
+
+      it "returns unavailable review with score 0" do
+        result = reviewer.call
+        expect(result[:overall_score]).to eq(0)
+        expect(result[:summary]).to include("unavailable")
+        expect(result[:findings]).to eq([])
+      end
+    end
+
+    context "with an empty API key" do
+      subject(:reviewer) { described_class.new(domain, api_key: "  ") }
+
+      it "returns unavailable review" do
+        result = reviewer.call
+        expect(result[:overall_score]).to eq(0)
+      end
+    end
+
+    context "with a valid API key" do
+      subject(:reviewer) { described_class.new(domain, api_key: "test-key") }
+
+      let(:canned_review) do
+        {
+          overall_score: 7,
+          summary: "Solid domain model with minor naming improvements needed.",
+          findings: [
+            {
+              target: "Pizza",
+              category: "value_objects",
+              severity: "suggestion",
+              message: "Consider extracting Topping as a value object.",
+              recommendation: "Add a Topping value object with name and amount attributes."
+            }
+          ]
+        }
+      end
+
+      let(:api_response_body) do
+        {
+          id: "msg_01",
+          type: "message",
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_01", name: "review_domain", input: canned_review }
+          ],
+          model: "claude-opus-4-5",
+          stop_reason: "tool_use"
+        }.to_json
+      end
+
+      before { stub_http_response(200, api_response_body) }
+
+      it "returns structured review with score and findings" do
+        result = reviewer.call
+        expect(result[:overall_score]).to eq(7)
+        expect(result[:summary]).to include("Solid domain")
+        expect(result[:findings].size).to eq(1)
+        expect(result[:findings].first[:severity]).to eq("suggestion")
+      end
+
+      it "serializes the domain before sending" do
+        reviewer.call
+        # The HTTP request was made (stub didn't raise), which means
+        # the domain was successfully serialized and sent
+      end
+    end
+
+    context "when the API returns an error" do
+      subject(:reviewer) { described_class.new(domain, api_key: "test-key") }
+
+      before { stub_http_response(500, '{"error": "server error"}') }
+
+      it "raises a descriptive error" do
+        expect { reviewer.call }
+          .to raise_error(RuntimeError, /Anthropic API error 500/)
+      end
+    end
+
+    context "when the API returns no tool_use block" do
+      subject(:reviewer) { described_class.new(domain, api_key: "test-key") }
+
+      let(:no_tool_body) do
+        { content: [{ type: "text", text: "here is your review" }] }.to_json
+      end
+
+      before { stub_http_response(200, no_tool_body) }
+
+      it "raises an error" do
+        expect { reviewer.call }
+          .to raise_error(RuntimeError, /No tool_use block/)
+      end
+    end
+  end
+
+  def stub_http_response(code, body)
+    response = instance_double(Net::HTTPResponse, code: code.to_s, body: body)
+    allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+  end
+end

--- a/hecks_ai/spec/prompts/domain_review_spec.rb
+++ b/hecks_ai/spec/prompts/domain_review_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::Prompts::DomainReview do
+  describe "SYSTEM_PROMPT" do
+    it "contains DDD reviewer role" do
+      expect(described_class::SYSTEM_PROMPT).to include("Domain-Driven Design reviewer")
+    end
+
+    it "defines severity levels" do
+      expect(described_class::SYSTEM_PROMPT).to include("critical")
+      expect(described_class::SYSTEM_PROMPT).to include("warning")
+      expect(described_class::SYSTEM_PROMPT).to include("suggestion")
+    end
+
+    it "covers aggregate boundaries" do
+      expect(described_class::SYSTEM_PROMPT).to include("Aggregate boundaries")
+    end
+
+    it "covers command design" do
+      expect(described_class::SYSTEM_PROMPT).to include("Command design")
+    end
+
+    it "covers value objects" do
+      expect(described_class::SYSTEM_PROMPT).to include("Value objects")
+    end
+  end
+
+  describe "TOOL_SCHEMA" do
+    subject(:schema) { described_class::TOOL_SCHEMA }
+
+    it "is named review_domain" do
+      expect(schema[:name]).to eq("review_domain")
+    end
+
+    it "requires overall_score, summary, and findings" do
+      required = schema[:input_schema][:required]
+      expect(required).to include("overall_score", "summary", "findings")
+    end
+
+    it "defines findings as an array" do
+      findings = schema[:input_schema][:properties][:findings]
+      expect(findings[:type]).to eq("array")
+    end
+
+    it "defines severity as an enum" do
+      finding_props = schema[:input_schema][:properties][:findings][:items][:properties]
+      expect(finding_props[:severity][:enum]).to eq(%w[critical warning suggestion])
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/extensions/ai/inspect_tools.rb
+++ b/hecks_workshop/lib/hecks/extensions/ai/inspect_tools.rb
@@ -13,6 +13,7 @@ module Hecks
     #   - +list_aggregates+  -- comma-separated list of aggregate names
     #   - +preview_code+     -- generated Ruby source code for an aggregate (or all)
     #   - +show_dsl+         -- the raw Hecks DSL source that defines the domain
+    #   - +review_domain+    -- AI-powered DDD review with structured findings
     #
     # All tools require an active session (enforced via +ctx.ensure_session!+).
     #
@@ -59,6 +60,19 @@ module Hecks
         ) do |_|
           ctx.ensure_session!
           ctx.workshop.to_dsl
+        end
+
+        server.define_tool(
+          name: "review_domain",
+          description: "AI-powered DDD review of the current domain model. Returns structured findings with severity, category, and recommendations. Requires ANTHROPIC_API_KEY.",
+          input_schema: { type: "object", properties: {} }
+        ) do |_|
+          ctx.ensure_session!
+          require "hecks_ai/domain_reviewer"
+          require "hecks_ai/prompts/domain_review"
+          domain = ctx.workshop.to_domain
+          review = Hecks::AI::DomainReviewer.new(domain).call
+          JSON.generate(review)
         end
       end
     end


### PR DESCRIPTION
## Summary
feat(ai): add AI domain review (HEC-103)

Add `hecks review` CLI command and `review_domain` MCP tool for AI-powered
DDD review of domain models. Evaluates aggregate boundaries, command design,
value objects, naming, references, policies, and missing patterns. Returns
structured findings with severity levels and concrete recommendations.
Degrades gracefully without ANTHROPIC_API_KEY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)