### PR TITLE
HEC-462: Clean up Node.js generator

### DIFF
--- a/hecks_targets/node/lib/node_hecks/generators/aggregate_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/aggregate_generator.rb
@@ -16,16 +16,13 @@ module NodeHecks
     end
 
     def generate
-      lines = []
-      lines << "export interface #{@agg.name} {"
-      lines << "  id: string;"
+      fields = ["id: string;"]
       @user_attrs.each do |attr|
-        lines << "  #{NodeUtils.camel_case(attr.name)}: #{NodeUtils.ts_type(attr)};"
+        fields << "#{NodeUtils.camel_case(attr.name)}: #{NodeUtils.ts_type(attr)};"
       end
-      lines << "  createdAt: string;"
-      lines << "  updatedAt: string;"
-      lines << "}"
-      lines.join("\n") + "\n"
+      fields << "createdAt: string;"
+      fields << "updatedAt: string;"
+      NodeUtils.join_lines(NodeUtils.ts_interface(@agg.name, fields))
     end
   end
 end

--- a/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
@@ -23,42 +23,32 @@ module NodeHecks
     end
 
     def generate
+      slug = NodeUtils.snake_case(@agg.name)
       lines = []
-      lines << "import { #{@agg.name} } from \"../aggregates/#{NodeUtils.snake_case(@agg.name)}\";"
-      lines << "import { #{@agg.name}Repository } from \"../repositories/#{NodeUtils.snake_case(@agg.name)}_repository\";"
-      lines << "import { randomUUID } from \"crypto\";"
+      lines << NodeUtils.ts_import(@agg.name, "../aggregates/#{slug}")
+      lines << NodeUtils.ts_import("#{@agg.name}Repository", "../repositories/#{slug}_repository")
+      lines << NodeUtils.ts_import("randomUUID", "crypto")
       lines << ""
       lines.concat(attrs_interface)
       lines << ""
       lines.concat(event_interface)
       lines << ""
       lines.concat(command_function)
-      lines.join("\n") + "\n"
+      NodeUtils.join_lines(lines)
     end
 
     private
 
     def attrs_interface
-      lines = []
-      lines << "export interface #{@cmd.name}Attrs {"
-      @cmd.attributes.each do |attr|
-        lines << "  #{NodeUtils.camel_case(attr.name)}: #{NodeUtils.ts_type(attr)};"
-      end
-      lines << "}"
-      lines
+      fields = @cmd.attributes.map { |a| "#{NodeUtils.camel_case(a.name)}: #{NodeUtils.ts_type(a)};" }
+      NodeUtils.ts_interface("#{@cmd.name}Attrs", fields)
     end
 
     def event_interface
-      lines = []
-      lines << "export interface #{@event.name} {"
-      lines << "  type: \"#{@event.name}\";"
-      lines << "  aggregateId: string;"
-      @cmd.attributes.each do |attr|
-        lines << "  #{NodeUtils.camel_case(attr.name)}: #{NodeUtils.ts_type(attr)};"
-      end
-      lines << "  occurredAt: string;"
-      lines << "}"
-      lines
+      fields = ["type: \"#{@event.name}\";", "aggregateId: string;"]
+      @cmd.attributes.each { |a| fields << "#{NodeUtils.camel_case(a.name)}: #{NodeUtils.ts_type(a)};" }
+      fields << "occurredAt: string;"
+      NodeUtils.ts_interface(@event.name, fields)
     end
 
     def command_function
@@ -93,14 +83,7 @@ module NodeHecks
       lines << "    updatedAt: now,"
       lines << "  };"
       lines << "  repo.save(#{NodeUtils.camel_case(@agg.name)});"
-      lines << "  return {"
-      lines << "    type: \"#{@event.name}\","
-      lines << "    aggregateId: #{NodeUtils.camel_case(@agg.name)}.id,"
-      @cmd.attributes.each do |a|
-        lines << "    #{NodeUtils.camel_case(a.name)}: attrs.#{NodeUtils.camel_case(a.name)},"
-      end
-      lines << "    occurredAt: now,"
-      lines << "  };"
+      lines.concat(event_return_block("#{NodeUtils.camel_case(@agg.name)}.id"))
       lines
     end
 
