### PR TITLE
HEC-239: Web explorer reference column names

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -477,6 +477,7 @@
 - Lifecycle badge on show pages — purple status badge with transition hint map
 - Direct-action buttons — commands with no user fields POST immediately (no empty form)
 - `reference_to` fields render as dropdowns populated from the referenced aggregate
+- Reference columns (`_id` attrs) show entity name instead of raw UUID, with short-ID fallback
 - Enum fields render as `<select>` dropdowns with valid values
 - Humanized labels everywhere — PascalCase split + ActiveSupport pluralization via UILabelContract
 - Nav sidebar grouped by origin domain in multi-domain servers

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator.rb
@@ -1,4 +1,5 @@
 require_relative "server_generator/data_routes"
+require_relative "server_generator/html_routes"
 require_relative "server_generator/ui_routes"
 require_relative "server_generator/domain_behavior_routes"
 
@@ -12,6 +13,7 @@ module GoHecks
   class ServerGenerator < Hecks::Generator
     include GoUtils
     include DataRoutes
+    include HtmlRoutes
     include UIRoutes
     include DomainBehaviorRoutes
 

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -29,7 +29,10 @@ module GoHecks
         ac = HecksTemplating::AggregateContract
         dc = HecksTemplating::DisplayContract
 
-        cols = attrs.map { |a| "{Label: \"#{HecksTemplating::UILabelContract.label(a.name)}\"}" }
+        cols = attrs.map { |a|
+          lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : HecksTemplating::UILabelContract.label(a.name)
+          "{Label: \"#{lbl}\"}"
+        }
         create_cmds, update_cmds = ac.partition_commands(agg)
 
         btns = create_cmds.map { |c|
@@ -46,7 +49,23 @@ module GoHecks
           end
         }
 
-        cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :go) }
+        ref_attrs = attrs.select { |a| dc.reference_attr?(a) }
+        ref_lookups = ref_attrs.map { |a|
+          ref_agg = dc.find_referenced_aggregate(a, @domain)
+          [a, ref_agg]
+        }.select { |_, ra| ra }
+
+        cell_exprs = attrs.map { |a|
+          ref_pair = ref_lookups.find { |ra, _| ra == a }
+          if ref_pair
+            ref_agg = ref_pair[1]
+            field = GoUtils.pascal_case(a.name)
+            map_name = "#{GoUtils.snake_case(ref_agg.name)}Names"
+            "func() string { if n, ok := #{map_name}[obj.#{field}]; ok { return n }; if len(obj.#{field}) > 8 { return obj.#{field}[:8]+\"...\" }; return obj.#{field} }()"
+          else
+            dc.cell_expression(a, "obj", lang: :go)
+          end
+        }
         desc = agg.description || ""
 
         lines = []
@@ -59,6 +78,12 @@ module GoHecks
         lines << "\t\t\titems, _ := app.#{safe}Repo.All(); jsonResponse(w, items); return"
         lines << "\t\t}"
         lines << "\t\titems, _ := app.#{safe}Repo.All()"
+        ref_lookups.each do |_, ref_agg|
+          map_name = "#{GoUtils.snake_case(ref_agg.name)}Names"
+          lines << "\t\t#{GoUtils.snake_case(ref_agg.name)}All, _ := app.#{ref_agg.name}Repo.All()"
+          lines << "\t\t#{map_name} := map[string]string{}"
+          lines << "\t\tfor _, m := range #{GoUtils.snake_case(ref_agg.name)}All { if m.Name != \"\" { #{map_name}[m.ID] = m.Name } else { #{map_name}[m.ID] = m.ID } }"
+        end
         lines << "\t\tvar rows []#{safe}IndexItem"
         lines << "\t\tfor _, obj := range items {"
         lines << "\t\t\t#{vc.go_short_id('obj.ID')}"
@@ -123,65 +148,6 @@ module GoHecks
         lines
       end
 
