### PR TITLE
HEC-479: Universal description keyword

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -7,6 +7,7 @@
 - Declare an explicit domain version with `Hecks.domain "Name", version: "2.1.0" { }` — semver and CalVer supported; propagates to generated gemspec and Go server header
 - Define aggregates with attributes, commands, events, policies, queries, and scopes
 - Inline aggregate definitions with `definition:` keyword — attaches a human-readable description to the aggregate IR, surfaced in `Hecks.aggregates` inspector output
+- Universal `description` keyword — available inside every DSL block (domain, aggregate, command, event, value object, entity, policy, service, workflow, read model, lifecycle). Stored on the IR node and round-tripped through DslSerializer. Feeds glossary, documentation, and LLM context.
 - Define value objects as immutable nested types within aggregates
 - Define entities within aggregates — sub-objects with identity (UUID), mutable, not frozen
 - Multi-domain support with shared event bus across domains

--- a/bluebook/lib/bluebook.rb
+++ b/bluebook/lib/bluebook.rb
@@ -8,6 +8,7 @@ require_relative "hecks/domain_model/names"
 
 # DSL builders (loaded in dependency order, before grammar so HANDLE_METHODS
 # can be derived from AggregateBuilder introspection)
+require_relative "hecks/dsl/describable"
 require_relative "hecks/dsl/attribute_collector"
 require_relative "hecks/dsl/event_builder"
 require_relative "hecks/dsl/command_builder"

--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -15,6 +15,7 @@ module Hecks
     # @return [String] valid Ruby DSL source code
     def serialize
       lines = ["Hecks.domain \"#{@domain.name}\" do"]
+      lines << "  description \"#{@domain.description}\"" if @domain.description
       @domain.aggregates.each_with_index do |agg, i|
         lines << "" if i > 0
         lines.concat(serialize_aggregate(agg))
@@ -28,6 +29,7 @@ module Hecks
 
     def serialize_aggregate(agg)
       lines = ["  aggregate \"#{agg.name}\" do"]
+      lines << "    description \"#{agg.description}\"" if agg.description
       lines.concat(serialize_attributes(agg.attributes, "    "))
       lines.concat(serialize_references(agg.references, "    "))
       lines.concat(serialize_value_objects(agg.value_objects))
@@ -52,6 +54,7 @@ module Hecks
     def serialize_value_objects(vos)
       vos.flat_map do |vo|
         lines = ["", "    value_object \"#{vo.name}\" do"]
+        lines << "      description \"#{vo.description}\"" if vo.description
         lines.concat(serialize_attributes(vo.attributes, "      "))
         lines.concat(serialize_invariants(vo.invariants, "      "))
         lines << "    end"
@@ -61,6 +64,7 @@ module Hecks
     def serialize_entities(entities)
       entities.flat_map do |ent|
         lines = ["", "    entity \"#{ent.name}\" do"]
+        lines << "      description \"#{ent.description}\"" if ent.description
         lines.concat(serialize_attributes(ent.attributes, "      "))
         lines.concat(serialize_invariants(ent.invariants, "      "))
         lines << "    end"
@@ -124,6 +128,7 @@ module Hecks
     def serialize_commands(commands)
       commands.flat_map do |cmd|
         lines = ["", "    command \"#{cmd.name}\" do"]
+        lines << "      description \"#{cmd.description}\"" if cmd.description
         if cmd.emits
           emits_names = Array(cmd.emits)
           lines << "      emits #{emits_names.map { |n| "\"#{n}\"" }.join(", ")}"
@@ -140,6 +145,7 @@ module Hecks
     def serialize_policies(policies)
       policies.flat_map do |pol|
         lines = ["", "    policy \"#{pol.name}\" do"]
+        lines << "      description \"#{pol.description}\"" if pol.description
         lines << "      on \"#{pol.event_name}\""
         lines << "      trigger \"#{pol.trigger_command}\""
         lines << "      async true" if pol.async

