### PR TITLE
HEC-464: World goals advisory validators

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -89,6 +89,12 @@
 - `:security` — command actors must be declared at domain level
 - **World Concerns Report** — `hecks validate` shows a per-concern PASS/FAIL summary with violations listed
 
+### World Goals (Advisory Validators)
+- `world_goals :equity, :sustainability` — opt-in advisory validators that produce warnings (never errors)
+- `:equity` — warns if only a single actor role is defined (concentrated authority)
+- `:sustainability` — warns if any aggregate lacks a lifecycle (no data retention/cleanup path)
+- Goals are only active when explicitly declared in the domain DSL
+
 ### Access Control & Ports
 - Define access-control ports that whitelist allowed methods per consumer
 - Import domains from event storm formats (Markdown and YAML)

--- a/bluebook/lib/hecks/domain/validator.rb
+++ b/bluebook/lib/hecks/domain/validator.rb
@@ -26,7 +26,7 @@ module Hecks
   class Validator
     # Trigger autoloading of all validation rule modules so each rule
     # registers itself with Hecks.register_validation_rule.
-    [ValidationRules::Naming, ValidationRules::References, ValidationRules::Structure, ValidationRules::WorldConcerns].each do |mod|
+    [ValidationRules::Naming, ValidationRules::References, ValidationRules::Structure, ValidationRules::WorldConcerns, ValidationRules::WorldGoals].each do |mod|
       mod.constants.each { |c| mod.const_get(c) }
     end
 

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -71,6 +71,10 @@ module Hecks
       #   (e.g. :transparency, :consent, :privacy, :security)
       attr_reader :world_concerns
 
+      # @return [Array<Symbol>] declared world goals for this domain
+      #   (e.g. :equity, :sustainability). Goals produce advisory warnings only.
+      attr_reader :world_goals
+
       # @return [Array<DomainModel::SubscriberRegistration>] event subscriber registrations at the domain level
       attr_reader :event_subscribers
 
@@ -102,7 +106,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil, world_concerns: [])
+                     version: nil, world_concerns: [], world_goals: [])
         validate_version!(version)
         @name = name
         @version = version
@@ -120,6 +124,7 @@ module Hecks
         @tenancy = tenancy
         @event_subscribers = event_subscribers
         @world_concerns = world_concerns.map(&:to_sym)
+        @world_goals = world_goals.map(&:to_sym)
       end
 
       # Returns the sanitized Ruby constant name for this domain.

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -66,6 +66,7 @@ module Hecks
         @tenancy = nil
         @event_subscribers = []
         @world_concerns = []
+        @world_goals = []
       end
 
       # Declare world concerns that this domain aspires to uphold.
@@ -78,6 +79,18 @@ module Hecks
       # @return [void]
       def world_concerns(*concerns)
         @world_concerns.concat(concerns.map(&:to_sym))
+      end
+
+      # Declare world goals that this domain aspires to. Goals produce advisory
+      # warnings (never errors) when the domain design could be improved.
+      # Available goals: :equity, :sustainability.
+      #
+      #   world_goals :equity, :sustainability
+      #
+      # @param goals [Array<Symbol>] one or more goal names
+      # @return [void]
+      def world_goals(*goals)
+        @world_goals.concat(goals.map(&:to_sym))
       end
 
       def actor(name, description: nil)
@@ -280,7 +293,8 @@ module Hecks
           event_subscribers: @event_subscribers,
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
           glossary_strict: @glossary_strict || false,
-          world_concerns: @world_concerns
+          world_concerns: @world_concerns,
+          world_goals: @world_goals
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/validation_rules/world_goals.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals.rb
@@ -1,0 +1,23 @@
+module Hecks
+  module ValidationRules
+
+    # Hecks::ValidationRules::WorldGoals
+    #
+    # Advisory validation rules activated by the +world_goals+ DSL keyword.
+    # Unlike world_concerns (which produce errors), world goals produce only
+    # warnings. Each rule checks a broad aspirational goal (equity,
+    # sustainability) and only fires when its goal is declared on the domain.
+    #
+    # Rules are autoloaded and self-register via +Hecks.register_validation_rule+.
+    #
+    #   Hecks.domain "GovAI" do
+    #     world_goals :equity, :sustainability
+    #     # ... aggregates ...
+    #   end
+    #
+    module WorldGoals
+      autoload :Equity,         "hecks/validation_rules/world_goals/equity"
+      autoload :Sustainability, "hecks/validation_rules/world_goals/sustainability"
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/equity.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/equity.rb
@@ -1,0 +1,40 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Equity
+      #
+      # When the :equity goal is declared, warns if the domain has only a single
+      # actor role. A single-actor domain concentrates all authority in one role,
+      # which may undermine equitable access. This is advisory -- it never
+      # prevents validation from passing.
+      #
+      #   world_goals :equity
+      #
+      #   # warning: only one actor role defined
+      #   actor "Admin"
+      #
+      #   # no warning: multiple roles provide checks and balances
+      #   actor "Admin"
+      #   actor "Reviewer"
+      #
+      class Equity < BaseRule
+        def errors
+          []
+        end
+
+        def warnings
+          return [] unless @domain.world_goals.include?(:equity)
+
+          issues = []
+          if @domain.actors.size == 1
+            role = @domain.actors.first.name
+            issues << "Equity: only one actor role '#{role}' -- consider additional roles for equitable access"
+          end
+          issues
+        end
+      end
+      Hecks.register_validation_rule(Equity)
+    end
+  end
+end