-      def html_routes
-        vc = HecksTemplating::ViewContract
-        ac = HecksTemplating::AggregateContract
-        dc = HecksTemplating::DisplayContract
-        lines = []
-
-        @domain.aggregates.each do |agg|
-          safe = agg.name
-          plural = GoUtils.snake_case(safe) + "s"
-          agg_snake = GoUtils.snake_case(safe)
-          attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
-
-          lines << "\t#{vc.go_struct(:show_field, vc::SHOW[:structs][:show_field], prefix: safe)}"
-          lines << "\t#{vc.go_struct(:show_data, vc::SHOW[:fields], prefix: safe)}"
-          lines << "\tmux.HandleFunc(\"GET /#{plural}/show\", func(w http.ResponseWriter, r *http.Request) {"
-          lines << "\t\tobj, _ := app.#{safe}Repo.Find(r.URL.Query().Get(\"id\"))"
-          lines << "\t\tif obj == nil { http.Error(w, \"Not found\", 404); return }"
-          lines << "\t\tfields := []#{safe}ShowField{"
-
-          lc = agg.lifecycle
-          lc_field = lc&.field&.to_s
-          attrs.each do |a|
-            field = GoUtils.pascal_case(a.name)
-            label = HecksTemplating::UILabelContract.label(a.name)
-            if a.list?
-              lines << "\t\t\t{Label: \"#{label}\", Type: \"list\", Items: func() []string { var s []string; for _, v := range obj.#{field} { s = append(s, fmt.Sprintf(\"%v\", v)) }; return s }()},"
-            elsif lc_field && a.name.to_s == lc_field
-              transitions = dc.lifecycle_transitions(lc)
-              trans_go = transitions.map { |t| "\"#{t}\"" }.join(", ")
-              lines << "\t\t\t{Label: \"#{label}\", Type: \"lifecycle\", Value: fmt.Sprintf(\"%v\", obj.#{field}), Transitions: []string{#{trans_go}}},"
-            else
-              lines << "\t\t\t{Label: \"#{label}\", Value: fmt.Sprintf(\"%v\", obj.#{field})},"
-            end
-          end
-          lines << "\t\t}"
-
-          # Update command buttons — from contract
-          _, update_cmds = ac.partition_commands(agg)
-          if update_cmds.any?
-            btn_exprs = update_cmds.map { |c|
-              cm = GoUtils.snake_case(c.name)
-              if ac.direct_action?(c, agg_snake)
-                self_ref = ac.self_ref_attr(c, agg_snake)
-                "#{safe}Button{Label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", Href: \"/#{plural}/#{cm}\", Allowed: true, Direct: true, IdField: \"#{self_ref.name}\"}"
-              else
-                "#{safe}Button{Label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", Href: \"/#{plural}/#{cm}/new?id=\" + obj.ID, Allowed: true}"
-              end
-            }
-            lines << "\t\tbuttons := []#{safe}Button{#{btn_exprs.join(', ')}}"
-          else
-            lines << "\t\tvar buttons []#{safe}Button"
-          end
-
-          lines << "\t\trenderer.Render(w, \"show\", \"#{safe}\", #{safe}ShowData{AggregateName: \"#{safe}\", BackHref: \"/#{plural}\", Id: obj.ID, Fields: fields, Buttons: buttons})"
-          lines << "\t})"
-          lines << ""
-        end
-        lines
-      end
     end
   end
 end

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/html_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/html_routes.rb
@@ -1,0 +1,89 @@
+# GoHecks::ServerGenerator::HtmlRoutes
+#
+# Generates Go HTML show page routes for aggregates. Renders field
+# labels, values, lifecycle states, and reference lookups (entity
+# name instead of raw UUID). Extracted from DataRoutes.
+#
+module GoHecks
+  class ServerGenerator < Hecks::Generator
+    module HtmlRoutes
+      private
+
+      def html_routes
+        vc = HecksTemplating::ViewContract
+        ac = HecksTemplating::AggregateContract
+        dc = HecksTemplating::DisplayContract
+        lines = []
+
+        @domain.aggregates.each do |agg|
+          safe = agg.name
+          plural = GoUtils.snake_case(safe) + "s"
+          agg_snake = GoUtils.snake_case(safe)
+          attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
+
+          ref_attrs = attrs.select { |a| dc.reference_attr?(a) }
+          show_ref_lookups = ref_attrs.map { |a| [a, dc.find_referenced_aggregate(a, @domain)] }.select { |_, ra| ra }
+
+          lines << "\t#{vc.go_struct(:show_field, vc::SHOW[:structs][:show_field], prefix: safe)}"
+          lines << "\t#{vc.go_struct(:show_data, vc::SHOW[:fields], prefix: safe)}"
+          lines << "\tmux.HandleFunc(\"GET /#{plural}/show\", func(w http.ResponseWriter, r *http.Request) {"
+          lines << "\t\tobj, _ := app.#{safe}Repo.Find(r.URL.Query().Get(\"id\"))"
+          lines << "\t\tif obj == nil { http.Error(w, \"Not found\", 404); return }"
+          show_ref_lookups.each do |_, ref_agg|
+            map_name = "#{GoUtils.snake_case(ref_agg.name)}Names"
+            lines << "\t\t#{GoUtils.snake_case(ref_agg.name)}All, _ := app.#{ref_agg.name}Repo.All()"
+            lines << "\t\t#{map_name} := map[string]string{}"
+            lines << "\t\tfor _, m := range #{GoUtils.snake_case(ref_agg.name)}All { if m.Name != \"\" { #{map_name}[m.ID] = m.Name } else { #{map_name}[m.ID] = m.ID } }"
+          end
+          lines << "\t\tfields := []#{safe}ShowField{"
+
+          lc = agg.lifecycle
+          lc_field = lc&.field&.to_s
+          attrs.each do |a|
+            field = GoUtils.pascal_case(a.name)
+            label = dc.reference_attr?(a) ? dc.reference_column_label(a) : HecksTemplating::UILabelContract.label(a.name)
+            if a.list?
+              lines << "\t\t\t{Label: \"#{label}\", Type: \"list\", Items: func() []string { var s []string; for _, v := range obj.#{field} { s = append(s, fmt.Sprintf(\"%v\", v)) }; return s }()},"
+            elsif lc_field && a.name.to_s == lc_field
+              transitions = dc.lifecycle_transitions(lc)
+              trans_go = transitions.map { |t| "\"#{t}\"" }.join(", ")
+              lines << "\t\t\t{Label: \"#{label}\", Type: \"lifecycle\", Value: fmt.Sprintf(\"%v\", obj.#{field}), Transitions: []string{#{trans_go}}},"
+            elsif dc.reference_attr?(a)
+              ref_pair = show_ref_lookups.find { |ra, _| ra == a }
+              if ref_pair
+                map_name = "#{GoUtils.snake_case(ref_pair[1].name)}Names"
+                lines << "\t\t\t{Label: \"#{label}\", Value: func() string { if n, ok := #{map_name}[obj.#{field}]; ok { return n }; if len(obj.#{field}) > 8 { return obj.#{field}[:8]+\"...\" }; return obj.#{field} }()},"
+              else
+                lines << "\t\t\t{Label: \"#{label}\", Value: func() string { if len(obj.#{field}) > 8 { return obj.#{field}[:8]+\"...\" }; return obj.#{field} }()},"
+              end
+            else
+              lines << "\t\t\t{Label: \"#{label}\", Value: fmt.Sprintf(\"%v\", obj.#{field})},"
+            end
+          end
+          lines << "\t\t}"
+
+          _, update_cmds = ac.partition_commands(agg)
+          if update_cmds.any?
+            btn_exprs = update_cmds.map { |c|
+              cm = GoUtils.snake_case(c.name)
+              if ac.direct_action?(c, agg_snake)
+                self_ref = ac.self_ref_attr(c, agg_snake)
+                "#{safe}Button{Label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", Href: \"/#{plural}/#{cm}\", Allowed: true, Direct: true, IdField: \"#{self_ref.name}\"}"
+              else
+                "#{safe}Button{Label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", Href: \"/#{plural}/#{cm}/new?id=\" + obj.ID, Allowed: true}"
+              end
+            }
+            lines << "\t\tbuttons := []#{safe}Button{#{btn_exprs.join(', ')}}"
+          else
+            lines << "\t\tvar buttons []#{safe}Button"
+          end
+
+          lines << "\t\trenderer.Render(w, \"show\", \"#{safe}\", #{safe}ShowData{AggregateName: \"#{safe}\", BackHref: \"/#{plural}\", Id: obj.ID, Fields: fields, Buttons: buttons})"
+          lines << "\t})"
+          lines << ""
+        end
+        lines
+      end
+    end
+  end
+end

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -1,5 +1,6 @@
 require_relative "ui_generator/form_routes"
 require_relative "ui_generator/config_routes"
