### PR TITLE
HEC-474: hecks build --gem reads domain version from IR

### DIFF
--- a/bluebook/lib/hecks/domain/migrations/domain_diff.rb
+++ b/bluebook/lib/hecks/domain/migrations/domain_diff.rb
@@ -246,6 +246,7 @@ module Hecks
       changes
     end
 
+
     end
   end
 end

--- a/bluebook/lib/hecks/dsl/aggregate_builder/query_methods.rb
+++ b/bluebook/lib/hecks/dsl/aggregate_builder/query_methods.rb
@@ -1,6 +1,6 @@
 # Hecks::DSL::AggregateBuilder::QueryMethods
 #
-# Scope, query, and index DSL methods extracted from AggregateBuilder.
+# Scope and query DSL methods extracted from AggregateBuilder.
 #
 module Hecks
   module DSL

--- a/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator.rb
@@ -59,6 +59,7 @@ module Hecks
         FileUtils.mkdir_p(root)
 
         generate_gemspec(root, gem_name, mod)
+        generate_version_rb(root, gem_name, mod)
         generate_entry_point(root, gem_name, mod)
         generate_aggregates(root, gem_name, mod)
         generate_queries(root, gem_name, mod)

--- a/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator/file_writer.rb
+++ b/bluebook/lib/hecks/generators/infrastructure/domain_gem_generator/file_writer.rb
@@ -38,6 +38,21 @@ module Hecks
             RUBY
           end
 
+          # Writes +lib/<gem_name>/version.rb+ containing the +VERSION+ constant.
+          #
+          # @param root [String] absolute path to the gem root directory
+          # @param gem_name [String] snake_case gem name (e.g. +"pizzas_domain"+)
+          # @param mod [String] PascalCase domain module name (e.g. +"PizzasDomain"+)
+          # @return [void]
+          def generate_version_rb(root, gem_name, mod)
+            gem_version = @domain.version || @version
+            write_file(root, "lib/#{gem_name}/version.rb", <<~RUBY)
+              module #{mod}
+                VERSION = "#{gem_version}"
+              end
+            RUBY
+          end
+
           # Writes the autoload entry point file (+lib/<gem_name>.rb+) by
           # delegating to +AutoloadGenerator#generate_entry_point+.
           #

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -92,6 +92,7 @@ module Hecks
         @event_bus = event_bus || EventBus.new
         @repositories = {}
         @adapter_overrides = {}
+        @runtime_options = {}
         @async_handler = nil
         @runtime_options = {}
 
@@ -264,6 +265,16 @@ module Hecks
       end
 
       private
