### PR TITLE
Add ExtensionContract

### DIFF
--- a/hecksties/lib/hecks/conventions.rb
+++ b/hecksties/lib/hecks/conventions.rb
@@ -52,4 +52,5 @@ module Hecks
   Contracts.register(:commands,   Conventions::CommandContract)
   Contracts.register(:routes,     Conventions::RouteContract)
   Contracts.register(:dispatch,   Conventions::DispatchContract)
+  Contracts.register(:extensions, Conventions::ExtensionContract)
 end

--- a/hecksties/lib/hecks/conventions/extension_contract.rb
+++ b/hecksties/lib/hecks/conventions/extension_contract.rb
@@ -1,0 +1,127 @@
+# = Hecks::Conventions::ExtensionContract
+#
+# Enforces the required interface for Hecks extensions. Every extension
+# must declare metadata via +Hecks.describe_extension+ and register a
+# boot hook via +Hecks.register_extension+. The boot hook must accept
+# three arguments: +domain_mod+, +domain+, and +runtime+.
+#
+# This contract validates that an extension module conforms to the
+# standard shape by checking the extension registry and metadata registry.
+#
+#   result = Hecks::Conventions::ExtensionContract.validate(:logging)
+#   result[:valid]   # => true
+#   result[:missing] # => []
+#
+#   result = Hecks::Conventions::ExtensionContract.validate(:bogus)
+#   result[:valid]   # => false
+#   result[:missing] # => ["describe_extension not called for :bogus", ...]
+#
+module Hecks::Conventions
+  module ExtensionContract
+    # Required keys in the metadata hash returned by describe_extension.
+    REQUIRED_META_KEYS = %i[description adapter_type wires_to].freeze
+
+    # Valid adapter types for extensions.
+    VALID_ADAPTER_TYPES = %i[driven driving].freeze
+
+    # Expected arity of the boot hook block (domain_mod, domain, runtime).
+    BOOT_HOOK_ARITY = 3
+
+    # Return the expected shape of a conforming extension as a hash.
+    # Useful for documentation and introspection.
+    #
+    # @return [Hash] the expected interface shape
+    def self.shape
+      {
+        describe_extension: {
+          required_keys: REQUIRED_META_KEYS,
+          adapter_type: VALID_ADAPTER_TYPES,
+        },
+        register_extension: {
+          boot_hook_arity: BOOT_HOOK_ARITY,
+        },
+      }
+    end
+
+    # Validate that a named extension conforms to the required interface.
+    # Checks both the metadata registry (describe_extension) and the
+    # extension registry (register_extension).
+    #
+    # @param name [Symbol] the extension name (e.g. :logging, :sqlite)
+    # @return [Hash] { valid: Boolean, missing: Array<String> }
+    def self.validate(name)
+      missing = []
+
+      meta = check_metadata(name, missing)
+      check_boot_hook(name, missing)
+      validate_meta_shape(meta, name, missing) if meta
+
+      { valid: missing.empty?, missing: missing }
+    end
+
+    # Validate all registered extensions at once.
+    # Returns a hash mapping extension names to their validation results.
+    #
+    # @return [Hash{Symbol => Hash}] name => { valid:, missing: }
+    def self.validate_all
+      names = all_extension_names
+      names.each_with_object({}) do |name, results|
+        results[name] = validate(name)
+      end
+    end
+
+    # List all known extension names from both registries.
+    #
+    # @return [Array<Symbol>] sorted unique extension names
+    def self.all_extension_names
+      names = []
+      names.concat(Hecks.extension_meta.map(&:first)) if Hecks.respond_to?(:extension_meta)
+      names.concat(Hecks.extension_registry.map(&:first)) if Hecks.respond_to?(:extension_registry)
+      names.uniq.sort
+    end
+
+    class << self
+      private
+
+      # Check that describe_extension was called for this name.
+      def check_metadata(name, missing)
+        return nil unless Hecks.respond_to?(:extension_meta)
+
+        meta = Hecks.extension_meta[name]
+        missing << "describe_extension not called for :#{name}" unless meta
+        meta
+      end
+
+      # Check that register_extension was called and the hook has correct arity.
+      def check_boot_hook(name, missing)
+        return unless Hecks.respond_to?(:extension_registry)
+
+        hook = Hecks.extension_registry[name]
+        unless hook
+          missing << "register_extension not called for :#{name}"
+          return
+        end
+
+        unless hook.respond_to?(:arity)
+          missing << "boot hook for :#{name} is not callable"
+          return
+        end
+
+        if hook.arity != BOOT_HOOK_ARITY && hook.arity >= 0
+          missing << "boot hook for :#{name} has arity #{hook.arity}, expected #{BOOT_HOOK_ARITY}"
+        end
+      end
+
+      # Validate the shape of the metadata hash.
+      def validate_meta_shape(meta, name, missing)
+        REQUIRED_META_KEYS.each do |key|
+          missing << "metadata for :#{name} missing :#{key}" unless meta.key?(key)
+        end
+
+        if meta[:adapter_type] && !VALID_ADAPTER_TYPES.include?(meta[:adapter_type])
+          missing << "metadata for :#{name} has invalid adapter_type: #{meta[:adapter_type].inspect}"
+        end
+      end
+    end
+  end
+end

