### PR TITLE
HEC-105: Policy trace logging

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -53,6 +53,7 @@ Boot fires driven extensions first so driving adapters see the fully wired runti
 | **logging** | `extend :logging` | driven | experimental | Command execution timing and logging. [Source](hecks_runtime/lib/hecks/extensions/logging.rb) |
 | **rate_limit** | `extend :rate_limit` | driven | experimental | Per-command rate limiting. [Source](hecks_runtime/lib/hecks/extensions/rate_limit.rb) |
 | **retry** | `extend :retry` | driven | experimental | Exponential backoff for transient errors. [Source](hecks_runtime/lib/hecks/extensions/retry.rb) |
+| **policy_tracing** | `extend :policy_tracing` | driven | experimental | Policy execution tracing with timing and condition data. [Source](hecksties/lib/hecks/extensions/policy_tracing.rb) |
 
 ## Infrastructure (driving)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -130,6 +130,7 @@
 - `hecks_idempotency` — command deduplication by fingerprint
 - `hecks_transactions` — DB transaction wrapping when SQL adapter present
 - `hecks_retry` — exponential backoff for transient errors
+- `hecks_policy_tracing` — policy execution tracing with timing, condition results, and action data; `Hecks.policy_traces` returns trace array
 
 ### Domain Connections DSL
 - `extend :sqlite` — declare persistence adapter

--- a/docs/usage/policy_tracing.md
+++ b/docs/usage/policy_tracing.md
@@ -1,0 +1,83 @@
+# Policy Tracing
+
+Trace every reactive policy execution with timing, condition results, and action data.
+
+## Setup
+
+```ruby
+app = Hecks.boot(__dir__) do
+  extend :policy_tracing
+end
+```
+
+Or apply at runtime:
+
+```ruby
+app = Hecks.boot(__dir__)
+app.extend(:policy_tracing)
+```
+
+## Reading Traces
+
+After commands fire policies, inspect the trace log:
+
+```ruby
+Hecks.policy_traces
+# => [
+#   {
+#     policy: "ShipNotification",
+#     event: "PlacedOrder",
+#     condition_result: true,
+#     action: "NotifyWarehouse",
+#     duration_ms: 0.12,
+#     timestamp: 2026-04-01 12:00:00 -0700
+#   }
+# ]
+```
+
+## Trace Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy` | String | Name of the reactive policy |
+| `event` | String | The triggering event class name |
+| `condition_result` | Boolean | Whether the policy condition passed |
+| `action` | String | The command the policy triggers |
+| `duration_ms` | Float | Execution time in milliseconds |
+| `timestamp` | Time | When the trace was recorded |
+
+## Example: Conditional Policy
+
+```ruby
+Hecks.domain "Orders" do
+  aggregate "Order" do
+    attribute :total, Float
+
+    command "PlaceOrder" do
+      attribute :total, Float
+    end
+
+    command "FlagHighValue" do
+      attribute :total, Float
+    end
+
+    policy "HighValueAlert" do
+      on "PlacedOrder"
+      trigger "FlagHighValue"
+      condition { |event| event.total > 1000 }
+    end
+  end
+end
+
+app = Hecks.boot(__dir__) do
+  extend :policy_tracing
+end
+
+app.run("PlaceOrder", total: 500.0)
+Hecks.policy_traces.last[:condition_result]
+# => false (policy skipped, but trace still recorded)
+
+app.run("PlaceOrder", total: 2000.0)
+Hecks.policy_traces.last[:condition_result]
+# => true (policy fired and traced)
+```

