### PR TITLE
HEC-444: World goals core

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -78,6 +78,13 @@
 ### Ubiquitous Language
 - `glossary { prefer "customer", not: ["user", "client"] }` — warn when banned terms appear in names across aggregates, commands, and events
 
+### World Goals
+- `world_goals :transparency, :consent, :privacy, :security` — opt-in ethical validation rules
+- `:transparency` — commands must emit events (no silent mutations)
+- `:consent` — user-like aggregate commands must declare actors
+- `:privacy` — PII attributes must be `visible: false`; PII aggregate commands need actors
+- `:security` — command actors must be declared at domain level
+
 ### Access Control & Ports
 - Define access-control ports that whitelist allowed methods per consumer
 - Import domains from event storm formats (Markdown and YAML)

--- a/bluebook/lib/hecks/domain/validator.rb
+++ b/bluebook/lib/hecks/domain/validator.rb
@@ -26,7 +26,7 @@ module Hecks
   class Validator
     # Trigger autoloading of all validation rule modules so each rule
     # registers itself with Hecks.register_validation_rule.
-    [ValidationRules::Naming, ValidationRules::References, ValidationRules::Structure].each do |mod|
+    [ValidationRules::Naming, ValidationRules::References, ValidationRules::Structure, ValidationRules::WorldGoals].each do |mod|
       mod.constants.each { |c| mod.const_get(c) }
     end
 

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -67,6 +67,10 @@ module Hecks
       # @return [Array<Hash>] logical module groupings within this domain
       attr_reader :modules
 
+      # @return [Array<Symbol>] declared world goals for this domain
+      #   (e.g. :transparency, :consent, :privacy, :security)
+      attr_reader :world_goals
+
       # @return [Array] event subscriber registrations at the domain level
       attr_reader :event_subscribers
 
@@ -98,7 +102,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil)
+                     version: nil, world_goals: [])
         validate_version!(version)
         @name = name
         @version = version
@@ -115,6 +119,7 @@ module Hecks
         @custom_verbs = custom_verbs
         @tenancy = tenancy
         @event_subscribers = event_subscribers
+        @world_goals = world_goals.map(&:to_sym)
       end
 
       # Returns the sanitized Ruby constant name for this domain.

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -65,6 +65,19 @@ module Hecks
         @modules = []
         @tenancy = nil
         @event_subscribers = []
+        @world_goals = []
+      end
+
+      # Declare world goals that this domain aspires to uphold.
+      # Goals activate corresponding validation rules that check domain design
+      # for alignment. Available goals: :transparency, :consent, :privacy, :security.
+      #
+      #   world_goals :transparency, :consent, :privacy
+      #
+      # @param goals [Array<Symbol>] one or more goal names
+      # @return [void]
+      def world_goals(*goals)
+        @world_goals.concat(goals.map(&:to_sym))
       end
 
       def actor(name, description: nil)