+require_relative "ui_generator/show_route"
 
 module HecksStatic
 # HecksStatic::UIGenerator
@@ -10,6 +11,7 @@ module HecksStatic
 class UIGenerator < Hecks::Generator
   include FormRoutes
   include ConfigRoutes
+  include ShowRoute
 
   def initialize(domain)
     @domain = domain
@@ -117,7 +119,10 @@ class UIGenerator < Hecks::Generator
     dc = HecksTemplating::DisplayContract
     create_cmds, update_cmds = ac.partition_commands(agg)
 
-    columns = attrs.map { |a| "{ label: \"#{humanize(a.name)}\" }" }
+    columns = attrs.map { |a|
+      lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+      "{ label: \"#{lbl}\" }"
+    }
     btns = create_cmds.map { |c| cm = domain_snake_name(c.name); "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }" }
     row_acts = update_cmds.map do |c|
       cm = domain_snake_name(c.name)
@@ -129,7 +134,7 @@ class UIGenerator < Hecks::Generator
       end
     end
 
-    cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :ruby) }
+    cell_exprs = attrs.map { |a| dc.cell_expression(a, "obj", lang: :ruby, domain: @domain) }
     cells_code = cell_exprs.map { |e| e }.join(", ")
 
     [
@@ -148,73 +153,5 @@ class UIGenerator < Hecks::Generator
     ]
   end
 