--- a/hecksties/lib/hecks/extensions/policy_tracing.rb
+++ b/hecksties/lib/hecks/extensions/policy_tracing.rb
@@ -1,0 +1,50 @@
+# HecksPolicyTracing
+#
+# Driven extension that instruments policy execution with trace callbacks.
+# Wraps PolicySetup#execute_policy to capture timing, condition results,
+# and action details for every reactive policy fired. Traces are stored
+# in-memory and accessible via Hecks.policy_traces.
+#
+# Trace data format:
+#   { policy:, event:, condition_result:, action:, duration_ms:, timestamp: }
+#
+# Usage:
+#   app = Hecks.boot(__dir__) do
+#     extend :policy_tracing
+#   end
+#
+#   Pizza.create(name: "Margherita")
+#   Hecks.policy_traces
+#   # => [{ policy: "NotifyKitchen", event: "CreatedPizza", ... }]
+#
+Hecks.describe_extension(:policy_tracing,
+  description: "Policy execution tracing with timing and condition data",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :event_bus)
+
+Hecks.register_extension(:policy_tracing) do |_domain_mod, _domain, runtime|
+  traces = []
+  Hecks.instance_variable_set(:@_policy_traces, traces)
+  Hecks.define_singleton_method(:policy_traces) { @_policy_traces }
+
+  original_execute = runtime.method(:execute_policy)
+
+  runtime.define_singleton_method(:execute_policy) do |policy, policy_key, event|
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    condition_result = !policy.condition || policy.condition.call(event)
+
+    original_execute.call(policy, policy_key, event)
+
+    duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
+
+    traces << {
+      policy: policy.name,
+      event: event.class.name.split("::").last,
+      condition_result: condition_result,
+      action: policy.trigger_command,
+      duration_ms: duration,
+      timestamp: Time.now
+    }
+  end
+end

--- a/hecksties/spec/extensions/policy_tracing_spec.rb
+++ b/hecksties/spec/extensions/policy_tracing_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+require "hecks/extensions/policy_tracing"
+
+RSpec.describe "Policy tracing extension" do
+  let(:domain) do
+    Hecks.domain "TracingTest" do
+      aggregate "Order" do
+        attribute :total, Float
+
+        command "PlaceOrder" do
+          attribute :total, Float
+        end
+
+        command "NotifyWarehouse" do
+          attribute :total, Float
+        end
+
+        command "FlagHighValue" do
+          attribute :total, Float
+        end
+
+        policy "ShipNotification" do
+          on "PlacedOrder"
+          trigger "NotifyWarehouse"
+        end
+
+        policy "HighValueAlert" do
+          on "PlacedOrder"
+          trigger "FlagHighValue"
+          condition { |event| event.total > 1000 }
+        end
+      end
+    end
+  end
+
+  it "records a trace for each policy execution" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    app.run("PlaceOrder", total: 500.0)
+
+    traces = Hecks.policy_traces
+    expect(traces.size).to eq(2)
+  end
+
+  it "captures policy name, event, action, and timestamp" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    app.run("PlaceOrder", total: 500.0)
+
+    trace = Hecks.policy_traces.find { |t| t[:policy] == "ShipNotification" }
+    expect(trace[:event]).to eq("PlacedOrder")
+    expect(trace[:action]).to eq("NotifyWarehouse")
+    expect(trace[:timestamp]).to be_a(Time)
+    expect(trace[:duration_ms]).to be_a(Float)
+  end
+
+  it "records condition_result true when condition passes" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    app.run("PlaceOrder", total: 2000.0)
+
+    trace = Hecks.policy_traces.find { |t| t[:policy] == "HighValueAlert" }
+    expect(trace[:condition_result]).to be true
+  end
+
+  it "records condition_result false when condition fails" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    app.run("PlaceOrder", total: 50.0)
+
+    trace = Hecks.policy_traces.find { |t| t[:policy] == "HighValueAlert" }
+    expect(trace[:condition_result]).to be false
+  end
+
+  it "records condition_result true for policies without conditions" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    app.run("PlaceOrder", total: 50.0)
+
+    trace = Hecks.policy_traces.find { |t| t[:policy] == "ShipNotification" }
+    expect(trace[:condition_result]).to be true
+  end
+
+  it "exposes traces via Hecks.policy_traces" do
+    app = Hecks.load(domain, force: true)
+    app.extend(:policy_tracing)
+
+    expect(Hecks.policy_traces).to eq([])
+
+    app.run("PlaceOrder", total: 100.0)
+
+    expect(Hecks.policy_traces).not_to be_empty
+  end
+end


### PR DESCRIPTION
## Summary
HEC-105: Add policy execution tracing extension

New driven extension :policy_tracing that wraps PolicySetup#execute_policy
to capture trace data for every reactive policy fired. Each trace records
the policy name, triggering event, condition result, trigger action,
duration in milliseconds, and timestamp. Access via Hecks.policy_traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)