--- a/bluebook/lib/hecks/domain_model/behavior/command.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/command.rb
@@ -35,7 +35,7 @@ module Hecks
       # @return [String, Array<String>, nil] explicit event name(s) declared via +emits+
       attr_reader :name, :attributes, :references, :handler, :guard_name, :read_models,
                   :external_systems, :actors, :call_body, :sets,
-                  :preconditions, :postconditions, :emits
+                  :preconditions, :postconditions, :emits, :description
 
       # Creates a new Command IR node.
       #
@@ -54,7 +54,8 @@ module Hecks
       # @return [Command]
       def initialize(name:, attributes: [], references: [], handler: nil, guard_name: nil,
                      read_models: [], external_systems: [], actors: [],
-                     call_body: nil, sets: {}, preconditions: [], postconditions: [], emits: nil)
+                     call_body: nil, sets: {}, preconditions: [], postconditions: [], emits: nil,
+                     description: nil)
         @name = Names.command_name(name)
         @attributes = attributes
         @references = references
@@ -68,6 +69,7 @@ module Hecks
         @preconditions = preconditions
         @postconditions = postconditions
         @emits = emits
+        @description = description
       end
 
       # Returns the event name(s) this command emits.

--- a/bluebook/lib/hecks/domain_model/behavior/domain_event.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/domain_event.rb
@@ -21,7 +21,7 @@ module Hecks
       # @return [String] PascalCase event name in past tense, e.g. "CreatedPizza"
       # @return [Array<Hecks::DomainModel::Structure::Attribute>] data attributes
       #   carried by the event, typically mirroring the originating command's attributes
-      attr_reader :name, :attributes, :references
+      attr_reader :name, :attributes, :references, :description
 
       # Creates a new DomainEvent IR node.
       #
@@ -32,10 +32,11 @@ module Hecks
       # @param references [Array<Hecks::DomainModel::Structure::Reference>] references
       #   carried by this event. Defaults to an empty array.
       # @return [DomainEvent]
-      def initialize(name:, attributes: [], references: [])
+      def initialize(name:, attributes: [], references: [], description: nil)
         @name = Names.event_name(name)
         @attributes = attributes
         @references = references
+        @description = description
       end
     end
     end

--- a/bluebook/lib/hecks/domain_model/behavior/policy.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/policy.rb
@@ -45,7 +45,7 @@ module Hecks
       #   event and must return truthy for the policy to fire
       # @return [Hash{Symbol => Object}] default values for command attributes not present
       #   on the event when a reactive policy fires
-      attr_reader :name, :event_name, :trigger_command, :async, :block, :attribute_map, :condition, :defaults
+      attr_reader :name, :event_name, :trigger_command, :async, :block, :attribute_map, :condition, :defaults, :description
 
       # Creates a new Policy IR node.
       #
@@ -62,7 +62,7 @@ module Hecks
       # @param defaults [Hash{Symbol => Object}] fallback attribute values for the
       #   triggered command. Defaults to empty hash.
       # @return [Policy]
-      def initialize(name:, event_name: nil, trigger_command: nil, async: false, block: nil, attribute_map: {}, condition: nil, defaults: {})
+      def initialize(name:, event_name: nil, trigger_command: nil, async: false, block: nil, attribute_map: {}, condition: nil, defaults: {}, description: nil)
         @name = name
         @event_name = event_name && Names.event_name(event_name)
         @trigger_command = trigger_command && Names.command_name(trigger_command)
@@ -71,6 +71,7 @@ module Hecks
         @attribute_map = attribute_map
         @condition = condition
         @defaults = defaults
+        @description = description
       end
 
       # Returns whether this policy is a guard policy (has a validation block).

--- a/bluebook/lib/hecks/domain_model/behavior/read_model.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/read_model.rb
@@ -27,7 +27,7 @@ module Hecks
         # @return [String] PascalCase read model name (e.g. "OrderSummary")
         # @return [Hash{String => Proc}] mapping of event names to projection procs.
         #   Each proc receives (event, current_state) and returns the new state.