@@ -118,9 +101,15 @@ module NodeHecks
       end
       lines << "  existing.updatedAt = now;"
       lines << "  repo.save(existing);"
+      lines.concat(event_return_block("existing.id"))
+      lines
+    end
+
+    def event_return_block(id_expr)
+      lines = []
       lines << "  return {"
       lines << "    type: \"#{@event.name}\","
-      lines << "    aggregateId: existing.id,"
+      lines << "    aggregateId: #{id_expr},"
       @cmd.attributes.each do |a|
         lines << "    #{NodeUtils.camel_case(a.name)}: attrs.#{NodeUtils.camel_case(a.name)},"
       end

--- a/hecks_targets/node/lib/node_hecks/generators/repository_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/repository_generator.rb
@@ -17,7 +17,7 @@ module NodeHecks
     def generate
       name = @agg.name
       lines = []
-      lines << "import { #{name} } from \"../aggregates/#{NodeUtils.snake_case(name)}\";"
+      lines << NodeUtils.ts_import(name, "../aggregates/#{NodeUtils.snake_case(name)}")
       lines << ""
       lines << "export class #{name}Repository {"
       lines << "  private store: Map<string, #{name}> = new Map();"
@@ -42,7 +42,7 @@ module NodeHecks
       lines << "    return this.store.size;"
       lines << "  }"
       lines << "}"
-      lines.join("\n") + "\n"
+      NodeUtils.join_lines(lines)
     end
   end
 end

--- a/hecks_targets/node/lib/node_hecks/generators/server_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/server_generator.rb
@@ -24,7 +24,7 @@ module NodeHecks
       lines.concat(routes)
       lines << ""
       lines.concat(listen)
-      lines.join("\n") + "\n"
+      NodeUtils.join_lines(lines)
     end
 
     private
@@ -34,10 +34,10 @@ module NodeHecks
       lines << 'import express from "express";'
       @domain.aggregates.each do |agg|
         slug = NodeUtils.snake_case(agg.name)
-        lines << "import { #{agg.name}Repository } from \"./repositories/#{slug}_repository\";"
+        lines << NodeUtils.ts_import("#{agg.name}Repository", "./repositories/#{slug}_repository")
         agg.commands.each do |cmd|
           fn = NodeUtils.camel_case(cmd.name)
-          lines << "import { #{fn} } from \"./commands/#{NodeUtils.snake_case(cmd.name)}\";"
+          lines << NodeUtils.ts_import(fn, "./commands/#{NodeUtils.snake_case(cmd.name)}")
         end
       end
       lines

--- a/hecks_targets/node/lib/node_hecks/node_utils.rb
+++ b/hecks_targets/node/lib/node_hecks/node_utils.rb
@@ -42,5 +42,21 @@ module NodeHecks
     def kebab_case(str)
       snake_case(str).tr("_", "-")
     end
+
+    def ts_import(name, path)
+      "import { #{name} } from \"#{path}\";"
+    end
+
+    def ts_interface(name, fields)
+      lines = []
+      lines << "export interface #{name} {"
+      fields.each { |f| lines << "  #{f}" }
+      lines << "}"
+      lines
+    end
+
+    def join_lines(lines)
+      lines.join("\n") + "\n"
+    end
   end
 end


### PR DESCRIPTION
## Summary
HEC-462: Extract repeated inline string building in Node.js generators

Add ts_import, ts_interface, and join_lines helpers to NodeUtils.
Refactor all generators to use shared helpers instead of duplicated
string concatenation. Extract event_return_block in CommandGenerator
to eliminate duplicate return-object assembly in create/update paths.
Pure refactor — generated TypeScript output is byte-for-byte identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)