### PR TITLE
HEC-111: Redis persistence adapter

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -107,6 +107,7 @@
 - `hecks_postgres` — PostgreSQL persistence
 - `hecks_mysql` — MySQL persistence
 - `hecks_mongodb` — MongoDB persistence; value objects embedded as nested documents (no join tables)
+- `hecks_redis_store` — Redis persistence (experimental); JSON-serialized aggregates under `hecks:<domain>:<aggregate>:<id>` keys; requires the `redis` gem
 - `hecks_cqrs` — named persistence connections for read/write separation
 - `hecks_mongodb` — MongoDB document persistence via the mongo Ruby driver
 

--- a/docs/usage/redis_adapter.md
+++ b/docs/usage/redis_adapter.md
@@ -1,0 +1,86 @@
+# Redis Adapter
+
+**Status: Experimental** -- API may change.
+
+Persist domain aggregates in Redis as JSON strings. Each aggregate is stored
+under a namespaced key: `hecks:<domain>:<aggregate>:<id>`.
+
+## Setup
+
+Add the `redis` gem to your Gemfile:
+
+```ruby
+gem "redis"
+```
+
+### Auto-wire via boot
+
+```ruby
+app = Hecks.boot(__dir__, adapter: :redis)
+```
+
+### Environment
+
+Set `REDIS_URL` to point at your Redis instance (default: `redis://localhost:6379`):
+
+```bash
+REDIS_URL=redis://localhost:6379/1 ruby app.rb
+```
+
+## Key namespace
+
+Keys follow the pattern:
+
+```
+hecks:<domain>:<aggregate>:<id>
+```
+
+For a `Pizzas` domain with a `Pizza` aggregate and ID `abc-123`:
+
+```
+hecks:pizzas:pizza:abc-123
+```
+
+## Repository interface
+
+The `RedisRepository` implements the standard Hecks repository methods:
+
+| Method   | Redis operation        |
+|----------|------------------------|
+| `find`   | `GET` key              |
+| `save`   | `SET` key with JSON    |
+| `delete` | `DEL` key              |
+| `all`    | `SCAN` + `MGET`        |
+| `count`  | `SCAN` (count keys)    |
+| `query`  | `SCAN` + filter/sort   |
+| `clear`  | `SCAN` + `DEL`         |
+
+## Direct usage (without boot)
+
+```ruby
+require "redis"
+require "hecks/extensions/redis_store"
+
+redis = Redis.new(url: "redis://localhost:6379")
+
+repo = Hecks::RedisRepository.new(
+  "Pizza",
+  PizzasDomain::Pizza,
+  redis: redis,
+  namespace: "hecks:pizzas:pizza"
+)
+
+repo.save(pizza)
+repo.find(pizza.id)
+repo.all
+repo.query(conditions: { name: "Margherita" }, order_key: :name, limit: 10)
+repo.clear
+```
+
+## Notes
+
+- All values are JSON-serialized strings. Redis is used as a document store.
+- `all`, `count`, `query`, and `clear` use `SCAN` to enumerate keys, which is
+  safe for large keyspaces but not transactional.
+- Value objects and nested attributes are serialized as embedded JSON objects.
+- Timestamps (`created_at`, `updated_at`) are stored as ISO 8601 strings.

