### PR TITLE
HEC-441: Persistence metadata

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -55,6 +55,7 @@
 - Define specifications as reusable composable predicates (`satisfied_by?`, `and`, `or`, `not`)
 - Define per-attribute validations (presence, uniqueness, length, format, custom)
 - Define indexes on aggregates with `index :field` and `index :field, unique: true`
+- `PersistenceMetadata` struct groups indexes and identity fields — accessible via `aggregate.persistence_metadata`
 - Define aggregate-level and value-object-level invariants as block constraints
 
 ### Domain Services

--- a/bluebook/lib/hecks/domain_model/structure.rb
+++ b/bluebook/lib/hecks/domain_model/structure.rb
@@ -56,7 +56,8 @@ module Hecks
       autoload :Lifecycle,        "hecks/domain_model/structure/lifecycle"
       autoload :StateTransition, "hecks/domain_model/structure/state_transition"
       autoload :Reference,         "hecks/domain_model/structure/reference"
-      autoload :ComputedAttribute, "hecks/domain_model/structure/computed_attribute"
+      autoload :ComputedAttribute,    "hecks/domain_model/structure/computed_attribute"
+      autoload :PersistenceMetadata, "hecks/domain_model/structure/persistence_metadata"
     end
   end
 end

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -60,8 +60,8 @@ module Hecks
       # @return [Array] event subscribers registered for this aggregate's events
       attr_reader :subscribers
 
-      # @return [Array] database index definitions for this aggregate's persisted fields
-      attr_reader :indexes
+      # @return [PersistenceMetadata] persistence-specific metadata (indexes, identity fields)
+      attr_reader :persistence_metadata
 
       # @return [Array] specification objects for complex query/filter logic
       attr_reader :specifications
@@ -78,8 +78,17 @@ module Hecks
       # @return [Lifecycle, nil] optional state machine definition
       attr_reader :lifecycle
 
+      # Delegates to persistence_metadata for backward compatibility.
+      # @return [Array] database index definitions
+      def indexes
+        persistence_metadata.indexes
+      end
+
+      # Delegates to persistence_metadata for backward compatibility.
       # @return [Array<Symbol>, nil] natural key fields for secondary identity lookup
-      attr_reader :identity_fields
+      def identity_fields
+        persistence_metadata.identity_fields
+      end
 
       # Creates a new Aggregate IR node.
       #
@@ -96,7 +105,8 @@ module Hecks
       # @param ports [Hash{Symbol => GateDefinition}] access-control port definitions
       # @param queries [Array<Behavior::Query>] named queries
       # @param subscribers [Array] event subscriber registrations
-      # @param indexes [Array] database index definitions
+      # @param persistence_metadata [PersistenceMetadata] persistence config (indexes, identity)
+      # @param indexes [Array] deprecated — pass via persistence_metadata instead
       # @param specifications [Array] specification objects for complex filtering
       # @param lifecycle [Lifecycle, nil] optional state machine definition
       # @param versioned [Boolean] whether this aggregate tracks version history
@@ -110,7 +120,7 @@ module Hecks
                      factories: [], computed_attributes: [],
                      lifecycle: nil, versioned: false,
                      attachable: false, metadata: {}, origin_domain: nil,
-                     identity_fields: nil)
+                     identity_fields: nil, persistence_metadata: nil)
         @name = Names.aggregate_name(name)
         @attributes = attributes
         @value_objects = value_objects
@@ -123,7 +133,10 @@ module Hecks
         @scopes = scopes
         @queries = queries
         @subscribers = subscribers
-        @indexes = indexes
+        @persistence_metadata = persistence_metadata || PersistenceMetadata.new(
+          indexes: indexes,
+          identity_fields: identity_fields
+        )
         @specifications = specifications
         @references = references
         @factories = factories
@@ -133,7 +146,6 @@ module Hecks
         @attachable = attachable
         @metadata = metadata
         @origin_domain = origin_domain
-        @identity_fields = identity_fields
       end
 
       attr_reader :metadata, :origin_domain