-        attr_reader :name, :projections
+        attr_reader :name, :projections, :description
 
         # Creates a new ReadModel IR node.
         #
@@ -37,9 +37,10 @@ module Hecks
         #   and the current projection state, and must return the updated state.
         #   Defaults to an empty hash.
         # @return [ReadModel]
-        def initialize(name:, projections: {})
+        def initialize(name:, projections: {}, description: nil)
           @name = name
           @projections = projections.transform_keys { |k| Names.event_name(k) }
+          @description = description
         end
       end
     end

--- a/bluebook/lib/hecks/domain_model/behavior/service.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/service.rb
@@ -29,13 +29,14 @@ module Hecks
         #   required to invoke this service
         # @return [Proc, nil] the orchestration body that dispatches commands;
         #   nil if the service has no inline implementation
-        attr_reader :name, :attributes, :coordinates, :call_body
+        attr_reader :name, :attributes, :coordinates, :call_body, :description
 
-        def initialize(name:, attributes: [], coordinates: [], call_body: nil)
+        def initialize(name:, attributes: [], coordinates: [], call_body: nil, description: nil)
           @name = name
           @attributes = attributes
           @coordinates = coordinates
           @call_body = call_body
+          @description = description
         end
       end
     end

--- a/bluebook/lib/hecks/domain_model/behavior/workflow.rb
+++ b/bluebook/lib/hecks/domain_model/behavior/workflow.rb
@@ -42,7 +42,7 @@ module Hecks
         #   ({ branch: { spec: String, if_steps: Array, else_steps: Array } })
         # @return [String, nil] schedule descriptor (e.g. a cron expression) for
         #   recurring workflows, or nil for on-demand workflows
-        attr_reader :name, :steps, :schedule
+        attr_reader :name, :steps, :schedule, :description
 
         # Creates a new Workflow IR node.
         #
@@ -54,10 +54,11 @@ module Hecks
         # @param schedule [String, nil] a cron expression or scheduling descriptor
         #   for recurring execution. Nil means the workflow runs on-demand only.
         # @return [Workflow]
-        def initialize(name:, steps: [], schedule: nil)
+        def initialize(name:, steps: [], schedule: nil, description: nil)
           @name = name
           @steps = steps
           @schedule = schedule
+          @description = description
         end
 
         # Returns whether this workflow is scheduled for recurring or timed execution.

--- a/bluebook/lib/hecks/domain_model/structure/aggregate.rb
+++ b/bluebook/lib/hecks/domain_model/structure/aggregate.rb
@@ -108,7 +108,7 @@ module Hecks
                      specifications: [], references: [],
                      factories: [], computed_attributes: [],
                      lifecycle: nil, metadata: {}, origin_domain: nil,
-                     identity_fields: nil)
+                     identity_fields: nil, description: nil)
         @name = Names.aggregate_name(name)
         @attributes = attributes
         @value_objects = value_objects
@@ -129,13 +129,10 @@ module Hecks
         @metadata = metadata
         @origin_domain = origin_domain
         @identity_fields = identity_fields
+        @description = description || @metadata[:description]
       end
 
-      attr_reader :metadata, :origin_domain
-
-      def description
-        @metadata[:description]
-      end
+      attr_reader :metadata, :origin_domain, :description
 
     end
     end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -102,7 +102,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil, world_concerns: [])
+                     version: nil, world_concerns: [], description: nil)
         validate_version!(version)
         @name = name
         @version = version
@@ -120,7 +120,11 @@ module Hecks
         @tenancy = tenancy
         @event_subscribers = event_subscribers
         @world_concerns = world_concerns.map(&:to_sym)
+        @description = description
       end
+
+      # @return [String, nil] human-readable description of this domain
+      attr_reader :description
 
       # Returns the sanitized Ruby constant name for this domain.
       # Strips non-alphanumeric characters and converts to PascalCase.

