### PR TITLE
HEC-230: Natural language REPL

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -269,6 +269,14 @@
 - Reference attributes: `Post.order_id reference_to("Order")`
 - Terse single-line feedback after every operation (e.g. "title attribute added to Post")
 
+### Natural Language DSL
+- `say "add a name attribute to Pizza"` — natural language domain editing in the REPL
+- LLM interprets requests into DSL operations (add_attribute, add_command, etc.)
+- Shows planned operations before applying: transparent interpretation
+- Conversation-scoped: maintains context across multiple `say` calls in a session
+- Graceful degradation: prints helpful message when ANTHROPIC_API_KEY is not set
+- DomainEdit prompt includes current domain state for context-aware suggestions
+
 ### Console Tour
 - Guided walkthrough via `hecks tour` — 15-step tour of sketch, play, and build
 - Also available inside the console: `tour`

--- a/docs/usage/natural_language_dsl.md
+++ b/docs/usage/natural_language_dsl.md
@@ -1,0 +1,71 @@
+# Natural Language DSL
+
+Use `say` in the Hecks REPL to describe domain changes in plain English.
+The LLM translates your request into DSL operations and applies them.
+
+## Setup
+
+Set your Anthropic API key:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Usage
+
+```ruby
+# Start the workshop
+hecks console Pizzas
+
+# Use natural language to build your domain
+say "create a Pizza aggregate with name and description attributes"
+#   Plan:
+#     Create aggregate Pizza
+#     Add name (String) to Pizza
+#     Add description (String) to Pizza
+#     Add command CreatePizza to Pizza
+
+say "add a price as a Float to Pizza"
+#   Plan:
+#     Add price (Float) to Pizza
+
+say "add an Order aggregate that references Pizza"
+#   Plan:
+#     Create aggregate Order
+#     Add command CreateOrder to Order
+#     Add reference_to Pizza on Order
+
+# Mix natural language with direct DSL
+Pizza.lifecycle :status, default: "available"
+say "add a transition to mark a pizza as sold out"
+#   Plan:
+#     Add transition MarkSoldOut => sold_out on Pizza
+```
+
+## How It Works
+
+1. Your text is sent to the Anthropic API with the current domain state as context
+2. The LLM returns structured operations (add_attribute, add_command, etc.)
+3. The plan is printed so you can see what will happen
+4. Operations are applied to the workshop session
+
+## Conversation Context
+
+The interpreter maintains conversation history within a session, so follow-up
+requests understand prior context:
+
+```ruby
+say "create a Customer aggregate"
+say "give it a name and email"  # knows "it" means Customer
+```
+
+## Without an API Key
+
+If `ANTHROPIC_API_KEY` is not set, `say` prints a helpful message:
+
+```ruby
+say "add a name to Pizza"
+# => Natural language requires ANTHROPIC_API_KEY. Set it and try again.
+```
+
+All other REPL features continue to work normally.

--- a/hecks_ai/lib/hecks_ai.rb
+++ b/hecks_ai/lib/hecks_ai.rb
@@ -22,6 +22,7 @@ module Hecks
     module Prompts
       autoload :DomainGeneration, "hecks_ai/prompts/domain_generation"
       autoload :DomainToolSchema, "hecks_ai/prompts/domain_tool_schema"
+      autoload :DomainEdit,      "hecks_ai/prompts/domain_edit"
     end
   end
 end

