### PR TITLE
HEC-452: Domain extractor for Ruby

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -359,17 +359,22 @@
 - Generated examples exclude this module — always use current API
 - `HecksDeprecations.registered` — introspect all registered deprecations
 
-### Rails Import (Reverse Engineering)
+### Domain Extraction (Reverse Engineering)
 - `hecks import rails /path/to/app` — extract domain from existing Rails app
 - `hecks import schema /path/to/schema.rb` — schema-only import
 - `hecks extract /path/to/project` — auto-detect project type and extract domain
 - Model-only extraction: works without schema.rb using belongs_to/has_many/validations/enums/AASM
-- `Hecks::Import.from_directory(path)` — programmatic auto-detecting extraction
+- Ruby project extraction: works on any Ruby codebase — POROs, Structs, Data.define classes
+- `Hecks::Import.from_directory(path)` — programmatic auto-detecting extraction (Rails, Rails models-only, or plain Ruby)
+- `Hecks::Import.from_ruby(path)` — programmatic Ruby project extraction
 - `Hecks::Import.from_models(models_dir)` — programmatic model-only extraction
+- RubyParser: regex-based scanning (no require, no eval) of attr_accessor, attr_reader, Struct.new, Data.define
+- Module nesting → aggregate grouping; nested classes → value objects
 - Parses db/schema.rb: tables → aggregates, columns → typed attributes, foreign keys → references
 - Parses app/models: validates → validations, enum → enum constraints, AASM → lifecycles
 - Auto-generates Create commands for each aggregate
 - Skips Rails internal tables (schema_migrations, active_storage_*, etc.)
+- Project type auto-detection: shows "Rails (schema.rb + models)", "Rails (models only)", or "Ruby project"
 - Preview mode with `--preview` flag
 
 ## CLI Commands

--- a/docs/usage/extract.md
+++ b/docs/usage/extract.md
@@ -17,10 +17,11 @@ hecks extract /path/to/app --output MyDomain --name Blog
 
 ## How It Works
 
-The extractor checks the given directory for `db/schema.rb`:
+The extractor checks the given directory and auto-detects the project type:
 
-- **With schema.rb**: Uses the full Rails import pipeline (SchemaParser + ModelParser + DomainAssembler). Column types, foreign keys, validations, enums, and state machines are all captured.
-- **Without schema.rb**: Falls back to model-only extraction (ModelParser + ModelOnlyAssembler). Derives structure from `belongs_to`, `has_many`, validations, enums, and AASM state machines.
+- **Rails with schema.rb**: Uses the full Rails import pipeline (SchemaParser + ModelParser + DomainAssembler). Column types, foreign keys, validations, enums, and state machines are all captured.
+- **Rails models only (no schema.rb)**: Falls back to model-only extraction (ModelParser + ModelOnlyAssembler). Derives structure from `belongs_to`, `has_many`, validations, enums, and AASM state machines.
+- **Any Ruby project**: Uses RubyParser to scan `*.rb` files and extract classes, Structs, Data.define classes, module nesting, and attr_accessor/attr_reader declarations. No Rails dependency required.
 
 ## Options
 
@@ -85,11 +86,46 @@ Hecks.domain "Ordering" do
 end
 ```
 
+### Any Ruby project (POROs, Structs, Data classes)
+
+```bash
+$ hecks extract ~/Projects/billing-lib --preview --name Billing
+
+Detected: Ruby project
+
+Hecks.domain "Billing" do
+  aggregate "Billing" do
+    attribute :total, String
+    attribute :currency, String
+
+    value_object "LineItem" do
+      attribute :description, String
+      attribute :price, String
+    end
+
+    command "CreateBilling" do
+      attribute :total, String
+      attribute :currency, String
+    end
+  end
+end
+```
+
+Supports:
+- Plain classes with `attr_accessor` / `attr_reader`
+- `Struct.new(:x, :y)` subclasses
+- `Data.define(:x, :y)` subclasses
+- Module nesting (grouped into aggregates)
+- Nested classes (become value objects)
+
 ## Programmatic API
 
 ```ruby
 # Auto-detect project type
 dsl = Hecks::Import.from_directory("/path/to/app", domain_name: "Blog")
