### PR TITLE
HEC-80: Outbox pattern for reliable event publishing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -721,6 +721,14 @@
 - No `Object.const_get`, `respond_to?`, or `instance_variable_get` in the UI layer
 - Same IR structs consumed by Ruby, Go, and Rails generators now also drive the Web Explorer
 
+### Event Log Browser (HEC-262)
+- Browse all published domain events in a filterable HTML table at `/events`
+- `EventIntrospector` reads `EventBus#events` with `all_entries(type_filter:, aggregate_filter:)`, `event_types`, `aggregate_types`
+- Filter bar with dropdowns for event type and aggregate type
+- Table columns: timestamp, type (badge), aggregate, expandable payload details
+- Events displayed in reverse chronological order (newest first)
+- "Events" link in the sidebar nav under System group
+
 ## Implicit DSL (HEC-229)
 
 ### Infer Domain Concepts from Structure

--- a/docs/usage/outbox.md
+++ b/docs/usage/outbox.md
@@ -1,0 +1,74 @@
+# Outbox Pattern -- Reliable Event Publishing
+
+The outbox extension guarantees at-least-once delivery of domain events. Instead of publishing events directly to the event bus (where listeners might fail), events are stored in a local outbox first. A synchronous poller then drains the outbox and publishes to the bus.
+
+## Quick Start
+
+```ruby
+app = Hecks.load(domain)
+app.extend(:outbox, enabled: true)
+
+Pizza.create(name: "Margherita")
+
+# Events were stored in the outbox, then drained to the bus
+Hecks.outbox.entries.size      # => 1
+Hecks.outbox.pending_count     # => 0  (already drained)
+app.events.size                # => 1  (delivered via poller)
+
+# Poller stats
+Hecks.outbox_poller.stats      # => { published: 1, pending: 0 }
+```
+
+## How It Works
+
+1. The extension wraps `event_bus.publish` to redirect events into the outbox
+2. After each command dispatch, middleware drains the outbox
+3. The poller reads unpublished entries and delivers them via the original publish path
+4. Each entry is marked as published so it won't be delivered again
+
+## Outbox Port API
+
+```ruby
+outbox = Hecks::Outbox::MemoryOutbox.new
+
+# Store an event
+entry = outbox.store(event)
+entry[:id]         # => "abc-123..."
+entry[:event]      # => the event object
+entry[:published]  # => false
+
+# Poll unpublished
+outbox.poll(limit: 50)     # => [entry, ...]
+
+# Mark as delivered
+outbox.mark_published(entry[:id])
+
+# Inspect
+outbox.pending_count  # => 0
+outbox.entries        # => all entries (published and unpublished)
+outbox.clear          # => remove everything
+```
+
+## Poller API
+
+```ruby
+poller = Hecks::Outbox::OutboxPoller.new(outbox, event_bus)
+
+# Drain all pending entries
+count = poller.drain(limit: 100)   # => number published
+
+# Stats
+poller.stats  # => { published: 3, pending: 0 }
+```
+
+The poller accepts an optional `publisher:` keyword for custom delivery:
+
+```ruby
+poller = Hecks::Outbox::OutboxPoller.new(outbox, bus, publisher: ->(evt) {
+  MyExternalBroker.send(evt)
+})
+```
+
+## Production Notes
+
+The in-memory outbox is suitable for development and testing. For production, implement an outbox adapter backed by your database (same transaction as the aggregate write) and run the poller in a background thread or separate process.

