### PR TITLE
HEC-256: Route contract

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -87,7 +87,7 @@ module GoHecks
       def command_route(safe, plural, cmd)
         cmd_snake = GoUtils.snake_case(cmd.name)
         lines = []
-        lines << "\tmux.HandleFunc(\"POST /#{plural}/#{cmd_snake}\", func(w http.ResponseWriter, r *http.Request) {"
+        lines << "\tmux.HandleFunc(\"POST #{HecksTemplating::RouteContract.submit_path(plural, cmd_snake)}\", func(w http.ResponseWriter, r *http.Request) {"
         lines << "\t\tvar cmd domain.#{cmd.name}"
         lines << "\t\tif r.Header.Get(\"Content-Type\") == \"application/json\" {"
         lines << "\t\t\tif err := json.NewDecoder(r.Body).Decode(&cmd); err != nil { http.Error(w, `{\"error\":\"invalid json\"}`, 400); return }"

--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/ui_routes.rb
@@ -22,7 +22,7 @@ module GoHecks
             cmd_snake = GoUtils.snake_case(cmd.name)
             self_id = ac.self_ref_attr(cmd, agg_snake)
 
-            lines << "\tmux.HandleFunc(\"GET /#{plural}/#{cmd_snake}/new\", func(w http.ResponseWriter, r *http.Request) {"
+            lines << "\tmux.HandleFunc(\"GET #{HecksTemplating::RouteContract.form_path(plural, cmd_snake)}\", func(w http.ResponseWriter, r *http.Request) {"
             lines << "\t\tfields := []FormField{"
             cmd.attributes.each do |a|
               if a == self_id
@@ -65,7 +65,7 @@ module GoHecks
 
             lines << "\t\trenderer.Render(w, \"form\", \"#{cmd.name}\", FormData{"
             lines << "\t\t\tCommandName: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\","
-            lines << "\t\t\tAction: \"/#{plural}/#{cmd_snake}\","
+            lines << "\t\t\tAction: \"#{HecksTemplating::RouteContract.submit_path(plural, cmd_snake)}\","
             lines << "\t\t\tFields: fields,"
             lines << "\t\t})"
             lines << "\t})"

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/form_routes.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/form_routes.rb
@@ -31,7 +31,7 @@ module HecksStatic
           end
 
           # Form GET
-          lines << "        server.mount_proc \"/#{p}/#{cmd_snake}/new\" do |req, res|"
+          lines << "        server.mount_proc \"#{HecksTemplating::RouteContract.form_path(p, cmd_snake)}\" do |req, res|"
           lines << "          unless #{mod}.role_allows?(\"#{safe}\", \"#{cmd_snake}\")"
           lines << "            html = renderer.render(:form, title: \"Denied — #{mod}\", brand: brand, nav_items: nav,"
           lines << "              command_name: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", action: \"\", error_message: \"Role '\" + #{mod}.current_role.to_s + \"' cannot #{cmd_snake}\", fields: [])"
@@ -39,7 +39,7 @@ module HecksStatic
           lines << "          end"
           lines << "          fields = #{build_fields_code(cmd, agg, self_id_attr)}"
           lines << "          html = renderer.render(:form, title: \"#{cmd.name} — #{mod}\", brand: brand, nav_items: nav,"
-          lines << "            command_name: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", action: \"/#{p}/#{cmd_snake}/submit\", error_message: nil, fields: fields)"
+          lines << "            command_name: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", action: \"#{HecksTemplating::RouteContract.submit_path(p, cmd_snake)}\", error_message: nil, fields: fields)"
           lines << "          res[\"Content-Type\"] = \"text/html\"; res.body = html"
           lines << "        end"
           lines << ""
@@ -91,7 +91,7 @@ module HecksStatic
 
       def submit_route(cmd, agg, mod, safe, p, cmd_snake, self_id_attr)
         lines = []
-        lines << "        server.mount_proc \"/#{p}/#{cmd_snake}/submit\" do |req, res|"
+        lines << "        server.mount_proc \"#{HecksTemplating::RouteContract.submit_path(p, cmd_snake)}\" do |req, res|"
         lines << "          unless #{mod}.role_allows?(\"#{safe}\", \"#{cmd_snake}\")"
         lines << "            res.status = 403; res.body = \"Forbidden\"; next"
         lines << "          end"
@@ -108,7 +108,7 @@ module HecksStatic
         lines << "            fields.each { |f| f[:value] = params[f[:name]] || f[:value] if f[:type] != :hidden }"
         lines << "            fields.each { |f| f[:error] = e.message if e.respond_to?(:field) && e.field.to_s == f[:name] }"
         lines << "            html = renderer.render(:form, title: \"#{cmd.name} — #{mod}\", brand: brand, nav_items: nav,"
