### PR TITLE
HEC-473: Add definition: kwarg to aggregate DSL

### DIFF
--- a/bluebook/lib/hecks/domain/dsl_serializer.rb
+++ b/bluebook/lib/hecks/domain/dsl_serializer.rb
@@ -28,8 +28,8 @@ module Hecks
     private
 
     def serialize_aggregate(agg)
-      lines = ["  aggregate \"#{agg.name}\" do"]
-      lines << "    description \"#{agg.description}\"" if agg.description
+      definition_kwarg = agg.description ? ", definition: \"#{agg.description}\"" : ""
+      lines = ["  aggregate \"#{agg.name}\"#{definition_kwarg} do"]
       lines.concat(serialize_attributes(agg.attributes, "    "))
       lines.concat(serialize_references(agg.references, "    "))
       lines.concat(serialize_value_objects(agg.value_objects))

--- a/bluebook/spec/domain/dsl_serializer_spec.rb
+++ b/bluebook/spec/domain/dsl_serializer_spec.rb
@@ -1,6 +1,42 @@
 require "spec_helper"
 
 RSpec.describe Hecks::DslSerializer do
+  it "serializes aggregate definition: kwarg inline" do
+    domain = Hecks.domain "Pizzas" do
+      aggregate "Pizza", definition: "A customizable food item" do
+        attribute :name, String
+      end
+    end
+
+    source = described_class.new(domain).serialize
+    expect(source).to include('aggregate "Pizza", definition: "A customizable food item"')
+    expect(source).not_to include("description")
+  end
+
+  it "round-trips aggregate definition: through eval" do
+    domain = Hecks.domain "Pizzas" do
+      aggregate "Pizza", definition: "A customizable food item" do
+        attribute :name, String
+      end
+    end
+
+    source = described_class.new(domain).serialize
+    restored = eval(source)
+    expect(restored.aggregates.first.description).to eq("A customizable food item")
+  end
+
+  it "omits definition: kwarg when not set" do
+    domain = Hecks.domain "Pizzas" do
+      aggregate "Pizza" do
+        attribute :name, String
+      end
+    end
+
+    source = described_class.new(domain).serialize
+    expect(source).to include('aggregate "Pizza" do')
+    expect(source).not_to include("definition:")
+  end
+
   it "serializes a domain back to DSL source" do
     domain = Hecks.domain "Pizzas" do
       aggregate "Pizza" do

--- a/bluebook/spec/dsl/describable_spec.rb
+++ b/bluebook/spec/dsl/describable_spec.rb
@@ -166,8 +166,7 @@ RSpec.describe "Describable keyword" do
     it "preserves descriptions through serialize and eval" do
       domain = Hecks.domain("Banking") do
         description "Core banking operations"
-        aggregate("Account") do
-          description "Manages customer funds"
+        aggregate("Account", definition: "Manages customer funds") do
           attribute :name, String
           value_object("Address") do
             description "Mailing address"
@@ -182,7 +181,7 @@ RSpec.describe "Describable keyword" do
 
       source = Hecks::DslSerializer.new(domain).serialize
       expect(source).to include('description "Core banking operations"')
-      expect(source).to include('description "Manages customer funds"')
+      expect(source).to include('definition: "Manages customer funds"')
       expect(source).to include('description "Mailing address"')
       expect(source).to include('description "Opens a new account"')
 

--- a/bluebook/spec/dsl/domain_builder_spec.rb
+++ b/bluebook/spec/dsl/domain_builder_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe Hecks::DSL::DomainBuilder do
       end
       expect(domain.aggregates.map(&:name)).to eq(["Widget", "Gadget"])
     end
+
+    describe "definition: kwarg" do
+      it "stores definition as description on the aggregate IR" do
+        domain = Hecks.domain("Pizzas") do
+          aggregate "Pizza", definition: "A customizable food item with a crust, sauce, and toppings" do
+            attribute :name, String
+          end
+        end
+        expect(domain.aggregates.first.description).to eq("A customizable food item with a crust, sauce, and toppings")
+      end
+
+      it "leaves description nil when definition: is omitted" do
+        domain = Hecks.domain("Pizzas") do
+          aggregate "Pizza" do
+            attribute :name, String
+          end
+        end
+        expect(domain.aggregates.first.description).to be_nil
+      end
+    end
   end
 
   describe "commands and events" do


### PR DESCRIPTION
## Why

Aggregates had no way to carry a human-readable definition inline. The DSL is meant to express ubiquitous language — a glossary — but there was nowhere to put the definition of what an aggregate actually *is* without a separate doc block outside the DSL.

## What changed

Added `definition:` as an optional inline kwarg on `aggregate`. The serializer now round-trips it as an inline kwarg rather than a nested block call.

```ruby
# Before — no way to declare this in DSL
aggregate "Pizza" do
  attribute :name, String
end

# After
aggregate "Pizza", definition: "A customizable food item with a crust, sauce, and toppings" do
  attribute :name, String
end
```

The definition is stored on the Aggregate IR as `description`, visible in `hecks inspect`, and round-tripped correctly by the DSL serializer.

## Test plan

- `definition:` stores into `aggregate.description`
- Omitting `definition:` leaves description nil
- Serializer emits inline kwarg form
- Round-trip: serialize → eval → re-serialize preserves definition