-  def show_route(agg, mod)
-    safe = domain_constant_name(agg.name)
-    p = plural(agg)
-    attrs = user_attrs(agg)
-    agg_snake = domain_snake_name(agg.name)
-
-    lc = agg.lifecycle
-    lc_field = lc&.field&.to_s
-
-    field_exprs = attrs.map do |a|
-      if a.list?
-        vo = agg.value_objects.find { |v| v.name == a.type.to_s }
-        if vo
-          vo_attrs = vo.attributes.map(&:name).map(&:to_s)
-          items_expr = "obj.#{a.name}.map { |v| #{vo_attrs.map { |va| "v.#{va}.to_s" }.join(' + " — " + ')} }"
-          "{ label: \"#{humanize(a.name)}\", type: :list, items: #{items_expr} }"
-        else
-          "{ label: \"#{humanize(a.name)}\", type: :list, items: obj.#{a.name}.map(&:to_s) }"
-        end
-      elsif lc_field && a.name.to_s == lc_field
-        transitions = HecksTemplating::DisplayContract.lifecycle_transitions(lc)
-        "{ label: \"#{humanize(a.name)}\", type: :lifecycle, value: obj.#{a.name}.to_s, transitions: #{transitions.inspect} }"
-      else
-        "{ label: \"#{humanize(a.name)}\", value: obj.#{a.name}.to_s }"
-      end
-    end
-
-    # Collect buttons — from contract
-    ac = HecksTemplating::AggregateContract
-    btn_parts = []
-    _, update_cmds = ac.partition_commands(agg)
-    update_cmds.each do |c|
-      cm = domain_snake_name(c.name)
-      if ac.direct_action?(c, agg_snake)
-        self_id = ac.self_ref_attr(c, agg_snake)
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id.name}\" }"
-      else
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
-      end
-    end
-    # Cross-aggregate commands
-    snake = domain_snake_name(agg.name)
-    @domain.aggregates.each do |other|
-      next if other.name == agg.name
-      other_safe = domain_constant_name(other.name)
-      other_p = plural(other)
-      other.commands.each do |cmd|
-        next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
-        cm = domain_snake_name(cmd.name)
-        btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", href: \"/#{other_p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{other_safe}\", \"#{cm}\") }"
-      end
-    end
-
-    [
-      "        server.mount_proc \"/#{p}/show\" do |req, res|",
-      "          obj = #{safe}.find(req.query[\"id\"])",
-      "          unless obj",
-      "            res.status = 404; res.body = \"Not found\"; next",
-      "          end",
-      "          html = renderer.render(:show, title: \"#{safe} — #{mod}\", brand: brand, nav_items: nav,",
-      "            aggregate_name: \"#{safe}\", back_href: \"/#{p}\",",
-      "            id: obj.id, fields: [#{field_exprs.join(', ')}],",
-      "            buttons: [#{btn_parts.join(', ')}])",
-      "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
-      "        end",
-      ""
-    ]
-  end
 end
 end

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/show_route.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/show_route.rb
@@ -1,0 +1,107 @@
+# HecksStatic::UIGenerator::ShowRoute
+#
+# Generates the show route handler for an aggregate detail page.
+# Renders field labels, values, lifecycle transitions, list items,
+# and reference lookups (entity name instead of raw UUID).
+#
+#   lines = show_route(agg, "MyApp")
+#
+module HecksStatic
+  class UIGenerator < Hecks::Generator
+    module ShowRoute
+      include HecksTemplating::NamingHelpers
+      private
+
+      def show_route(agg, mod)
+        safe = domain_constant_name(agg.name)
+        p = plural(agg)
+        attrs = user_attrs(agg)
+        agg_snake = domain_snake_name(agg.name)
+
+        lc = agg.lifecycle
+        lc_field = lc&.field&.to_s
+
+        dc = HecksTemplating::DisplayContract
+        field_exprs = attrs.map { |a| show_field_expr(a, agg, lc, lc_field, dc) }
+
+        btn_parts = show_buttons(agg, mod, safe, p, agg_snake)
+
+        [
+          "        server.mount_proc \"/#{p}/show\" do |req, res|",
+          "          obj = #{safe}.find(req.query[\"id\"])",
+          "          unless obj",
+          "            res.status = 404; res.body = \"Not found\"; next",
+          "          end",
+          "          html = renderer.render(:show, title: \"#{safe} — #{mod}\", brand: brand, nav_items: nav,",
+          "            aggregate_name: \"#{safe}\", back_href: \"/#{p}\",",
+          "            id: obj.id, fields: [#{field_exprs.join(', ')}],",
+          "            buttons: [#{btn_parts.join(', ')}])",
+          "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
+          "        end",
+          ""
+        ]
+      end
+
+      def show_field_expr(a, agg, lc, lc_field, dc)
+        label = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+        if a.list?
+          show_list_field(a, agg, label)
+        elsif lc_field && a.name.to_s == lc_field
+          transitions = dc.lifecycle_transitions(lc)
+          "{ label: \"#{label}\", type: :lifecycle, value: obj.#{a.name}.to_s, transitions: #{transitions.inspect} }"
+        elsif dc.reference_attr?(a)
+          show_reference_field(a, label, dc)
+        else
+          "{ label: \"#{label}\", value: obj.#{a.name}.to_s }"
+        end
+      end
+
+      def show_list_field(a, agg, label)
+        vo = agg.value_objects.find { |v| v.name == a.type.to_s }
+        if vo
+          vo_attrs = vo.attributes.map(&:name).map(&:to_s)
+          items_expr = "obj.#{a.name}.map { |v| #{vo_attrs.map { |va| "v.#{va}.to_s" }.join(' + " — " + ')} }"
+          "{ label: \"#{label}\", type: :list, items: #{items_expr} }"
+        else
+          "{ label: \"#{label}\", type: :list, items: obj.#{a.name}.map(&:to_s) }"
+        end
+      end
+
+      def show_reference_field(a, label, dc)
+        ref_agg = dc.find_referenced_aggregate(a, @domain)
+        if ref_agg
+          "{ label: \"#{label}\", value: (-> { _r = #{ref_agg.name}.all.find { |x| x.id == obj.#{a.name} }; _r&.respond_to?(:name) ? _r.name.to_s : obj.#{a.name}.to_s[0..7] + \"...\" }).call }"
+        else
+          "{ label: \"#{label}\", value: obj.#{a.name}.to_s[0..7] + \"...\" }"
+        end
+      end
+
+      def show_buttons(agg, mod, safe, p, agg_snake)
+        ac = HecksTemplating::AggregateContract
+        btn_parts = []
+        _, update_cmds = ac.partition_commands(agg)
+        update_cmds.each do |c|
+          cm = domain_snake_name(c.name)
+          if ac.direct_action?(c, agg_snake)
+            self_id = ac.self_ref_attr(c, agg_snake)
+            btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/submit\", allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\"), direct: true, id_field: \"#{self_id.name}\" }"
+          else
+            btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(c.name)}\", href: \"/#{p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{safe}\", \"#{cm}\") }"
+          end
+        end
+        snake = domain_snake_name(agg.name)
+        @domain.aggregates.each do |other|
+          next if other.name == agg.name
+          other_safe = domain_constant_name(other.name)
+          other_p = plural(other)
+          other.commands.each do |cmd|
+            next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
+            cm = domain_snake_name(cmd.name)
+            btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", href: \"/#{other_p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{other_safe}\", \"#{cm}\") }"
+          end
+        end
+        btn_parts
+      end
+    end
+  end
+end

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_ui_routes.rb
@@ -29,9 +29,9 @@ module Hecks
           remaining = sub_path.sub("/#{p}", "")
 
           if remaining == "" || remaining == "/"
