### PR TITLE
HEC-465: Extract naming module

### DIFF
--- a/hecksties/lib/hecks/conventions/naming_contract.rb
+++ b/hecksties/lib/hecks/conventions/naming_contract.rb
@@ -94,6 +94,20 @@ module Hecks::Conventions
         map
       end
 
+      # "PizzasDomain::Pizza::Commands::CreatePizza" → "PizzasDomain::Pizza"
+      # Extracts the aggregate module path from a fully-qualified command class name.
+      def aggregate_module_from_command(command_class_name)
+        command_class_name.split("::")[0..-3].join("::")
+      end
+
+      # Resolves the command class constant from a domain module.
+      #
+      #   Names.resolve_command_const(PizzasDomain, "Pizza", "CreatePizza")
+      #   # => PizzasDomain::Pizza::Commands::CreatePizza
+      def resolve_command_const(mod, agg_name, cmd_name)
+        mod.const_get("#{agg_name}::Commands::#{cmd_name}")
+      end
+
       # ("Blog", "Post") → "/blog/posts"
       def domain_route_path(domain_name, aggregate_name)
         "/#{domain_slug(domain_name)}/#{domain_aggregate_slug(aggregate_name)}"

--- a/hecksties/lib/hecks/conventions/naming_contract.rb
+++ b/hecksties/lib/hecks/conventions/naming_contract.rb
@@ -64,6 +64,36 @@ module Hecks::Conventions
         Hecks::Conventions::CommandContract.method_name(cmd_name, agg_name)
       end
 
+      # ("PizzasDomain", "Pizza", "CreatePizza") → "PizzasDomain::Pizza::Commands::CreatePizza"
+      def domain_command_fqn(domain_mod_name, agg_name, cmd_name)
+        "#{domain_mod_name}::#{agg_name}::Commands::#{cmd_name}"
+      end
+
+      # ("PizzasDomain", "Pizza", "CreatedPizza") → "PizzasDomain::Pizza::Events::CreatedPizza"
+      def domain_event_fqn(domain_mod_name, agg_name, event_name)
+        "#{domain_mod_name}::#{agg_name}::Events::#{event_name}"
+      end
+
+      # ("PizzasDomain", "Pizza", "CanCreate") → "PizzasDomain::Pizza::Policies::CanCreate"
+      def domain_policy_fqn(domain_mod_name, agg_name, policy_name)
+        "#{domain_mod_name}::#{agg_name}::Policies::#{policy_name}"
+      end
+
+      # Builds { fqn_string => [role_names] } for all commands with actor declarations.
+      #
+      #   Names.actor_roles_for(domain, domain_mod)
+      #   # => { "CatsDomain::Cat::Commands::Adopt" => ["Admin", "Vet"] }
+      def actor_roles_for(domain, domain_mod)
+        map = {}
+        domain.aggregates.each do |agg|
+          agg.commands.each do |cmd|
+            next if cmd.actors.empty?
+            map[domain_command_fqn(domain_mod.name, agg.name, cmd.name)] = cmd.actors.map(&:name)
+          end
+        end
+        map
+      end
+
       # ("Blog", "Post") → "/blog/posts"
       def domain_route_path(domain_name, aggregate_name)
         "/#{domain_slug(domain_name)}/#{domain_aggregate_slug(aggregate_name)}"

--- a/hecksties/lib/hecks/conventions/naming_helpers.rb
+++ b/hecksties/lib/hecks/conventions/naming_helpers.rb
@@ -49,6 +49,22 @@ module Hecks::Conventions
       Hecks::Conventions::Names.domain_command_method(cmd_name, agg_name)
     end
 
+    def domain_command_fqn(domain_mod_name, agg_name, cmd_name)
+      Hecks::Conventions::Names.domain_command_fqn(domain_mod_name, agg_name, cmd_name)
+    end
+
+    def domain_event_fqn(domain_mod_name, agg_name, event_name)
+      Hecks::Conventions::Names.domain_event_fqn(domain_mod_name, agg_name, event_name)
+    end
+
+    def domain_policy_fqn(domain_mod_name, agg_name, policy_name)
+      Hecks::Conventions::Names.domain_policy_fqn(domain_mod_name, agg_name, policy_name)
+    end
+
+    def actor_roles_for(domain, domain_mod)
+      Hecks::Conventions::Names.actor_roles_for(domain, domain_mod)
+    end
+
     def domain_route_path(domain_name, aggregate_name)
       Hecks::Conventions::Names.domain_route_path(domain_name, aggregate_name)
     end

