### PR TITLE
HEC-227: Failover extension

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -629,6 +629,15 @@
 - `Hecks.boot(__dir__, adapter: :filesystem)` explicit wiring
 - Same interface as memory: find, save, delete, all, count, query, clear
 
+### hecks_failover
+- Driven extension wrapping repos with FailoverProxy decorator
+- Transparent failover to in-memory store when primary repo raises errors
+- Write log captures all writes during failover for replay on recovery
+- `Hecks.failover_status` returns current mode and write log size
+- `Hecks.failover_recover!` forces immediate recovery attempt
+- RecoveryMonitor for periodic background recovery via `start(interval:)`
+- `failed_over?` predicate on each proxy
+
 ### hecks_validations
 - Server-side parameter validation from domain rules
 - Reads validation rules and VO invariants from domain IR at boot

--- a/docs/usage/failover.md
+++ b/docs/usage/failover.md
@@ -1,0 +1,84 @@
+# Failover Extension
+
+Automatic repository failover with write-log recovery. When a primary
+repository (e.g. SQL, Mongo) becomes unavailable, the FailoverProxy
+transparently switches to an in-memory fallback. All writes are logged
+for replay when the primary recovers.
+
+## Setup
+
+```ruby
+require "hecks/extensions/failover"
+
+domain = Hecks.domain "Orders" do
+  aggregate "Order" do
+    attribute :total, Float
+    command "PlaceOrder" do
+      attribute :total, Float
+    end
+  end
+end
+
+app = Hecks.load(domain)
+# Extension auto-wires -- all repos are now wrapped with FailoverProxy
+```
+
+## Checking status
+
+```ruby
+Hecks.failover_status
+# => { mode: :primary, write_log_size: 0 }
+
+# After a primary failure:
+# => { mode: :failover, write_log_size: 3 }
+```
+
+## Manual recovery
+
+```ruby
+Hecks.failover_recover!
+# => { recovered: 1, still_failed: 0 }
+```
+
+## Background recovery
+
+```ruby
+# Start a background thread that checks every 30 seconds
+monitor = Hecks.instance_variable_get(:@_failover_monitor)
+monitor.start(interval: 30)
+
+# Stop background recovery
+monitor.stop
+```
+
+## How it works
+
+1. Each repository gets wrapped with `HecksFailover::FailoverProxy`
+2. Reads and writes delegate to the primary repository
+3. When the primary raises any `StandardError`, the proxy:
+   - Switches to `:failover` mode
+   - Copies existing primary data to in-memory fallback (best effort)
+   - Routes all operations to the fallback
+4. Writes during failover are recorded in `write_log`
+5. `recover!` tests the primary, replays the write log, and switches back
+
+## FailoverProxy API
+
+```ruby
+proxy = HecksFailover::FailoverProxy.new(sql_repo)
+
+proxy.mode          # => :primary or :failover
+proxy.failed_over?  # => true/false
+proxy.write_log     # => [{ op: :save, args: [...], at: Time }]
+proxy.recover!      # => true if recovery succeeded
+```
+
+## RecoveryMonitor API
+
+```ruby
+monitor = HecksFailover::RecoveryMonitor.new(proxies)
+
+monitor.recover!               # => { recovered: N, still_failed: N }
+monitor.start(interval: 30)    # background thread
+monitor.stop                   # stop background thread
+```