-            serve_index(res, agg, klass, safe, p, prefix)
+            serve_index(res, agg, klass, safe, p, prefix, domain)
           elsif remaining == "/show"
-            serve_show(req, res, agg, klass, safe, p, prefix)
+            serve_show(req, res, agg, klass, safe, p, prefix, domain)
           elsif remaining =~ /\/(\w+)\/new$/
             serve_form(req, res, agg, klass, safe, p, prefix, $1)
           elsif remaining =~ /\/(\w+)\/submit$/
@@ -41,13 +41,24 @@ module Hecks
           end
         end
 
-        def serve_index(res, agg, klass, safe, p, prefix)
+        def serve_index(res, agg, klass, safe, p, prefix, domain)
+          dc = HecksTemplating::DisplayContract
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
           items = klass.all.map do |obj|
-            cells = user_attrs.map { |a| obj.send(a.name).to_s }
+            cells = user_attrs.map { |a|
+              if dc.reference_attr?(a)
+                ref_agg = dc.find_referenced_aggregate(a, domain)
+                resolve_reference(obj, a, ref_agg, klass)
+              else
+                obj.send(a.name).to_s
+              end
+            }
             { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
           end
-          columns = user_attrs.map { |a| { label: humanize(a.name) } }
+          columns = user_attrs.map { |a|
+            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+            { label: lbl }
+          }
           create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
@@ -61,13 +72,23 @@ module Hecks
           res.body = html
         end
 
-        def serve_show(req, res, agg, klass, safe, p, prefix)
+        def serve_show(req, res, agg, klass, safe, p, prefix, domain)
+          dc = HecksTemplating::DisplayContract
           obj = klass.find(req.query["id"])
           unless obj
             res.status = 404; res.body = "Not found"; return
           end
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
-          fields = user_attrs.map { |a| { label: humanize(a.name), value: obj.send(a.name).to_s } }
+          fields = user_attrs.map { |a|
+            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+            val = if dc.reference_attr?(a)
+              ref_agg = dc.find_referenced_aggregate(a, domain)
+              resolve_reference(obj, a, ref_agg, klass)
+            else
+              obj.send(a.name).to_s
+            end
+            { label: lbl, value: val }
+          }
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",
@@ -118,6 +139,16 @@ module Hecks
             error_message: e.message, fields: fields)
           res["Content-Type"] = "text/html"
           res.body = html
