### PR TITLE
HEC-262: Event log browser

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -647,7 +647,7 @@
 ### Domain UI as an Extension
 - ERB templates for browsing aggregates, executing commands, viewing events
 - Templates shared between Ruby static and Go targets
-- Views: layout, home, index, show, form, config
+- Views: layout, home, index, show, form, events, config
 - Renderer class with layout wrapping and HTML escaping
 - Registers with runtime, auto-wires when loaded
 
@@ -656,6 +656,7 @@
 - Runtime CRUD operations (find, all, create, delete) isolated behind `RuntimeBridge`
 - No `Object.const_get`, `respond_to?`, or `instance_variable_get` in the UI layer
 - Same IR structs consumed by Ruby, Go, and Rails generators now also drive the Web Explorer
+- Events view (`/events`) lists all domain events from the IR, grouped by aggregate with attribute details
 
 ## Implicit DSL (HEC-229)
 

--- a/docs/usage/events_view.md
+++ b/docs/usage/events_view.md
@@ -1,0 +1,52 @@
+# Events View
+
+Browse all domain events defined in the Bluebook IR from the Web Explorer.
+
+## Access
+
+Navigate to `/events` in the Web Explorer sidebar (under **System**), or visit
+`http://localhost:9292/events` directly.
+
+## What it shows
+
+A table listing every domain event across all aggregates:
+
+| Column      | Description                                      |
+|-------------|--------------------------------------------------|
+| Event       | PascalCase event name (e.g. `CreatedPizza`)      |
+| Aggregate   | The aggregate that emits the event (linked)       |
+| Attributes  | Comma-separated attribute names carried by event  |
+
+## Example
+
+Given a pizza domain:
+
+```ruby
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+    command "RatePizza" do
+      attribute :pizza_id, String
+      attribute :stars, Integer
+    end
+  end
+end
+```
+
+The `/events` page displays:
+
+```
+Events (2)
+Event           Aggregate   Attributes
+CreatedPizza    Pizza       name
+RatedPizza      Pizza       pizza_id, stars
+```
+
+## Multi-domain
+
+When serving multiple domains, events from all domains appear in a single
+combined table. The aggregate link routes to the correct domain-scoped
+aggregate index.

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -1,6 +1,7 @@
 require_relative "ui_generator/form_routes"
 require_relative "ui_generator/config_routes"
 require_relative "ui_generator/show_route"
+require_relative "ui_generator/events_route"
 
 module HecksStatic
 # HecksStatic::UIGenerator
@@ -12,6 +13,7 @@ class UIGenerator < Hecks::Generator
   include FormRoutes
   include ConfigRoutes
   include ShowRoute
+  include EventsRoute
 
   def initialize(domain)
     @domain = domain
@@ -36,6 +38,7 @@ class UIGenerator < Hecks::Generator
     @domain.aggregates.each { |agg| lines.concat(index_route(agg, mod)) }
     @domain.aggregates.each { |agg| lines.concat(show_route(agg, mod)) }
     @domain.aggregates.each { |agg| lines.concat(new_routes(agg, mod)) }
+    lines.concat(events_route(mod))
     lines.concat(config_route(mod))
     lines.concat(reboot_route(mod))
     lines << "      end"
@@ -54,6 +57,7 @@ class UIGenerator < Hecks::Generator
     @domain.aggregates.each do |agg|
       items << { label: HecksTemplating::UILabelContract.plural_label(agg.name), href: "/#{plural(agg)}" }
     end
+    items << { label: "Events", href: "/events" }
     items << { label: "Config", href: "/config" }
     items
   end

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/events_route.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/events_route.rb
@@ -1,0 +1,39 @@
+# HecksStatic::UIGenerator::EventsRoute
+#
+# Generates the /events page route for the static UI server. Lists all
+# domain events from the Bluebook IR grouped by aggregate, showing each
+# event's name and attributes.
+#
+#   lines = events_route(mod)
+#   # => ["server.mount_proc \"/events\" do ...", ...]
+#
+module HecksStatic
+  class UIGenerator < Hecks::Generator
+    module EventsRoute
+      include HecksTemplating::NamingHelpers
+      private
+
+      def events_route(mod)
+        event_rows = @domain.aggregates.flat_map do |agg|
+          p = plural(agg)
+          agg.events.map do |evt|
+            attrs = evt.attributes.map(&:name).join(", ")
+            attrs = "(none)" if attrs.empty?
+            "{ name: \"#{evt.name}\", aggregate: \"#{agg.name}\", " \
+              "aggregate_href: \"/#{p}\", attributes: \"#{attrs}\" }"
+          end
+        end
+
+        [
+          "        server.mount_proc \"/events\" do |req, res|",
+          "          next unless req.request_method == \"GET\"",
+          "          html = renderer.render(:events, title: \"Events — #{mod}\", brand: brand, nav_items: nav,",
+          "            events: [#{event_rows.join(', ')}])",
+          "          res[\"Content-Type\"] = \"text/html\"; res.body = html",
+          "        end",
+          ""
+        ]
+      end
+    end
+  end
+end

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -84,6 +84,7 @@ module Hecks
             }
           end
         end