--- a/hecksties/lib/hecks/extensions/failover.rb
+++ b/hecksties/lib/hecks/extensions/failover.rb
@@ -1,0 +1,53 @@
+# HecksFailover
+#
+# Driven extension that wraps repository adapters with a FailoverProxy
+# decorator. When the primary repository raises an error, the proxy
+# transparently fails over to an in-memory fallback, logging all writes
+# for later recovery. A RecoveryMonitor periodically checks if the
+# primary is back and replays the write log.
+#
+# Usage:
+#   require "hecks/extensions/failover"
+#
+#   app = Hecks.load(domain)
+#   # Extension auto-wires -- repos are now wrapped with FailoverProxy
+#
+#   Hecks.failover_status          # => { mode: :primary, write_log_size: 0 }
+#   Hecks.failover_recover!        # => forces immediate recovery attempt
+#
+require "hecks"
+require_relative "failover/failover_proxy"
+require_relative "failover/recovery_monitor"
+
+Hecks.describe_extension(:failover,
+  description: "Automatic repository failover with write-log recovery",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :repository)
+
+Hecks.register_extension(:failover) do |_domain_mod, domain, runtime|
+  proxies = []
+
+  domain.aggregates.each do |agg|
+    repo = runtime[agg.name]
+    proxy = HecksFailover::FailoverProxy.new(repo)
+    proxies << proxy
+    runtime.swap_adapter(agg.name, proxy)
+  end
+
+  monitor = HecksFailover::RecoveryMonitor.new(proxies)
+
+  Hecks.instance_variable_set(:@_failover_proxies, proxies)
+  Hecks.instance_variable_set(:@_failover_monitor, monitor)
+
+  Hecks.define_singleton_method(:failover_status) do
+    modes = @_failover_proxies.map(&:mode).uniq
+    mode = modes.length == 1 ? modes.first : :mixed
+    log_size = @_failover_proxies.sum { |p| p.write_log.size }
+    { mode: mode, write_log_size: log_size }
+  end
+
+  Hecks.define_singleton_method(:failover_recover!) do
+    @_failover_monitor.recover!
+  end
+end