@@ -263,7 +276,8 @@ module Hecks
           actors: @actors, tenancy: @tenancy,
           event_subscribers: @event_subscribers,
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
-          glossary_strict: @glossary_strict || false
+          glossary_strict: @glossary_strict || false,
+          world_goals: @world_goals
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/validation_rules/world_goals.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals.rb
@@ -1,0 +1,24 @@
+module Hecks
+  module ValidationRules
+
+    # Hecks::ValidationRules::WorldGoals
+    #
+    # Validation rules activated by the +world_goals+ DSL keyword. Each rule
+    # checks a specific ethical or governance concern (transparency, consent,
+    # privacy, security) and only fires when its goal is declared on the domain.
+    #
+    # Rules are autoloaded and self-register via +Hecks.register_validation_rule+.
+    #
+    #   Hecks.domain "Health" do
+    #     world_goals :transparency, :consent, :privacy, :security
+    #     # ... aggregates ...
+    #   end
+    #
+    module WorldGoals
+      autoload :Transparency, "hecks/validation_rules/world_goals/transparency"
+      autoload :Consent,      "hecks/validation_rules/world_goals/consent"
+      autoload :Privacy,      "hecks/validation_rules/world_goals/privacy"
+      autoload :Security,     "hecks/validation_rules/world_goals/security"
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/consent.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/consent.rb
@@ -1,0 +1,55 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Consent
+      #
+      # When the :consent goal is declared, commands on user-like aggregates
+      # must declare at least one actor. User-like aggregates are identified
+      # by name heuristic: User, Account, Member, Customer, Patient, Person,
+      # Profile.
+      #
+      # Without an actor declaration, there is no record of who initiated the
+      # action -- consent cannot be verified.
+      #
+      #   world_goals :consent
+      #
+      #   aggregate "Patient" do
+      #     command "UpdateRecord" do
+      #       attribute :notes, String
+      #       actor "Doctor"          # <-- required by consent rule
+      #     end
+      #   end
+      #
+      class Consent < BaseRule
+        USER_PATTERNS = %w[
+          User Account Member Customer Patient Person Profile
+        ].freeze
+
+        def errors
+          return [] unless @domain.world_goals.include?(:consent)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            next unless user_like?(agg.name)
+
+            agg.commands.each do |cmd|
+              if cmd.actors.empty?
+                issues << "Consent: #{agg.name}##{cmd.name} has no actor. " \
+                          "Commands on user-like aggregates must declare who initiates them."
+              end
+            end
+          end
+          issues
+        end
+
+        private
+
+        def user_like?(name)
+          USER_PATTERNS.any? { |pat| name.include?(pat) }
+        end
+      end
+      Hecks.register_validation_rule(Consent)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/privacy.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/privacy.rb
@@ -1,0 +1,56 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Privacy
+      #
+      # When the :privacy goal is declared, PII attributes must be marked
+      # +visible: false+ so they are hidden from generated UIs and explorers.
+      # Additionally, commands on aggregates containing PII must declare an
+      # actor so there is an audit trail of who accessed or modified PII.
+      #
+      #   world_goals :privacy
+      #
+      #   aggregate "Patient" do
+      #     attribute :ssn, String, pii: true, visible: false  # good
+      #     attribute :email, String, pii: true                 # violation: visible PII
+      #   end
+      #
+      class Privacy < BaseRule
+        def errors
+          return [] unless @domain.world_goals.include?(:privacy)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            check_visible_pii(agg, issues)
+            check_pii_commands_need_actor(agg, issues)
+          end
+          issues
+        end
+
+        private
+
+        def check_visible_pii(agg, issues)
+          agg.attributes.each do |attr|
+            if attr.pii? && attr.visible?
+              issues << "Privacy: #{agg.name}##{attr.name} is PII but visible. " \
+                        "Mark PII attributes visible: false."
+            end
+          end
+        end
+
+        def check_pii_commands_need_actor(agg, issues)
+          return unless agg.attributes.any?(&:pii?)
+
+          agg.commands.each do |cmd|
+            if cmd.actors.empty?
+              issues << "Privacy: #{agg.name}##{cmd.name} touches PII aggregate " \
+                        "but has no actor. Declare who can access PII."
+            end
+          end
+        end
+      end
+      Hecks.register_validation_rule(Privacy)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/security.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/security.rb
@@ -1,0 +1,47 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Security
+      #
+      # When the :security goal is declared, commands that declare actors must
+      # reference actors that are also declared at the domain level. This ensures
+      # that every role used in access control is a recognized part of the domain
+      # model -- no dangling or misspelled actor references.
+      #
+      #   world_goals :security
+      #
+      #   actor "Admin"
+      #
+      #   aggregate "Config" do
+      #     command "UpdateConfig" do
+      #       actor "Admin"       # good -- declared at domain level
+      #       actor "SuperAdmin"  # violation -- not a domain actor
+      #     end
+      #   end
+      #
+      class Security < BaseRule
+        def errors
+          return [] unless @domain.world_goals.include?(:security)
+
+          domain_actor_names = @domain.actors.map { |a| a.is_a?(Hash) ? a[:name] : a.name }
+          issues = []
+
+          @domain.aggregates.each do |agg|
+            agg.commands.each do |cmd|
+              cmd.actors.each do |actor|
+                actor_name = actor.respond_to?(:name) ? actor.name : actor.to_s
+                unless domain_actor_names.include?(actor_name)
+                  issues << "Security: #{agg.name}##{cmd.name} declares actor '#{actor_name}' " \
+                            "which is not a domain-level actor. Add: actor '#{actor_name}'"
+                end
+              end
+            end
+          end
+          issues
+        end
+      end
+      Hecks.register_validation_rule(Security)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/transparency.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/transparency.rb
@@ -1,0 +1,38 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Transparency
+      #
+      # When the :transparency goal is declared, every command must emit at least
+      # one domain event. Silent mutations violate transparency because observers
+      # and audit logs have no way to know a change occurred.
+      #
+      #   world_goals :transparency
+      #
+      #   # violation: a command with no events
+      #   command "DeleteRecord" do
+      #     attribute :id, String
+      #     emits []          # <-- transparency rule flags this
+      #   end
+      #
+      class Transparency < BaseRule
+        def errors
+          return [] unless @domain.world_goals.include?(:transparency)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            agg.commands.each do |cmd|
+              if cmd.emits.is_a?(Array) && cmd.emits.empty?
+                issues << "Transparency: #{agg.name}##{cmd.name} emits no events. " \
+                          "Commands must emit events so changes are observable."
+              end
+            end
+          end
+          issues
+        end
+      end
+      Hecks.register_validation_rule(Transparency)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/world_goals/world_goals_spec.rb
+++ b/bluebook/spec/validation_rules/world_goals/world_goals_spec.rb
@@ -1,0 +1,179 @@
+require "spec_helper"
+
+RSpec.describe "World Goals validation rules" do
+  def validate(domain)
+    validator = Hecks::Validator.new(domain)
+    [validator.valid?, validator.errors]
+  end
+
+  describe "no goals declared" do
+    it "passes with no world goals" do
+      domain = Hecks.domain "Clean" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      valid, _errors = validate(domain)
+      expect(valid).to be true
+    end
+  end
+
+  describe ":transparency" do
+    it "flags commands that emit no events" do
+      domain = Hecks.domain "Opaque" do
+        world_goals :transparency
+        aggregate "Record" do
+          attribute :name, String
+          command "DeleteRecord" do
+            attribute :id, String
+            emits []
+          end
+        end
+      end
+
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors).to include(/Transparency.*DeleteRecord.*emits no events/)
+    end
+
+    it "passes when commands emit events normally" do
+      domain = Hecks.domain "Transparent" do
+        world_goals :transparency
+        aggregate "Record" do
+          attribute :name, String
+          command "CreateRecord" do
+            attribute :name, String
+          end
+        end
+      end
+
+      valid, _errors = validate(domain)
+      expect(valid).to be true
+    end
+  end
+
+  describe ":consent" do
+    it "flags user-like aggregates with actor-less commands" do
+      domain = Hecks.domain "NoConsent" do
+        world_goals :consent
+        aggregate "Patient" do
+          attribute :name, String
+          command "UpdatePatient" do
+            attribute :name, String
+          end
+        end
+      end
+
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors).to include(/Consent.*Patient#UpdatePatient.*no actor/)
+    end
+
+    it "passes when user-like aggregate commands have actors" do
+      domain = Hecks.domain "WithConsent" do
+        world_goals :consent
+        aggregate "Patient" do
+          attribute :name, String
+          command "UpdatePatient" do
+            attribute :name, String
+            actor "Doctor"
+          end
+        end
+      end
+
+      valid, _errors = validate(domain)
+      expect(valid).to be true
+    end
+  end
+
+  describe ":privacy" do
+    it "flags PII attributes that are visible" do
+      domain = Hecks.domain "LeakyPII" do
+        world_goals :privacy
+        aggregate "Patient" do
+          attribute :ssn, String, pii: true
+          command "CreatePatient" do
+            attribute :ssn, String
+            actor "Admin"
+          end
+        end
+      end
+
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors).to include(/Privacy.*Patient#ssn.*PII but visible/)
+    end
+
+    it "flags PII aggregate commands without actors" do
+      domain = Hecks.domain "NoAudit" do
+        world_goals :privacy
+        aggregate "Patient" do
+          attribute :ssn, String, pii: true, visible: false
+          command "CreatePatient" do
+            attribute :ssn, String
+          end
+        end
+      end
+
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors).to include(/Privacy.*CreatePatient.*touches PII.*no actor/)
+    end
+
+    it "passes when PII is hidden and commands have actors" do
+      domain = Hecks.domain "Secure" do
+        world_goals :privacy
+        aggregate "Patient" do
+          attribute :ssn, String, pii: true, visible: false
+          command "CreatePatient" do
+            attribute :ssn, String
+            actor "Admin"
+          end
+        end
+      end
+
+      valid, _errors = validate(domain)
+      expect(valid).to be true
+    end
+  end
+
+  describe ":security" do
+    it "flags command actors not declared at domain level" do
+      domain = Hecks.domain "Dangling" do
+        world_goals :security
+        aggregate "Config" do
+          attribute :key, String
+          command "UpdateConfig" do
+            attribute :key, String
+            actor "Ghost"
+          end
+        end
+      end
+
+      valid, errors = validate(domain)
+      expect(valid).to be false
+      expect(errors).to include(/Security.*UpdateConfig.*'Ghost'.*not a domain-level actor/)
+    end
+
+    it "passes when command actors match domain actors" do
+      domain = Hecks.domain "Locked" do
+        world_goals :security
+        actor "Admin"
+        aggregate "Config" do
+          attribute :key, String
+          command "UpdateConfig" do
+            attribute :key, String
+            actor "Admin"
+          end
+        end
+      end
+
+      valid, _errors = validate(domain)
+      expect(valid).to be true
+    end
+  end
+end

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -90,6 +90,9 @@ Hecks.domain "Banking" do
   actor "Customer"
   actor "Admin", description: "System administrator"
 
