### PR TITLE
HEC-366: Add port visualization to domain diagram

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -368,6 +368,7 @@
   - `--type flows` — sequenceDiagram of reactive chain flows
   - `--type slices` — slice flowchart with subgraph per vertical slice
   - `--type ports` — hexagonal port diagram showing driving/driven adapters around the domain
+  - `--type aggregate-ports` — per-aggregate port diagram: commands as driving-port arrows (left), optional Persistence/EventBus as driven-port nodes (right); pass `show_persistence:` / `show_event_bus:` to enable driven nodes
   - `--browser` — self-contained HTML with Mermaid CDN opened in browser
   - `--output <file>` — write Mermaid markdown to a file
 - `hecks context_map` — CLI command renders DDD context map of bounded context relationships

--- a/bluebook/lib/hecks/domain/visualizer.rb
+++ b/bluebook/lib/hecks/domain/visualizer.rb
@@ -27,11 +27,13 @@ module Hecks
       @domain = domain
     end
 
-    # Generate both the structure and behavior Mermaid diagrams as a single
-    # markdown string with two code-fenced blocks.
+    # Generate the structure, behavior, and aggregate-ports Mermaid diagrams
+    # as a single markdown string with three code-fenced blocks.
     #
-    # @return [String] markdown with two ```mermaid blocks (structure then behavior)
-    def generate
+    # @param show_persistence [Boolean] include Persistence driven-port nodes
+    # @param show_event_bus   [Boolean] include EventBus driven-port nodes
+    # @return [String] markdown with three ```mermaid blocks
+    def generate(show_persistence: false, show_event_bus: false)
       parts = []
       parts << "```mermaid"
       parts << generate_structure
@@ -39,6 +41,13 @@ module Hecks
       parts << ""
       parts << "```mermaid"
       parts << generate_behavior
+      parts << "```"
+      parts << ""
+      parts << "```mermaid"
+      parts << generate_aggregate_ports(
+        show_persistence: show_persistence,
+        show_event_bus: show_event_bus
+      )
       parts << "```"
       parts.join("\n")
     end

--- a/bluebook/lib/hecks/domain/visualizer_parts/port_diagram.rb
+++ b/bluebook/lib/hecks/domain/visualizer_parts/port_diagram.rb
@@ -1,15 +1,23 @@
 # Hecks::DomainVisualizer::PortDiagram
 #
-# Builds a Mermaid flowchart showing the hexagonal architecture of a domain:
-# driving ports (HTTP, MCP, CLI, etc.) on the left, the domain hexagon in
-# the center, and driven ports (persistence, auth, logging, etc.) on the
-# right. Arrows show data flow direction.
+# Builds two Mermaid flowcharts that expose the hexagonal architecture of a
+# domain:
 #
-# Extension metadata is read from Hecks.extension_meta when available.
-# An explicit +extensions+ parameter can override this for testing.
+# 1. generate_ports — shows registered extension adapters. Driving adapters
+#    (HTTP, MCP, CLI) appear on the left; driven adapters (persistence, auth,
+#    logging) appear on the right. Arrows show data-flow direction.
+#    Extension metadata is read from Hecks.extension_meta when available; an
+#    explicit +extensions+ parameter can override this for testing.
+#
+# 2. generate_aggregate_ports — shows each aggregate's commands as driving
+#    port arrows entering the aggregate from the left, and optional driven
+#    port nodes (Persistence, EventBus) exiting to the right. Pass
+#    +show_persistence: true+ and/or +show_event_bus: true+ to enable the
+#    driven-port nodes.
 #
 #   include PortDiagram
-#   generate_ports  # => "flowchart LR\n    subgraph Driving Ports\n..."
+#   generate_ports               # => "flowchart LR\n    subgraph Driving…"
+#   generate_aggregate_ports     # => "flowchart LR\n    subgraph Pizza…"
 #
 module Hecks
   class DomainVisualizer
@@ -30,6 +38,35 @@ module Hecks
         domain_node(lines)
         driven_nodes(lines, driven)
         flow_arrows(lines, driving, driven)
+        lines.join("\n")
+      end
+
+      # Generate a Mermaid flowchart showing per-aggregate hexagonal ports.
+      # Commands appear as driving-port nodes (left), the aggregate sits in
+      # the centre, and optional persistence / event-bus nodes appear as
+      # driven-port nodes (right).
+      #
+      # @param show_persistence [Boolean] include a Persistence node (default false)
+      # @param show_event_bus   [Boolean] include an EventBus node (default false)
+      # @return [String] Mermaid flowchart source code
+      def generate_aggregate_ports(show_persistence: false, show_event_bus: false)
+        lines = ["flowchart LR"]
+
+        @domain.aggregates.each do |agg|
+          lines << "    subgraph #{agg.name}"
+          agg.commands.each do |cmd|
+            cmd_node = "#{agg.name}_#{cmd.name}_cmd"
+            lines << "        #{cmd_node}([#{cmd.name}])-->#{agg.name}"
+          end
+          if show_persistence
+            lines << "        #{agg.name}-->#{agg.name}_Persistence[(Persistence)]"
+          end
+          if show_event_bus
+            lines << "        #{agg.name}-->#{agg.name}_EventBus{{EventBus}}"
+          end
+          lines << "    end"
+        end
+
         lines.join("\n")
       end
 

--- a/bluebook/spec/domain/visualizer_spec.rb
+++ b/bluebook/spec/domain/visualizer_spec.rb
@@ -129,4 +129,54 @@ RSpec.describe Hecks::DomainVisualizer do
       expect { domain.visualize }.to output(/classDiagram/).to_stdout
     end
   end