-        lines << "              command_name: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", action: \"/#{p}/#{cmd_snake}/submit\","
+        lines << "              command_name: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", action: \"#{HecksTemplating::RouteContract.submit_path(p, cmd_snake)}\","
         lines << "              error_message: (e.respond_to?(:field) && e.field ? nil : e.message), fields: fields)"
         lines << "            res[\"Content-Type\"] = \"text/html\"; res.body = html"
         lines << "          rescue #{@domain.module_name}Domain::Error => e"

--- a/hecksties/lib/hecks/conventions/route_contract.rb
+++ b/hecksties/lib/hecks/conventions/route_contract.rb
@@ -1,0 +1,21 @@
+# = Hecks::Conventions::RouteContract
+#
+# Single source of truth for URL patterns used by Ruby and Go generators
+# and the smoke test. Eliminates divergent route definitions and the
+# fallback heuristic in form_submission.rb.
+#
+#   RouteContract.form_path("pizzas", "create_pizza")    # => "/pizzas/create_pizza/new"
+#   RouteContract.submit_path("pizzas", "create_pizza")  # => "/pizzas/create_pizza/submit"
+#   RouteContract.query_path("pizzas", "by_name")        # => "/pizzas/queries/by_name"
+#
+module Hecks::Conventions
+  module RouteContract
+    def self.form_path(plural, cmd_snake)    = "/#{plural}/#{cmd_snake}/new"
+    def self.submit_path(plural, cmd_snake)  = "/#{plural}/#{cmd_snake}/submit"
+    def self.index_path(plural)              = "/#{plural}"
+    def self.show_path(plural)               = "/#{plural}/show"
+    def self.query_path(plural, query_snake) = "/#{plural}/queries/#{query_snake}"
+    def self.scope_path(plural, scope_name)  = "/#{plural}/scopes/#{scope_name}"
+    def self.spec_path(plural, spec_snake)   = "/#{plural}/specifications/#{spec_snake}"
+  end
+end

--- a/hecksties/lib/hecks/smoke/behavior_tests.rb
+++ b/hecksties/lib/hecks/smoke/behavior_tests.rb
@@ -15,7 +15,7 @@ module HecksTemplating
           plural = underscore(agg.name) + "s"
           agg.queries.each do |query|
             query_snake = underscore(query.name)
-            path = "/#{plural}/queries/#{query_snake}"
+            path = HecksTemplating::RouteContract.query_path(plural, query_snake)
             path += "?value=example" if query.block.arity > 0
             results << check_get(path, "#{agg.name} query #{query.name}")
           end
@@ -26,7 +26,7 @@ module HecksTemplating
         @domain.aggregates.each do |agg|
           plural = underscore(agg.name) + "s"
           agg.scopes.each do |scope|
-            path = "/#{plural}/scopes/#{scope.name}"
+            path = HecksTemplating::RouteContract.scope_path(plural, scope.name)
             path += "?value=example" if scope.callable?
             results << check_get(path, "#{agg.name} scope #{scope.name}")
           end
@@ -41,7 +41,7 @@ module HecksTemplating
 
           agg.specifications.each do |spec|
             spec_snake = underscore(spec.name)
-            path = "/#{plural}/specifications/#{spec_snake}?id=#{id}"
+            path = "#{HecksTemplating::RouteContract.spec_path(plural, spec_snake)}?id=#{id}"
             results << check_get(path, "#{agg.name} spec #{spec.name}")
           end
         end
@@ -149,7 +149,7 @@ module HecksTemplating
             # GET form, parse action, POST with empty values
             uri = URI("#{@base}#{form_path}")
             html = Net::HTTP.get(uri) rescue ""
-            action = parse_form_action(html) || "/#{plural}/#{cmd_snake}/submit"
+            action = parse_form_action(html) || HecksTemplating::RouteContract.submit_path(plural, cmd_snake)
             post_uri = URI("#{@base}#{action}")
             res = Net::HTTP.post_form(post_uri, {})
             code = res.code.to_i

--- a/hecksties/spec/conventions/route_contract_spec.rb
+++ b/hecksties/spec/conventions/route_contract_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::RouteContract do
+  it { expect(described_class.form_path("pizzas", "create_pizza")).to eq("/pizzas/create_pizza/new") }
+  it { expect(described_class.submit_path("pizzas", "create_pizza")).to eq("/pizzas/create_pizza/submit") }
+  it { expect(described_class.index_path("pizzas")).to eq("/pizzas") }
+  it { expect(described_class.show_path("pizzas")).to eq("/pizzas/show") }
+  it { expect(described_class.query_path("pizzas", "by_name")).to eq("/pizzas/queries/by_name") }
+  it { expect(described_class.scope_path("pizzas", "active")).to eq("/pizzas/scopes/active") }
+  it { expect(described_class.spec_path("pizzas", "is_valid")).to eq("/pizzas/specifications/is_valid") }
+end


### PR DESCRIPTION
## Summary
HEC-256: RouteContract — formalize URL patterns across targets

Standardizes Ruby and Go on /plural/cmd/submit for POST (Go previously
used /plural/cmd). Removes smoke test fallback heuristic in favor of
RouteContract.submit_path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)