+        items << { label: "Events", href: "/events", group: "System" }
         items << { label: "Config", href: "/config", group: "System" }
         items
       end
@@ -95,6 +96,8 @@ module Hecks
         path = req.path
         if path == "/"
           serve_home(res)
+        elsif path == "/events"
+          serve_events(res)
         elsif path == "/config"
           serve_config(res)
         else
@@ -145,6 +148,26 @@ module Hecks
           title: "Config — #{@brand}", brand: @brand, nav_items: @nav,
           aggregates: summaries, policies: policies, roles: roles,
           current_role: "admin", adapter: "memory", events: [])
+        res["Content-Type"] = "text/html"
+        res.body = html
+      end
+
+      def serve_events(res)
+        events = @entries.flat_map do |e|
+          ir = e[:ir]
+          ir.domain.aggregates.flat_map do |agg|
+            p = plural(agg)
+            agg.events.map do |evt|
+              attrs = evt.attributes.map(&:name).join(", ")
+              { name: evt.name, aggregate: agg.name,
+                aggregate_href: "/#{e[:slug]}/#{p}",
+                attributes: attrs.empty? ? "(none)" : attrs }
+            end
+          end
+        end
+        html = @renderer.render(:events,
+          title: "Events — #{@brand}", brand: @brand, nav_items: @nav,
+          events: events)
         res["Content-Type"] = "text/html"
         res.body = html
       end

--- a/hecks_workshop/explorer/lib/hecks_explorer/views/events.erb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/views/events.erb
@@ -1,0 +1,23 @@
+<h1>Events (<%= events.size %>)</h1>
+<% if events.empty? %>
+  <p style="color:#666">No domain events defined.</p>
+<% else %>
+  <table>
+    <thead>
+      <tr>
+        <th>Event</th>
+        <th>Aggregate</th>
+        <th>Attributes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% events.each do |evt| %>
+        <tr>
+          <td class="mono"><%= h(evt[:name]) %></td>
+          <td><a href="<%= evt[:aggregate_href] %>"><%= h(evt[:aggregate]) %></a></td>
+          <td class="mono"><%= h(evt[:attributes]) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -102,6 +102,15 @@ module Hecks
         HecksTemplating::DisplayContract.available_roles(@domain)
       end
 
+      def domain_events
+        @domain.aggregates.flat_map do |agg|
+          agg.events.map do |evt|
+            attrs = evt.attributes.map(&:name).join(", ")
+            { name: evt.name, aggregate: agg.name, attributes: attrs.empty? ? "(none)" : attrs }
+          end
+        end
+      end
+
       private
 
       def humanize(name)

--- a/hecksties/lib/hecks/extensions/web_explorer/views/events.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/events.erb
@@ -1,0 +1,23 @@
+<h1>Events (<%= events.size %>)</h1>
+<% if events.empty? %>
+  <p style="color:#666">No domain events defined.</p>
+<% else %>
+  <table>
+    <thead>
+      <tr>
+        <th>Event</th>
+        <th>Aggregate</th>
+        <th>Attributes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% events.each do |evt| %>
+        <tr>
+          <td class="mono"><%= h(evt[:name]) %></td>
+          <td><a href="<%= evt[:aggregate_href] %>"><%= h(evt[:aggregate]) %></a></td>
+          <td class="mono"><%= h(evt[:attributes]) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>


### PR DESCRIPTION
## Summary
HEC-262: Add events view to Web Explorer

Add /events page that lists all domain events from the Bluebook IR,
showing event name, originating aggregate, and carried attributes.
Includes events.erb template, route handler, navigation entry, and
static UI generator support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)