--- a/hecksties/lib/hecks/extensions/outbox.rb
+++ b/hecksties/lib/hecks/extensions/outbox.rb
@@ -1,0 +1,59 @@
+# HecksOutbox
+#
+# Outbox extension for reliable event publishing. When active, events
+# are intercepted at the event bus level and stored in a local outbox
+# instead of being delivered to listeners immediately. A synchronous
+# poller drains the outbox after each command dispatch, publishing
+# stored events to listeners and guaranteeing at-least-once delivery.
+#
+# This works with both dispatch paths: the command bus (app.run) and
+# the aggregate shortcut methods (Pizza.create). Events always flow
+# through the event bus publish method, which is wrapped by this extension.
+#
+# Usage:
+#   app = Hecks.load(domain)
+#   app.extend(:outbox, enabled: true)
+#
+#   Pizza.create(name: "Margherita")
+#   Hecks.outbox.entries.size     # => 1 (stored + already drained)
+#   Hecks.outbox.pending_count    # => 0 (poller drained it)
+#   app.events.size               # => 1 (delivered via poller)
+#
+require_relative "../ports/outbox/outbox"
+
+Hecks.describe_extension(:outbox,
+  description: "Reliable event publishing via transactional outbox pattern",
+  adapter_type: :driven,
+  config: { enabled: { default: false, desc: "Must be explicitly enabled" } },
+  wires_to: :event_bus)
+
+Hecks.register_extension(:outbox) do |_domain_mod, _domain, runtime, **kwargs|
+  # Only activate when explicitly requested. Passing any keyword argument
+  # signals intent (e.g., app.extend(:outbox, enabled: true)).
+  next if kwargs.empty?
+
+  outbox = Hecks::Outbox::MemoryOutbox.new
+  bus = runtime.event_bus
+
+  # Wrap the event bus publish to store in outbox instead of delivering
+  original_publish = bus.method(:publish)
+  bus.define_singleton_method(:publish) do |event|
+    outbox.store(event)
+  end
+
+  # Build a poller that uses the original publish to deliver events
+  poller = Hecks::Outbox::OutboxPoller.new(outbox, bus, publisher: original_publish)
+
+  # Drain the outbox after every command dispatch via middleware
+  runtime.use(:outbox_poller) do |_cmd, next_handler|
+    result = next_handler.call
+    poller.drain
+    result
+  end
+
+  # Expose outbox and poller on the Hecks module
+  Hecks.instance_variable_set(:@_outbox, outbox)
+  Hecks.instance_variable_set(:@_outbox_poller, poller)
+  Hecks.define_singleton_method(:outbox) { @_outbox }
+  Hecks.define_singleton_method(:outbox_poller) { @_outbox_poller }
+end

--- a/hecksties/lib/hecks/ports/outbox/memory_outbox.rb
+++ b/hecksties/lib/hecks/ports/outbox/memory_outbox.rb
@@ -1,0 +1,82 @@
+# Hecks::Outbox::MemoryOutbox
+#
+# In-memory implementation of the outbox port. Stores event entries in an
+# array, suitable for development and testing. Production adapters would
+# use a database table within the same transaction as the aggregate write.
+#
+# Each entry is a Hash with :id, :event, :stored_at, and :published keys.
+# The +poll+ method returns unpublished entries in insertion order.
+# The +mark_published+ method flags an entry so it is excluded from future polls.
+#
+# == Usage
+#
+#   outbox = Hecks::Outbox::MemoryOutbox.new
+#   outbox.store(pizza_created_event)
+#   outbox.poll          # => [{ id: "abc...", event: ..., stored_at: ..., published: false }]
+#   outbox.mark_published("abc...")
+#   outbox.poll          # => []
+#   outbox.entries.size  # => 1
+#
+require "securerandom"
+
+module Hecks
+  module Outbox
+    class MemoryOutbox
+      # @return [Array<Hash>] all stored outbox entries
+      attr_reader :entries
+
+      # Creates a new empty in-memory outbox.
+      def initialize
+        @entries = []
+      end
+
+      # Stores an event in the outbox for later publishing.
+      #
+      # @param event [Object] the domain event to store
+      # @return [Hash] the created outbox entry
+      def store(event)
+        entry = {
+          id: SecureRandom.uuid,
+          event: event,
+          stored_at: Time.now,
+          published: false
+        }
+        @entries << entry
+        entry
+      end
+
+      # Returns all unpublished entries in insertion order.
+      #
+      # @param limit [Integer] maximum entries to return (default: 100)
+      # @return [Array<Hash>] unpublished outbox entries
+      def poll(limit: 100)
+        @entries.select { |e| !e[:published] }.first(limit)
+      end
+
+      # Marks an outbox entry as published so it is excluded from future polls.
+      #
+      # @param entry_id [String] the UUID of the entry to mark
+      # @return [Boolean] true if the entry was found and marked, false otherwise
+      def mark_published(entry_id)
+        entry = @entries.find { |e| e[:id] == entry_id }
+        return false unless entry
+        entry[:published] = true
+        true
+      end
+
+      # Returns the count of unpublished entries.
+      #
+      # @return [Integer]
+      def pending_count
+        @entries.count { |e| !e[:published] }
+      end
+
+      # Clears all entries from the outbox.
+      #
+      # @return [void]
+      def clear
+        @entries.clear
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/ports/outbox/outbox.rb
+++ b/hecksties/lib/hecks/ports/outbox/outbox.rb
@@ -1,0 +1,26 @@
+# Hecks::Outbox
+#
+# Port interface for the transactional outbox pattern. Events are stored
+# in a local outbox table (same transaction as the aggregate write) and
+# later polled and published to the event bus. This guarantees at-least-once
+# delivery even when the event bus or downstream consumers are unavailable.
+#
+# The outbox stores event entries with :id, :event, :stored_at, and
+# :published flags. The poller calls +poll+ to retrieve unpublished
+# entries and +mark_published+ to flag them after successful bus delivery.
+#
+# == Usage
+#
+#   outbox = Hecks::Outbox::MemoryOutbox.new
+#   outbox.store(my_event)
+#   outbox.poll.each do |entry|
+#     bus.publish(entry[:event])
+#     outbox.mark_published(entry[:id])
+#   end
+#
+module Hecks
+  module Outbox
+    autoload :MemoryOutbox,  "hecks/ports/outbox/memory_outbox"
+    autoload :OutboxPoller,  "hecks/ports/outbox/outbox_poller"
+  end
+end