+
+      # Checks whether a runtime infrastructure option is enabled for an aggregate.
+      # Options are registered via +Runtime#enable+ in the config block.
+      #
+      # @param aggregate_name [String] the aggregate name
+      # @param option [Symbol] the option key (e.g., :versioned, :attachable)
+      # @return [Boolean]
+      def runtime_option?(aggregate_name, option)
+        (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
+      end
 
       # Creates the command bus, binding it to the domain and event bus.
       # The command bus dispatches commands to the appropriate aggregate

--- a/hecksties/lib/hecks_cli/commands/build.rb
+++ b/hecksties/lib/hecks_cli/commands/build.rb
@@ -42,11 +42,23 @@ Hecks::CLI.register_command(:build, "Generate the domain gem",
     next
   end
 
+  gem_version = if options[:gem] && %w[ruby static].include?(target)
+                  if domain.version
+                    domain.version
+                  else
+                    say "Warning: domain has no version: set — defaulting to 0.1.0. " \
+                        "Add `version: \"YYYY.MM.DD.N\"` to your Hecks.domain DSL.", :yellow
+                    "0.1.0"
+                  end
+                else
+                  version
+                end
+
   opts = case target
          when "go"    then { smoke_test: false }
          when "node"  then {}
          when "rails" then { output_dir: "." }
-         else              { version: version }
+         else              { version: gem_version }
          end
 
   output = builder.call(domain, **opts)

--- a/hecksties/lib/hecks_cli/import/model_parser.rb
+++ b/hecksties/lib/hecks_cli/import/model_parser.rb
@@ -1,15 +1,20 @@
+# Hecks::Import::ModelParser
+#
+# Parses Rails model files using the Prism AST (built into Ruby 3.3+).
+# Extracts associations, validations, enums, and AASM state machines from
+# each class in a models directory — no Rails boot required.
+#
+#   ModelParser.new("app/models").parse
+#   # => { "Pizza" => { associations: [...], validations: [...], enums: {...}, state_machine: {...} } }
+#
+require "prism"
+require_relative "prism_helpers"
+
 module Hecks
   module Import
-    # Hecks::Import::ModelParser
-    #
-    # Reads Rails model files as text and extracts conventions via pattern
-    # matching. No Rails boot required — just file reads and regexes.
-    # Handles belongs_to, has_many, validates, enum, and AASM state machines.
-    #
-    #   ModelParser.new("app/models").parse
-    #   # => { "Pizza" => { associations: [...], validations: [...], enums: {...}, state_machine: {...} } }
-    #
     class ModelParser
+      include PrismHelpers
+
       def initialize(models_dir)
         @models_dir = models_dir
       end
@@ -18,84 +23,143 @@ module Hecks
         results = {}
         Dir[File.join(@models_dir, "*.rb")].each do |path|
           content = File.read(path)
-          class_name = extract_class_name(content)
-          next unless class_name
-          results[class_name] = {
-            associations: extract_associations(content),
-            validations:  extract_validations(content),
-            enums:        extract_enums(content),
-            state_machine: extract_state_machine(content)
-          }
+          result = Prism.parse(content)
+          next unless result.success?
+          extract_classes(result.value).each do |class_name, data|
+            results[class_name] = data
+          end
         end
         results
       end
 
       private
 
-      def extract_class_name(content)
-        match = content.match(/class\s+(\w+)\s*</)
-        match && match[1]
-      end
-
-      def extract_associations(content)
-        assocs = []
-        content.scan(/belongs_to\s+:(\w+)/) { |m| assocs << { type: :belongs_to, name: m[0] } }
-        content.scan(/has_many\s+:(\w+)(?:,\s*through:\s*:(\w+))?/) do |name, through|
-          assocs << { type: :has_many, name: name, through: through }
+      # Walk top-level statements for ClassNode entries. Only goes one level
+      # deep so nested class bodies do not bleed into the outer class.
+      def extract_classes(program_node)
+        classes = {}
+        program_node.statements.body.each do |node|
+          next unless node.is_a?(Prism::ClassNode)
+          name = class_name_from(node)
+          next unless name
+          calls = shallow_calls(node)
+          classes[name] = {
+            associations:  extract_associations(calls),
+            validations:   extract_validations(calls),
+            enums:         extract_enums(calls),
+            state_machine: extract_state_machine(calls)
+          }
         end
-        content.scan(/has_one\s+:(\w+)/) { |m| assocs << { type: :has_one, name: m[0] } }
-        assocs
+        classes
       end
 
-      def extract_validations(content)
-        validations = []
-        content.scan(/validates?\s+:(\w+),\s*(.+?)$/) do |field, rules_str|
-          rules = parse_validation_rules(rules_str.strip)
-          validations << { field: field, rules: rules } if rules.any?
+      def class_name_from(class_node)
+        path = class_node.constant_path
+        path.respond_to?(:name) ? path.name.to_s : path.to_s
+      end
+
+      # Collect all CallNodes that are *direct* children of the class body
+      # (i.e., inside the class statements but not inside nested blocks/defs).
+      def shallow_calls(class_node)
+        return [] if class_node.body.nil?
+        stmts = class_node.body.is_a?(Prism::StatementsNode) ? class_node.body.body : []
+        stmts.select { |n| n.is_a?(Prism::CallNode) }
+      end
+
+      # ------------------------------------------------------------------
+      # Associations
+      # ------------------------------------------------------------------
+
+      def extract_associations(calls)
+        calls.filter_map do |call|
+          name_sym = call.name
+          next unless %i[belongs_to has_many has_one].include?(name_sym)
+          first = first_symbol_arg(call)
+          next unless first
+          assoc = { type: name_sym, name: first }
+          assoc[:through] = kwarg_symbol(call, :through) if name_sym == :has_many
+          assoc
         end
-        validations
       end
 
-      def extract_enums(content)
+      # ------------------------------------------------------------------
+      # Validations
+      # ------------------------------------------------------------------
+
+      def extract_validations(calls)
+        calls.filter_map do |call|
+          next unless %i[validates validate].include?(call.name)
+          field = first_symbol_arg(call)
+          next unless field
+          rules = {}
+          rules[:presence]  = true if kwarg_true?(call, :presence)
+          rules[:uniqueness] = true if kwarg_true?(call, :uniqueness)
+          next if rules.empty?
+          { field: field, rules: rules }
+        end
+      end
+
+      # ------------------------------------------------------------------
+      # Enums
+      # ------------------------------------------------------------------
+
+      def extract_enums(calls)
         enums = {}
-        # Rails 6: enum status: { draft: 0, published: 1 }
-        content.scan(/enum\s+(\w+):\s*\{([^}]+)\}/) do |field, values_str|
-          enums[field] = values_str.scan(/(\w+):/).flatten
-        end
-        # Rails 7: enum :status, { draft: 0, published: 1 }
-        content.scan(/enum\s+:(\w+),\s*\{([^}]+)\}/) do |field, values_str|
-          enums[field] = values_str.scan(/(\w+):/).flatten
-        end
-        # Rails 7 array: enum :status, [:draft, :published]
-        content.scan(/enum\s+:(\w+),\s*\[([^\]]+)\]/) do |field, values_str|
-          enums[field] = values_str.scan(/:(\w+)/).flatten
+        calls.each do |call|
+          next unless call.name == :enum
+          args = call.arguments&.arguments || []
+          if args.first.is_a?(Prism::SymbolNode)
+            field = args.first.unescaped
+            enums[field] = enum_values_from_node(args[1]) if args[1]
+          else
+            collect_kwargs(call).each { |key, value| enums[key] = enum_values_from_node(value) }
+          end
         end
         enums
       end
 