--- a/bluebook/lib/hecks/domain_model/structure/entity.rb
+++ b/bluebook/lib/hecks/domain_model/structure/entity.rb
@@ -43,11 +43,15 @@ module Hecks
       # @param invariants [Array<Invariant>] business rules enforced on this entity
       #
       # @return [Entity] a new Entity instance
-      def initialize(name:, attributes: [], invariants: [])
+      def initialize(name:, attributes: [], invariants: [], description: nil)
         @name = name
         @attributes = attributes
         @invariants = invariants
+        @description = description
       end
+
+      # @return [String, nil] human-readable description of this entity
+      attr_reader :description
     end
     end
   end

--- a/bluebook/lib/hecks/domain_model/structure/lifecycle.rb
+++ b/bluebook/lib/hecks/domain_model/structure/lifecycle.rb
@@ -46,11 +46,15 @@ module Hecks
         #   string or a Hash like +{ target: "approved", from: "draft" }+.
         #
         # @return [Lifecycle] a new Lifecycle instance
-        def initialize(field:, default:, transitions: {})
+        def initialize(field:, default:, transitions: {}, description: nil)
           @field = field.to_sym
           @default = default.to_s
           @transitions = transitions
+          @description = description
         end
+
+        # @return [String, nil] human-readable description of this lifecycle
+        attr_reader :description
 
         # Returns all unique states reachable in this lifecycle, including the default.
         # Useful for generating enum validations or state-related documentation.

--- a/bluebook/lib/hecks/domain_model/structure/value_object.rb
+++ b/bluebook/lib/hecks/domain_model/structure/value_object.rb
@@ -47,11 +47,15 @@ module Hecks
       # @param invariants [Array<Invariant>] business rules enforced at construction time
       #
       # @return [ValueObject] a new ValueObject instance
-      def initialize(name:, attributes: [], invariants: [])
+      def initialize(name:, attributes: [], invariants: [], description: nil)
         @name = name
         @attributes = attributes
         @invariants = invariants
+        @description = description
       end
+
+      # @return [String, nil] human-readable description of this value object
+      attr_reader :description
     end
     end
   end

--- a/bluebook/lib/hecks/dsl/aggregate_builder.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder.rb
@@ -25,6 +25,7 @@ module Hecks
       Behavior  = DomainModel::Behavior
 
       include AttributeCollector
+      include Describable
       include BehaviorMethods
       include ConstraintMethods
       include QueryMethods
@@ -190,7 +191,8 @@ module Hecks
           specifications: @specifications, computed_attributes: @computed_attributes,
           lifecycle: @lifecycle,
           metadata: @metadata, references: @references,
-          factories: @factories, identity_fields: @identity_fields
+          factories: @factories, identity_fields: @identity_fields,
+          description: @description
         )
       end
 

--- a/bluebook/lib/hecks/dsl/command_builder.rb
+++ b/bluebook/lib/hecks/dsl/command_builder.rb
@@ -33,6 +33,7 @@ module Hecks
       Behavior  = DomainModel::Behavior
 
       include AttributeCollector
+      include Describable
 
       # @return [Array<DomainModel::Structure::Attribute>] the command's input attributes
       attr_reader :attributes
@@ -229,7 +230,7 @@ module Hecks
           read_models: @read_models, external_systems: @external_systems, actors: @actors,
           call_body: @call_body, sets: @sets,
           preconditions: @preconditions, postconditions: @postconditions,
