### PR TITLE
HEC-457: Bubble contexts (ACL)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -130,6 +130,7 @@
 - `hecks_idempotency` — command deduplication by fingerprint
 - `hecks_transactions` — DB transaction wrapping when SQL adapter present
 - `hecks_retry` — exponential backoff for transient errors
+- `hecks_bubble` — anti-corruption layer (ACL) for legacy data translation; context DSL with `map_aggregate`, `from_legacy` (field renaming + transforms), `map_out` (reverse mapping); API: `context.translate(:Pizza, :create, legacy_data)` and `context.reverse(:Pizza, :create, domain_data)`
 
 ### Domain Connections DSL
 - `extend :sqlite` — declare persistence adapter

--- a/docs/usage/bubble_contexts.md
+++ b/docs/usage/bubble_contexts.md
@@ -1,0 +1,92 @@
+# Bubble Contexts — Anti-Corruption Layer
+
+Bubble contexts provide an ACL (Anti-Corruption Layer) for translating
+legacy or external system data into clean domain commands. Field renames,
+value transforms, and reverse mappings keep integration code out of
+your domain model.
+
+## Setup
+
+```ruby
+require "hecks/extensions/bubble"
+```
+
+## Defining a Context
+
+```ruby
+ctx = HecksBubble::Context.new do
+  map_aggregate :Pizza do
+    from_legacy :create,
+      rename: { pizza_nm: :name, desc_text: :description },
+      transform: { name: ->(v) { v.strip.capitalize } }
+
+    map_out :create,
+      rename: { name: :pizza_nm, description: :desc_text }
+  end
+end
+```
+
+## Translating Inbound Data
+
+```ruby
+ctx.translate(:Pizza, :create, pizza_nm: "  margherita ", desc_text: "Classic")
+# => { name: "Margherita", description: "Classic" }
+```
+
+Fields are renamed first, then transforms are applied on the renamed keys.
+Unmapped fields pass through unchanged.
+
+## Reverse Mapping (Outbound)
+
+```ruby
+ctx.reverse(:Pizza, :create, name: "Margherita", description: "Classic")
+# => { pizza_nm: "Margherita", desc_text: "Classic" }
+```
+
+## Using with a Domain Module
+
+When the `:bubble` extension is registered, each domain module gets
+`bubble_context` and `bubble` methods:
+
+```ruby
+app = Hecks.boot(__dir__)
+
+PizzasDomain.bubble_context do
+  map_aggregate :Pizza do
+    from_legacy :create,
+      rename: { pizza_nm: :name },
+      transform: { name: ->(v) { v.strip.capitalize } }
+  end
+end
+
+# Translate legacy API payload into a domain command
+clean = PizzasDomain.bubble.translate(:Pizza, :create, pizza_nm: " pepperoni ")
+Pizza.create(**clean)
+```
+
+## Multiple Aggregates
+
+```ruby
+ctx = HecksBubble::Context.new do
+  map_aggregate :Pizza do
+    from_legacy :create, rename: { nm: :name }
+  end
+
+  map_aggregate :Order do
+    from_legacy :place, rename: { qty: :quantity, cust: :customer_name }
+  end
+end
+
+ctx.translate(:Pizza, :create, nm: "Hawaiian")
+# => { name: "Hawaiian" }
+
+ctx.translate(:Order, :place, qty: 3, cust: "Alice")
+# => { quantity: 3, customer_name: "Alice" }
+```
+
+## Introspection
+
+```ruby
+ctx.mapped_aggregates  # => [:Pizza, :Order]
+ctx.mapper_for(:Pizza) # => HecksBubble::AggregateMapper
+```