--- a/hecks_ai/lib/hecks_ai/prompts/domain_edit.rb
+++ b/hecks_ai/lib/hecks_ai/prompts/domain_edit.rb
@@ -1,0 +1,91 @@
+# Hecks::AI::Prompts::DomainEdit
+#
+# System prompt and tool schema for incremental domain edits via natural
+# language. The LLM interprets a user request and returns a list of DSL
+# operations (add_attribute, add_command, etc.) to apply to the current
+# workshop session.
+#
+#   Hecks::AI::Prompts::DomainEdit::SYSTEM_PROMPT  # => String
+#   Hecks::AI::Prompts::DomainEdit::TOOL_SCHEMA    # => Hash
+#
+module Hecks
+  module AI
+    module Prompts
+      module DomainEdit
+        SYSTEM_PROMPT = <<~PROMPT
+          You are an expert domain modeler working inside the Hecks workshop REPL.
+          The user describes changes to their domain in plain English. You translate
+          each request into a sequence of DSL operations.
+
+          Available operations:
+          - add_aggregate: create a new aggregate
+          - add_attribute: add an attribute to an aggregate
+          - add_command: add a command to an aggregate
+          - add_command_attribute: add an attribute to a command
+          - add_value_object: add a value object to an aggregate
+          - add_reference: add a reference_to between aggregates
+          - add_lifecycle: add lifecycle state tracking
+          - add_transition: add a state transition command
+          - remove_aggregate: remove an aggregate
+          - remove_attribute: remove an attribute from an aggregate
+          - remove_command: remove a command from an aggregate
+
+          Rules:
+          - Aggregate names are PascalCase (e.g. Pizza, OrderItem)
+          - Command names are PascalCase VerbNoun (e.g. CreatePizza, PlaceOrder)
+          - Attribute types: String, Integer, Float, Boolean, Date, DateTime
+          - Collection types: list_of(TypeName)
+          - Reference types: reference_to(TypeName)
+          - Always include a Create command when adding a new aggregate
+          - Return ONLY operations, no explanations
+        PROMPT
+
+        OPERATION_SCHEMA = {
+          type: "object",
+          required: %w[op],
+          properties: {
+            op:        { type: "string", enum: %w[
+              add_aggregate add_attribute add_command add_command_attribute
+              add_value_object add_reference add_lifecycle add_transition
+              remove_aggregate remove_attribute remove_command
+            ] },
+            aggregate: { type: "string", description: "Target aggregate name" },
+            name:      { type: "string", description: "Name of the item" },
+            type:      { type: "string", description: "Attribute type" },
+            command:   { type: "string", description: "Command name (for add_command_attribute/transition)" },
+            field:     { type: "string", description: "Lifecycle field name" },
+            default:   { type: "string", description: "Lifecycle default state" },
+            target:    { type: "string", description: "Transition target state or reference target" },
+            attributes: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  type: { type: "string" }
+                }
+              },
+              description: "Value object attributes"
+            }
+          }
+        }.freeze
+
+        TOOL_SCHEMA = {
+          name: "edit_domain",
+          description: "Apply incremental edits to the current domain model",
+          input_schema: {
+            type: "object",
+            required: %w[operations],
+            properties: {
+              operations: {
+                type: "array",
+                items: OPERATION_SCHEMA,
+                description: "Ordered list of DSL operations to apply"
+              }
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/hecks_ai/spec/prompts/domain_edit_spec.rb
+++ b/hecks_ai/spec/prompts/domain_edit_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Hecks::AI::Prompts::DomainEdit do
+  describe "SYSTEM_PROMPT" do
+    it "describes the domain editing role" do
+      expect(described_class::SYSTEM_PROMPT).to include("domain modeler")
+    end
+
+    it "lists available operations" do
+      expect(described_class::SYSTEM_PROMPT).to include("add_aggregate")
+      expect(described_class::SYSTEM_PROMPT).to include("add_attribute")
+      expect(described_class::SYSTEM_PROMPT).to include("add_command")
+    end
+
+    it "mentions PascalCase naming convention" do
+      expect(described_class::SYSTEM_PROMPT).to include("PascalCase")
+    end
+  end
+
+  describe "TOOL_SCHEMA" do
+    subject(:schema) { described_class::TOOL_SCHEMA }
+
+    it "is named edit_domain" do
+      expect(schema[:name]).to eq("edit_domain")
+    end
+
+    it "requires operations array" do
+      required = schema[:input_schema][:required]
+      expect(required).to include("operations")
+    end
+
+    it "defines operation items with op enum" do
+      items = schema[:input_schema][:properties][:operations][:items]
+      ops = items[:properties][:op][:enum]
+      expect(ops).to include("add_aggregate", "add_attribute", "remove_command")
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/natural_language_interpreter.rb
+++ b/hecks_workshop/lib/hecks/workshop/natural_language_interpreter.rb
@@ -1,0 +1,197 @@
+# Hecks::Workshop::NaturalLanguageInterpreter
+#
+# Wraps HecksAi::LlmClient with a conversation-scoped prompt for
+# incremental domain edits. Translates natural language into DSL
+# operations and applies them to the workshop runner.
+#
+# Degrades gracefully when no API key is set — prints a helpful message
+# instead of raising.
+#
+#   interpreter = NaturalLanguageInterpreter.new(runner)
+#   interpreter.interpret("Add a title attribute to Pizza")
+#   # => prints the planned operations, then applies them
+#
+module Hecks
+  class Workshop
+    class NaturalLanguageInterpreter
+      def initialize(runner, client: nil)
+        @runner = runner
+        @client = client
+        @messages = []
+      end
+
+      # Interpret a natural language request and apply DSL operations.
+      # Returns the list of operations applied, or nil if unavailable.
+      def interpret(text)
+        unless available?
+          puts "Natural language requires ANTHROPIC_API_KEY. Set it and try again."
+          return nil
+        end
+
+        operations = fetch_operations(text)
+        return nil unless operations
+
+        show_plan(operations)
+        apply(operations)
+        operations
+      end
+
+      # Whether the interpreter has a working LLM client.
+      def available?
+        !!client
+      end
+
+      private
+
+      def client
+        @client ||= build_client
+      end
+
+      def build_client
+        key = ENV["ANTHROPIC_API_KEY"]
+        return nil unless key && !key.empty?
+
+        require "hecks_ai"
+        Hecks::AI::LlmClient.new(api_key: key)
+      end
+
+      def fetch_operations(text)
+        @messages << { role: "user", content: text }
+        body = build_request
+        response = client.send(:post, body)
+        result = client.send(:extract_tool_result, response)
+        ops = result[:operations] || []
+        @messages << { role: "assistant", content: "Applied #{ops.size} operations." }
+        ops
+      rescue RuntimeError => e
+        puts "LLM error: #{e.message}"
+        nil
+      end
+
+      def build_request
+        {
+          model: client.class::MODEL,
+          max_tokens: client.class::MAX_TOKENS,
+          system: domain_context,
+          tools: [Hecks::AI::Prompts::DomainEdit::TOOL_SCHEMA],
+          tool_choice: { type: "tool", name: "edit_domain" },
+          messages: @messages
+        }
+      end
+
+      def domain_context
+        base = Hecks::AI::Prompts::DomainEdit::SYSTEM_PROMPT
+        workshop = @runner.instance_variable_get(:@workshop)
+        return base unless workshop
+
+        aggregates = workshop.aggregate_builders.map do |name, builder|
+          attrs = builder.attributes.map { |a| "#{a.name}: #{a.type}" }.join(", ")
+          cmds = builder.commands.map(&:name).join(", ")
+          "  #{name}(#{attrs}) commands: [#{cmds}]"
+        end.join("\n")
+
+        "#{base}\n\nCurrent domain: #{workshop.name}\nAggregates:\n#{aggregates}"
+      end
+
+      def show_plan(operations)
+        puts ""
+        puts "  Plan:"
+        operations.each do |op|
+          puts "    #{format_operation(op)}"
+        end
+        puts ""
+      end
+
+      def format_operation(op)
+        case op[:op]
+        when "add_aggregate"
+          "Create aggregate #{op[:name]}"
+        when "add_attribute"
+          "Add #{op[:name]} (#{op[:type] || 'String'}) to #{op[:aggregate]}"
+        when "add_command"
+          "Add command #{op[:name]} to #{op[:aggregate]}"
+        when "add_command_attribute"
+          "Add #{op[:name]} (#{op[:type]}) to #{op[:aggregate]}.#{op[:command]}"
+        when "add_value_object"
+          "Add value object #{op[:name]} to #{op[:aggregate]}"
+        when "add_reference"
+          "Add reference_to #{op[:target]} on #{op[:aggregate]}"
+        when "add_lifecycle"
+          "Add lifecycle :#{op[:field]} to #{op[:aggregate]}"
+        when "add_transition"
+          "Add transition #{op[:command]} => #{op[:target]} on #{op[:aggregate]}"
+        when "remove_aggregate"
+          "Remove aggregate #{op[:name] || op[:aggregate]}"
+        when "remove_attribute"
+          "Remove #{op[:name]} from #{op[:aggregate]}"
+        when "remove_command"
+          "Remove command #{op[:name]} from #{op[:aggregate]}"
+        else
+          op.inspect
+        end
+      end
+
+      def apply(operations)
+        operations.each { |op| apply_one(op) }
+      end
+
+      def apply_one(op)
+        case op[:op]
+        when "add_aggregate"
+          @runner.aggregate(op[:name])
+        when "add_attribute"
+          handle = @runner.aggregate(op[:name_of_aggregate] || op[:aggregate])
+          handle.attr(op[:name], resolve_type(op[:type]))
+        when "add_command"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.command(op[:name])
+        when "add_command_attribute"
+          handle = @runner.aggregate(op[:aggregate])
+          cmd = handle.command(op[:command])
+          cmd.attr(op[:name], resolve_type(op[:type]))
+        when "add_value_object"
+          handle = @runner.aggregate(op[:aggregate])
+          attrs = op[:attributes] || []
+          handle.value_object(op[:name]) do
+            attrs.each { |a| attribute a[:name].to_sym, resolve_type(a[:type]) }
+          end
+        when "add_reference"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.reference_to(op[:target])
+        when "add_lifecycle"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.lifecycle(op[:field].to_sym, default: op[:default])
+        when "add_transition"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.transition(op[:command] => op[:target])
+        when "remove_aggregate"
+          @runner.remove(op[:name] || op[:aggregate])
+        when "remove_attribute"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.remove(op[:name])
+        when "remove_command"
+          handle = @runner.aggregate(op[:aggregate])
+          handle.remove_command(op[:name])
+        end
+      rescue => e
+        puts "  Failed: #{op[:op]} — #{e.message}"
+      end
+
+      def resolve_type(type_str)
+        return String if type_str.nil? || type_str.empty?
+
+        case type_str
+        when "String"   then String
+        when "Integer"  then Integer
+        when "Float"    then Float
+        when "Boolean"  then String  # maps to String in Hecks
+        when "Date"     then String
+        when "DateTime" then String
+        when /\Alist_of\((\w+)\)\z/  then { list: $1 }
+        when /\Areference_to\((\w+)\)\z/ then type_str
+        else type_str
+        end
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
+++ b/hecks_workshop/lib/hecks/workshop/workshop_runner.rb
@@ -1,4 +1,5 @@
 require_relative "workshop_runner/constant_hoister"
+require_relative "natural_language_interpreter"
 
 module Hecks
   class Workshop
@@ -43,6 +44,11 @@ module Hecks
 
     def extend(name, **kwargs)
       @workshop.extend(name, **kwargs)
+    end
+
+    def say(text)
+      @interpreter ||= NaturalLanguageInterpreter.new(self)
+      @interpreter.interpret(text)
     end
 
     def play!
@@ -211,6 +217,8 @@ module Hecks
       puts "  Post.create.title String         # add attribute to command"
       puts "  Post.lifecycle :status, default: \"draft\""
       puts "  Post.transition \"PublishPost\" => \"published\""
+      puts ""
+      puts "  say \"add a name to Pizza\"         # natural language editing"
       puts ""
       puts "  play! / sketch!                  # switch modes"
       puts "  reload!                          # re-read DSL, reboot playground"

--- a/hecks_workshop/spec/natural_language_interpreter_spec.rb
+++ b/hecks_workshop/spec/natural_language_interpreter_spec.rb
@@ -1,0 +1,138 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Workshop::NaturalLanguageInterpreter do
+  let(:runner) { Hecks::Workshop::WorkshopRunner.new }
+  let(:fake_client) { instance_double(Hecks::AI::LlmClient) }
+
+  before do
+    allow($stdout).to receive(:puts)
+    runner.instance_variable_set(:@workshop, Hecks::Workshop.new("Test"))
+  end
+
+  subject(:interpreter) { described_class.new(runner, client: fake_client) }
+
+  describe "#available?" do
+    it "returns true when client is present" do
+      expect(interpreter.available?).to be true
+    end
+
+    it "returns false when client is nil" do
+      no_key = described_class.new(runner, client: nil)
+      expect(no_key.available?).to be false
+    end
+  end
+
+  describe "#interpret" do
+    context "without API key" do
+      subject(:interpreter) { described_class.new(runner, client: nil) }
+
+      it "prints a helpful message and returns nil" do
+        expect(interpreter.interpret("add a name to Pizza")).to be_nil
+      end
+    end
+
+    context "with a working client" do
+      let(:operations) do
+        [
+          { op: "add_aggregate", name: "Pizza" },
+          { op: "add_attribute", aggregate: "Pizza", name: "name", type: "String" }
+        ]
+      end
+
+      let(:api_response) do
+        {
+          content: [
+            { type: "tool_use", id: "toolu_01", name: "edit_domain",
+              input: { operations: operations } }
+          ]
+        }
+      end
+
+      before do
+        allow(fake_client).to receive(:send).with(:post, anything).and_return(api_response)
+        allow(fake_client).to receive(:send).with(:extract_tool_result, api_response).and_return(api_response[:content].first[:input])
+        stub_const("Hecks::AI::LlmClient::MODEL", "test-model")
+        stub_const("Hecks::AI::LlmClient::MAX_TOKENS", 1024)
+        allow(fake_client).to receive(:class).and_return(Hecks::AI::LlmClient)
+      end
+
+      it "returns the list of operations" do
+        result = interpreter.interpret("create a Pizza with a name")
+        expect(result.size).to eq(2)
+        expect(result.first[:op]).to eq("add_aggregate")
+      end
+
+      it "applies the operations to the runner" do
+        interpreter.interpret("create a Pizza with a name")
+        expect(runner.aggregates).to include("Pizza")
+      end
+    end
+
+    context "when LLM returns an error" do
+      before do
+        allow(fake_client).to receive(:send).with(:post, anything)
+          .and_raise(RuntimeError, "API timeout")
+        stub_const("Hecks::AI::LlmClient::MODEL", "test-model")
+        stub_const("Hecks::AI::LlmClient::MAX_TOKENS", 1024)
+        allow(fake_client).to receive(:class).and_return(Hecks::AI::LlmClient)
+      end
+
+      it "prints error and returns nil" do
+        expect(interpreter.interpret("do something")).to be_nil
+      end
+    end
+  end
+
+  describe "operation application" do
+    let(:operations) do
+      [{ op: "add_aggregate", name: "Order" }]
+    end
+
+    let(:api_response) do
+      {
+        content: [
+          { type: "tool_use", id: "toolu_01", name: "edit_domain",
+            input: { operations: operations } }
+        ]
+      }
+    end
+
+    before do
+      allow(fake_client).to receive(:send).with(:post, anything).and_return(api_response)
+      allow(fake_client).to receive(:send).with(:extract_tool_result, api_response).and_return(api_response[:content].first[:input])
+      stub_const("Hecks::AI::LlmClient::MODEL", "test-model")
+      stub_const("Hecks::AI::LlmClient::MAX_TOKENS", 1024)
+      allow(fake_client).to receive(:class).and_return(Hecks::AI::LlmClient)
+    end
+
+    it "creates aggregates via add_aggregate" do
+      interpreter.interpret("add an order")
+      expect(runner.aggregates).to include("Order")
+    end
+  end
+
+  describe "#format_operation" do
+    it "formats add_aggregate" do
+      op = { op: "add_aggregate", name: "Pizza" }
+      result = interpreter.send(:format_operation, op)
+      expect(result).to eq("Create aggregate Pizza")
+    end
+
+    it "formats add_attribute" do
+      op = { op: "add_attribute", aggregate: "Pizza", name: "name", type: "String" }
+      result = interpreter.send(:format_operation, op)
+      expect(result).to eq("Add name (String) to Pizza")
+    end
+
+    it "formats remove_aggregate" do
+      op = { op: "remove_aggregate", name: "Pizza" }
+      result = interpreter.send(:format_operation, op)
+      expect(result).to eq("Remove aggregate Pizza")
+    end
+  end
+
+  after do
+    Hecks::Utils.remove_constant(:Pizza, from: Hecks::Workshop::WorkshopRunner)
+    Hecks::Utils.remove_constant(:Order, from: Hecks::Workshop::WorkshopRunner)
+  end
+end


### PR DESCRIPTION
## Summary
feat: add natural language DSL editing via `say` in REPL (HEC-230)

New NaturalLanguageInterpreter in hecks_workshop wraps LlmClient with
conversation-scoped DomainEdit prompt for incremental edits. The `say`
method on WorkshopRunner sends plain English to the Anthropic API and
applies structured DSL operations (add_attribute, add_command, etc.).
Shows plan before applying. Degrades gracefully without API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)