--- a/bluebook/lib/hecks/validation_rules/world_goals/sustainability.rb
+++ b/bluebook/lib/hecks/validation_rules/world_goals/sustainability.rb
@@ -1,0 +1,42 @@
+module Hecks
+  module ValidationRules
+    module WorldGoals
+
+      # Hecks::ValidationRules::WorldGoals::Sustainability
+      #
+      # When the :sustainability goal is declared, warns if any aggregate lacks a
+      # lifecycle. Aggregates without lifecycles have no defined end state, which
+      # means data may accumulate indefinitely with no archival or cleanup path.
+      # This is advisory -- it never prevents validation from passing.
+      #
+      #   world_goals :sustainability
+      #
+      #   # warning: no lifecycle defined
+      #   aggregate "Report" do
+      #     attribute :title, String
+      #     command "CreateReport" do
+      #       attribute :title, String
+      #     end
+      #   end
+      #
+      class Sustainability < BaseRule
+        def errors
+          []
+        end
+
+        def warnings
+          return [] unless @domain.world_goals.include?(:sustainability)
+
+          issues = []
+          @domain.aggregates.each do |agg|
+            unless agg.lifecycle
+              issues << "Sustainability: #{agg.name} has no lifecycle -- consider adding one for data retention and cleanup"
+            end
+          end
+          issues
+        end
+      end
+      Hecks.register_validation_rule(Sustainability)
+    end
+  end
+end

--- a/bluebook/spec/validation_rules/world_goals/world_goals_spec.rb
+++ b/bluebook/spec/validation_rules/world_goals/world_goals_spec.rb
@@ -1,0 +1,143 @@
+require "spec_helper"
+
+RSpec.describe "World Goals advisory validators" do
+  def validate(domain)
+    validator = Hecks::Validator.new(domain)
+    validator.valid?
+    [validator.valid?, validator.errors, validator.warnings]
+  end
+
+  describe "no goals declared" do
+    it "produces no warnings" do
+      domain = Hecks.domain "Clean" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings.grep(/Equity|Sustainability/)).to be_empty
+    end
+  end
+
+  describe ":equity" do
+    it "warns when only one actor role is defined" do
+      domain = Hecks.domain "Monopoly" do
+        world_goals :equity
+        actor "Admin"
+        aggregate "Config" do
+          attribute :key, String
+          command "UpdateConfig" do
+            attribute :key, String
+          end
+        end
+      end
+
+      valid, _errors, warnings = validate(domain)
+      expect(valid).to be true
+      expect(warnings).to include(/Equity.*only one actor role 'Admin'/)
+    end
+
+    it "does not warn when multiple actor roles exist" do
+      domain = Hecks.domain "Balanced" do
+        world_goals :equity
+        actor "Admin"
+        actor "Reviewer"
+        aggregate "Config" do
+          attribute :key, String
+          command "UpdateConfig" do
+            attribute :key, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings.grep(/Equity/)).to be_empty
+    end
+
+    it "does not warn when no actors are defined" do
+      domain = Hecks.domain "NoActors" do
+        world_goals :equity
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings.grep(/Equity/)).to be_empty
+    end
+  end
+
+  describe ":sustainability" do
+    it "warns when an aggregate has no lifecycle" do
+      domain = Hecks.domain "Ephemeral" do
+        world_goals :sustainability
+        aggregate "Report" do
+          attribute :title, String
+          command "CreateReport" do
+            attribute :title, String
+          end
+        end
+      end
+
+      valid, _errors, warnings = validate(domain)
+      expect(valid).to be true
+      expect(warnings).to include(/Sustainability.*Report.*no lifecycle/)
+    end
+
+    it "does not warn when aggregates have lifecycles" do
+      domain = Hecks.domain "Durable" do
+        world_goals :sustainability
+        aggregate "Report" do
+          attribute :title, String
+          attribute :status, String
+
+          lifecycle :status, default: "draft" do
+            transition "PublishReport" => "published"
+            transition "ArchiveReport" => "archived"
+          end
+
+          command "CreateReport" do
+            attribute :title, String
+          end
+          command "PublishReport" do
+            attribute :title, String
+          end
+          command "ArchiveReport" do
+            attribute :title, String
+          end
+        end
+      end
+
+      _valid, _errors, warnings = validate(domain)
+      expect(warnings.grep(/Sustainability/)).to be_empty
+    end
+  end
+
+  describe "world_goals never produce errors" do
+    it "domain remains valid even when goals are violated" do
+      domain = Hecks.domain "AllGoals" do
+        world_goals :equity, :sustainability
+        actor "Solo"
+        aggregate "Temp" do
+          attribute :name, String
+          command "CreateTemp" do
+            attribute :name, String
+          end
+        end
+      end
+
+      valid, errors, warnings = validate(domain)
+      expect(valid).to be true
+      expect(errors).to be_empty
+      expect(warnings).to include(/Equity/)
+      expect(warnings).to include(/Sustainability/)
+    end
+  end
+end

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -90,8 +90,11 @@ Hecks.domain "Banking" do
   actor "Customer"
   actor "Admin", description: "System administrator"
 