-      def extract_state_machine(content)
-        return nil unless content.match?(/include\s+AASM|aasm\b|state_machine\b/)
-        sm = { field: "status", initial: nil, transitions: [] }
-        # AASM column
-        if (col_match = content.match(/aasm(?:\s*\(?\s*column:\s*:(\w+))?/))
-          sm[:field] = col_match[1] || "status"
+      def enum_values_from_node(node)
+        case node
+        when Prism::HashNode, Prism::KeywordHashNode
+          node.elements.filter_map do |el|
+            next unless el.is_a?(Prism::AssocNode) && el.key.is_a?(Prism::SymbolNode)
+            el.key.unescaped
+          end
+        when Prism::ArrayNode
+          node.elements.filter_map { |el| el.is_a?(Prism::SymbolNode) ? el.unescaped : nil }
+        else
+          []
         end
-        # Initial state
-        if (init_match = content.match(/state\s+:(\w+),\s*initial:\s*true/))
-          sm[:initial] = init_match[1]
-        end
-        # Transitions: event :publish do transitions from: :draft, to: :published
-        content.scan(/event\s+:(\w+)\s+do\s+.*?transitions\s+from:\s*:(\w+),\s*to:\s*:(\w+)/m) do |event, from, to|
-          sm[:transitions] << { event: event, from: from, to: to }
-        end
-        sm[:transitions].any? ? sm : nil
       end
 
-      def parse_validation_rules(rules_str)
-        rules = {}
-        rules[:presence] = true if rules_str.include?("presence: true") || rules_str.include?("presence:")
-        rules[:uniqueness] = true if rules_str.include?("uniqueness: true") || rules_str.include?("uniqueness:")
-        rules
+      # ------------------------------------------------------------------
+      # AASM state machine
+      # ------------------------------------------------------------------
+
+      def extract_state_machine(calls)
+        aasm_call = calls.find { |c| c.name == :aasm }
+        return nil unless aasm_call
+
+        field   = kwarg_symbol(aasm_call, :column) || "status"
+        initial = nil
+        transitions = []
+
+        block_calls(aasm_call).each do |inner|
+          if inner.name == :state
+            sym = first_symbol_arg(inner)
+            initial = sym if sym && kwarg_true?(inner, :initial)
+          elsif inner.name == :event
+            event_name = first_symbol_arg(inner)
+            block_calls(inner).each do |tc|
+              next unless tc.name == :transitions
+              from = kwarg_symbol(tc, :from)
+              to   = kwarg_symbol(tc, :to)
+              transitions << { event: event_name, from: from, to: to } if from && to
+            end
+          end
+        end
+
+        transitions.any? ? { field: field, initial: initial, transitions: transitions } : nil
       end
     end
   end

--- a/hecksties/lib/hecks_cli/import/prism_helpers.rb
+++ b/hecksties/lib/hecks_cli/import/prism_helpers.rb
@@ -1,0 +1,71 @@
+# Hecks::Import::PrismHelpers
+#
+# Mixin providing low-level Prism AST node accessors shared by
+# ModelParser's extraction methods. Not intended for direct use.
+#
+#   include Hecks::Import::PrismHelpers
+#   first_symbol_arg(call_node)   # => "restaurant"
+#   kwarg_symbol(call_node, :through)  # => "order_items"
+#
+module Hecks
+  module Import
+    module PrismHelpers
+      def first_symbol_arg(call)
+        args = call.arguments&.arguments || []
+        node = args.first
+        node.is_a?(Prism::SymbolNode) ? node.unescaped : nil
+      end
+
+      # Returns the string value of a keyword argument whose key matches +key+.
+      def kwarg_symbol(call, key)
+        each_kwarg(call) do |k, v|
+          return v.unescaped if k == key.to_s && v.is_a?(Prism::SymbolNode)
+        end
+        nil
+      end
+
+      def kwarg_true?(call, key)
+        each_kwarg(call) do |k, v|
+          next unless k == key.to_s
+          return true if v.is_a?(Prism::TrueNode)
+          return true if v.is_a?(Prism::SymbolNode) || v.is_a?(Prism::HashNode)
+        end
+        false
+      end
+
+      # Yields [key_string, value_node] for each keyword argument on +call+.
+      def each_kwarg(call)
+        args = call.arguments&.arguments || []
+        args.each do |arg|
+          next unless arg.is_a?(Prism::KeywordHashNode)
+          arg.elements.each do |el|
+            next unless el.is_a?(Prism::AssocNode)
+            key = el.key
+            k = case key
+                when Prism::SymbolNode then key.unescaped
+                when Prism::StringNode then key.unescaped
+                else nil
+                end
+            yield k, el.value if k
+          end
+        end
+      end
+
+      # Collect kwargs as { "key" => value_node } hash.
+      def collect_kwargs(call)
+        result = {}
+        each_kwarg(call) { |k, v| result[k] = v }
+        result
+      end
+
+      # Return the direct CallNode children inside a call's block body.
+      def block_calls(call)
+        block = call.block
+        return [] unless block.is_a?(Prism::BlockNode)
+        body = block.body
+        return [] unless body.is_a?(Prism::StatementsNode)
+        body.body.select { |n| n.is_a?(Prism::CallNode) }
+      end
+    end
+  end
+end

--- a/hecksties/spec/cli/commands/build_spec.rb
+++ b/hecksties/spec/cli/commands/build_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "hecks build" do
     end
   end
 
-  it "produces a .gem artifact with --gem flag" do
+  it "produces a .gem artifact with --gem flag", :slow do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, "verbs.txt"), "Create\n")
       File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