--- a/hecksties/lib/hecks/conventions/naming_helpers.rb
+++ b/hecksties/lib/hecks/conventions/naming_helpers.rb
@@ -65,6 +65,14 @@ module Hecks::Conventions
       Hecks::Conventions::Names.actor_roles_for(domain, domain_mod)
     end
 
+    def aggregate_module_from_command(command_class_name)
+      Hecks::Conventions::Names.aggregate_module_from_command(command_class_name)
+    end
+
+    def resolve_command_const(mod, agg_name, cmd_name)
+      Hecks::Conventions::Names.resolve_command_const(mod, agg_name, cmd_name)
+    end
+
     def domain_route_path(domain_name, aggregate_name)
       Hecks::Conventions::Names.domain_route_path(domain_name, aggregate_name)
     end

--- a/hecksties/lib/hecks/extensions/auth.rb
+++ b/hecksties/lib/hecks/extensions/auth.rb
@@ -44,14 +44,7 @@ Hecks.register_extension(:auth) do |domain_mod, domain, runtime, **opts|
   # actor declarations. The key is the fully-qualified Ruby class name
   # (e.g. "CatsDomain::Cat::Commands::Adopt"), and the value is an Array
   # of role name strings (e.g. ["Admin", "Vet"]).
-  actor_map = {}
-  domain.aggregates.each do |agg|
-    agg.commands.each do |cmd|
-      next if cmd.actors.empty?
-      fqn = "#{domain_mod.name}::#{agg.name}::Commands::#{cmd.name}"
-      actor_map[fqn] = cmd.actors.map(&:name)
-    end
-  end
+  actor_map = Hecks::Conventions::Names.actor_roles_for(domain, domain_mod)
 
   next if actor_map.empty?
 

--- a/hecksties/lib/hecks/extensions/pii.rb
+++ b/hecksties/lib/hecks/extensions/pii.rb
@@ -111,7 +111,7 @@ Hecks.register_extension(:pii) do |domain_mod, domain, runtime|
     pii_lookup = {}
     domain.aggregates.each do |agg|
       agg.commands.each do |cmd|
-        fqn = "#{domain_mod.name}::#{agg.name}::Commands::#{cmd.name}"
+        fqn = Hecks::Conventions::Names.domain_command_fqn(domain_mod.name, agg.name, cmd.name)
         pii_names = HecksPii.pii_fields(agg)
         pii_lookup[fqn] = pii_names unless pii_names.empty?
       end

--- a/hecksties/lib/hecks/mixins/command.rb
+++ b/hecksties/lib/hecks/mixins/command.rb
@@ -102,7 +102,7 @@ module Hecks
       # @return [Class] the event class (e.g. +Pizza::Events::CreatedPizza+)
       # @raise [NameError] if the event class cannot be found
       def event_class
-        agg_module = name.split("::")[0..-3].join("::")
+        agg_module = Hecks::Conventions::Names.aggregate_module_from_command(name)
         Object.const_get("#{agg_module}::Events::#{event_name}")
       end
 
@@ -111,7 +111,7 @@ module Hecks
       # @return [Array<Class>] all event classes
       # @raise [NameError] if any event class cannot be found
       def event_classes
-        agg_module = name.split("::")[0..-3].join("::")
+        agg_module = Hecks::Conventions::Names.aggregate_module_from_command(name)
         event_names.map { |en| Object.const_get("#{agg_module}::Events::#{en}") }
       end
 
@@ -240,7 +240,7 @@ module Hecks
       policy_name = self.class.guarded_by
       return unless policy_name
 
-      agg_module = self.class.name.split("::")[0..-3].join("::")
+      agg_module = Hecks::Conventions::Names.aggregate_module_from_command(self.class.name)
       policy_class = Object.const_get("#{agg_module}::Policies::#{policy_name}")
       result = policy_class.new.call(self)
       unless result

--- a/hecksties/lib/hecks/runtime/reference_authorizer_check.rb
+++ b/hecksties/lib/hecks/runtime/reference_authorizer_check.rb
@@ -75,7 +75,7 @@ module Hecks
       # @param cmd [DomainModel::Behavior::Command]
       # @return [Class, nil]
       def resolve_command_class(agg, cmd)
-        @mod.const_get("#{agg.name}::Commands::#{cmd.name}")
+        Hecks::Conventions::Names.resolve_command_const(@mod, agg.name, cmd.name)
       rescue NameError
         nil
       end