-  # World concerns (opt-in ethical validation)
+  # World concerns (opt-in ethical validation -- errors)
   world_concerns :transparency, :consent, :privacy, :security
+
+  # World goals (opt-in advisory validation -- warnings only)
+  world_goals :equity, :sustainability
 
   # Multi-tenancy
   tenancy :row

--- a/docs/usage/world_goals.md
+++ b/docs/usage/world_goals.md
@@ -1,0 +1,126 @@
+# World Goals -- Advisory Validators
+
+World goals are opt-in advisory validators that produce **warnings only** (never errors). They encourage better domain design without blocking compilation or validation.
+
+## Available Goals
+
+| Goal              | What it checks                                      |
+|-------------------|-----------------------------------------------------|
+| `:equity`         | Warns if only a single actor role is defined         |
+| `:sustainability` | Warns if any aggregate lacks a lifecycle definition  |
+
+## DSL Usage
+
+```ruby
+Hecks.domain "GovAI" do
+  world_goals :equity, :sustainability
+
+  actor "Admin"
+  actor "Reviewer"
+
+  aggregate "Report" do
+    attribute :title, String
+    attribute :status, String
+
+    lifecycle :status, default: "draft" do
+      transition "PublishReport" => "published"
+      transition "ArchiveReport" => "archived"
+    end
+
+    command "CreateReport" do
+      attribute :title, String
+    end
+    command "PublishReport" do
+      attribute :title, String
+    end
+    command "ArchiveReport" do
+      attribute :title, String
+    end
+  end
+end
+```
+
+## Equity
+
+The `:equity` goal warns when only a single actor role exists. A single-actor domain concentrates all authority in one role with no checks and balances.
+
+```ruby
+# Triggers equity warning -- single actor role
+Hecks.domain "Monopoly" do
+  world_goals :equity
+  actor "Admin"
+
+  aggregate "Config" do
+    attribute :key, String
+    command "UpdateConfig" do
+      attribute :key, String
+    end
+  end
+end
+# Warning: Equity: only one actor role 'Admin' -- consider additional roles for equitable access
+```
+
+Adding a second actor silences the warning:
+
+```ruby
+actor "Admin"
+actor "Reviewer"
+# No equity warning
+```
+
+## Sustainability
+
+The `:sustainability` goal warns when an aggregate has no lifecycle. Without a lifecycle, data accumulates indefinitely with no archival or cleanup path.
+
+```ruby
+# Triggers sustainability warning -- no lifecycle
+Hecks.domain "Ephemeral" do
+  world_goals :sustainability
+
+  aggregate "Report" do
+    attribute :title, String
+    command "CreateReport" do
+      attribute :title, String
+    end
+  end
+end
+# Warning: Sustainability: Report has no lifecycle -- consider adding one for data retention and cleanup
+```
+
+Adding a lifecycle silences the warning:
+
+```ruby
+aggregate "Report" do
+  attribute :title, String
+  attribute :status, String
+
+  lifecycle :status, default: "draft" do
+    transition "ArchiveReport" => "archived"
+  end
+
+  command "CreateReport" do
+    attribute :title, String
+  end
+  command "ArchiveReport" do
+    attribute :title, String
+  end
+end
+# No sustainability warning
+```
+
+## Key Differences from World Concerns
+
+| Aspect          | World Concerns            | World Goals               |
+|-----------------|--------------------------|---------------------------|
+| DSL keyword     | `world_concerns`         | `world_goals`             |
+| Output          | Errors (block validation)| Warnings (advisory only)  |
+| Purpose         | Enforce ethical rules    | Encourage better design   |
+
+## Programmatic Access
+
+```ruby
+domain = Hecks.domain("Example") { ... }
+validator = Hecks::Validator.new(domain)
+validator.valid?
+validator.warnings  # => ["Equity: ...", "Sustainability: ..."]
+```

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -66,6 +66,7 @@ module Hecks
     autoload :References,  "hecks/validation_rules/references"
     autoload :Structure,   "hecks/validation_rules/structure"
     autoload :WorldConcerns, "hecks/validation_rules/world_concerns"
+    autoload :WorldGoals,    "hecks/validation_rules/world_goals"
   end
 
   # = Hecks::DomainModel


### PR DESCRIPTION
## Summary
feat: add world_goals advisory validators (equity, sustainability)

Add world_goals DSL keyword alongside world_concerns. Unlike concerns
(which produce errors), goals produce warnings only -- they encourage
better domain design without blocking validation.

- :equity warns when a single actor role concentrates all authority
- :sustainability warns when aggregates lack lifecycle definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)