--- a/hecksties/lib/hecks/extensions/failover/failover_proxy.rb
+++ b/hecksties/lib/hecks/extensions/failover/failover_proxy.rb
@@ -1,0 +1,158 @@
+# HecksFailover::FailoverProxy
+#
+# Repository decorator that wraps a primary repository and falls back to
+# an in-memory store when the primary raises errors. All writes during
+# failover mode are recorded in a write log for later replay. The proxy
+# exposes @mode (:primary or :failover) and @write_log for introspection.
+#
+# Usage:
+#   proxy = HecksFailover::FailoverProxy.new(sql_repo)
+#   proxy.save(pizza)          # delegates to sql_repo
+#   # sql_repo goes down...
+#   proxy.save(pizza)          # transparently uses fallback
+#   proxy.failed_over?         # => true
+#   proxy.write_log            # => [{ op: :save, args: [pizza], at: Time }]
+#   proxy.recover!(sql_repo)   # replays write log, switches back to primary
+#
+require_relative "memory_fallback"
+
+module HecksFailover
+  class FailoverProxy
+    attr_reader :mode, :write_log
+
+    # Create a failover proxy wrapping a primary repository.
+    #
+    # @param primary [Object] the primary repository to delegate to;
+    #   must respond to find, save, delete, all, count, query, clear
+    # @return [FailoverProxy] proxy in :primary mode
+    def initialize(primary)
+      @primary = primary
+      @fallback = build_fallback
+      @mode = :primary
+      @write_log = []
+    end
+
+    # Whether the proxy is currently in failover mode.
+    #
+    # @return [Boolean] true if operating against the fallback store
+    def failed_over?
+      @mode == :failover
+    end
+
+    # Attempt recovery: replay the write log against the primary.
+    #
+    # Tests the primary with a count call. If it succeeds, replays all
+    # logged writes in order, then switches back to :primary mode and
+    # clears the write log. If the primary is still down, stays in
+    # failover mode.
+    #
+    # @return [Boolean] true if recovery succeeded
+    def recover!
+      @primary.count
+      @write_log.each { |entry| @primary.send(entry[:op], *entry[:args]) }
+      @write_log.clear
+      @mode = :primary
+      true
+    rescue StandardError
+      false
+    end
+
+    def find(id)
+      delegate_read(:find, id)
+    end
+
+    def save(aggregate)
+      delegate_write(:save, aggregate)
+    end
+
+    def delete(id)
+      delegate_write(:delete, id)
+    end
+
+    def all
+      delegate_read(:all)
+    end
+
+    def count
+      delegate_read(:count)
+    end
+
+    def query(**kwargs)
+      delegate_read_kw(:query, **kwargs)
+    end
+
+    def clear
+      delegate_write(:clear)
+    end
+
+    private
+
+    # Delegate a read operation. On failure, switch to failover.
+    #
+    # @param method [Symbol] the method name to call
+    # @param args [Array] positional arguments
+    # @return [Object] the result from primary or fallback
+    def delegate_read(method, *args)
+      target = @mode == :primary ? @primary : @fallback
+      target.send(method, *args)
+    rescue StandardError => e
+      switch_to_failover! if @mode == :primary
+      @fallback.send(method, *args)
+    end
+
+    # Delegate a read with keyword arguments.
+    #
+    # @param method [Symbol] the method name to call
+    # @param kwargs [Hash] keyword arguments
+    # @return [Object] the result from primary or fallback
+    def delegate_read_kw(method, **kwargs)
+      target = @mode == :primary ? @primary : @fallback
+      target.send(method, **kwargs)
+    rescue StandardError => e
+      switch_to_failover! if @mode == :primary
+      @fallback.send(method, **kwargs)
+    end
+
+    # Delegate a write operation. On failure, switch to failover and log.
+    #
+    # @param method [Symbol] the method name to call
+    # @param args [Array] positional arguments
+    # @return [Object] the result from primary or fallback
+    def delegate_write(method, *args)
+      if @mode == :primary
+        begin
+          return @primary.send(method, *args)
+        rescue StandardError
+          switch_to_failover!
+        end
+      end
+      result = @fallback.send(method, *args)
+      @write_log << { op: method, args: args, at: Time.now }
+      result
+    end
+
+    # Switch to failover mode, copying primary data to fallback.
+    #
+    # @return [void]
+    def switch_to_failover!
+      @mode = :failover
+      copy_to_fallback
+    end
+
+    # Copy all records from primary to fallback (best effort).
+    #
+    # @return [void]
+    def copy_to_fallback
+      @primary.all.each { |agg| @fallback.save(agg) }
+    rescue StandardError
+      # primary may be completely unreachable
+    end
+
+    # Build a simple in-memory fallback store.
+    #
+    # @return [MemoryFallback] a hash-backed repository
+    def build_fallback
+      MemoryFallback.new
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/failover/memory_fallback.rb
+++ b/hecksties/lib/hecks/extensions/failover/memory_fallback.rb
@@ -1,0 +1,88 @@
+# HecksFailover::MemoryFallback
+#
+# Minimal in-memory repository used as the failover backing store.
+# Implements the same interface as generated memory adapters (find, save,
+# delete, all, count, query, clear) using a simple hash keyed by ID.
+#
+# Usage:
+#   fallback = HecksFailover::MemoryFallback.new
+#   fallback.save(pizza)
+#   fallback.find(pizza.id)  # => pizza
+#   fallback.all             # => [pizza]
+#
+module HecksFailover
+  class MemoryFallback
+    def initialize
+      @store = {}
+    end
+
+    # Find an aggregate by ID.
+    #
+    # @param id [String] the aggregate ID
+    # @return [Object, nil] the aggregate or nil
+    def find(id)
+      @store[id]
+    end
+
+    # Save an aggregate, keyed by its ID.
+    #
+    # @param aggregate [Object] must respond to #id
+    # @return [Object] the saved aggregate
+    def save(aggregate)
+      @store[aggregate.id] = aggregate
+    end
+
+    # Delete an aggregate by ID.
+    #
+    # @param id [String] the aggregate ID
+    # @return [Object, nil] the removed aggregate or nil
+    def delete(id)
+      @store.delete(id)
+    end
+
+    # Return all stored aggregates.
+    #
+    # @return [Array<Object>] all aggregates
+    def all
+      @store.values
+    end
+
+    # Return the count of stored aggregates.
+    #
+    # @return [Integer] number of aggregates
+    def count
+      @store.size
+    end
+
+    # Query with conditions (simplified -- delegates to filter).
+    #
+    # @param conditions [Hash] attribute conditions
+    # @param order_key [Symbol, nil] sort key
+    # @param order_direction [Symbol] :asc or :desc
+    # @param limit [Integer, nil] max results
+    # @param offset [Integer, nil] skip count
+    # @return [Array<Object>] matching aggregates
+    def query(conditions: {}, order_key: nil, order_direction: :asc, limit: nil, offset: nil)
+      results = @store.values
+      unless conditions.empty?
+        results = results.select do |obj|
+          conditions.all? { |k, v| obj.respond_to?(k) && obj.send(k) == v }
+        end
+      end
+      if order_key
+        results = results.sort_by { |obj| obj.respond_to?(order_key) ? obj.send(order_key) : "" }
+        results = results.reverse if order_direction == :desc
+      end
+      results = results.drop(offset) if offset
+      results = results.take(limit) if limit
+      results
+    end
+
+    # Clear all stored aggregates.
+    #
+    # @return [void]
+    def clear
+      @store.clear
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/failover/recovery_monitor.rb
+++ b/hecksties/lib/hecks/extensions/failover/recovery_monitor.rb
@@ -1,0 +1,77 @@
+# HecksFailover::RecoveryMonitor
+#
+# Coordinates recovery across all FailoverProxy instances. Provides a
+# synchronous recover! method that attempts recovery on every proxy that
+# is currently in failover mode. Designed to be called periodically by
+# a background thread or on-demand via Hecks.failover_recover!.
+#
+# Usage:
+#   monitor = HecksFailover::RecoveryMonitor.new(proxies)
+#   monitor.recover!                    # try all proxies now
+#   monitor.start(interval: 30)         # background thread every 30s
+#   monitor.stop                        # stop background thread
+#
+module HecksFailover
+  class RecoveryMonitor
+    # Create a monitor for the given proxies.
+    #
+    # @param proxies [Array<FailoverProxy>] the proxies to monitor
+    # @return [RecoveryMonitor]
+    def initialize(proxies)
+      @proxies = proxies
+      @thread = nil
+    end
+
+    # Attempt recovery on all failed-over proxies.
+    #
+    # Iterates through proxies, calling recover! on each that is in
+    # failover mode. Returns a hash with counts of recovered and
+    # still-failed proxies.
+    #
+    # @return [Hash] { recovered: Integer, still_failed: Integer }
+    def recover!
+      recovered = 0
+      still_failed = 0
+
+      @proxies.each do |proxy|
+        next unless proxy.failed_over?
+        if proxy.recover!
+          recovered += 1
+        else
+          still_failed += 1
+        end
+      end
+
+      { recovered: recovered, still_failed: still_failed }
+    end
+
+    # Start a background recovery thread.
+    #
+    # Spawns a daemon thread that calls recover! at the given interval.
+    # Only one background thread runs at a time; calling start again
+    # is a no-op if already running.
+    #
+    # @param interval [Numeric] seconds between recovery attempts (default: 30)
+    # @return [void]
+    def start(interval: 30)
+      return if @thread&.alive?
+
+      @thread = Thread.new do
+        loop do
+          sleep(interval)
+          recover!
+        end
+      end
+      @thread.abort_on_exception = false
+      nil
+    end
+
+    # Stop the background recovery thread.
+    #
+    # @return [void]
+    def stop
+      @thread&.kill
+      @thread = nil
+    end
+  end
+end

