### PR TITLE
HEC-454: Domain-first architecture

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem "rspec", "~> 3.0"
   gem "webrick"
   gem "railties", "~> 8.0"
+  gem "activemodel", ">= 6.0", "< 10.0"
   gem "sqlite3", ">= 1.4", "< 3.0"
   gem "rdoc", ">= 6.4", "< 6.7"
   gem "sdoc"

--- a/hecksties/hecksties.gemspec
+++ b/hecksties/hecksties.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bluebook", Hecks::VERSION
   spec.add_dependency "rwordnet", ">= 1.0", "< 3.0"
-  spec.add_dependency "activemodel", ">= 6.0", "< 10.0"
 end

--- a/hecksties/lib/hecks/conventions/ui_label_contract.rb
+++ b/hecksties/lib/hecks/conventions/ui_label_contract.rb
@@ -2,13 +2,12 @@
 #
 # Single source of truth for converting names to display labels.
 # Handles both snake_case (field names) and PascalCase (command
-# names, aggregate names). Uses ActiveSupport for pluralization.
+# names, aggregate names). Pure Ruby — no ActiveSupport dependency.
 #
 #   Hecks::Conventions::UILabelContract.label(:effective_date)    # => "Effective Date"
 #   Hecks::Conventions::UILabelContract.label("ReportIncident")   # => "Report Incident"
 #   Hecks::Conventions::UILabelContract.plural_label("GovernancePolicy")  # => "Governance Policies"
 #
-require "active_support/core_ext/string/inflections"
 
 module Hecks::Conventions
   module UILabelContract
@@ -24,8 +23,20 @@ module Hecks::Conventions
     # "GovernancePolicy" → "Governance Policies"
     def self.plural_label(name)
       words = label(name).split(" ")
-      words[-1] = words[-1].pluralize
+      words[-1] = pluralize(words[-1])
       words.join(" ")
+    end
+
+    # Inline pluralizer covering common English patterns for Ruby class names.
+    # Handles: s/x/z/ch/sh → +es, consonant+y → ies, everything else → +s.
+    def self.pluralize(word)
+      if word.match?(/(?:s|x|z|ch|sh)\z/i)
+        "#{word}es"
+      elsif word.match?(/[^aeiou]y\z/i)
+        "#{word[0..-2]}ies"
+      else
+        "#{word}s"
+      end
     end
   end
 end

--- a/hecksties/spec/conventions/ui_label_contract_spec.rb
+++ b/hecksties/spec/conventions/ui_label_contract_spec.rb
@@ -1,0 +1,90 @@
+# = UILabelContract spec
+#
+# Covers label conversion and the inline pluralizer that replaced
+# ActiveSupport::String#pluralize (HEC-454).
+
+require "spec_helper"
+
+RSpec.describe Hecks::Conventions::UILabelContract do
+  describe ".label" do
+    it "humanizes snake_case field names" do
+      expect(described_class.label(:effective_date)).to eq("Effective Date")
+    end
+
+    it "splits PascalCase command names" do
+      expect(described_class.label("ReportIncident")).to eq("Report Incident")
+    end
+
+    it "handles single-word strings" do
+      expect(described_class.label("Pizza")).to eq("Pizza")
+    end
+
+    it "handles consecutive capitals (e.g. UILabel)" do
+      expect(described_class.label("UILabel")).to eq("Ui Label")
+    end
+  end
+
+  describe ".plural_label" do
+    it "pluralizes the last word — regular noun" do
+      expect(described_class.plural_label("Order")).to eq("Orders")
+    end
+
+    it "pluralizes the last word — consonant+y → ies" do
+      expect(described_class.plural_label("GovernancePolicy")).to eq("Governance Policies")
+    end
+
+    it "pluralizes the last word — ends in ch → es" do
+      expect(described_class.plural_label("Dispatch")).to eq("Dispatches")
+    end
+
+    it "pluralizes the last word — ends in sh → es" do
+      expect(described_class.plural_label("Dish")).to eq("Dishes")
+    end
+
+    it "pluralizes the last word — ends in x → es" do
+      expect(described_class.plural_label("Index")).to eq("Indexes")
+    end
+
+    it "leaves earlier words singular" do
+      expect(described_class.plural_label("GovernancePolicy")).to eq("Governance Policies")
+    end
+  end
+
+  describe ".pluralize" do
+    it "adds s for regular words" do
+      expect(described_class.pluralize("Pizza")).to eq("Pizzas")
+    end
+
+    it "adds es for words ending in s" do
+      expect(described_class.pluralize("Status")).to eq("Statuses")
+    end
+
+    it "adds es for words ending in x" do
+      expect(described_class.pluralize("Box")).to eq("Boxes")
+    end
+
+    it "adds es for words ending in z" do
+      expect(described_class.pluralize("Topaz")).to eq("Topazes")
+    end
+
+    it "adds es for words ending in ch" do
+      expect(described_class.pluralize("Batch")).to eq("Batches")
+    end
+
+    it "adds es for words ending in sh" do
+      expect(described_class.pluralize("Brush")).to eq("Brushes")
+    end
+
+    it "replaces y with ies for consonant+y words" do
+      expect(described_class.pluralize("Category")).to eq("Categories")
+    end
+
+    it "replaces y with ies for Policy" do
+      expect(described_class.pluralize("Policy")).to eq("Policies")
+    end
+
+    it "adds s for vowel+y words (e.g. Day)" do
+      expect(described_class.pluralize("Day")).to eq("Days")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
HEC-454: Add explicit activemodel dependency to Gemfile

hecksties no longer pulls in activemodel, but hecks_on_rails/active_hecks.rb
requires it. Declare it explicitly so CI can resolve it without the transitive dep.

HEC-454: Remove Rails coupling from core Hecks — drop activemodel dep, inline pluralizer

- Remove `activemodel` gem dependency from hecksties.gemspec; it was
  declared but unused, pulling activesupport into the core as a side
  effect and violating domain-first / pure-Ruby principles.
- Replace `require "active_support/core_ext/string/inflections"` and
  String#pluralize in UILabelContract with a small inline pluralizer
  covering s/x/z/ch/sh → +es, consonant+y → ies, and the default +s.
- Add UILabelContract spec covering label/plural_label and all
  pluralize branches (1491 examples, 0 failures, < 1 second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)