### PR TITLE
HEC-458: Extract wildcard? and clean up match? in all 4 server files

### DIFF
--- a/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb
@@ -237,8 +237,15 @@ module Hecks
       # @param path [String] the actual request path (e.g. "/pizzas/abc123")
       # @return [Boolean] true if the path matches the pattern
       def match?(pattern, path)
-        pp = pattern.split("/"); ap = path.split("/")
-        pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
+        pattern_segments = pattern.split("/")
+        actual_segments  = path.split("/")
+        return false unless pattern_segments.size == actual_segments.size
+
+        pattern_segments.zip(actual_segments).all? { |pat, act| wildcard?(pat) || pat == act }
+      end
+
+      def wildcard?(segment)
+        segment.start_with?(":")
       end
 
       # Set CORS headers on the response using ENV-driven origin config.

--- a/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
+++ b/hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb
@@ -179,8 +179,15 @@ module Hecks
       end
 
       def match?(pattern, path)
-        pp = pattern.split("/"); ap = path.split("/")
-        pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
+        pattern_segments = pattern.split("/")
+        actual_segments  = path.split("/")
+        return false unless pattern_segments.size == actual_segments.size
+
+        pattern_segments.zip(actual_segments).all? { |pat, act| wildcard?(pat) || pat == act }
+      end
+
+      def wildcard?(segment)
+        segment.start_with?(":")
       end
     end
   end

--- a/hecksties/lib/hecks/extensions/serve/domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/domain_server.rb
@@ -271,8 +271,15 @@ module Hecks
       # @param path [String] the actual request path (e.g. "/pizzas/abc123")
       # @return [Boolean] true if the path matches the pattern
       def route_matches_request_path?(pattern, path)
-        pp = pattern.split("/"); ap = path.split("/")
-        pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
+        pattern_segments = pattern.split("/")
+        actual_segments  = path.split("/")
+        return false unless pattern_segments.size == actual_segments.size
+
+        pattern_segments.zip(actual_segments).all? { |pat, act| wildcard?(pat) || pat == act }
+      end
+
+      def wildcard?(segment)
+        segment.start_with?(":")
       end
 
       # Set CORS headers on the response using ENV-driven origin config.

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -190,8 +190,15 @@ module Hecks
       end
 
       def route_matches_request_path?(pattern, path)
-        pp = pattern.split("/"); ap = path.split("/")
-        pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
+        pattern_segments = pattern.split("/")
+        actual_segments  = path.split("/")
+        return false unless pattern_segments.size == actual_segments.size
+
+        pattern_segments.zip(actual_segments).all? { |pat, act| wildcard?(pat) || pat == act }
+      end
+
+      def wildcard?(segment)
+        segment.start_with?(":")
       end
     end
   end


### PR DESCRIPTION
## Why

The `match?` method in all four server files used cryptic one-letter variable names (`pp`, `ap`) and an anonymous inline segment check. It reads like a puzzle — anyone tracing a routing bug has to decode the abbreviations before understanding the logic.

## What changed

Extracted the segment wildcard check to a named `wildcard?(segment)` predicate and renamed variables to `pattern_segments`/`actual_segments` across all 4 files:

- `hecksties/lib/hecks/extensions/serve/domain_server.rb`
- `hecksties/lib/hecks/extensions/serve/multi_domain_server.rb`
- `hecks_workshop/explorer/lib/hecks_explorer/domain_server.rb`
- `hecks_workshop/explorer/lib/hecks_explorer/multi_domain_server.rb`

## Before / After

```ruby
# Before
def match?(pattern, path)
  pp = pattern.split("/"); ap = path.split("/")
  pp.size == ap.size && pp.zip(ap).all? { |p, a| p.start_with?(":") || p == a }
end

# After
def match?(pattern, path)
  pattern_segments = pattern.split("/")
  actual_segments  = path.split("/")
  return false unless pattern_segments.size == actual_segments.size

  pattern_segments.zip(actual_segments).all? { |pat, act| wildcard?(pat) || pat == act }
end

def wildcard?(segment)
  segment.start_with?(":")
end
```

No behavior change — all existing routing specs pass.