-          emits: @emits
+          emits: @emits, description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/describable.rb
+++ b/bluebook/lib/hecks/dsl/describable.rb
@@ -1,0 +1,33 @@
+module Hecks
+  module DSL
+
+    # Hecks::DSL::Describable
+    #
+    # Mixin that adds a `description` keyword to any DSL builder. When called
+    # with an argument it stores the text; when called without it returns the
+    # stored value. Builders that include this module pass @description through
+    # to their IR node's `description:` keyword.
+    #
+    #   class MyBuilder
+    #     include Describable
+    #
+    #     def build
+    #       SomeIRNode.new(name: @name, description: @description)
+    #     end
+    #   end
+    #
+    #   builder = MyBuilder.new("Foo")
+    #   builder.description "A short explanation"
+    #   builder.description  # => "A short explanation"
+    #
+    module Describable
+      def description(text = nil)
+        if text
+          @description = text
+        else
+          @description
+        end
+      end
+    end
+  end
+end

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -41,6 +41,7 @@ module Hecks
       Structure = DomainModel::Structure
 
       include AttributeCollector
+      include Describable
       include Hecksagon::ExtensionsDSL if defined?(Hecksagon::ExtensionsDSL)
       include Hecksagon::StrategicDSL if defined?(Hecksagon::StrategicDSL)
 
@@ -196,7 +197,7 @@ module Hecks
 
         builder = AggregateBuilder.new(name)
         desc = definition || description
-        builder.instance_variable_get(:@metadata)[:description] = desc if desc
+        builder.description(desc) if desc
         begin
           builder.instance_eval(&block) if block
         rescue Hecks::Error
@@ -280,7 +281,8 @@ module Hecks
           event_subscribers: @event_subscribers,
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
           glossary_strict: @glossary_strict || false,
-          world_concerns: @world_concerns
+          world_concerns: @world_concerns,
+          description: @description
         )
         classify_references(domain)
         if domain.respond_to?(:driving_ports=)

--- a/bluebook/lib/hecks/dsl/entity_builder.rb
+++ b/bluebook/lib/hecks/dsl/entity_builder.rb
@@ -30,6 +30,7 @@ module Hecks
       Structure = DomainModel::Structure
 
       include AttributeCollector
+      include Describable
 
       # Initialize a new entity builder with the given entity name.
       #