--- a/hecksties/lib/hecks/extensions/bubble.rb
+++ b/hecksties/lib/hecks/extensions/bubble.rb
@@ -1,0 +1,66 @@
+# HecksBubble
+#
+# Anti-Corruption Layer (ACL) extension for Hecks domains. Defines
+# translation contexts that map legacy or external system data into
+# clean domain commands. Each context declares field renames, value
+# transforms, and optional reverse mappings for outbound translation.
+#
+# Usage:
+#   require "hecks/extensions/bubble"
+#
+#   ctx = HecksBubble::Context.new do
+#     map_aggregate :Pizza do
+#       from_legacy :create,
+#         rename: { pizza_nm: :name, desc_text: :description },
+#         transform: { name: ->(v) { v.strip.capitalize } }
+#
+#       map_out :create,
+#         rename: { name: :pizza_nm, description: :desc_text }
+#     end
+#   end
+#
+#   ctx.translate(:Pizza, :create, pizza_nm: " margherita ", desc_text: "Classic")
+#   # => { name: "Margherita", description: "Classic" }
+#
+#   ctx.reverse(:Pizza, :create, name: "Margherita", description: "Classic")
+#   # => { pizza_nm: "Margherita", desc_text: "Classic" }
+#
+module HecksBubble
+  # A single inbound mapping: field renames + optional value transforms.
+  #
+  # @attr_reader rename [Hash{Symbol => Symbol}] legacy key to domain key
+  # @attr_reader transform [Hash{Symbol => Proc}] domain key to transform proc
+  Mapping = Struct.new(:rename, :transform, keyword_init: true) do
+    def initialize(rename: {}, transform: {})
+      super(rename: rename, transform: transform)
+    end
+  end
+
+  # A single outbound mapping: domain keys back to legacy keys.
+  #
+  # @attr_reader rename [Hash{Symbol => Symbol}] domain key to legacy key
+  OutMapping = Struct.new(:rename, keyword_init: true) do
+    def initialize(rename: {})
+      super(rename: rename)
+    end
+  end
+end
+
+require_relative "bubble/aggregate_mapper"
+require_relative "bubble/context"
+
+Hecks.describe_extension(:bubble,
+  description: "Anti-corruption layer for legacy data translation",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :commands)
+
+Hecks.register_extension(:bubble) do |domain_mod, _domain, _runtime|
+  domain_mod.define_singleton_method(:bubble_context) do |&block|
+    @_bubble_context = HecksBubble::Context.new(&block)
+  end
+
+  domain_mod.define_singleton_method(:bubble) do
+    @_bubble_context
+  end
+end