+        end
+        def resolve_reference(obj, attr, ref_agg, klass)
+          raw = obj.send(attr.name).to_s
+          return raw[0..7] + "..." unless ref_agg
+          ref_const = domain_constant_name(ref_agg.name)
+          mod = klass.is_a?(Module) ? klass.to_s.split("::")[0..-2].join("::") : nil
+          ref_klass = mod ? Object.const_get("#{mod}::#{ref_const}") : Object.const_get(ref_const) rescue nil
+          return raw[0..7] + "..." unless ref_klass
+          found = ref_klass.all.find { |x| x.id == raw }
+          found&.respond_to?(:name) ? found.name.to_s : raw[0..7] + "..."
         end
       end
     end

--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -12,19 +12,66 @@
 #
 module Hecks::Conventions
   module DisplayContract
+    # True when the attribute is a foreign-key reference (ends in _id, type String).
+    #
+    # @param attr [Attribute] the attribute to check
+    # @return [Boolean]
+    def self.reference_attr?(attr)
+      attr.name.to_s.end_with?("_id") && attr.type == String && !attr.list?
+    end
+
+    # Column/field label for a reference attribute — strips "_id" and humanizes.
+    #   reference_column_label(attr_named(:model_id)) # => "Model"
+    #
+    # @param attr [Attribute] a reference attribute
+    # @return [String] humanized label without "Id"
+    def self.reference_column_label(attr)
+      base = attr.name.to_s.sub(/_id\z/, "")
+      UILabelContract.label(base)
+    end
+
+    # Find the aggregate referenced by a _id attribute within a domain.
+    #
+    # @param attr [Attribute] a reference attribute
+    # @param domain [Domain] the domain IR to search
+    # @return [Aggregate, nil]
+    def self.find_referenced_aggregate(attr, domain)
+      base = attr.name.to_s.sub(/_id\z/, "")
+      pascal = Hecks::Utils.sanitize_constant(base)
+      domain.aggregates.find { |a| a.name == pascal } ||
+        domain.aggregates.find { |a| a.name.end_with?(pascal) }
+    end
+
     # Format a cell value for index table display.
     # List attributes show "N items"; scalars show the value.
