### PR TITLE
HEC-463: Extract reference_attribute?

### DIFF
--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/lifecycle_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/lifecycle_spec.rb
@@ -86,43 +86,17 @@ module Hecks
           private
 
           def find_create_cmd(aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
             aggregate.commands.find do |cmd|
-              cmd.attributes.none? { |a|
-                a.name.to_s.end_with?("_id") &&
-                  suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-              }
+              Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, aggregate.name).nil?
             end
           end
 
           def derive_method(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name).to_s
           end
 
           def update_args(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            self_ref = cmd.attributes.find { |a|
-              a.name.to_s.end_with?("_id") &&
-                suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-            }
+            self_ref = Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg.name)
 
             cmd.attributes.map { |attr|
               if self_ref && attr.name == self_ref.name

--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/policy_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/policy_spec.rb
@@ -93,29 +93,11 @@ module Hecks
           end
 
           def derive_method(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name).to_s
           end
 
           def is_update_cmd?(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            cmd.attributes.any? { |a|
-              a.name.to_s.end_with?("_id") &&
-                suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-            }
+            Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg.name) != nil
           end
 
           def find_create_cmd(agg)
@@ -123,14 +105,7 @@ module Hecks
           end
 
           def update_args_for(cmd, agg)
-            self_ref = cmd.attributes.find { |a|
-              agg_snake = domain_snake_name(agg.name)
-              suffixes = agg_snake.split("_").each_index.map { |i|
-                agg_snake.split("_").drop(i).join("_")
-              }.uniq
-              a.name.to_s.end_with?("_id") &&
-                suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-            }
+            self_ref = Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg.name)
 
             cmd.attributes.map { |attr|
               if self_ref && attr.name == self_ref.name

--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/port_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/port_spec.rb
@@ -69,30 +69,13 @@ module Hecks
           private
 
           def find_port_create_cmd(aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
             aggregate.commands.find do |cmd|
-              cmd.attributes.none? { |a|
-                a.name.to_s.end_with?("_id") &&
-                  suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-              }
+              Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, aggregate.name).nil?
             end
           end
 
           def derive_port_method(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name).to_s
           end
         end
       end

--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/query_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/query_spec.rb
@@ -51,32 +51,14 @@ module Hecks
 
           # Find the first create command (no self-ref id attribute).
           def find_create_command(aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
             aggregate.commands.find do |cmd|
-              cmd.attributes.none? { |a|
-                a.name.to_s.end_with?("_id") &&
-                  suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-              }
+              Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, aggregate.name).nil?
             end
           end
 
           # Derive the shortcut method name for a command.
           def command_method_name(cmd, aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, aggregate.name).to_s
           end
 
           # Try to extract the where conditions from a query block.

--- a/bluebook/lib/hecks/generators/infrastructure/spec_generator/scope_spec.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/spec_generator/scope_spec.rb
@@ -78,31 +78,13 @@ module Hecks
           end
 
           def find_scope_create_cmd(aggregate)
-            agg_snake = domain_snake_name(aggregate.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
             aggregate.commands.find do |cmd|
-              cmd.attributes.none? { |a|
-                a.name.to_s.end_with?("_id") &&
-                  suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-              }
+              Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, aggregate.name).nil?
             end
           end
 
           def derive_scope_method(cmd, agg)
-            agg_snake = domain_snake_name(agg.name)
-            suffixes = agg_snake.split("_").each_index.map { |i|
-              agg_snake.split("_").drop(i).join("_")
-            }.uniq
-
-            full = domain_snake_name(cmd.name)
-            suffixes.each do |s|
-              stripped = full.sub(/_#{s}$/, "")
-              return stripped if stripped != full
-            end
-            full
+            Hecks::Conventions::CommandContract.method_name(cmd.name, agg.name).to_s
           end
 
           def create_args_override(cmd, field, value)

--- a/hecks_targets/go/lib/go_hecks/generators/command_generator.rb
+++ b/hecks_targets/go/lib/go_hecks/generators/command_generator.rb
@@ -13,11 +13,7 @@ module GoHecks
       @agg = aggregate
       @event = event
       @package = package
-      suffixes = HecksTemplating::CommandContract.agg_suffixes(@agg.name)
-      @self_id = @cmd.attributes.find { |a|
-        a.name.to_s.end_with?("_id") &&
-          suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-      }
+      @self_id = HecksTemplating::CommandContract.find_self_ref(@cmd.attributes, @agg.name)
       @is_create = @self_id.nil?
       # Event type name in Go — suffixed if it collides with command name
       @go_event_name = @event.name == @cmd.name ? "#{@event.name}Event" : @event.name

--- a/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
+++ b/hecks_targets/node/lib/node_hecks/generators/command_generator.rb
@@ -14,11 +14,7 @@ module NodeHecks
       @cmd = command
       @agg = aggregate
       @event = event
-      suffixes = HecksTemplating::CommandContract.agg_suffixes(@agg.name)
-      @self_id = @cmd.attributes.find { |a|
-        a.name.to_s.end_with?("_id") &&
-          suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-      }
+      @self_id = HecksTemplating::CommandContract.find_self_ref(@cmd.attributes, @agg.name)
       @is_create = @self_id.nil?
     end
 

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator.rb
@@ -69,24 +69,11 @@ class UIGenerator < Hecks::Generator
   end
 
   def self_ref?(cmd, agg_snake)
-    suffixes = agg_snake.split("_").each_index.map { |i|
-      agg_snake.split("_").drop(i).join("_")
-    }.uniq
-    cmd.attributes.any? { |a|
-      a.name.to_s.end_with?("_id") &&
-        suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-    }
+    Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg_snake) != nil
   end
 
   def find_self_ref_attr(cmd, agg)
-    agg_snake = domain_snake_name(agg.name)
-    suffixes = agg_snake.split("_").each_index.map { |i|
-      agg_snake.split("_").drop(i).join("_")
-    }.uniq
-    cmd.attributes.find { |a|
-      a.name.to_s.end_with?("_id") &&
-        suffixes.any? { |s| a.name.to_s == "#{s}_id" }
-    }
+    Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg.name)
   end
 
   def required_field?(agg, attr_name)