--- a/hecksties/lib/hecks/extensions/bubble/aggregate_mapper.rb
+++ b/hecksties/lib/hecks/extensions/bubble/aggregate_mapper.rb
@@ -1,0 +1,89 @@
+# HecksBubble::AggregateMapper
+#
+# Collects inbound and outbound field mappings for a single aggregate.
+# Used inside a Context DSL block via +map_aggregate+ to declare how
+# legacy fields translate to domain command attributes and back.
+#
+#   mapper = HecksBubble::AggregateMapper.new
+#   mapper.from_legacy(:create,
+#     rename: { pizza_nm: :name },
+#     transform: { name: ->(v) { v.strip } })
+#   mapper.map_out(:create, rename: { name: :pizza_nm })
+#
+#   mapper.translate(:create, pizza_nm: " Margherita ")
+#   # => { name: "Margherita" }
+#
+#   mapper.reverse(:create, name: "Margherita")
+#   # => { pizza_nm: "Margherita" }
+#
+module HecksBubble
+  class AggregateMapper
+    def initialize
+      @inbound  = {}
+      @outbound = {}
+    end
+
+    # Declare an inbound mapping for a command action.
+    #
+    # @param action [Symbol] the command action (e.g. :create, :update)
+    # @param rename [Hash{Symbol => Symbol}] legacy key to domain key
+    # @param transform [Hash{Symbol => Proc}] domain key to transform proc
+    # @return [void]
+    def from_legacy(action, rename: {}, transform: {})
+      @inbound[action] = Mapping.new(rename: rename, transform: transform)
+    end
+
+    # Declare an outbound (reverse) mapping for a command action.
+    #
+    # @param action [Symbol] the command action
+    # @param rename [Hash{Symbol => Symbol}] domain key to legacy key
+    # @return [void]
+    def map_out(action, rename: {})
+      @outbound[action] = OutMapping.new(rename: rename)
+    end
+
+    # Translate legacy data into domain attributes using the inbound mapping.
+    #
+    # Applies field renames first, then value transforms on the renamed keys.
+    # Unknown fields pass through unchanged.
+    #
+    # @param action [Symbol] the command action
+    # @param data [Hash{Symbol => Object}] the legacy data hash
+    # @return [Hash{Symbol => Object}] the translated domain attributes
+    def translate(action, data)
+      mapping = @inbound[action]
+      return data unless mapping
+
+      result = {}
+      data.each do |key, value|
+        new_key = mapping.rename.fetch(key, key)
+        result[new_key] = value
+      end
+
+      mapping.transform.each do |key, fn|
+        result[key] = fn.call(result[key]) if result.key?(key)
+      end
+
+      result
+    end
+
+    # Reverse-translate domain attributes back to legacy field names.
+    #
+    # Applies the outbound rename mapping. Unknown fields pass through.
+    #
+    # @param action [Symbol] the command action
+    # @param data [Hash{Symbol => Object}] the domain attributes
+    # @return [Hash{Symbol => Object}] the legacy-keyed hash
+    def reverse(action, data)
+      mapping = @outbound[action]
+      return data unless mapping
+
+      result = {}
+      data.each do |key, value|
+        new_key = mapping.rename.fetch(key, key)
+        result[new_key] = value
+      end
+      result
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/bubble/context.rb
+++ b/hecksties/lib/hecks/extensions/bubble/context.rb
@@ -1,0 +1,81 @@
+# HecksBubble::Context
+#
+# DSL host for declaring aggregate-level field mappings. A context groups
+# one or more aggregate mappers and provides +translate+ and +reverse+
+# entry points that delegate to the appropriate mapper.
+#
+#   ctx = HecksBubble::Context.new do
+#     map_aggregate :Pizza do
+#       from_legacy :create,
+#         rename: { pizza_nm: :name },
+#         transform: { name: ->(v) { v.strip.capitalize } }
+#       map_out :create, rename: { name: :pizza_nm }
+#     end
+#   end
+#
+#   ctx.translate(:Pizza, :create, pizza_nm: " pepperoni ")
+#   # => { name: "Pepperoni" }
+#
+module HecksBubble
+  class Context
+    # Build a context by evaluating the given block.
+    #
+    # @yield the DSL block containing +map_aggregate+ calls
+    def initialize(&block)
+      @mappers = {}
+      instance_eval(&block) if block
+    end
+
+    # Declare mappings for an aggregate.
+    #
+    # @param name [Symbol] the aggregate name (e.g. :Pizza)
+    # @yield evaluated in the scope of an {AggregateMapper}
+    # @return [void]
+    def map_aggregate(name, &block)
+      mapper = AggregateMapper.new
+      mapper.instance_eval(&block) if block
+      @mappers[name] = mapper
+    end
+
+    # Translate legacy data into domain command attributes.
+    #
+    # @param aggregate [Symbol] the aggregate name
+    # @param action [Symbol] the command action
+    # @param data [Hash{Symbol => Object}] legacy data
+    # @return [Hash{Symbol => Object}] translated domain attributes
+    def translate(aggregate, action, data)
+      mapper = @mappers[aggregate]
+      return data unless mapper
+
+      mapper.translate(action, data)
+    end
+
+    # Reverse-translate domain attributes to legacy field names.
+    #
+    # @param aggregate [Symbol] the aggregate name
+    # @param action [Symbol] the command action
+    # @param data [Hash{Symbol => Object}] domain data
+    # @return [Hash{Symbol => Object}] legacy-keyed hash
+    def reverse(aggregate, action, data)
+      mapper = @mappers[aggregate]
+      return data unless mapper
+
+      mapper.reverse(action, data)
+    end
+
+    # Return the mapper for a given aggregate, or nil if none declared.
+    #
+    # @param name [Symbol] the aggregate name
+    # @return [AggregateMapper, nil]
+    def mapper_for(name)
+      @mappers[name]
+    end
+
+    # List all aggregate names that have mappings.
+    #
+    # @return [Array<Symbol>]
+    def mapped_aggregates
+      @mappers.keys
+    end
+  end
+end