+    # Reference attributes resolve to the referenced entity's name.
     #
     # @param attr [Attribute] the attribute to display
     # @param obj_var [String] the variable name for the object
     # @param lang [Symbol] :ruby or :go
+    # @param domain [Domain, nil] domain IR for reference lookups
     # @return [String] code expression
-    def self.cell_expression(attr, obj_var, lang:)
+    def self.cell_expression(attr, obj_var, lang:, domain: nil)
       field = lang == :go ? GoFieldName.call(attr.name) : attr.name
       if attr.list?
         case lang
         when :go then "fmt.Sprintf(\"%d items\", len(#{obj_var}.#{field}))"
         when :ruby then "#{obj_var}.#{field}.size.to_s + \" items\""
+        end
+      elsif reference_attr?(attr) && domain
+        ref_agg = find_referenced_aggregate(attr, domain)
+        if ref_agg
+          ref_const = ref_agg.name
+          case lang
+          when :ruby
+            "(-> { _r = #{ref_const}.all.find { |x| x.id == #{obj_var}.#{field} }; _r&.respond_to?(:name) ? _r.name.to_s : #{obj_var}.#{field}.to_s[0..7] + \"...\" }).call"
+          when :go then "fmt.Sprintf(\"%v\", #{obj_var}.#{field})"
+          end
+        else
+          case lang
+          when :go then "fmt.Sprintf(\"%v\", #{obj_var}.#{field})"
+          when :ruby then "#{obj_var}.#{field}.to_s[0..7] + \"...\""
+          end
         end
       else
         case lang

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
@@ -29,9 +29,9 @@ module Hecks
           remaining = sub_path.sub("/#{p}", "")
 
           if remaining == "" || remaining == "/"
-            serve_index(res, agg, klass, safe, p, prefix)
+            serve_index(res, agg, klass, safe, p, prefix, domain)
           elsif remaining == "/show"
-            serve_show(req, res, agg, klass, safe, p, prefix)
+            serve_show(req, res, agg, klass, safe, p, prefix, domain)
           elsif remaining =~ /\/(\w+)\/new$/
             serve_form(req, res, agg, klass, safe, p, prefix, $1)
           elsif remaining =~ /\/(\w+)\/submit$/
@@ -41,13 +41,24 @@ module Hecks
           end
         end
 
-        def serve_index(res, agg, klass, safe, p, prefix)
+        def serve_index(res, agg, klass, safe, p, prefix, domain)
+          dc = HecksTemplating::DisplayContract
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
           items = klass.all.map do |obj|
-            cells = user_attrs.map { |a| obj.send(a.name).to_s }
+            cells = user_attrs.map { |a|
+              if dc.reference_attr?(a)
+                ref_agg = dc.find_referenced_aggregate(a, domain)
+                resolve_reference(obj, a, ref_agg, klass)
+              else
+                obj.send(a.name).to_s
+              end
+            }
             { id: obj.id, short_id: obj.id[0..7], show_href: "#{prefix}/#{p}/show?id=#{obj.id}", cells: cells }
           end
