### PR TITLE
HEC-119: Domain inspect command

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -379,6 +379,7 @@
 - `hecks console [NAME]` — interactive REPL with domain loaded
 - `hecks validate` — check domain against DDD rules
 - `hecks mcp` — start MCP server
+- `hecks inspect` — show full domain definition including business logic (attributes, lifecycle, commands, policies, invariants, etc.)
 - `hecks dump` — show glossary, visualizer, and DSL output
 - `hecks migrations` — schema migration management
 - `hecks docs update` — sync doc headers and READMEs

--- a/docs/usage/domain_inspect.md
+++ b/docs/usage/domain_inspect.md
@@ -1,0 +1,55 @@
+# Domain Inspect
+
+Show the full domain definition including business logic, formatted for terminal reading.
+
+## Usage
+
+```bash
+# Inspect the full domain
+hecks inspect
+
+# Inspect a specific aggregate
+hecks inspect --aggregate Order
+
+# Inspect a domain by path
+hecks inspect --domain path/to/domain
+```
+
+## Output Sections
+
+Per aggregate: attributes, value objects, entities, lifecycle (field, default, transitions), commands (params, events, preconditions, postconditions, body), events, queries, validations, invariants, policies (guard + reactive with source), scopes, specifications, subscribers, references.
+
+Domain-level: policies, services, views, workflows, sagas, actors, glossary rules.
+
+## Example Output
+
+```
+Domain: Shop
+============
+
+Aggregate: Order
+=================
+
+  Attributes:
+    name: String
+    status: String
+
+  Value Objects:
+    LineItem (product: String, qty: Integer)
+
+  Lifecycle:
+    field: status, default: "draft"
+    states: draft, placed
+    transitions:
+      PlaceOrder -> placed
+
+  Commands:
+    CreateOrder(name: String) -> emits CreatedOrder
+    PlaceOrder() -> emits PlacedOrder
+
+  Invariants:
+    name must be present: !name.nil? && !name.empty?
+
+  Policies:
+    HighValue: guard — cmd.respond_to?(:name)
+```

--- a/hecksties/lib/hecks_cli/commands/inspect_domain.rb
+++ b/hecksties/lib/hecks_cli/commands/inspect_domain.rb
@@ -1,0 +1,25 @@
+# Hecks::CLI — inspect command
+#
+# Shows the full domain definition including business logic, formatted
+# for terminal reading. Walks the domain IR to display attributes, value
+# objects, entities, lifecycle, commands, events, queries, validations,
+# invariants, policies, scopes, specifications, subscribers, and references.
+#
+#   hecks inspect                          # full domain
+#   hecks inspect --aggregate Order        # single aggregate
+#   hecks inspect --domain path/to/domain  # explicit domain path
+#
+require_relative "../domain_inspector"
+
+Hecks::CLI.register_command(:inspect, "Show full domain definition including business logic",
+  options: {
+    domain:    { type: :string, desc: "Domain gem name or path" },
+    aggregate: { type: :string, desc: "Filter to a single aggregate by name" }
+  }
+) do
+  domain = resolve_domain_option
+  next unless domain
+
+  output = Hecks::CLI::DomainInspector.new(domain).generate(aggregate: options[:aggregate])
+  say output
+end