--- a/hecksties/spec/extensions/bubble_spec.rb
+++ b/hecksties/spec/extensions/bubble_spec.rb
@@ -1,0 +1,143 @@
+require "spec_helper"
+require "hecks/extensions/bubble"
+
+RSpec.describe HecksBubble do
+  describe "Context DSL" do
+    let(:context) do
+      HecksBubble::Context.new do
+        map_aggregate :Pizza do
+          from_legacy :create,
+            rename: { pizza_nm: :name, desc_text: :description },
+            transform: { name: ->(v) { v.strip.capitalize } }
+
+          map_out :create,
+            rename: { name: :pizza_nm, description: :desc_text }
+        end
+      end
+    end
+
+    describe "#translate" do
+      it "renames legacy fields to domain attributes" do
+        result = context.translate(:Pizza, :create,
+          pizza_nm: "margherita", desc_text: "Classic")
+
+        expect(result[:name]).to eq("Margherita")
+        expect(result[:description]).to eq("Classic")
+      end
+
+      it "applies value transforms after renaming" do
+        result = context.translate(:Pizza, :create,
+          pizza_nm: "  pepperoni  ", desc_text: "Spicy")
+
+        expect(result[:name]).to eq("Pepperoni")
+      end
+
+      it "passes through unmapped fields" do
+        result = context.translate(:Pizza, :create,
+          pizza_nm: "test", extra: "bonus")
+
+        expect(result[:extra]).to eq("bonus")
+      end
+
+      it "returns data unchanged for unmapped aggregates" do
+        result = context.translate(:Order, :create, qty: 5)
+        expect(result).to eq(qty: 5)
+      end
+
+      it "returns data unchanged for unmapped actions" do
+        result = context.translate(:Pizza, :delete, id: "abc")
+        expect(result).to eq(id: "abc")
+      end
+    end
+
+    describe "#reverse" do
+      it "maps domain attributes back to legacy field names" do
+        result = context.reverse(:Pizza, :create,
+          name: "Margherita", description: "Classic")
+
+        expect(result[:pizza_nm]).to eq("Margherita")
+        expect(result[:desc_text]).to eq("Classic")
+      end
+
+      it "passes through unmapped fields on reverse" do
+        result = context.reverse(:Pizza, :create,
+          name: "Test", id: "abc-123")
+
+        expect(result[:pizza_nm]).to eq("Test")
+        expect(result[:id]).to eq("abc-123")
+      end
+
+      it "returns data unchanged for unmapped aggregates" do
+        result = context.reverse(:Order, :create, total: 42)
+        expect(result).to eq(total: 42)
+      end
+    end
+
+    describe "#mapped_aggregates" do
+      it "lists aggregates with mappings" do
+        expect(context.mapped_aggregates).to eq([:Pizza])
+      end
+    end
+
+    describe "#mapper_for" do
+      it "returns the mapper for a known aggregate" do
+        expect(context.mapper_for(:Pizza)).to be_a(HecksBubble::AggregateMapper)
+      end
+
+      it "returns nil for unknown aggregates" do
+        expect(context.mapper_for(:Order)).to be_nil
+      end
+    end
+  end
+
+  describe "multiple aggregates" do
+    let(:context) do
+      HecksBubble::Context.new do
+        map_aggregate :Pizza do
+          from_legacy :create, rename: { nm: :name }
+        end
+
+        map_aggregate :Order do
+          from_legacy :place, rename: { qty: :quantity }
+        end
+      end
+    end
+
+    it "translates each aggregate independently" do
+      pizza = context.translate(:Pizza, :create, nm: "Hawaiian")
+      order = context.translate(:Order, :place, qty: 3)
+
+      expect(pizza).to eq(name: "Hawaiian")
+      expect(order).to eq(quantity: 3)
+    end
+  end
+
+  describe "extension registration" do
+    let(:domain) do
+      Hecks.domain "BubbleTest" do
+        aggregate "Pizza" do
+          attribute :name, String
+          command "CreatePizza" do
+            attribute :name, String
+          end
+        end
+      end
+    end
+
+    it "adds bubble_context DSL to domain module" do
+      app = Hecks.load(domain)
+      Hecks.extension_registry[:bubble]&.call(
+        Object.const_get("BubbleTestDomain"), domain, app
+      )
+
+      BubbleTestDomain.bubble_context do
+        map_aggregate :Pizza do
+          from_legacy :create, rename: { nm: :name }
+        end
+      end
+
+      result = BubbleTestDomain.bubble.translate(:Pizza, :create, nm: "Test")
+      expect(result).to eq(name: "Test")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
feat: add bubble contexts ACL extension for legacy data translation

HEC-457: Anti-corruption layer extension with context DSL supporting
map_aggregate, from_legacy (field renaming + value transforms), and
map_out (reverse mapping). Translates external/legacy payloads into
clean domain command attributes and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)