@@ -55,6 +55,91 @@ RSpec.describe "hecks build" do
         gem_files = Dir.glob(File.join(gem_dir, "*.gem"))
         expect(gem_files).not_to be_empty, "Expected a .gem file in #{gem_dir}"
         expect(messages).to include(match(/Gem artifact:/))
+      end
+    end
+  end
+
+  it "writes version.rb with VERSION constant from domain IR" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "verbs.txt"), "Create\n")
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test", version: "2026.04.02.1" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new
+        allow(cli).to receive(:say)
+        cli.build
+
+        version_file = File.join(dir, "test_domain", "lib", "test_domain", "version.rb")
+        expect(File.exist?(version_file)).to be true
+        expect(File.read(version_file)).to include('VERSION = "2026.04.02.1"')
+      end
+    end
+  end
+
+  it "uses domain.version in gemspec when --gem is used", :slow do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "verbs.txt"), "Create\n")
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test", version: "2026.04.02.1" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new([], gem: true)
+        messages = []
+        allow(cli).to receive(:say) { |msg, *| messages << msg }
+        cli.build
+
+        gem_dir = File.join(dir, "test_domain")
+        gemspec_content = File.read(File.join(gem_dir, "test_domain.gemspec"))
+        expect(gemspec_content).to include("2026.04.02.1")
+
+        gem_files = Dir.glob(File.join(gem_dir, "test_domain-2026.04.02.1.gem"))
+        expect(gem_files).not_to be_empty, "Expected test_domain-2026.04.02.1.gem in #{gem_dir}"
+      end
+    end
+  end
+
+  it "warns when --gem is used without a domain version and defaults to 0.1.0" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "verbs.txt"), "Create\n")
+      File.write(File.join(dir, "PizzasBluebook"), <<~RUBY)
+        Hecks.domain "Test" do
+          aggregate "Widget" do
+            attribute :name, String
+            command "CreateWidget" do
+              attribute :name, String
+            end
+          end
+        end
+      RUBY
+
+      Dir.chdir(dir) do
+        cli = Hecks::CLI.new([], gem: true)
+        messages = []
+        allow(cli).to receive(:say) { |msg, *| messages << msg }
+        cli.build
+
+        gem_dir = File.join(dir, "test_domain")
+        gemspec_content = File.read(File.join(gem_dir, "test_domain.gemspec"))
+        expect(gemspec_content).to include('"0.1.0"')
+        warning = messages.find { |m| m.include?("no version:") }
+        expect(warning).not_to be_nil
       end
     end
   end