-          columns = user_attrs.map { |a| { label: humanize(a.name) } }
+          columns = user_attrs.map { |a|
+            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+            { label: lbl }
+          }
           create_cmds = agg.commands.select { |c| c.name.start_with?("Create") }
           buttons = create_cmds.map do |c|
             cm = domain_snake_name(c.name)
@@ -61,13 +72,23 @@ module Hecks
           res.body = html
         end
 
-        def serve_show(req, res, agg, klass, safe, p, prefix)
+        def serve_show(req, res, agg, klass, safe, p, prefix, domain)
+          dc = HecksTemplating::DisplayContract
           obj = klass.find(req.query["id"])
           unless obj
             res.status = 404; res.body = "Not found"; return
           end
           user_attrs = agg.attributes.reject { |a| Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(a.name.to_s) }
-          fields = user_attrs.map { |a| { label: humanize(a.name), value: obj.send(a.name).to_s } }
+          fields = user_attrs.map { |a|
+            lbl = dc.reference_attr?(a) ? dc.reference_column_label(a) : humanize(a.name)
+            val = if dc.reference_attr?(a)
+              ref_agg = dc.find_referenced_aggregate(a, domain)
+              resolve_reference(obj, a, ref_agg, klass)
+            else
+              obj.send(a.name).to_s
+            end
+            { label: lbl, value: val }
+          }
           html = @renderer.render(:show,
             title: "#{safe} — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, back_href: "#{prefix}/#{p}",
@@ -118,6 +139,16 @@ module Hecks
             error_message: e.message, fields: fields)
           res["Content-Type"] = "text/html"
           res.body = html
+        end
+        def resolve_reference(obj, attr, ref_agg, klass)
+          raw = obj.send(attr.name).to_s
+          return raw[0..7] + "..." unless ref_agg
+          ref_const = domain_constant_name(ref_agg.name)
+          mod = klass.is_a?(Module) ? klass.to_s.split("::")[0..-2].join("::") : nil
+          ref_klass = mod ? Object.const_get("#{mod}::#{ref_const}") : Object.const_get(ref_const) rescue nil
+          return raw[0..7] + "..." unless ref_klass
+          found = ref_klass.all.find { |x| x.id == raw }
+          found&.respond_to?(:name) ? found.name.to_s : raw[0..7] + "..."
         end
       end
     end

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::DisplayContract do
+  let(:attr_class) { Hecks::DomainModel::Structure::Attribute }
+
+  describe ".reference_attr?" do
+    it "returns true for _id String attrs" do
+      attr = attr_class.new(name: :model_id, type: String)
+      expect(described_class.reference_attr?(attr)).to be true
+    end
+
+    it "returns false for non-_id attrs" do
+      attr = attr_class.new(name: :name, type: String)
+      expect(described_class.reference_attr?(attr)).to be false
+    end
+
+    it "returns false for _id attrs with non-String type" do
+      attr = attr_class.new(name: :model_id, type: Integer)
+      expect(described_class.reference_attr?(attr)).to be false
+    end
+
+    it "returns false for list _id attrs" do
+      attr = attr_class.new(name: :model_id, type: String, list: true)
+      expect(described_class.reference_attr?(attr)).to be false
+    end
+  end
+
+  describe ".reference_column_label" do
+    it "strips _id and humanizes" do
+      attr = attr_class.new(name: :model_id, type: String)
+      expect(described_class.reference_column_label(attr)).to eq("Model")
+    end
+
+    it "handles multi-word references" do
+      attr = attr_class.new(name: :pizza_topping_id, type: String)
+      expect(described_class.reference_column_label(attr)).to eq("Pizza Topping")
+    end
+  end
+
+  describe ".cell_expression with domain" do
+    it "returns short-id fallback when no domain given for reference attr" do
+      attr = attr_class.new(name: :model_id, type: String)
+      expr = described_class.cell_expression(attr, "obj", lang: :ruby)
+      expect(expr).to eq("obj.model_id.to_s")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
HEC-239: Web explorer reference columns show entity name not raw ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)