@@ -59,7 +60,8 @@ module Hecks
         Structure::Entity.new(
           name: @name,
           attributes: @attributes,
-          invariants: @invariants
+          invariants: @invariants,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/event_builder.rb
+++ b/bluebook/lib/hecks/dsl/event_builder.rb
@@ -12,6 +12,7 @@ module Hecks
     #
     class EventBuilder
       include AttributeCollector
+      include Describable
 
       def initialize(name)
         @name = name
@@ -21,7 +22,8 @@ module Hecks
       def build
         DomainModel::Behavior::DomainEvent.new(
           name: @name,
-          attributes: @attributes
+          attributes: @attributes,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/lifecycle_builder.rb
+++ b/bluebook/lib/hecks/dsl/lifecycle_builder.rb
@@ -22,6 +22,8 @@ module Hecks
     class LifecycleBuilder
       Structure = DomainModel::Structure
 
+      include Describable
+
       # Initialize a lifecycle builder for the given state field with a default value.
       #
       # @param field [Symbol] the attribute that holds the state value (e.g. :status)
@@ -66,7 +68,8 @@ module Hecks
       # @return [DomainModel::Structure::Lifecycle] the fully built lifecycle IR object
       def build
         Structure::Lifecycle.new(
-          field: @field, default: @default, transitions: @transitions
+          field: @field, default: @default, transitions: @transitions,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/policy_builder.rb
+++ b/bluebook/lib/hecks/dsl/policy_builder.rb
@@ -32,6 +32,8 @@ module Hecks
     class PolicyBuilder
       Behavior = DomainModel::Behavior
 
+      include Describable
+
       # Initialize a new policy builder with the given policy name.
       #
       # @param name [String] the policy name (e.g. "FraudAlert", "DisburseFunds")
@@ -134,7 +136,8 @@ module Hecks
           async: @async,
           attribute_map: @attribute_map,
           condition: @condition,
-          defaults: @defaults
+          defaults: @defaults,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/read_model_builder.rb
+++ b/bluebook/lib/hecks/dsl/read_model_builder.rb
@@ -23,6 +23,8 @@ module Hecks
     class ReadModelBuilder
       Behavior = DomainModel::Behavior
 
+      include Describable
+
       # Initialize a new read model builder with the given view name.
       #
       # @param name [String] the read model name (e.g. "OrderSummary", "AccountBalance")
@@ -56,7 +58,8 @@ module Hecks
       def build
         Behavior::ReadModel.new(
           name: @name,
-          projections: @projections
+          projections: @projections,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/service_builder.rb
+++ b/bluebook/lib/hecks/dsl/service_builder.rb
@@ -30,6 +30,7 @@ module Hecks
       Behavior = DomainModel::Behavior
 
       include AttributeCollector
+      include Describable
 
       # Initialize a new service builder with the given service name.
       #
@@ -67,7 +68,8 @@ module Hecks
           name: @name,
           attributes: @attributes,
           coordinates: @coordinates,
-          call_body: @call_body
+          call_body: @call_body,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/value_object_builder.rb
+++ b/bluebook/lib/hecks/dsl/value_object_builder.rb
@@ -29,6 +29,7 @@ module Hecks
       Structure = DomainModel::Structure
 
       include AttributeCollector
+      include Describable
 
       # Initialize a new value object builder with the given type name.
       #
@@ -71,7 +72,8 @@ module Hecks
         Structure::ValueObject.new(
           name: @name,
           attributes: @attributes,
-          invariants: @invariants
+          invariants: @invariants,
+          description: @description
         )
       end
     end

--- a/bluebook/lib/hecks/dsl/workflow_builder.rb
+++ b/bluebook/lib/hecks/dsl/workflow_builder.rb
@@ -26,6 +26,8 @@ module Hecks
     class WorkflowBuilder
       Behavior = DomainModel::Behavior
 
+      include Describable
+
       # Initialize a new workflow builder with the given workflow name.
       #
       # @param name [String] the workflow name (e.g. "LoanApproval")
@@ -101,7 +103,7 @@ module Hecks
       #
       # @return [DomainModel::Behavior::Workflow] the fully built workflow IR object
       def build
-        Behavior::Workflow.new(name: @name, steps: @steps, schedule: @schedule)
+        Behavior::Workflow.new(name: @name, steps: @steps, schedule: @schedule, description: @description)
       end
     end
 

--- a/bluebook/spec/dsl/describable_spec.rb
+++ b/bluebook/spec/dsl/describable_spec.rb
@@ -1,0 +1,196 @@
+require "spec_helper"
+
+RSpec.describe "Describable keyword" do
+  describe "domain description" do
+    it "stores description on the domain IR" do
+      domain = Hecks.domain("Banking") do
+        description "Core banking operations"
+        aggregate("Account") { attribute :name, String; command("CreateAccount") { attribute :name, String } }
+      end
+      expect(domain.description).to eq("Core banking operations")
+    end
+
+    it "returns nil when no description is provided" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") { attribute :name, String; command("CreateAccount") { attribute :name, String } }
+      end
+      expect(domain.description).to be_nil
+    end
+  end
+
+  describe "aggregate description" do
+    it "stores description via the description keyword inside the block" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          description "Manages customer funds and balances"
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("Manages customer funds and balances")
+    end
+
+    it "stores description via positional arg (backward compat)" do
+      domain = Hecks.domain("Banking") do
+        aggregate "Account", "Manages customer funds" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.description).to eq("Manages customer funds")
+    end
+  end
+
+  describe "command description" do
+    it "stores description on command IR" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          attribute :name, String
+          command("CreateAccount") do
+            description "Opens a new bank account"
+            attribute :name, String
+          end
+        end
+      end
+      expect(domain.aggregates.first.commands.first.description).to eq("Opens a new bank account")
+    end
+  end
+
+  describe "value object description" do
+    it "stores description on value object IR" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          attribute :name, String
+          value_object("Address") do
+            description "Mailing address for statements"
+            attribute :street, String
+          end
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.value_objects.first.description).to eq("Mailing address for statements")
+    end
+  end
+
+  describe "entity description" do
+    it "stores description on entity IR" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          attribute :name, String
+          entity("LedgerEntry") do
+            description "Records a single financial transaction"
+            attribute :amount, Float
+          end
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      expect(domain.aggregates.first.entities.first.description).to eq("Records a single financial transaction")
+    end
+  end
+
+  describe "event description" do
+    it "stores description on explicit event IR" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          attribute :name, String
+          event("AccountOverdrawn") do
+            description "Emitted when balance goes negative"
+            attribute :amount, Float
+          end
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+      event = domain.aggregates.first.events.find { |e| e.name == "AccountOverdrawn" }
+      expect(event.description).to eq("Emitted when balance goes negative")
+    end
+  end
+
+  describe "policy description" do
+    it "stores description on policy IR" do
+      domain = Hecks.domain("Banking") do
+        aggregate("Account") do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+          command("FlagSuspicious") { attribute :name, String }
+          policy("FraudAlert") do
+            description "Flags large withdrawals for review"
+            on "CreatedAccount"
+            trigger "FlagSuspicious"
+          end
+        end
+      end
+      expect(domain.aggregates.first.policies.first.description).to eq("Flags large withdrawals for review")
+    end
+  end
+
+  describe "service description" do
+    it "stores description on service IR" do
+      domain = Hecks.domain("Banking") do
+        service("TransferMoney") do
+          description "Moves funds between two accounts"
+          attribute :amount, Float
+        end
+        aggregate("Account") { attribute :name, String; command("CreateAccount") { attribute :name, String } }
+      end
+      expect(domain.services.first.description).to eq("Moves funds between two accounts")
+    end
+  end
+
+  describe "workflow description" do
+    it "stores description on workflow IR" do
+      domain = Hecks.domain("Banking") do
+        workflow("LoanApproval") do
+          description "Multi-step loan evaluation process"
+          step "ScoreLoan"
+        end
+        aggregate("Loan") { attribute :amount, Float; command("ScoreLoan") { attribute :amount, Float } }
+      end
+      expect(domain.workflows.first.description).to eq("Multi-step loan evaluation process")
+    end
+  end
+
+  describe "read model description" do
+    it "stores description on read model IR" do
+      domain = Hecks.domain("Banking") do
+        view("AccountBalance") do
+          description "Running balance projection"
+          project("CreatedAccount") { |event, state| state }
+        end
+        aggregate("Account") { attribute :name, String; command("CreateAccount") { attribute :name, String } }
+      end
+      expect(domain.views.first.description).to eq("Running balance projection")
+    end
+  end
+
+  describe "DslSerializer round-trip" do
+    it "preserves descriptions through serialize and eval" do
+      domain = Hecks.domain("Banking") do
+        description "Core banking operations"
+        aggregate("Account") do
+          description "Manages customer funds"
+          attribute :name, String
+          value_object("Address") do
+            description "Mailing address"
+            attribute :street, String
+          end
+          command("CreateAccount") do
+            description "Opens a new account"
+            attribute :name, String
+          end
+        end
+      end
+
+      source = Hecks::DslSerializer.new(domain).serialize
+      expect(source).to include('description "Core banking operations"')
+      expect(source).to include('description "Manages customer funds"')
+      expect(source).to include('description "Mailing address"')
+      expect(source).to include('description "Opens a new account"')
+
+      restored = eval(source)
+      expect(restored.description).to eq("Core banking operations")
+      expect(restored.aggregates.first.description).to eq("Manages customer funds")
+      expect(restored.aggregates.first.value_objects.first.description).to eq("Mailing address")
+      expect(restored.aggregates.first.commands.first.description).to eq("Opens a new account")
+    end
+  end
+end

--- a/docs/usage/description.md
+++ b/docs/usage/description.md
@@ -1,0 +1,103 @@
+# Universal `description` Keyword
+
+Every DSL block in Hecks supports a `description` method that attaches
+human-readable text to the IR node. Descriptions feed the domain glossary,
+generated documentation, MCP tool context, and LLM prompts.
+
+## Usage
+
+```ruby
+Hecks.domain "Banking" do
+  description "Core banking operations for retail customers"
+
+  aggregate "Account" do
+    description "Manages customer funds and balances"
+    attribute :name, String
+    attribute :balance, Float
+
+    value_object "Address" do
+      description "Mailing address for account statements"
+      attribute :street, String
+      attribute :city, String
+    end
+
+    entity "LedgerEntry" do
+      description "Records a single financial transaction"
+      attribute :amount, Float
+    end
+
+    command "OpenAccount" do
+      description "Opens a new bank account for a customer"
+      attribute :name, String
+    end
+
+    event "AccountOverdrawn" do
+      description "Emitted when balance goes negative"
+      attribute :amount, Float
+    end
+
+    policy "FraudAlert" do
+      description "Flags large withdrawals for review"
+      on "OpenedAccount"
+      trigger "FlagSuspicious"
+    end
+  end
+
+  service "TransferMoney" do
+    description "Moves funds between two accounts"
+    attribute :amount, Float
+  end
+
+  workflow "LoanApproval" do
+    description "Multi-step loan evaluation process"
+    step "ScoreLoan"
+  end
+
+  view "AccountBalance" do
+    description "Running balance projection"
+    project("OpenedAccount") { |event, state| state }
+  end
+end
+```
+
+## Accessing descriptions from the IR
+
+```ruby
+domain = Hecks.domain("Banking") { ... }
+
+domain.description
+# => "Core banking operations for retail customers"
+
+domain.aggregates.first.description
+# => "Manages customer funds and balances"
+
+domain.aggregates.first.commands.first.description
+# => "Opens a new bank account for a customer"
+```
+
+## DslSerializer round-trip
+
+Descriptions are preserved when serializing a domain back to DSL source:
+
+```ruby
+source = Hecks::DslSerializer.new(domain).serialize
+restored = eval(source)
+restored.aggregates.first.description
+# => "Manages customer funds and balances"
+```
+
+## Supported blocks
+
+| DSL block        | IR node                          |
+|------------------|----------------------------------|
+| `domain`         | `DomainModel::Structure::Domain` |
+| `aggregate`      | `DomainModel::Structure::Aggregate` |
+| `command`        | `DomainModel::Behavior::Command` |
+| `event`          | `DomainModel::Behavior::DomainEvent` |
+| `value_object`   | `DomainModel::Structure::ValueObject` |
+| `entity`         | `DomainModel::Structure::Entity` |
+| `policy`         | `DomainModel::Behavior::Policy` |
+| `service`        | `DomainModel::Behavior::Service` |
+| `workflow`       | `DomainModel::Behavior::Workflow` |
+| `view`           | `DomainModel::Behavior::ReadModel` |
+| `lifecycle`      | `DomainModel::Structure::Lifecycle` |

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -42,6 +42,9 @@ At the domain level you can declare aggregates, cross-aggregate policies, servic
 
 ```ruby
 Hecks.domain "Banking" do
+  # Human-readable description (available in every DSL block)
+  description "Core banking operations for retail customers"
+
   aggregate "Account" do ... end
 
   # Cross-aggregate reactive policies


### PR DESCRIPTION
## Summary
feat: universal description keyword for all DSL blocks

Add a Describable mixin that provides `description "text"` as a
setter/getter in every DSL builder. The description flows through to
each IR node and round-trips via DslSerializer. Supported blocks:
domain, aggregate, command, event, value_object, entity, policy,
service, workflow, view (read model), and lifecycle.

Migrates aggregate description from metadata[:description] to a
first-class `description:` keyword arg while preserving backward
compatibility with positional and `definition:` syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)