--- a/hecksties/lib/hecks/ports/outbox/outbox_poller.rb
+++ b/hecksties/lib/hecks/ports/outbox/outbox_poller.rb
@@ -1,0 +1,66 @@
+# Hecks::Outbox::OutboxPoller
+#
+# Synchronous poller that reads unpublished entries from the outbox and
+# publishes them to the event bus. After successful publication, each entry
+# is marked as published so it will not be delivered again.
+#
+# In the memory adapter this runs synchronously in the same process.
+# Production adapters can run the poller in a background thread or
+# separate process against a shared database outbox table.
+#
+# Accepts an optional +publisher+ callable. When the event bus's publish
+# method has been wrapped (e.g., to redirect into the outbox), the publisher
+# bypasses the wrapper and delivers events to the original listeners.
+#
+# == Usage
+#
+#   poller = Hecks::Outbox::OutboxPoller.new(outbox, event_bus)
+#   poller.drain    # publishes all pending entries
+#   poller.stats    # => { published: 3, pending: 0 }
+#
+module Hecks
+  module Outbox
+    class OutboxPoller
+      # @return [Object] the outbox to poll from (responds to poll, mark_published)
+      attr_reader :outbox
+
+      # @return [Hecks::EventBus] the event bus reference
+      attr_reader :event_bus
+
+      # Creates a new poller wired to an outbox and event bus.
+      #
+      # @param outbox [Hecks::Outbox::MemoryOutbox] the outbox to poll
+      # @param event_bus [Hecks::EventBus] the event bus to publish to
+      # @param publisher [#call, nil] optional callable for delivering events;
+      #   defaults to event_bus.method(:publish) if not provided
+      def initialize(outbox, event_bus, publisher: nil)
+        @outbox = outbox
+        @event_bus = event_bus
+        @publisher = publisher || event_bus.method(:publish)
+        @published_count = 0
+      end
+
+      # Polls the outbox and publishes all pending entries to the event bus.
+      # Each entry is marked as published after successful delivery.
+      #
+      # @param limit [Integer] maximum entries to process per drain (default: 100)
+      # @return [Integer] the number of entries published in this drain
+      def drain(limit: 100)
+        entries = @outbox.poll(limit: limit)
+        entries.each do |entry|
+          @publisher.call(entry[:event])
+          @outbox.mark_published(entry[:id])
+          @published_count += 1
+        end
+        entries.size
+      end
+
+      # Returns stats about the poller's lifetime activity.
+      #
+      # @return [Hash] with :published (total ever published) and :pending counts
+      def stats
+        { published: @published_count, pending: @outbox.pending_count }
+      end
+    end
+  end
+end