--- a/hecksties/spec/extensions/failover_spec.rb
+++ b/hecksties/spec/extensions/failover_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+require "hecks/extensions/failover"
+
+RSpec.describe "hecks_failover extension" do
+  let(:domain) do
+    Hecks.domain "FailoverTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  after do
+    Hecks.actor = nil
+    Hecks.tenant = nil
+  end
+
+  describe HecksFailover::FailoverProxy do
+    it "delegates to primary in normal mode" do
+      app = Hecks.load(domain)
+      repo = app["Widget"]
+      proxy = HecksFailover::FailoverProxy.new(repo)
+
+      FailoverTestDomain::Widget.create(name: "Bolt")
+      saved = repo.all.first
+
+      expect(proxy.find(saved.id)).to eq(saved)
+      expect(proxy.all.size).to eq(1)
+      expect(proxy.count).to eq(1)
+      expect(proxy.mode).to eq(:primary)
+      expect(proxy.failed_over?).to be false
+    end
+
+    it "fails over to fallback when primary raises" do
+      failing_repo = Object.new
+      def failing_repo.find(_id); raise "connection lost"; end
+      def failing_repo.save(_a); raise "connection lost"; end
+      def failing_repo.delete(_id); raise "connection lost"; end
+      def failing_repo.all; raise "connection lost"; end
+      def failing_repo.count; raise "connection lost"; end
+      def failing_repo.query(**_kw); raise "connection lost"; end
+      def failing_repo.clear; raise "connection lost"; end
+
+      proxy = HecksFailover::FailoverProxy.new(failing_repo)
+
+      expect(proxy.all).to eq([])
+      expect(proxy.failed_over?).to be true
+      expect(proxy.mode).to eq(:failover)
+    end
+
+    it "logs writes during failover for later replay" do
+      failing_repo = Object.new
+      def failing_repo.all; raise "down"; end
+      def failing_repo.count; raise "down"; end
+      def failing_repo.save(_a); raise "down"; end
+      def failing_repo.find(_id); raise "down"; end
+      def failing_repo.delete(_id); raise "down"; end
+      def failing_repo.query(**_kw); raise "down"; end
+      def failing_repo.clear; raise "down"; end
+
+      proxy = HecksFailover::FailoverProxy.new(failing_repo)
+      proxy.all # trigger failover
+
+      widget = Struct.new(:id, :name).new("w1", "Gear")
+      proxy.save(widget)
+
+      expect(proxy.write_log.size).to eq(1)
+      expect(proxy.write_log.first[:op]).to eq(:save)
+      expect(proxy.find("w1").name).to eq("Gear")
+    end
+
+    it "recovers when primary comes back" do
+      store = {}
+      healthy_repo = Object.new
+      healthy_repo.define_singleton_method(:all) { store.values }
+      healthy_repo.define_singleton_method(:count) { store.size }
+      healthy_repo.define_singleton_method(:save) { |a| store[a.id] = a }
+      healthy_repo.define_singleton_method(:find) { |id| store[id] }
+      healthy_repo.define_singleton_method(:delete) { |id| store.delete(id) }
+
+      # Start with a broken wrapper to simulate failure
+      broken = true
+      wrapper = Object.new
+      wrapper.define_singleton_method(:all) { broken ? (raise "down") : healthy_repo.all }
+      wrapper.define_singleton_method(:count) { broken ? (raise "down") : healthy_repo.count }
+      wrapper.define_singleton_method(:save) { |a| broken ? (raise "down") : healthy_repo.save(a) }
+      wrapper.define_singleton_method(:find) { |id| broken ? (raise "down") : healthy_repo.find(id) }
+      wrapper.define_singleton_method(:delete) { |id| broken ? (raise "down") : healthy_repo.delete(id) }
+
+      proxy = HecksFailover::FailoverProxy.new(wrapper)
+      proxy.all # trigger failover
+
+      widget = Struct.new(:id, :name).new("w1", "Bolt")
+      proxy.save(widget)
+
+      expect(proxy.failed_over?).to be true
+
+      # "Fix" the primary
+      broken = false
+      expect(proxy.recover!).to be true
+      expect(proxy.failed_over?).to be false
+      expect(proxy.write_log).to be_empty
+      expect(store["w1"].name).to eq("Bolt")
+    end
+  end
+
+  describe HecksFailover::RecoveryMonitor do
+    it "recovers all failed-over proxies" do
+      store = {}
+      repo = Object.new
+      repo.define_singleton_method(:all) { store.values }
+      repo.define_singleton_method(:count) { store.size }
+      repo.define_singleton_method(:save) { |a| store[a.id] = a }
+
+      broken = true
+      wrapper = Object.new
+      wrapper.define_singleton_method(:all) { broken ? (raise "down") : repo.all }
+      wrapper.define_singleton_method(:count) { broken ? (raise "down") : repo.count }
+      wrapper.define_singleton_method(:save) { |a| broken ? (raise "down") : repo.save(a) }
+
+      proxy = HecksFailover::FailoverProxy.new(wrapper)
+      proxy.all # trigger failover
+
+      monitor = HecksFailover::RecoveryMonitor.new([proxy])
+
+      # Still broken
+      result = monitor.recover!
+      expect(result[:still_failed]).to eq(1)
+
+      # Fix it
+      broken = false
+      result = monitor.recover!
+      expect(result[:recovered]).to eq(1)
+      expect(proxy.failed_over?).to be false
+    end
+  end
+
+  describe "extension wiring" do
+    it "provides Hecks.failover_status and Hecks.failover_recover!" do
+      Hecks.extension_registry.delete(:failover)
+      load File.expand_path("../../../lib/hecks/extensions/failover.rb", __FILE__)
+
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:failover]&.call(
+        Object.const_get("FailoverTestDomain"), domain, app
+      )
+
+      status = Hecks.failover_status
+      expect(status[:mode]).to eq(:primary)
+      expect(status[:write_log_size]).to eq(0)
+
+      result = Hecks.failover_recover!
+      expect(result[:recovered]).to eq(0)
+      expect(result[:still_failed]).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add hecks_failover extension for automatic repository failover

Driven extension that wraps repository adapters with FailoverProxy.
When primary repos fail, transparently falls over to in-memory store
with write-log capture for replay on recovery. Includes RecoveryMonitor
for background recovery and Hecks.failover_status/failover_recover! API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)