--- a/hecksties/spec/conventions/extension_contract_spec.rb
+++ b/hecksties/spec/conventions/extension_contract_spec.rb
@@ -1,0 +1,124 @@
+require "spec_helper"
+require "hecks/extensions/logging"
+require "hecks/extensions/tenancy"
+require "hecks/extensions/audit"
+
+RSpec.describe Hecks::Conventions::ExtensionContract do
+  describe ".shape" do
+    it "returns the expected interface shape" do
+      shape = described_class.shape
+      expect(shape).to have_key(:describe_extension)
+      expect(shape).to have_key(:register_extension)
+      expect(shape[:describe_extension][:required_keys]).to eq(%i[description adapter_type wires_to])
+      expect(shape[:register_extension][:boot_hook_arity]).to eq(3)
+    end
+  end
+
+  describe ".validate" do
+    it "passes for a well-formed extension like :logging" do
+      result = described_class.validate(:logging)
+      expect(result[:valid]).to be true
+      expect(result[:missing]).to be_empty
+    end
+
+    it "passes for a driven extension like :audit" do
+      result = described_class.validate(:audit)
+      expect(result[:valid]).to be true
+    end
+
+    it "passes for a driven extension like :tenancy" do
+      result = described_class.validate(:tenancy)
+      expect(result[:valid]).to be true
+    end
+
+    it "fails for an unregistered extension" do
+      result = described_class.validate(:bogus_nonexistent)
+      expect(result[:valid]).to be false
+      expect(result[:missing]).to include("describe_extension not called for :bogus_nonexistent")
+      expect(result[:missing]).to include("register_extension not called for :bogus_nonexistent")
+    end
+  end
+
+  describe ".validate — metadata-only registration" do
+    around do |example|
+      Hecks.describe_extension(:test_meta_only,
+        description: "Test extension",
+        adapter_type: :driven,
+        config: {},
+        wires_to: :command_bus)
+      example.run
+      Hecks.extension_meta.delete(:test_meta_only)
+    end
+
+    it "fails when register_extension is missing" do
+      result = described_class.validate(:test_meta_only)
+      expect(result[:valid]).to be false
+      expect(result[:missing]).to include("register_extension not called for :test_meta_only")
+    end
+  end
+
+  describe ".validate — hook-only registration" do
+    around do |example|
+      Hecks.register_extension(:test_hook_only) { |_dm, _d, _r| }
+      example.run
+      Hecks.extension_registry.delete(:test_hook_only)
+    end
+
+    it "fails when describe_extension is missing" do
+      result = described_class.validate(:test_hook_only)
+      expect(result[:valid]).to be false
+      expect(result[:missing]).to include("describe_extension not called for :test_hook_only")
+    end
+  end
+
+  describe ".validate — invalid adapter_type" do
+    around do |example|
+      Hecks.describe_extension(:test_bad_type,
+        description: "Bad type",
+        adapter_type: :bogus,
+        config: {},
+        wires_to: :command_bus)
+      Hecks.register_extension(:test_bad_type) { |_dm, _d, _r| }
+      example.run
+      Hecks.extension_meta.delete(:test_bad_type)
+      Hecks.extension_registry.delete(:test_bad_type)
+    end
+
+    it "reports invalid adapter_type" do
+      result = described_class.validate(:test_bad_type)
+      expect(result[:valid]).to be false
+      expect(result[:missing]).to include("metadata for :test_bad_type has invalid adapter_type: :bogus")
+    end
+  end
+
+  describe ".validate_all" do
+    it "returns results for all known extensions" do
+      results = described_class.validate_all
+      expect(results).to be_a(Hash)
+      expect(results.keys).to include(:logging)
+      results.each_value do |result|
+        expect(result).to have_key(:valid)
+        expect(result).to have_key(:missing)
+      end
+    end
+  end
+
+  describe ".all_extension_names" do
+    it "includes known extensions" do
+      names = described_class.all_extension_names
+      expect(names).to include(:logging, :tenancy, :audit)
+    end
+
+    it "returns sorted unique symbols" do
+      names = described_class.all_extension_names
+      expect(names).to eq(names.sort)
+      expect(names).to eq(names.uniq)
+    end
+  end
+
+  describe "VALID_ADAPTER_TYPES" do
+    it "includes :driven and :driving" do
+      expect(described_class::VALID_ADAPTER_TYPES).to eq(%i[driven driving])
+    end
+  end
+end


### PR DESCRIPTION
## Why
Extensions (logging, sqlite, tenancy) follow a two-step registration pattern but nothing enforced it. A fork adding a custom extension had no way to know the required shape without reading source.

## Summary
- New `Hecks::Conventions::ExtensionContract` validates `describe_extension` + `register_extension` pattern
- Checks adapter_type is `:driven` or `:driving`, boot hook has 3-arity block

## Contracts
- Adds: ExtensionContract

## Test plan
- [x] All specs pass
- [x] Validates real extensions (logging, audit, tenancy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)