--- a/hecksties/spec/extensions/outbox_spec.rb
+++ b/hecksties/spec/extensions/outbox_spec.rb
@@ -1,0 +1,149 @@
+require "spec_helper"
+require "hecks/extensions/outbox"
+
+RSpec.describe "outbox extension" do
+  let(:domain) do
+    Hecks.domain "OutboxTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  def fresh_boot
+    Hecks.extension_registry.delete(:outbox)
+    load File.expand_path("../../../lib/hecks/extensions/outbox.rb", __FILE__)
+
+    app = Hecks.load(domain)
+    mod = Object.const_get("OutboxTestDomain")
+    Hecks.extension_registry[:outbox]&.call(mod, domain, app, enabled: true)
+    app
+  end
+
+  it "stores events in the outbox" do
+    app = fresh_boot
+    app.run("CreateWidget", name: "Sprocket")
+
+    expect(Hecks.outbox.entries.size).to eq(1)
+    expect(Hecks.outbox.entries.first[:event].name).to eq("Sprocket")
+  end
+
+  it "poller drains outbox and publishes to event bus" do
+    app = fresh_boot
+    app.run("CreateWidget", name: "Gear")
+
+    expect(Hecks.outbox.pending_count).to eq(0)
+    expect(app.events.size).to eq(1)
+  end
+
+  it "marks entries as published after drain" do
+    app = fresh_boot
+    app.run("CreateWidget", name: "Bolt")
+
+    entry = Hecks.outbox.entries.first
+    expect(entry[:published]).to eq(true)
+  end
+
+  it "reports poller stats" do
+    app = fresh_boot
+    app.run("CreateWidget", name: "Nut")
+
+    stats = Hecks.outbox_poller.stats
+    expect(stats[:published]).to eq(1)
+    expect(stats[:pending]).to eq(0)
+  end
+
+  it "handles multiple commands" do
+    app = fresh_boot
+    app.run("CreateWidget", name: "Alpha")
+    app.run("CreateWidget", name: "Beta")
+
+    expect(Hecks.outbox.entries.size).to eq(2)
+    expect(Hecks.outbox.pending_count).to eq(0)
+    expect(app.events.size).to eq(2)
+    expect(Hecks.outbox_poller.stats[:published]).to eq(2)
+  end
+end
+
+RSpec.describe Hecks::Outbox::MemoryOutbox do
+  subject(:outbox) { described_class.new }
+
+  let(:fake_event) { Struct.new(:name).new("TestEvent") }
+
+  it "stores events and returns entries" do
+    entry = outbox.store(fake_event)
+    expect(entry[:id]).not_to be_nil
+    expect(entry[:event]).to eq(fake_event)
+    expect(entry[:published]).to eq(false)
+  end
+
+  it "polls only unpublished entries" do
+    outbox.store(fake_event)
+    outbox.store(fake_event)
+    outbox.mark_published(outbox.entries.first[:id])
+
+    expect(outbox.poll.size).to eq(1)
+  end
+
+  it "respects poll limit" do
+    5.times { outbox.store(fake_event) }
+    expect(outbox.poll(limit: 2).size).to eq(2)
+  end
+
+  it "reports pending count" do
+    outbox.store(fake_event)
+    outbox.store(fake_event)
+    expect(outbox.pending_count).to eq(2)
+
+    outbox.mark_published(outbox.entries.first[:id])
+    expect(outbox.pending_count).to eq(1)
+  end
+
+  it "clears all entries" do
+    outbox.store(fake_event)
+    outbox.clear
+    expect(outbox.entries).to be_empty
+  end
+end
+
+RSpec.describe Hecks::Outbox::OutboxPoller do
+  let(:outbox) { Hecks::Outbox::MemoryOutbox.new }
+  let(:event_bus) { Hecks::EventBus.new }
+  subject(:poller) { described_class.new(outbox, event_bus) }
+
+  let(:fake_event) { Struct.new(:name).new("TestEvent") }
+
+  it "drains unpublished entries to the event bus" do
+    outbox.store(fake_event)
+    outbox.store(fake_event)
+
+    count = poller.drain
+    expect(count).to eq(2)
+    expect(event_bus.events.size).to eq(2)
+    expect(outbox.pending_count).to eq(0)
+  end
+
+  it "tracks cumulative stats" do
+    outbox.store(fake_event)
+    poller.drain
+    outbox.store(fake_event)
+    poller.drain
+
+    expect(poller.stats).to eq(published: 2, pending: 0)
+  end
+
+  it "uses custom publisher when provided" do
+    delivered = []
+    custom_pub = ->(event) { delivered << event }
+    custom_poller = described_class.new(outbox, event_bus, publisher: custom_pub)
+
+    outbox.store(fake_event)
+    custom_poller.drain
+
+    expect(delivered.size).to eq(1)
+    expect(event_bus.events).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary
- Outbox port with MemoryOutbox and OutboxPoller
- Extension wraps event_bus.publish to redirect events into outbox
- Synchronous drain after each command dispatch
- 13 specs, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)