--- a/hecksties/lib/hecks/extensions/redis_store.rb
+++ b/hecksties/lib/hecks/extensions/redis_store.rb
@@ -1,0 +1,194 @@
+# HecksRedisStore (Experimental)
+#
+# Redis persistence extension for Hecks domains. Stores each aggregate
+# as a JSON-serialized string under a namespaced key:
+#
+#   hecks:<domain>:<aggregate>:<id>
+#
+# Auto-wires when present in the Gemfile. Requires the `redis` gem.
+#
+# Future gem: hecks_redis_store
+#
+#   # Gemfile
+#   gem "cats_domain"
+#   gem "hecks_redis_store"   # auto-wires at boot
+#
+#   # Or explicitly:
+#   app = Hecks.boot(__dir__, adapter: :redis)
+#
+#   # With custom URL:
+#   REDIS_URL=redis://localhost:6379/1 ruby app.rb
+#
+# STATUS: Experimental — API may change.
+#
+Hecks.describe_extension(:redis_store,
+  description: "Redis persistence (experimental)",
+  adapter_type: :driven,
+  config: { url: { default: "redis://localhost:6379", desc: "Redis connection URL" } },
+  wires_to: :repository)
+
+Hecks.register_extension(:redis_store) do |domain_mod, domain, runtime|
+  require "json"
+  require "time"
+
+  redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+
+  begin
+    require "redis"
+    redis = Redis.new(url: redis_url)
+  rescue LoadError
+    raise "hecks_redis_store requires the `redis` gem. Add `gem 'redis'` to your Gemfile."
+  end
+
+  domain_name = domain_mod.name.sub(/Domain\z/, "").downcase
+
+  domain.aggregates.each do |agg|
+    repo = Hecks::RedisRepository.new(
+      agg.name,
+      domain_mod.const_get(agg.name),
+      redis: redis,
+      namespace: "hecks:#{domain_name}:#{agg.name.downcase}"
+    )
+    runtime.swap_adapter(agg.name, repo)
+  end
+end
+
+# Alias for convenience: adapter: :redis
+Hecks.extension_registry[:redis] = Hecks.extension_registry[:redis_store]
+
+module Hecks
+  # Hecks::RedisRepository
+  #
+  # Redis-backed persistence for a single aggregate type. Keys follow
+  # the pattern namespace:id. Values are JSON strings.
+  #
+  # Implements the standard Hecks repository interface: find, save,
+  # delete, all, count, query, clear.
+  #
+  #   repo = Hecks::RedisRepository.new("Pizza", PizzaClass,
+  #     redis: redis_client, namespace: "hecks:pizzas:pizza")
+  #   repo.save(pizza)
+  #   repo.find(pizza.id)
+  #
+  class RedisRepository
+    def initialize(aggregate_name, aggregate_class, redis:, namespace:)
+      @aggregate_name = aggregate_name
+      @aggregate_class = aggregate_class
+      @redis = redis
+      @namespace = namespace
+    end
+
+    def find(id)
+      json = @redis.get(key_for(id))
+      return nil unless json
+      deserialize(JSON.parse(json))
+    end
+
+    def save(obj)
+      @redis.set(key_for(obj.id), JSON.generate(serialize(obj)))
+      obj
+    end
+
+    def delete(id)
+      @redis.del(key_for(id))
+    end
+
+    def all
+      keys = scan_keys
+      return [] if keys.empty?
+      @redis.mget(*keys).compact.map { |json| deserialize(JSON.parse(json)) }
+    end
+
+    def count
+      scan_keys.size
+    end
+
+    def query(conditions: {}, order_key: nil, order_direction: :asc, limit: nil, offset: nil)
+      results = all
+      results = filter(results, conditions) unless conditions.empty?
+      results = sort(results, order_key, order_direction) if order_key
+      results = results.drop([offset, 0].max) if offset
+      results = results.take([limit, 0].max) if limit
+      results
+    end
+
+    def clear
+      keys = scan_keys
+      @redis.del(*keys) unless keys.empty?
+    end
+
+    private
+
+    def key_for(id)
+      "#{@namespace}:#{id}"
+    end
+
+    def scan_keys
+      pattern = "#{@namespace}:*"
+      keys = []
+      cursor = "0"
+      loop do
+        cursor, batch = @redis.scan(cursor, match: pattern, count: 100)
+        keys.concat(batch)
+        break if cursor == "0"
+      end
+      keys
+    end
+
+    def filter(results, conditions)
+      results.select do |obj|
+        conditions.all? do |k, v|
+          next false unless obj.respond_to?(k)
+          actual = obj.send(k)
+          v.is_a?(Hecks::Querying::Operators::Operator) ? v.match?(actual) : actual == v
+        end
+      end
+    end
+
+    def sort(results, order_key, order_direction)
+      sorted = results.sort_by do |obj|
+        val = obj.respond_to?(order_key) ? obj.send(order_key) : nil
+        val.nil? ? "" : val
+      end
+      order_direction == :desc ? sorted.reverse : sorted
+    end
+
+    def serialize(obj)
+      h = { "id" => obj.id }
+      if obj.class.respond_to?(:hecks_attributes)
+        obj.class.hecks_attributes.each do |attr|
+          h[attr[:name].to_s] = serialize_value(obj.send(attr[:name]))
+        end
+      end
+      h["created_at"] = obj.created_at&.iso8601 if obj.respond_to?(:created_at)
+      h["updated_at"] = obj.updated_at&.iso8601 if obj.respond_to?(:updated_at)
+      h
+    end
+
+    def serialize_value(val)
+      case val
+      when Array then val.map { |v| serialize_value(v) }
+      when ->(v) { v.class.respond_to?(:hecks_attributes) }
+        h = {}
+        val.class.hecks_attributes.each { |a| h[a.name.to_s] = serialize_value(val.send(a.name)) }
+        h
+      else val
+      end
+    end
+
+    def deserialize(data)
+      attrs = {}
+      if @aggregate_class.respond_to?(:hecks_attributes)
+        @aggregate_class.hecks_attributes.each do |attr|
+          attrs[attr[:name]] = data[attr[:name].to_s]
+        end
+      end
+      obj = @aggregate_class.new(id: data["id"], **attrs)
+      if data["created_at"]
+        obj.instance_variable_set(:@created_at, Time.parse(data["created_at"])) rescue nil
+        obj.instance_variable_set(:@updated_at, Time.parse(data["updated_at"])) rescue nil
+      end
+      obj
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/adapter_registry.rb
+++ b/hecksties/lib/hecks/registries/adapter_registry.rb
@@ -25,7 +25,7 @@ module Hecks
     private
 
     def adapter_registry