+
+# Ruby project extraction (any Ruby, not just Rails)
+dsl = Hecks::Import.from_ruby("/path/to/lib", domain_name: "Billing")
 
 # Model-only extraction
 dsl = Hecks::Import.from_models("/path/to/models", domain_name: "Blog")

--- a/hecksties/lib/hecks_cli/commands/extract.rb
+++ b/hecksties/lib/hecks_cli/commands/extract.rb
@@ -2,11 +2,12 @@ require_relative "../import"
 
 # Hecks CLI — extract command
 #
-# Auto-detects a project's type (Rails with schema, or models-only)
-# and generates a Hecks domain DSL file from the source.
+# Auto-detects a project's type and generates a Hecks domain DSL file.
+# Supports Rails apps (schema.rb), Rails models-only, and any Ruby
+# project (POROs, Structs, Data.define classes).
 #
 #   hecks extract /path/to/rails/app
-#   hecks extract /path/to/app --preview --name Blog
+#   hecks extract /path/to/ruby/gem --preview --name Billing
 #
 Hecks::CLI.register_command(:extract, "Extract a domain from an existing project",
   args: %w[PATH],
@@ -26,6 +27,16 @@ Hecks::CLI.register_command(:extract, "Extract a domain from an existing project
     puts "Error: #{path} is not a directory"
     next
   end
+
+  project_type = if Hecks::Import.rails_project?(path)
+                   "Rails (schema.rb + models)"
+                 elsif Hecks::Import.rails_models?(path)
+                   "Rails (models only)"
+                 else
+                   "Ruby project"
+                 end
+  puts "Detected: #{project_type}"
+  puts ""
 
   dsl = Hecks::Import.from_directory(path, domain_name: options[:name])
   puts dsl

--- a/hecksties/lib/hecks_cli/import.rb
+++ b/hecksties/lib/hecks_cli/import.rb
@@ -2,22 +2,25 @@ require_relative "import/schema_parser"
 require_relative "import/model_parser"
 require_relative "import/domain_assembler"
 require_relative "import/model_only_assembler"
+require_relative "import/ruby_parser"
+require_relative "import/ruby_assembler"
 
 module Hecks
   # Hecks::Import
   #
-  # Reverse-engineers a Rails application into a Hecks domain definition.
-  # Parses db/schema.rb for structure and app/models/*.rb for behavior
-  # (validations, enums, state machines). Outputs valid Hecks DSL.
+  # Reverse-engineers existing projects into Hecks domain definitions.
+  # Supports Rails apps (via schema.rb + models), Rails model-only
+  # projects, and any plain Ruby project (POROs, Structs, Data classes).
   #
   #   Hecks::Import.from_rails("/path/to/rails/app")
-  #   # => "Hecks.domain \"Blog\" do\n  aggregate \"Post\" do\n    ..."
+  #   Hecks::Import.from_ruby("/path/to/ruby/lib")
+  #   Hecks::Import.from_directory("/path/to/project")  # auto-detects
   #
   module Import
     def self.from_rails(app_path, domain_name: nil)
       schema_path = File.join(app_path, "db", "schema.rb")
       models_dir  = File.join(app_path, "app", "models")
-      domain_name ||= Hecks::Utils.sanitize_constant(File.basename(File.expand_path(app_path)))
+      domain_name ||= infer_domain_name(app_path)
 
       schema_data = SchemaParser.new(schema_path).parse
       model_data  = File.directory?(models_dir) ? ModelParser.new(models_dir).parse : {}
@@ -29,21 +32,38 @@ module Hecks
       DomainAssembler.new(schema_data, {}, domain_name: domain_name).assemble
     end
 
-    def self.from_directory(path, domain_name: nil)
-      schema_path = File.join(path, "db", "schema.rb")
-      domain_name ||= Hecks::Utils.sanitize_constant(File.basename(File.expand_path(path)))
+    def self.from_ruby(path, domain_name: nil)
+      domain_name ||= infer_domain_name(path)
+      parsed = RubyParser.new(path).parse
+      RubyAssembler.new(parsed, domain_name: domain_name).assemble
+    end
 
-      if File.exist?(schema_path)
+    def self.from_directory(path, domain_name: nil)
+      domain_name ||= infer_domain_name(path)
+
+      if rails_project?(path)
         from_rails(path, domain_name: domain_name)
-      else
+      elsif rails_models?(path)
         models_dir = detect_models_dir(path)
         from_models(models_dir, domain_name: domain_name)
+      else
+        ruby_dir = detect_ruby_dir(path)
+        from_ruby(ruby_dir, domain_name: domain_name)
       end
     end
 
     def self.from_models(models_dir, domain_name: "MyDomain")
       model_data = ModelParser.new(models_dir).parse
       ModelOnlyAssembler.new(model_data, domain_name: domain_name).assemble
+    end
+
+    def self.rails_project?(path)
+      File.exist?(File.join(path, "db", "schema.rb"))
+    end
+
+    def self.rails_models?(path)
+      detect_models_dir(path) != path ||
+        Dir[File.join(path, "**", "*.rb")].any? { |f| File.read(f).include?("ApplicationRecord") }
     end
 
     def self.detect_models_dir(path)
@@ -54,6 +74,16 @@ module Hecks
       ]
       candidates.find { |d| File.directory?(d) } || path
     end
-    private_class_method :detect_models_dir
+
+    def self.detect_ruby_dir(path)
+      lib_dir = File.join(path, "lib")
+      File.directory?(lib_dir) ? lib_dir : path
+    end
+
+    def self.infer_domain_name(path)
+      Hecks::Utils.sanitize_constant(File.basename(File.expand_path(path)))
+    end
+
+    private_class_method :detect_models_dir, :detect_ruby_dir, :infer_domain_name
   end
 end

--- a/hecksties/lib/hecks_cli/import/ruby_assembler.rb
+++ b/hecksties/lib/hecks_cli/import/ruby_assembler.rb
@@ -1,0 +1,86 @@
+module Hecks
+  module Import
+    # Hecks::Import::RubyAssembler
+    #
+    # Builds a Hecks DSL domain definition from RubyParser output. Groups
+    # classes by top-level module into aggregates. Classes without a module
+    # become their own aggregate. Nested classes become value objects.
+    #
+    #   parsed = RubyParser.new("/path/to/lib").parse
+    #   RubyAssembler.new(parsed, domain_name: "Billing").assemble
+    #   # => 'Hecks.domain "Billing" do ...'
+    #
+    class RubyAssembler
+      def initialize(parsed_classes, domain_name: "MyDomain")
+        @parsed_classes = parsed_classes
+        @domain_name = domain_name
+      end
+
+      def assemble
+        lines = ["Hecks.domain \"#{@domain_name}\" do"]
+        aggregates = group_into_aggregates
+        aggregates.each_with_index do |(agg_name, members), i|
+          lines << "" if i > 0
+          lines.concat(assemble_aggregate(agg_name, members))
+        end
+        lines << "end"
+        lines.join("\n") + "\n"
+      end
+
+      private
+
+      def group_into_aggregates
+        groups = {}
+        @parsed_classes.each do |cls|
+          group = cls[:module] || cls[:name]
+          (groups[group] ||= []) << cls
+        end
+        groups
+      end
+
+      def assemble_aggregate(agg_name, members)
+        root = members.first
+        lines = ["  aggregate \"#{agg_name}\" do"]
+
+        # Root class attributes
+        (root[:attributes] || []).each do |attr|
+          lines << "    attribute :#{attr[:name]}, #{attr[:type]}"
+        end
+
+        # Nested classes as value objects
+        (root[:nested_classes] || []).each do |nested|
+          lines.concat(assemble_value_object(nested))
+        end
+
+        # Additional classes in same module as value objects
+        members[1..].each do |cls|
+          lines.concat(assemble_value_object(cls))
+        end
+
+        # Create command with all attributes
+        writable = root[:attributes] || []
+        if writable.any?
+          lines << ""
+          lines << "    command \"Create#{agg_name}\" do"
+          writable.each do |attr|
+            lines << "      attribute :#{attr[:name]}, #{attr[:type]}"
+          end
+          lines << "    end"
+        end
+
+        lines << "  end"
+        lines
+      end
+
+      def assemble_value_object(cls)
+        lines = [""]
+        lines << "    value_object \"#{cls[:name]}\" do"
+        (cls[:attributes] || []).each do |attr|
+          lines << "      attribute :#{attr[:name]}, #{attr[:type]}"
+        end
+        lines << "    end"
+        lines
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/import/ruby_parser.rb
+++ b/hecksties/lib/hecks_cli/import/ruby_parser.rb
@@ -1,0 +1,146 @@
+module Hecks
+  module Import
+    # Hecks::Import::RubyParser
+    #
+    # Scans Ruby source files via regex (no require, no eval) and extracts
+    # class structure: modules, superclasses, attributes, Struct/Data members,
+    # and nested classes. Works on any Ruby project — POROs, Structs, Data
+    # classes, gems, scripts. No Rails dependency.
+    #
+    #   RubyParser.new("/path/to/lib").parse
+    #   # => [{ name: "Order", module: "Billing", superclass: nil,
+    #   #       attributes: [{name: "total", type: "String"}],
+    #   #       nested_classes: [{name: "LineItem", ...}] }]
+    #
+    class RubyParser
+      def initialize(path)
+        @path = path
+      end
+
+      def parse
+        ruby_files.flat_map { |f| parse_file(f) }
+      end
+
+      private
+
+      def ruby_files
+        Dir[File.join(@path, "**", "*.rb")].sort
+      end
+
+      def parse_file(path)
+        content = File.read(path)
+        classes = extract_classes(content)
+        classes.reject { |c| c[:name].nil? }
+      end
+
+      def extract_classes(content)
+        results = []
+        modules = []
+        # Stack tracks what each nesting level is: :module, :class, or :other
+        stack = []
+        content.each_line do |line|
+          stripped = line.strip
+          next if stripped.start_with?("#")
+
+          if (mod = stripped.match(/\Amodule\s+([A-Z][\w:]*)/))
+            modules.push(mod[1])
+            stack.push(:module)
+          elsif (cls = parse_class_line(stripped))
+            cls[:module] = modules.join("::") unless modules.empty?
+            cls[:attributes] ||= []
+            cls[:nested_classes] ||= []
+            extract_body_info(content, cls)
+            results << cls
+            stack.push(:class)
+          elsif opens_block?(stripped)
+            stack.push(:other)
+          elsif end_line?(stripped) && stack.any?
+            kind = stack.pop
+            modules.pop if kind == :module
+          end
+        end
+        results
+      end
+
+      def parse_class_line(line)
+        # class Foo::Bar < Struct.new(:x, :y)
+        if (m = line.match(/\Aclass\s+([A-Z][\w:]*)\s*<\s*Struct\.new\(([^)]*)\)/))
+          { name: short_name(m[1]), superclass: "Struct", attributes: parse_members(m[2]) }
+        # class Foo < Data.define(:x, :y)
+        elsif (m = line.match(/\Aclass\s+([A-Z][\w:]*)\s*<\s*Data\.define\(([^)]*)\)/))
+          { name: short_name(m[1]), superclass: "Data", attributes: parse_members(m[2]) }
+        # class Foo < SomeParent
+        elsif (m = line.match(/\Aclass\s+([A-Z][\w:]*)\s*<\s*([A-Z][\w:]*)/))
+          { name: short_name(m[1]), superclass: m[2] }
+        # class Foo (plain class)
+        elsif (m = line.match(/\Aclass\s+([A-Z][\w:]*)\s*$/))
+          { name: short_name(m[1]) }
+        end
+      end
+
+      def parse_members(args_str)
+        args_str.scan(/:(\w+)/).flatten.map { |n| { name: n, type: "String" } }
+      end
+
+      def short_name(full_name)
+        full_name.split("::").last
+      end
+
+      def extract_body_info(content, cls)
+        extract_attr_declarations(content, cls)
+        extract_nested_classes(content, cls)
+      end
+
+      def extract_attr_declarations(content, cls)
+        existing = cls[:attributes].map { |a| a[:name] }
+        content.scan(/attr_(?:accessor|reader)\s+(.+)$/) do |match|
+          match[0].scan(/:(\w+)/).flatten.each do |attr_name|
+            next if existing.include?(attr_name)
+            cls[:attributes] << { name: attr_name, type: "String" }
+            existing << attr_name
+          end
+        end
+      end
+
+      def extract_nested_classes(content, cls)
+        in_class = false
+        depth = 0
+        content.each_line do |line|
+          stripped = line.strip
+          if !in_class && stripped.match?(/\Aclass\s+#{Regexp.escape(cls[:name])}\b/)
+            in_class = true
+            depth = 1
+            next
+          end
+          next unless in_class
+
+          depth += count_opens(stripped)
+          depth -= 1 if end_line?(stripped)
+
+          if depth > 1 && (nested = parse_class_line(stripped))
+            nested[:module] = nil
+            nested[:attributes] ||= []
+            nested[:nested_classes] = []
+            cls[:nested_classes] << nested
+          end
+
+          break if depth <= 0
+        end
+      end
+
+      def opens_block?(line)
+        line.match?(/\b(def|do|if|unless|case|begin)\b/) && !end_line?(line)
+      end
+
+      def count_opens(line)
+        opens = 0
+        opens += 1 if line.match?(/\b(class|module|def|do|if|unless|case|begin)\b/) && !end_line?(line)
+        opens
+      end
+
+      def end_line?(line)
+        line.match?(/\Aend\b/)
+      end
+    end
+  end
+end

--- a/hecksties/spec/import/from_ruby_spec.rb
+++ b/hecksties/spec/import/from_ruby_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+require "hecks_cli"
+require "tmpdir"
+
+RSpec.describe "Import.from_ruby" do
+  let(:project_dir) { Dir.mktmpdir }
+
+  after { FileUtils.remove_entry(project_dir) }
+
+  def write_file(relative_path, content)
+    full_path = File.join(project_dir, relative_path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, content)
+  end
+
+  it "generates a domain from plain Ruby classes" do
+    write_file("order.rb", <<~RUBY)
+      class Order
+        attr_accessor :total, :status
+      end
+    RUBY
+
+    dsl = Hecks::Import.from_ruby(project_dir, domain_name: "Shop")
+    expect(dsl).to include('Hecks.domain "Shop"')
+    expect(dsl).to include('aggregate "Order"')
+    expect(dsl).to include("attribute :total, String")
+    expect(dsl).to include("attribute :status, String")
+  end
+
+  it "generates a domain from Struct-based classes" do
+    write_file("point.rb", <<~RUBY)
+      class Point < Struct.new(:x, :y)
+      end
+    RUBY
+
+    dsl = Hecks::Import.from_ruby(project_dir, domain_name: "Geometry")
+    expect(dsl).to include('aggregate "Point"')
+    expect(dsl).to include("attribute :x, String")
+  end
+
+  it "groups module-nested classes into aggregates" do
+    write_file("billing.rb", <<~RUBY)
+      module Billing
+        class Invoice
+          attr_accessor :total
+        end
+
+        class LineItem
+          attr_accessor :description
+        end
+      end
+    RUBY
+
+    dsl = Hecks::Import.from_ruby(project_dir, domain_name: "Acme")
+    expect(dsl).to include('aggregate "Billing"')
+    expect(dsl).to include("attribute :total, String")
+    expect(dsl).to include('value_object "LineItem"')
+  end
+
+  describe "from_directory auto-detection" do
+    it "uses from_ruby for non-Rails projects" do
+      write_file("lib/widget.rb", <<~RUBY)
+        class Widget
+          attr_accessor :name
+        end
+      RUBY
+
+      dsl = Hecks::Import.from_directory(project_dir, domain_name: "Factory")
+      expect(dsl).to include('aggregate "Widget"')
+    end
+
+    it "detects Rails projects by schema.rb presence" do
+      expect(Hecks::Import.rails_project?(project_dir)).to be false
+
+      FileUtils.mkdir_p(File.join(project_dir, "db"))
+      File.write(File.join(project_dir, "db", "schema.rb"), "")
+      expect(Hecks::Import.rails_project?(project_dir)).to be true
+    end
+  end
+end

--- a/hecksties/spec/import/ruby_assembler_spec.rb
+++ b/hecksties/spec/import/ruby_assembler_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+require "hecks_cli"
+
+RSpec.describe Hecks::Import::RubyAssembler do
+  describe "#assemble" do
+    it "generates DSL from parsed classes" do
+      parsed = [
+        { name: "Order", module: nil, attributes: [{ name: "total", type: "String" }],
+          nested_classes: [] }
+      ]
+      dsl = described_class.new(parsed, domain_name: "Shop").assemble
+      expect(dsl).to include('Hecks.domain "Shop"')
+      expect(dsl).to include('aggregate "Order"')
+      expect(dsl).to include("attribute :total, String")
+    end
+
+    it "groups classes by module into aggregates" do
+      parsed = [
+        { name: "Invoice", module: "Billing", attributes: [{ name: "amount", type: "String" }],
+          nested_classes: [] },
+        { name: "LineItem", module: "Billing", attributes: [{ name: "desc", type: "String" }],
+          nested_classes: [] }
+      ]
+      dsl = described_class.new(parsed, domain_name: "Acme").assemble
+      expect(dsl).to include('aggregate "Billing"')
+      expect(dsl).to include('value_object "LineItem"')
+      expect(dsl).to include("attribute :amount, String")
+    end
+
+    it "generates Create commands for root aggregates" do
+      parsed = [
+        { name: "Widget", module: nil, attributes: [{ name: "size", type: "String" }],
+          nested_classes: [] }
+      ]
+      dsl = described_class.new(parsed, domain_name: "Factory").assemble
+      expect(dsl).to include('command "CreateWidget"')
+    end
+
+    it "renders nested classes as value objects" do
+      parsed = [
+        { name: "Order", module: nil,
+          attributes: [{ name: "total", type: "String" }],
+          nested_classes: [
+            { name: "Address", attributes: [{ name: "street", type: "String" }], nested_classes: [] }
+          ] }
+      ]
+      dsl = described_class.new(parsed, domain_name: "Shop").assemble
+      expect(dsl).to include('value_object "Address"')
+      expect(dsl).to include("attribute :street, String")
+    end
+  end
+end

--- a/hecksties/spec/import/ruby_parser_spec.rb
+++ b/hecksties/spec/import/ruby_parser_spec.rb
@@ -1,0 +1,145 @@
+require "spec_helper"
+require "hecks_cli"
+require "tmpdir"
+
+RSpec.describe Hecks::Import::RubyParser do
+  let(:project_dir) { Dir.mktmpdir }
+
+  after { FileUtils.remove_entry(project_dir) }
+
+  def write_file(relative_path, content)
+    full_path = File.join(project_dir, relative_path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, content)
+  end
+
+  subject(:parsed) { described_class.new(project_dir).parse }
+
+  describe "plain Ruby classes (POROs)" do
+    before do
+      write_file("order.rb", <<~RUBY)
+        class Order
+          attr_accessor :total, :currency
+          attr_reader :status
+        end
+      RUBY
+    end
+
+    it "extracts the class name" do
+      expect(parsed.map { |c| c[:name] }).to include("Order")
+    end
+
+    it "extracts attr_accessor and attr_reader attributes" do
+      order = parsed.find { |c| c[:name] == "Order" }
+      names = order[:attributes].map { |a| a[:name] }
+      expect(names).to contain_exactly("total", "currency", "status")
+    end
+
+    it "defaults attribute types to String" do
+      order = parsed.find { |c| c[:name] == "Order" }
+      expect(order[:attributes]).to all(include(type: "String"))
+    end
+  end
+
+  describe "Struct.new subclasses" do
+    before do
+      write_file("point.rb", <<~RUBY)
+        class Point < Struct.new(:x, :y, :z)
+        end
+      RUBY
+    end
+
+    it "extracts Struct members as attributes" do
+      point = parsed.find { |c| c[:name] == "Point" }
+      names = point[:attributes].map { |a| a[:name] }
+      expect(names).to contain_exactly("x", "y", "z")
+    end
+
+    it "records Struct as superclass" do
+      point = parsed.find { |c| c[:name] == "Point" }
+      expect(point[:superclass]).to eq("Struct")
+    end
+  end
+
+  describe "Data.define subclasses" do
+    before do
+      write_file("money.rb", <<~RUBY)
+        class Money < Data.define(:amount, :currency)
+        end
+      RUBY
+    end
+
+    it "extracts Data members as attributes" do
+      money = parsed.find { |c| c[:name] == "Money" }
+      names = money[:attributes].map { |a| a[:name] }
+      expect(names).to contain_exactly("amount", "currency")
+    end
+
+    it "records Data as superclass" do
+      money = parsed.find { |c| c[:name] == "Money" }
+      expect(money[:superclass]).to eq("Data")
+    end
+  end
+
+  describe "module nesting" do
+    before do
+      write_file("billing/invoice.rb", <<~RUBY)
+        module Billing
+          class Invoice
+            attr_accessor :total, :due_date
+          end
+        end
+      RUBY
+    end
+
+    it "captures the module as the group" do
+      invoice = parsed.find { |c| c[:name] == "Invoice" }
+      expect(invoice[:module]).to eq("Billing")
+    end
+  end
+
+  describe "classes with inheritance" do
+    before do
+      write_file("admin_user.rb", <<~RUBY)
+        class AdminUser < User
+          attr_accessor :role
+        end
+      RUBY
+    end
+
+    it "captures the superclass" do
+      admin = parsed.find { |c| c[:name] == "AdminUser" }
+      expect(admin[:superclass]).to eq("User")
+    end
+  end
+
+  describe "colon-separated class names" do
+    before do
+      write_file("thing.rb", <<~RUBY)
+        class Billing::LineItem < Struct.new(:desc, :price)
+        end
+      RUBY
+    end
+
+    it "uses the short name" do
+      item = parsed.find { |c| c[:name] == "LineItem" }
+      expect(item).not_to be_nil
+      expect(item[:attributes].map { |a| a[:name] }).to contain_exactly("desc", "price")
+    end
+  end
+
+  describe "scanning subdirectories" do
+    before do
+      write_file("lib/models/foo.rb", <<~RUBY)
+        class Foo
+          attr_accessor :bar
+        end
+      RUBY
+    end
+
+    it "finds files in nested directories" do
+      foo = parsed.find { |c| c[:name] == "Foo" }
+      expect(foo).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
HEC-452 + HEC-466: Domain extractor supports any Ruby project

Add RubyParser and RubyAssembler to extract domain definitions from
any Ruby codebase — POROs, Structs, Data.define classes — not just
Rails. The extract command now auto-detects project type (Rails with
schema, Rails models-only, or plain Ruby) and delegates accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)