--- a/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/show_route.rb
+++ b/hecks_targets/ruby/lib/hecks_static/generators/ui_generator/show_route.rb
@@ -96,7 +96,7 @@ module HecksStatic
           other_safe = domain_constant_name(other.name)
           other_p = plural(other)
           other.commands.each do |cmd|
-            next unless cmd.attributes.any? { |a| a.name.to_s == "#{snake}_id" }
+            next unless Hecks::Conventions::CommandContract.find_self_ref(cmd.attributes, agg.name)
             cm = domain_snake_name(cmd.name)
             btn_parts << "{ label: \"#{HecksTemplating::UILabelContract.label(cmd.name)}\", href: \"/#{other_p}/#{cm}/new?id=\" + obj.id, allowed: #{mod}.role_allows?(\"#{other_safe}\", \"#{cm}\") }"
           end

--- a/hecksties/lib/hecks/conventions/command_contract.rb
+++ b/hecksties/lib/hecks/conventions/command_contract.rb
@@ -38,5 +38,32 @@ module Hecks::Conventions
         agg_snake.split("_").drop(i).join("_")
       }.uniq
     end
+
+    # True when +attr_name+ is a reference attribute pointing at +agg_name+.
+    # Matches any aggregate-suffix variant with an +_id+ tail:
+    #   reference_attribute?("policy_id", "GovernancePolicy") # => true
+    #   reference_attribute?("name",      "GovernancePolicy") # => false
+    #
+    # @param attr_name [String, Symbol] the attribute name to check
+    # @param agg_name  [String] the aggregate class name (camel or snake)
+    # @return [Boolean]
+    def self.reference_attribute?(attr_name, agg_name)
+      name = attr_name.to_s
+      return false unless name.end_with?("_id")
+      agg_suffixes(agg_name).any? { |s| name == "#{s}_id" }
+    end
+
+    # Find the self-referencing attribute in a list of attributes.
+    # Returns the first attribute whose name is a reference to +agg_name+.
+    #
+    #   find_self_ref(cmd.attributes, "GovernancePolicy")
+    #   # => #<Attribute name="policy_id" ...>  or nil
+    #
+    # @param attributes [Array] attribute objects responding to +#name+
+    # @param agg_name   [String] aggregate class name
+    # @return [Object, nil] the matching attribute, or nil
+    def self.find_self_ref(attributes, agg_name)
+      attributes.find { |a| reference_attribute?(a.name, agg_name) }
+    end
   end
 end

--- a/hecksties/spec/conventions/command_contract_spec.rb
+++ b/hecksties/spec/conventions/command_contract_spec.rb
@@ -14,4 +14,31 @@ RSpec.describe Hecks::Conventions::CommandContract do
     it { expect(described_class.agg_suffixes("Pizza")).to eq(["pizza"]) }
     it { expect(described_class.agg_suffixes("governance_policy")).to eq(["governance_policy", "policy"]) }
   end
+
+  describe ".reference_attribute?" do
+    it { expect(described_class.reference_attribute?("policy_id", "GovernancePolicy")).to be true }
+    it { expect(described_class.reference_attribute?("governance_policy_id", "GovernancePolicy")).to be true }
+    it { expect(described_class.reference_attribute?("pizza_id", "Pizza")).to be true }
+    it { expect(described_class.reference_attribute?("name", "GovernancePolicy")).to be false }
+    it { expect(described_class.reference_attribute?("other_id", "Pizza")).to be false }
+    it { expect(described_class.reference_attribute?(:policy_id, "GovernancePolicy")).to be true }
+  end
+
+  describe ".find_self_ref" do
+    let(:policy_id) { double(name: "policy_id") }
+    let(:name_attr) { double(name: "name") }
+    let(:other_id) { double(name: "other_id") }
+
+    it "returns the matching attribute" do
+      expect(described_class.find_self_ref([name_attr, policy_id], "GovernancePolicy")).to eq(policy_id)
+    end
+
+    it "returns nil when no match" do
+      expect(described_class.find_self_ref([name_attr, other_id], "GovernancePolicy")).to be_nil
+    end
+
+    it "returns nil for an empty list" do
+      expect(described_class.find_self_ref([], "Pizza")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary
feat: extract reference_attribute? and find_self_ref predicates into CommandContract

Centralizes the duplicated _id suffix-matching pattern used across 11
files into two reusable methods on CommandContract, eliminating ~70
lines of repeated suffix computation and attribute scanning logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)