-      @adapter_registry ||= SetRegistry.new(%i[memory sqlite postgres mysql mysql2 filesystem filesystem_store mongodb])
+      @adapter_registry ||= SetRegistry.new(%i[memory sqlite postgres mysql mysql2 filesystem filesystem_store mongodb redis redis_store])
     end
   end
 end

--- a/hecksties/spec/extensions/redis_store_spec.rb
+++ b/hecksties/spec/extensions/redis_store_spec.rb
@@ -1,0 +1,186 @@
+require "spec_helper"
+
+# Mock Redis client -- hash-based, no gem required.
+# Implements get/set/del/mget/scan to exercise RedisRepository.
+class MockRedis
+  def initialize
+    @store = {}
+  end
+
+  def get(key)
+    @store[key]
+  end
+
+  def set(key, value)
+    @store[key] = value
+  end
+
+  def del(*keys)
+    keys.flatten.each { |k| @store.delete(k) }
+  end
+
+  def mget(*keys)
+    keys.flatten.map { |k| @store[k] }
+  end
+
+  def scan(cursor, match:, count: 100)
+    pattern = Regexp.new("\\A" + Regexp.escape(match).gsub("\\*", ".*") + "\\z")
+    matching = @store.keys.select { |k| k.match?(pattern) }
+    ["0", matching]
+  end
+end
+
+require "hecks/extensions/redis_store"
+
+RSpec.describe Hecks::RedisRepository do
+  before(:all) do
+    domain = Hecks.domain "RedisTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        attribute :weight, Integer
+
+        command "CreateWidget" do
+          attribute :name, String
+          attribute :weight, Integer
+        end
+      end
+    end
+    @app = Hecks.load(domain)
+  end
+
+  let(:mock_redis) { MockRedis.new }
+
+  let(:repo) do
+    Hecks::RedisRepository.new(
+      "Widget",
+      RedisTestDomain::Widget,
+      redis: mock_redis,
+      namespace: "hecks:redistest:widget"
+    )
+  end
+
+  def build_widget(name:, weight:)
+    cmd = RedisTestDomain::Widget.create(name: name, weight: weight)
+    cmd.aggregate
+  end
+
+  describe "#save and #find" do
+    it "round-trips an aggregate" do
+      widget = build_widget(name: "Sprocket", weight: 42)
+      repo.save(widget)
+
+      found = repo.find(widget.id)
+      expect(found).not_to be_nil
+      expect(found.id).to eq(widget.id)
+      expect(found.name).to eq("Sprocket")
+      expect(found.weight).to eq(42)
+    end
+
+    it "returns nil for missing id" do
+      expect(repo.find("nonexistent")).to be_nil
+    end
+  end
+
+  describe "#delete" do
+    it "removes an aggregate" do
+      widget = build_widget(name: "Gone", weight: 1)
+      repo.save(widget)
+      repo.delete(widget.id)
+
+      expect(repo.find(widget.id)).to be_nil
+    end
+  end
+
+  describe "#all" do
+    it "returns all saved aggregates" do
+      w1 = build_widget(name: "A", weight: 1)
+      w2 = build_widget(name: "B", weight: 2)
+      repo.save(w1)
+      repo.save(w2)
+
+      expect(repo.all.map(&:name).sort).to eq(["A", "B"])
+    end
+
+    it "returns empty array when nothing saved" do
+      expect(repo.all).to eq([])
+    end
+  end
+
+  describe "#count" do
+    it "returns the number of stored aggregates" do
+      expect(repo.count).to eq(0)
+
+      w1 = build_widget(name: "X", weight: 1)
+      repo.save(w1)
+      expect(repo.count).to eq(1)
+    end
+  end
+
+  describe "#query" do
+    before do
+      [
+        { name: "Alpha", weight: 30 },
+        { name: "Beta",  weight: 10 },
+        { name: "Gamma", weight: 20 }
+      ].each do |attrs|
+        w = build_widget(**attrs)
+        repo.save(w)
+      end
+    end
+
+    it "filters by conditions" do
+      results = repo.query(conditions: { name: "Beta" })
+      expect(results.size).to eq(1)
+      expect(results.first.name).to eq("Beta")
+    end
+
+    it "sorts by order_key ascending" do
+      results = repo.query(order_key: :weight)
+      expect(results.map(&:weight)).to eq([10, 20, 30])
+    end
+
+    it "sorts descending" do
+      results = repo.query(order_key: :weight, order_direction: :desc)
+      expect(results.map(&:weight)).to eq([30, 20, 10])
+    end
+
+    it "applies limit and offset" do
+      results = repo.query(order_key: :weight, limit: 1, offset: 1)
+      expect(results.size).to eq(1)
+      expect(results.first.weight).to eq(20)
+    end
+  end
+
+  describe "#clear" do
+    it "removes all stored aggregates" do
+      w = build_widget(name: "Temp", weight: 0)
+      repo.save(w)
+      expect(repo.count).to eq(1)
+
+      repo.clear
+      expect(repo.count).to eq(0)
+    end
+  end
+
+  describe "key namespace" do
+    it "stores under hecks:domain:aggregate:id" do
+      widget = build_widget(name: "Keyed", weight: 5)
+      repo.save(widget)
+
+      raw = mock_redis.get("hecks:redistest:widget:#{widget.id}")
+      expect(raw).not_to be_nil
+      parsed = JSON.parse(raw)
+      expect(parsed["name"]).to eq("Keyed")
+    end
+  end
+
+  describe "extension registration" do
+    it "registers :redis_store in the extension registry" do
+      expect(Hecks.extension_registry[:redis_store]).not_to be_nil
+    end
+
+    it "aliases :redis to :redis_store" do
+      expect(Hecks.extension_registry[:redis]).to eq(Hecks.extension_registry[:redis_store])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: register redis in adapter registry and update FEATURES.md

Add :redis and :redis_store to the adapter registry so boot treats them
as persistence extensions. Document the new extension in FEATURES.md.

feat: add Redis adapter extension (experimental)

HEC-111: RedisRepository implements find/save/delete/all/count/query/clear
using Redis GET/SET/DEL/SCAN with JSON serialization. Key namespace follows
hecks:domain:aggregate:id pattern. Registered as :redis_store/:redis adapter.
Unit tests use a hash-based MockRedis (no gem dependency in test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)