+
+  describe "aggregate ports diagram" do
+    subject(:ports_diagram) { visualizer.generate_aggregate_ports }
+
+    it "contains a flowchart block" do
+      expect(ports_diagram).to include("flowchart LR")
+    end
+
+    it "groups commands by aggregate subgraph" do
+      expect(ports_diagram).to include("subgraph Pizza")
+      expect(ports_diagram).to include("subgraph Order")
+    end
+
+    it "shows commands as driving-port nodes entering the aggregate" do
+      expect(ports_diagram).to include("Pizza_CreatePizza_cmd([CreatePizza])-->Pizza")
+      expect(ports_diagram).to include("Order_PlaceOrder_cmd([PlaceOrder])-->Order")
+    end
+
+    it "omits persistence node by default" do
+      expect(ports_diagram).not_to include("Persistence")
+    end
+
+    it "omits event bus node by default" do
+      expect(ports_diagram).not_to include("EventBus")
+    end
+
+    context "with show_persistence: true" do
+      subject(:ports_diagram) { visualizer.generate_aggregate_ports(show_persistence: true) }
+
+      it "includes a Persistence driven-port node for each aggregate" do
+        expect(ports_diagram).to include("Pizza-->Pizza_Persistence[(Persistence)]")
+        expect(ports_diagram).to include("Order-->Order_Persistence[(Persistence)]")
+      end
+    end
+
+    context "with show_event_bus: true" do
+      subject(:ports_diagram) { visualizer.generate_aggregate_ports(show_event_bus: true) }
+
+      it "includes an EventBus driven-port node for each aggregate" do
+        expect(ports_diagram).to include("Pizza-->Pizza_EventBus{{EventBus}}")
+        expect(ports_diagram).to include("Order-->Order_EventBus{{EventBus}}")
+      end
+    end
+
+    context "generate includes the aggregate ports block" do
+      it "the main generate output contains the ports flowchart" do
+        expect(mermaid).to include("Pizza_CreatePizza_cmd([CreatePizza])-->Pizza")
+      end
+    end
+  end
 end

--- a/docs/usage/port_visualization.md
+++ b/docs/usage/port_visualization.md
@@ -36,7 +36,40 @@ flowchart LR
     Domain --> port_auth
 ```
 
-## Programmatic Usage
+## Aggregate-Level Port Visualization
+
+Show per-aggregate hexagonal architecture: commands as driving-port arrows entering from the left, and optional Persistence / EventBus nodes as driven-port arrows exiting to the right.
+
+```ruby
+domain = Hecks.domain("Pizzas") do
+  aggregate "Pizza" do
+    command "CreatePizza" do; attribute :name, String; end
+    command "AddTopping" do; attribute :name, String; end
+  end
+end
+
+viz = Hecks::DomainVisualizer.new(domain)
+
+# Commands only (default)
+puts viz.generate_aggregate_ports
+
+# Commands + driven ports
+puts viz.generate_aggregate_ports(show_persistence: true, show_event_bus: true)
+```
+
+### Example Output (commands + driven ports)
+
+```mermaid
+flowchart LR
+    subgraph Pizza
+        Pizza_CreatePizza_cmd([CreatePizza])-->Pizza
+        Pizza_AddTopping_cmd([AddTopping])-->Pizza
+        Pizza-->Pizza_Persistence[(Persistence)]
+        Pizza-->Pizza_EventBus{{EventBus}}
+    end
+```
+
+## Programmatic Usage (extension-level ports)
 
 ```ruby
 domain = Hecks.domain("Pizzas") { aggregate("Pizza") { attribute :name, String } }
@@ -55,5 +88,7 @@ puts viz.generate_ports(extensions: {
 ## How It Works
 
 The port diagram reads from `Hecks.extension_meta`, which is populated by each extension's `Hecks.describe_extension` call. Extensions declare themselves as `:driving` (inbound adapters like HTTP, CLI, MCP) or `:driven` (outbound adapters like persistence, auth, logging).
+
+The aggregate ports diagram reads directly from the domain IR — no extensions needed. Each aggregate's commands become driving-port stadium nodes with arrows into the aggregate. Driven-port nodes (Persistence, EventBus) are opt-in via keyword arguments.
 
 Arrows show data flow direction: driving ports push data into the domain, and the domain pushes data out to driven ports.


### PR DESCRIPTION
## Why

The domain diagram showed aggregate relationships but not the hexagonal architecture itself. Looking at the diagram, there was no way to see which commands drive the domain in or which ports (persistence, event bus) it drives out to. The architecture was invisible in the visualization.

## What changed

Extended the visualizer to emit a third Mermaid diagram block — an aggregate ports diagram — showing:

- **Driving ports** (commands) as stadium-shape nodes with arrows pointing into the aggregate
- **Driven ports** (persistence, event bus) as nodes the aggregate points out to (opt-in via `show_persistence:` / `show_event_bus:`)

```
flowchart LR
  subgraph Pizza
    Pizza_CreatePizza_cmd([CreatePizza])-->Pizza
    Pizza_AddTopping_cmd([AddTopping])-->Pizza
    Pizza-->Pizza_Persistence[(Persistence)]
  end
```

Driven-port nodes default to off to avoid cluttering simple domains. The existing structure and behavior diagrams are unchanged.

## Test plan

- Command nodes appear as driving port arrows into each aggregate
- Persistence/event bus nodes appear only when opted in
- Existing visualizer specs still pass