+  # World goals (opt-in ethical validation)
+  world_goals :transparency, :consent, :privacy, :security
+
   # Multi-tenancy
   tenancy :row
 

--- a/docs/usage/world_goals.md
+++ b/docs/usage/world_goals.md
@@ -1,0 +1,70 @@
+# World Goals
+
+Declare ethical and governance aspirations for your domain. Each goal activates
+validation rules that check your model for alignment.
+
+## DSL
+
+```ruby
+Hecks.domain "Healthcare" do
+  world_goals :transparency, :consent, :privacy, :security
+
+  actor "Doctor"
+  actor "Admin"
+
+  aggregate "Patient" do
+    attribute :name, String
+    attribute :ssn, String, pii: true, visible: false
+
+    command "CreatePatient" do
+      attribute :name, String
+      attribute :ssn, String
+      actor "Admin"
+    end
+
+    command "UpdateRecord" do
+      attribute :notes, String
+      actor "Doctor"
+    end
+  end
+end
+```
+
+## Available Goals
+
+### `:transparency`
+
+Every command must emit at least one domain event. Silent mutations violate
+transparency because observers and audit logs cannot track changes.
+
+**Violation:** `emits []` on a command.
+
+### `:consent`
+
+Commands on user-like aggregates (User, Account, Member, Customer, Patient,
+Person, Profile) must declare at least one `actor`. Without an actor, there is
+no record of who initiated the action.
+
+### `:privacy`
+
+PII attributes (marked `pii: true`) must also be `visible: false` so they are
+hidden from generated UIs. Commands on aggregates that contain PII must declare
+an actor for audit trails.
+
+### `:security`
+
+Command-level actors must be declared at the domain level with `actor "Name"`.
+This prevents dangling or misspelled role references.
+
+## Example Validation Output
+
+```
+Privacy: Patient#ssn is PII but visible. Mark PII attributes visible: false.
+Consent: Patient#UpdateRecord has no actor. Commands on user-like aggregates must declare who initiates them.
+Security: Config#UpdateConfig declares actor 'Ghost' which is not a domain-level actor. Add: actor 'Ghost'
+Transparency: Record#DeleteRecord emits no events. Commands must emit events so changes are observable.
+```
+
+## No Goals, No Rules
+
+If you do not declare `world_goals`, none of these rules fire. They are opt-in.

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -63,6 +63,7 @@ module Hecks
     autoload :Naming,      "hecks/validation_rules/naming"
     autoload :References,  "hecks/validation_rules/references"
     autoload :Structure,   "hecks/validation_rules/structure"
+    autoload :WorldGoals,  "hecks/validation_rules/world_goals"
   end
 
   # = Hecks::DomainModel


### PR DESCRIPTION
## Summary
HEC-444: Add world_goals DSL keyword with transparency, consent, privacy, security validators

Opt-in ethical validation rules activated by declaring world_goals on a domain.
Each goal checks a specific governance concern and only fires when declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)