### PR TITLE
HEC-258: Go show page cross-aggregate buttons

### DIFF
--- a/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/server_generator/data_routes.rb
@@ -176,6 +176,19 @@ module GoHecks
             lines << "\t\tvar buttons []#{safe}Button"
           end
 
+          # Cross-aggregate command buttons
+          @domain.aggregates.each do |other|
+            next if other.name == agg.name
+            other_plural = GoUtils.snake_case(other.name) + "s"
+            other.commands.each do |cmd|
+              snake = GoUtils.snake_case(agg.name)
+              next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
+              cm = GoUtils.snake_case(cmd.name)
+              label = HecksTemplating::UILabelContract.label(cmd.name)
+              lines << "\t\tbuttons = append(buttons, #{safe}Button{Label: \"#{label}\", Href: \"/#{other_plural}/#{cm}/new?id=\" + obj.ID, Allowed: true})"
+            end
+          end
+
           lines << "\t\trenderer.Render(w, \"show\", \"#{safe}\", #{safe}ShowData{AggregateName: \"#{safe}\", BackHref: \"/#{plural}\", Id: obj.ID, Fields: fields, Buttons: buttons})"
           lines << "\t})"
           lines << ""

--- a/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
+++ b/hecks_targets/go/spec/generators/server_generator/data_routes_spec.rb
@@ -71,6 +71,38 @@ RSpec.describe GoHecks::ServerGenerator do
     end
   end
 
+  describe "cross-aggregate command buttons on show page" do
+    let(:domain) do
+      Hecks.domain("Shop") do
+        aggregate("Product", "A product") do
+          attribute :name, String
+          command("CreateProduct") { attribute :name, String }
+        end
+        aggregate("Review", "A review") do
+          attribute :body, String
+          attribute :product_id, String
+          command("CreateReview") { attribute :body, String; attribute :product_id, String }
+        end
+      end
+    end
+
+    let(:server) { GoHecks::ServerGenerator.new(domain, module_path: "shop") }
+    let(:output) { server.generate }
+
+    it "renders cross-aggregate button on Product show page for CreateReview" do
+      expect(output).to include('buttons = append(buttons, ProductButton{Label: "Create Review", Href: "/reviews/create_review/new?id=" + obj.ID, Allowed: true})')
+    end
+
+    it "does not render CreateReview as cross-aggregate on Review show page" do
+      # CreateReview belongs to Review aggregate — it's same-aggregate, not cross
+      lines = output.lines
+      review_show_start = lines.index { |l| l.include?('GET /reviews/show') }
+      review_show_end = lines[review_show_start..].index { |l| l.include?("})") }
+      review_show_block = lines[review_show_start..(review_show_start + review_show_end)].join
+      expect(review_show_block).not_to include("append(buttons, ReviewButton")
+    end
+  end
+
   describe "nav items" do
     it "does not include duplicate Home entry" do
       expect(output.scan('"Home"').size).to eq(0)


### PR DESCRIPTION
## Summary
HEC-258: Go show page renders cross-aggregate command buttons

Go show pages now render buttons for commands from other aggregates
that reference the current one via _id attributes, matching Ruby
target behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)