--- a/bluebook/lib/hecks/domain_model/structure/persistence_metadata.rb
+++ b/bluebook/lib/hecks/domain_model/structure/persistence_metadata.rb
@@ -1,0 +1,42 @@
+module Hecks
+  module DomainModel
+    module Structure
+
+    # Hecks::DomainModel::Structure::PersistenceMetadata
+    #
+    # Holds persistence-specific concerns for an aggregate: database indexes,
+    # identity fields (natural keys), and future storage hints. Separates
+    # persistence details from the core Aggregate IR so generators and the
+    # migration system have a single place to look for storage configuration.
+    #
+    # Built by AggregateBuilder and attached to the Aggregate via
+    # +aggregate.persistence_metadata+.
+    #
+    #   meta = PersistenceMetadata.new(
+    #     indexes: [{ fields: [:email], unique: true }],
+    #     identity_fields: [:team, :start_date]
+    #   )
+    #   meta.indexes          # => [{ fields: [:email], unique: true }]
+    #   meta.identity_fields  # => [:team, :start_date]
+    #
+    class PersistenceMetadata
+      # @return [Array<Hash>] database index definitions with :fields and :unique keys
+      attr_reader :indexes
+
+      # @return [Array<Symbol>, nil] natural key fields for secondary identity lookup
+      attr_reader :identity_fields
+
+      # Creates a new PersistenceMetadata.
+      #
+      # @param indexes [Array<Hash>] index definitions, each with :fields (Array<Symbol>)
+      #   and :unique (Boolean)
+      # @param identity_fields [Array<Symbol>, nil] natural key fields
+      # @return [PersistenceMetadata]
+      def initialize(indexes: [], identity_fields: nil)
+        @indexes = indexes
+        @identity_fields = identity_fields
+      end
+    end
+    end
+  end
+end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -197,11 +197,14 @@ module Hecks
           commands: @commands, events: events, policies: @policies,
           validations: @validations, invariants: @invariants,
           scopes: @scopes, queries: @queries,
-          subscribers: @subscribers, indexes: @indexes,
+          subscribers: @subscribers,
+          persistence_metadata: Structure::PersistenceMetadata.new(
+            indexes: @indexes, identity_fields: @identity_fields
+          ),
           specifications: @specifications, computed_attributes: @computed_attributes,
           lifecycle: @lifecycle, versioned: @versioned, attachable: @attachable,
           metadata: @metadata, references: @references,
-          factories: @factories, identity_fields: @identity_fields
+          factories: @factories
         )
       end
 

--- a/bluebook/spec/domain_model/persistence_metadata_spec.rb
+++ b/bluebook/spec/domain_model/persistence_metadata_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+RSpec.describe Hecks::DomainModel::Structure::PersistenceMetadata do
+  describe "defaults" do
+    subject(:meta) { described_class.new }
+
+    it "has empty indexes" do
+      expect(meta.indexes).to eq([])
+    end
+
+    it "has nil identity_fields" do
+      expect(meta.identity_fields).to be_nil
+    end
+  end
+
+  describe "with values" do
+    subject(:meta) do
+      described_class.new(
+        indexes: [{ fields: [:email], unique: true }],
+        identity_fields: [:team, :start_date]
+      )
+    end
+
+    it "stores indexes" do
+      expect(meta.indexes).to eq([{ fields: [:email], unique: true }])
+    end
+
+    it "stores identity_fields" do
+      expect(meta.identity_fields).to eq([:team, :start_date])
+    end
+  end
+
+  describe "Aggregate integration" do
+    it "delegates indexes to persistence_metadata" do
+      meta = described_class.new(indexes: [{ fields: [:name], unique: false }])
+      agg = Hecks::DomainModel::Structure::Aggregate.new(
+        name: "Pizza", persistence_metadata: meta
+      )
+
+      expect(agg.indexes).to eq([{ fields: [:name], unique: false }])
+      expect(agg.persistence_metadata).to equal(meta)
+    end
+
+    it "delegates identity_fields to persistence_metadata" do
+      meta = described_class.new(identity_fields: [:slug])
+      agg = Hecks::DomainModel::Structure::Aggregate.new(
+        name: "Pizza", persistence_metadata: meta
+      )
+
+      expect(agg.identity_fields).to eq([:slug])
+    end
+
+    it "builds persistence_metadata from legacy kwargs" do
+      agg = Hecks::DomainModel::Structure::Aggregate.new(
+        name: "Pizza",
+        indexes: [{ fields: [:name], unique: false }],
+        identity_fields: [:name]
+      )
+
+      expect(agg.persistence_metadata).to be_a(described_class)
+      expect(agg.indexes).to eq([{ fields: [:name], unique: false }])
+      expect(agg.identity_fields).to eq([:name])
+    end
+  end
+
+  describe "DSL integration" do
+    it "populates persistence_metadata from DSL index declarations" do
+      domain = Hecks.domain "PMetaTest" do
+        aggregate "User" do
+          attribute :email, String
+          index :email, unique: true
+          identity :email
+          command "CreateUser" do
+            attribute :email, String
+          end
+        end
+      end
+
+      user = domain.aggregates.first
+      expect(user.persistence_metadata).to be_a(described_class)
+      expect(user.indexes).to eq([{ fields: [:email], unique: true }])
+      expect(user.identity_fields).to eq([:email])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: extract indexes and identity_fields into PersistenceMetadata struct

Move persistence-specific fields (indexes, identity_fields) from
Aggregate into a dedicated PersistenceMetadata value object. Aggregate
delegates #indexes and #identity_fields for backward compatibility, and
the constructor still accepts legacy kwargs that auto-build the struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)