--- a/hecksties/lib/hecks_cli/domain_inspector.rb
+++ b/hecksties/lib/hecks_cli/domain_inspector.rb
@@ -1,0 +1,137 @@
+# Hecks::CLI::DomainInspector
+#
+# Formats a Domain IR into comprehensive, readable terminal output showing
+# the full domain definition including business logic. Walks all aggregates,
+# domain-level policies, services, views, workflows, sagas, actors, and
+# glossary rules.
+#
+#   inspector = Hecks::CLI::DomainInspector.new(domain)
+#   inspector.generate                    # => String
+#   inspector.generate(aggregate: "Order") # => String (single aggregate)
+#
+require_relative "domain_inspector/aggregate_formatter"
+
+module Hecks
+  class CLI
+    class DomainInspector
+      # @param domain [Hecks::DomainModel::Structure::Domain]
+      def initialize(domain)
+        @domain = domain
+      end
+
+      # Generate the full inspection output.
+      #
+      # @param aggregate [String, nil] optional aggregate name filter
+      # @return [String] formatted domain inspection
+      def generate(aggregate: nil)
+        lines = []
+        lines << "Domain: #{@domain.name}"
+        lines << "#{'=' * (8 + @domain.name.length)}"
+        lines << ""
+
+        aggregates = @domain.aggregates
+        if aggregate
+          aggregates = aggregates.select { |a| a.name == aggregate }
+          if aggregates.empty?
+            lines << "No aggregate named '#{aggregate}' found."
+            return lines.join("\n")
+          end
+        end
+
+        aggregates.each do |agg|
+          lines.concat(AggregateFormatter.new(agg).format)
+          lines << ""
+        end
+
+        lines.concat(format_domain_policies)
+        lines.concat(format_services)
+        lines.concat(format_views)
+        lines.concat(format_workflows)
+        lines.concat(format_sagas)
+        lines.concat(format_actors)
+        lines.concat(format_glossary_rules)
+
+        lines.join("\n")
+      end
+
+      private
+
+      def format_domain_policies
+        return [] if @domain.policies.empty?
+        lines = ["Domain Policies:"]
+        @domain.policies.each do |pol|
+          async_note = pol.async ? " [async]" : ""
+          if pol.reactive?
+            cond = pol.condition ? " when #{Hecks::Utils.block_source(pol.condition)}" : ""
+            lines << "  #{pol.name}: #{pol.event_name} -> #{pol.trigger_command}#{async_note}#{cond}"
+          else
+            body = Hecks::Utils.block_source(pol.block)
+            lines << "  #{pol.name}: guard#{async_note} — #{body}"
+          end
+        end
+        lines << ""
+      end
+
+      def format_services
+        return [] if @domain.services.empty?
+        lines = ["Services:"]
+        @domain.services.each do |svc|
+          name = svc.respond_to?(:name) ? svc.name : svc.to_s
+          lines << "  #{name}"
+        end
+        lines << ""
+      end
+
+      def format_views
+        return [] if @domain.views.empty?
+        lines = ["Views:"]
+        @domain.views.each do |view|
+          name = view.respond_to?(:name) ? view.name : view.to_s
+          lines << "  #{name}"
+        end
+        lines << ""
+      end
+
+      def format_workflows
+        return [] if @domain.workflows.empty?
+        lines = ["Workflows:"]
+        @domain.workflows.each do |wf|
+          name = wf.respond_to?(:name) ? wf.name : wf.to_s
+          lines << "  #{name}"
+        end
+        lines << ""
+      end
+
+      def format_sagas
+        return [] if @domain.sagas.empty?
+        lines = ["Sagas:"]
+        @domain.sagas.each do |saga|
+          name = saga.respond_to?(:name) ? saga.name : saga.to_s
+          lines << "  #{name}"
+        end
+        lines << ""
+      end
+
+      def format_actors
+        return [] if @domain.actors.empty?
+        lines = ["Actors:"]
+        @domain.actors.each do |actor|
+          name = actor.respond_to?(:name) ? actor.name : actor.to_s
+          lines << "  #{name}"
+        end
+        lines << ""
+      end
+
+      def format_glossary_rules
+        return [] if @domain.glossary_rules.empty?
+        lines = ["Glossary Rules:"]
+        @domain.glossary_rules.each do |rule|
+          term = rule.respond_to?(:term) ? rule.term : rule[:term]
+          defn = rule.respond_to?(:definition) ? rule.definition : rule[:definition]
+          lines << "  #{term}: #{defn}"
+        end
+        lines << ""
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/domain_inspector/aggregate_formatter.rb
+++ b/hecksties/lib/hecks_cli/domain_inspector/aggregate_formatter.rb
@@ -1,0 +1,211 @@
+# Hecks::CLI::DomainInspector::AggregateFormatter
+#
+# Formats a single aggregate from the domain IR into readable terminal output.
+# Covers attributes, value objects, entities, lifecycle, commands, events,
+# queries, validations, invariants, policies, scopes, specifications,
+# subscribers, and references.
+#
+#   formatter = AggregateFormatter.new(aggregate)
+#   formatter.format  # => Array<String>
+#
+module Hecks
+  class CLI
+    class DomainInspector
+      class AggregateFormatter
+        # @param agg [Hecks::DomainModel::Structure::Aggregate]
+        def initialize(agg)
+          @agg = agg
+        end
+
+        # @return [Array<String>] formatted lines for this aggregate
+        def format
+          lines = []
+          lines << "Aggregate: #{@agg.name}"
+          lines << "=" * (11 + @agg.name.length)
+          lines << ""
+          lines.concat(format_attributes)
+          lines.concat(format_value_objects)
+          lines.concat(format_entities)
+          lines.concat(format_lifecycle)
+          lines.concat(format_commands)
+          lines.concat(format_events)
+          lines.concat(format_queries)
+          lines.concat(format_validations)
+          lines.concat(format_invariants)
+          lines.concat(format_policies)
+          lines.concat(format_scopes)
+          lines.concat(format_specifications)
+          lines.concat(format_subscribers)
+          lines.concat(format_references)
+          lines
+        end
+
+        private
+
+        def format_attributes
+          return [] if @agg.attributes.empty?
+          lines = ["  Attributes:"]
+          @agg.attributes.each do |attr|
+            lines << "    #{attr.name}: #{Hecks::Utils.type_label(attr)}"
+          end
+          lines << ""
+        end
+
+        def format_value_objects
+          return [] if @agg.value_objects.empty?
+          lines = ["  Value Objects:"]
+          @agg.value_objects.each do |vo|
+            attrs = vo.attributes.map { |a| "#{a.name}: #{Hecks::Utils.type_label(a)}" }.join(", ")
+            lines << "    #{vo.name} (#{attrs})"
+            vo.invariants.each { |inv| lines << "      invariant: #{inv.message}" }
+          end
+          lines << ""
+        end
+
+        def format_entities
+          return [] if @agg.entities.empty?
+          lines = ["  Entities:"]
+          @agg.entities.each do |ent|
+            attrs = ent.attributes.map { |a| "#{a.name}: #{Hecks::Utils.type_label(a)}" }.join(", ")
+            lines << "    #{ent.name} (#{attrs})"
+            ent.invariants.each { |inv| lines << "      invariant: #{inv.message}" }
+          end
+          lines << ""
+        end
+
+        def format_lifecycle
+          lc = @agg.lifecycle
+          return [] unless lc
+          lines = ["  Lifecycle:"]
+          lines << "    field: #{lc.field}, default: #{lc.default.inspect}"
+          lines << "    states: #{lc.states.join(', ')}"
+          lines << "    transitions:"
+          lc.transitions.each do |cmd, transition|
+            if transition.respond_to?(:constrained?) && transition.constrained?
+              lines << "      #{cmd} -> #{transition.target} (from: #{transition.from})"
+            else
+              target = transition.respond_to?(:target) ? transition.target : transition.to_s
+              lines << "      #{cmd} -> #{target}"
+            end
+          end
+          lines << ""
+        end
+
+        def format_commands
+          return [] if @agg.commands.empty?
+          lines = ["  Commands:"]
+          @agg.commands.each_with_index do |cmd, i|
+            event = @agg.events[i]
+            params = cmd.attributes.map { |a| "#{a.name}: #{Hecks::Utils.type_label(a)}" }.join(", ")
+            event_info = event ? " -> emits #{event.name}" : ""
+            lines << "    #{cmd.name}(#{params})#{event_info}"
+            cmd.preconditions.each { |c| lines << "      precondition: #{c.message}" }
+            cmd.postconditions.each { |c| lines << "      postcondition: #{c.message}" }
+            if cmd.call_body
+              lines << "      body: #{Hecks::Utils.block_source(cmd.call_body)}"
+            end
+          end
+          lines << ""
+        end
+
+        def format_events
+          return [] if @agg.events.compact.empty?
+          lines = ["  Events:"]
+          @agg.events.compact.each do |ev|
+            attrs = ev.attributes.map { |a| "#{a.name}: #{Hecks::Utils.type_label(a)}" }.join(", ")
+            lines << "    #{ev.name}(#{attrs})"
+          end
+          lines << ""
+        end
+
+        def format_queries
+          return [] if @agg.queries.empty?
+          lines = ["  Queries:"]
+          @agg.queries.each do |q|
+            body = Hecks::Utils.block_source(q.block)
+            lines << "    #{q.name}: #{body}"
+          end
+          lines << ""
+        end
+
+        def format_validations
+          return [] if @agg.validations.empty?
+          lines = ["  Validations:"]
+          @agg.validations.each do |v|
+            rules = v.rules.map { |k, val| "#{k}: #{val}" }.join(", ")
+            lines << "    #{v.field}: #{rules}"
+          end
+          lines << ""
+        end
+
+        def format_invariants
+          return [] if @agg.invariants.empty?
+          lines = ["  Invariants:"]
+          @agg.invariants.each do |inv|
+            body = Hecks::Utils.block_source(inv.block)
+            lines << "    #{inv.message}: #{body}"
+          end
+          lines << ""
+        end
+
+        def format_policies
+          return [] if @agg.policies.empty?
+          lines = ["  Policies:"]
+          @agg.policies.each do |pol|
+            lines << format_policy(pol)
+          end
+          lines << ""
+        end
+
+        def format_policy(pol)
+          async_note = pol.async ? " [async]" : ""
+          if pol.reactive?
+            cond = pol.condition ? " when #{Hecks::Utils.block_source(pol.condition)}" : ""
+            "    #{pol.name}: #{pol.event_name} -> #{pol.trigger_command}#{async_note}#{cond}"
+          else
+            body = Hecks::Utils.block_source(pol.block)
+            "    #{pol.name}: guard#{async_note} — #{body}"
+          end
+        end
+
+        def format_scopes
+          return [] if @agg.scopes.empty?
+          lines = ["  Scopes:"]
+          @agg.scopes.each { |s| lines << "    #{s.name}" }
+          lines << ""
+        end
+
+        def format_specifications
+          return [] if @agg.specifications.empty?
+          lines = ["  Specifications:"]
+          @agg.specifications.each do |s|
+            body = Hecks::Utils.block_source(s.block)
+            lines << "    #{s.name}: #{body}"
+          end
+          lines << ""
+        end
+
+        def format_subscribers
+          return [] if @agg.subscribers.empty?
+          lines = ["  Subscribers:"]
+          @agg.subscribers.each do |s|
+            async_note = s.async ? " [async]" : ""
+            body = Hecks::Utils.block_source(s.block)
+            lines << "    #{s.name}: on #{s.event_name}#{async_note} — #{body}"
+          end
+          lines << ""
+        end
+
+        def format_references
+          return [] if @agg.references.empty?
+          lines = ["  References:"]
+          @agg.references.each do |ref|
+            target = ref.respond_to?(:target) ? ref.target : ref.to_s
+            lines << "    -> #{target}"
+          end
+          lines << ""
+        end
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/domain_inspector/aggregate_formatter.rb
+++ b/hecksties/lib/hecks_cli/domain_inspector/aggregate_formatter.rb
@@ -200,8 +200,8 @@ module Hecks
           return [] if @agg.references.empty?
           lines = ["  References:"]
           @agg.references.each do |ref|