--- a/hecksties/lib/hecks_multidomain/queue_wiring.rb
+++ b/hecksties/lib/hecks_multidomain/queue_wiring.rb
@@ -17,7 +17,7 @@ module Hecks
               rt.domain.aggregates.each do |agg|
                 next unless agg.commands.any? { |c| c.name == cmd_name }
                 mod = Object.const_get(domain_module_name(rt.domain.name))
-                klass = mod.const_get(agg.name).const_get(:Commands).const_get(cmd_name)
+                klass = Hecks::Conventions::Names.resolve_command_const(mod, agg.name, cmd_name)
                 return klass.call(**attrs)
               end
             end

--- a/hecksties/spec/conventions/naming_fqn_spec.rb
+++ b/hecksties/spec/conventions/naming_fqn_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe "Hecks::Conventions::Names FQN builders" do
     end
   end
 
+  describe ".aggregate_module_from_command" do
+    it "extracts aggregate module path from command class name" do
+      expect(names.aggregate_module_from_command("CatsDomain::Cat::Commands::Adopt"))
+        .to eq("CatsDomain::Cat")
+    end
+
+    it "handles deeply nested module paths" do
+      expect(names.aggregate_module_from_command("A::B::Commands::C"))
+        .to eq("A::B")
+    end
+  end
+
+  describe ".resolve_command_const" do
+    it "resolves the command class from a domain module" do
+      stub_const("TestDomain::Cat::Commands::Adopt", Class.new)
+      mod = Object.const_get("TestDomain")
+
+      expect(names.resolve_command_const(mod, "Cat", "Adopt"))
+        .to eq(TestDomain::Cat::Commands::Adopt)
+    end
+
+  end
+
   describe ".actor_roles_for" do
     it "builds actor map from domain aggregates" do
       actor = double(:actor, name: "Admin")

--- a/hecksties/spec/conventions/naming_fqn_spec.rb
+++ b/hecksties/spec/conventions/naming_fqn_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe "Hecks::Conventions::Names FQN builders" do
+  let(:names) { Hecks::Conventions::Names }
+
+  describe ".domain_command_fqn" do
+    it "builds fully-qualified command class name" do
+      expect(names.domain_command_fqn("CatsDomain", "Cat", "Adopt"))
+        .to eq("CatsDomain::Cat::Commands::Adopt")
+    end
+  end
+
+  describe ".domain_event_fqn" do
+    it "builds fully-qualified event class name" do
+      expect(names.domain_event_fqn("CatsDomain", "Cat", "AdoptedCat"))
+        .to eq("CatsDomain::Cat::Events::AdoptedCat")
+    end
+  end
+
+  describe ".domain_policy_fqn" do
+    it "builds fully-qualified policy class name" do
+      expect(names.domain_policy_fqn("CatsDomain", "Cat", "CanAdopt"))
+        .to eq("CatsDomain::Cat::Policies::CanAdopt")
+    end
+  end
+
+  describe ".actor_roles_for" do
+    it "builds actor map from domain aggregates" do
+      actor = double(:actor, name: "Admin")
+      cmd_with_actor = double(:command, name: "Adopt", actors: [actor])
+      cmd_without_actor = double(:command, name: "Feed", actors: [])
+      agg = double(:aggregate, name: "Cat", commands: [cmd_with_actor, cmd_without_actor])
+      domain = double(:domain, aggregates: [agg])
+      domain_mod = double(:domain_mod, name: "CatsDomain")
+
+      result = names.actor_roles_for(domain, domain_mod)
+
+      expect(result).to eq("CatsDomain::Cat::Commands::Adopt" => ["Admin"])
+      expect(result).not_to have_key("CatsDomain::Cat::Commands::Feed")
+    end
+
+    it "returns empty hash when no actors declared" do
+      cmd = double(:command, name: "Feed", actors: [])
+      agg = double(:aggregate, name: "Cat", commands: [cmd])
+      domain = double(:domain, aggregates: [agg])
+      domain_mod = double(:domain_mod, name: "CatsDomain")
+
+      expect(names.actor_roles_for(domain, domain_mod)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
HEC-465: Extract remaining inline FQN construction into Conventions::Names

Adds aggregate_module_from_command and resolve_command_const helpers,
replacing inline const_get chains in command.rb, reference_authorizer_check.rb,
and queue_wiring.rb with centralized naming conventions.

HEC-465: Extract FQN builders and actor_roles_for into Conventions::Names

Centralizes fully-qualified name construction for commands, events, and
policies into Hecks::Conventions::Names, replacing inline string
interpolation in auth.rb and pii.rb. Adds actor_roles_for to extract
the actor-map building logic from the auth extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)