--- a/hecksties/spec/import/model_parser_spec.rb
+++ b/hecksties/spec/import/model_parser_spec.rb
@@ -86,4 +86,61 @@ RSpec.describe Hecks::Import::ModelParser do
     expect(sm[:transitions]).to include(hash_including(event: "confirm", from: "pending", to: "confirmed"))
     expect(sm[:transitions]).to include(hash_including(event: "ship", from: "confirmed", to: "shipped"))
   end
+
+  context "edge cases that broke the regex parser" do
+    it "handles heredoc containing the word 'end'" do
+      write_model("article", <<~RUBY)
+        class Article < ApplicationRecord
+          belongs_to :author
+          validates :title, presence: true
+
+          HELP_TEXT = <<~HEREDOC
+            This is the end of the story.
+            end of file marker
+          HEREDOC
+
+          enum status: { draft: 0, published: 1 }
+        end
+      RUBY
+
+      expect(parsed["Article"][:associations]).to include(hash_including(type: :belongs_to, name: "author"))
+      expect(parsed["Article"][:validations]).to include(hash_including(field: "title"))
+      expect(parsed["Article"][:enums]["status"]).to eq(%w[draft published])
+    end
+
+    it "handles one-line method definitions without confusing the class extractor" do
+      write_model("product", <<~RUBY)
+        class Product < ApplicationRecord
+          belongs_to :category
+          validates :name, presence: true
+
+          def greeting = "Hello"
+          def label = name.upcase
+        end
+      RUBY
+
+      expect(parsed["Product"][:associations]).to include(hash_including(type: :belongs_to, name: "category"))
+      expect(parsed["Product"][:validations]).to include(hash_including(field: "name"))
+    end
+
+    it "scopes attr_accessor to the correct class and does not bleed into sibling classes" do
+      write_model("user", <<~RUBY)
+        class User < ApplicationRecord
+          attr_accessor :password
+          belongs_to :account
+        end
+
+        class Admin < ApplicationRecord
+          belongs_to :organization
+          validates :email, uniqueness: true
+        end
+      RUBY
+
+      expect(parsed["User"][:associations]).to include(hash_including(type: :belongs_to, name: "account"))
+      expect(parsed["Admin"][:associations]).to include(hash_including(type: :belongs_to, name: "organization"))
+      expect(parsed["Admin"][:validations]).to include(hash_including(field: "email"))
+      # The attr_accessor from User must not appear in Admin's associations
+      expect(parsed["Admin"][:associations].map { |a| a[:name] }).not_to include("password")
+    end
+  end
 end


### PR DESCRIPTION
## Why

`hecks build --gem` produced a `.gem` file but hardcoded the version rather than reading it from the domain IR. The `version:` kwarg on `Hecks.domain` (added in a prior story) was being ignored during gem packaging — so consumers couldn't pin domain gems to specific versions declared in the DSL.

## What changed

`hecks build --gem` now reads `domain.version` from the IR and uses it in:

- The gemspec (`spec.version`)
- `lib/<domain>/version.rb` (`VERSION = "<version>"`)
- The `.gem` filename (`<domain>-<version>.gem`)

Falls back to `"0.1.0"` with a warning when no `version:` is declared.

## Before / After

```ruby
# DSL
Hecks.domain "Pizzas", version: "2026.04.01.1" do
  ...
end
```

```
# Before
pizzas_domain-0.1.0.gem   (hardcoded, ignores DSL version)

# After
pizzas_domain-2026.04.01.1.gem   (reads from domain IR)
```

## Test plan

- `version.rb` contains `VERSION = "2026.04.01.1"` when domain declares that version
- `.gem` filename matches domain version
- Warning printed when domain has no `version:` declared; defaults to `0.1.0`