-            target = ref.respond_to?(:target) ? ref.target : ref.to_s
-            lines << "    -> #{target}"
+            kind = ref.respond_to?(:kind) && ref.kind ? " (#{ref.kind})" : ""
+            lines << "    -> #{ref.type}#{kind}"
           end
           lines << ""
         end

--- a/hecksties/spec/cli/commands/inspect_spec.rb
+++ b/hecksties/spec/cli/commands/inspect_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+require "hecks_cli"
+
+# Hecks CLI inspect command spec
+#
+# Verifies that `hecks inspect` produces terminal output covering
+# all major domain IR sections: attributes, lifecycle, policies,
+# invariants, value objects, commands, and events.
+RSpec.describe "hecks inspect" do
+  let(:cli) { Hecks::CLI.new }
+
+  before { allow($stdout).to receive(:puts) }
+
+  it "shows full domain definition with all sections" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Shop" do
+          aggregate "Order" do
+            attribute :name, String
+            attribute :status, String
+
+            value_object "LineItem" do
+              attribute :product, String
+              attribute :qty, Integer
+            end
+
+            invariant "name must be present" do
+              !name.nil? && !name.empty?
+            end
+
+            lifecycle :status, default: "draft" do
+              transition "PlaceOrder" => "placed"
+            end
+
+            command "CreateOrder" do
+              attribute :name, String
+            end
+
+            command "PlaceOrder" do
+              reference_to "Order"
+            end
+
+            policy "HighValue" do |cmd|
+              cmd.respond_to?(:name)
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_inspect_output(dir)
+        expect(output).to include("Domain: Shop")
+        expect(output).to include("Aggregate: Order")
+        expect(output).to include("name: String")
+        expect(output).to include("LineItem")
+        expect(output).to include("Lifecycle:")
+        expect(output).to include("draft")
+        expect(output).to include("CreateOrder")
+        expect(output).to include("Invariants:")
+        expect(output).to include("name must be present")
+        expect(output).to include("Policies:")
+      end
+    end
+  end
+
+  it "filters to a single aggregate" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "TestBluebook"), <<~RUBY)
+        Hecks.domain "Multi" do
+          aggregate "Foo" do
+            attribute :x, String
+            command "CreateFoo" do
+              attribute :x, String
+            end
+          end
+          aggregate "Bar" do
+            attribute :y, String
+            command "CreateBar" do
+              attribute :y, String
+            end
+          end
+        end
+      RUBY
+      Dir.chdir(dir) do
+        output = capture_inspect_output(dir, aggregate: "Foo")
+        expect(output).to include("Foo")
+        expect(output).not_to include("Aggregate: Bar")
+      end
+    end
+  end
+
+  def capture_inspect_output(domain_path, aggregate: nil)
+    allow(cli).to receive(:options).and_return(
+      { domain: domain_path, aggregate: aggregate }
+    )
+    output = StringIO.new
+    allow(cli.shell).to receive(:say) { |msg, *| output.puts(msg) }
+    cli.inspect
+    output.string
+  end
+end


### PR DESCRIPTION
## Summary
HEC-119: Fix reference formatting to use .type instead of .to_s


HEC-119: Add `hecks inspect` command for full domain definition output

Walks the domain IR to produce readable terminal output covering all
aggregate sections (attributes, value objects, entities, lifecycle,
commands, events, queries, validations, invariants, policies, scopes,
specifications, subscribers, references) and domain-level sections
(policies, services, views, workflows, sagas, actors, glossary rules).
Uses Hecks::Utils.block_source to show business logic inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)