### PR TITLE
HEC-445: Add world goals onboarding prompt to hecks new

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -427,7 +427,7 @@
 - Preview mode with `--preview` flag
 
 ## CLI Commands
-- `hecks new NAME` — scaffold a complete project with interactive world goals onboarding (opt-out by pressing Enter; skipped in non-interactive/CI)
+- `hecks new NAME` — scaffold a complete project with interactive world goals onboarding: choose to declare goals, skip, or mark as not applicable; `--no-world-goals` flag skips prompt entirely (for CI)
 - `hecks build` — validate and generate versioned gem
 - `hecks build --gem` — produce a publishable `.gem` artifact after building (runs `gem build` on generated output); supported for `ruby` and `static` targets
 - `hecks serve [--rpc]` — start REST or JSON-RPC server

--- a/docs/usage/world_concerns_onboarding.md
+++ b/docs/usage/world_concerns_onboarding.md
@@ -1,54 +1,57 @@
 # World Concerns Onboarding
 
-When creating a new project with `hecks new`, you are prompted to select
-world concerns interactively. Concerns are opt-in ethical validation rules that
-check your domain design for alignment with stated values.
+When creating a new project with `hecks new`, you are prompted to declare
+world concerns — opt-in ethical validation rules that check your domain
+design for alignment with stated values.
 
 ## Available concerns
 
-| Concern         | What it checks                                       |
-|-----------------|------------------------------------------------------|
-| `:transparency` | Commands must emit events (no silent mutations)      |
-| `:consent`      | User-like aggregate commands must declare actors     |
-| `:privacy`      | PII attributes must be `visible: false`              |
-| `:security`     | Sensitive aggregates need auth guards                |
+| Concern           | What it checks                                       |
+|-------------------|------------------------------------------------------|
+| `:privacy`        | PII attributes must be `visible: false`              |
+| `:transparency`   | Commands must emit events (no silent mutations)      |
+| `:equity`         | Reserved for future equity-focused rules             |
+| `:sustainability` | Reserved for future sustainability-focused rules     |
+| `:consent`        | User-like aggregate commands must declare actors     |
+| `:security`       | Sensitive aggregates need auth guards                |
 
 ## Interactive usage
 
 ```
 $ hecks new my_app
 
-World concerns are opt-in ethical validation rules for your domain.
-Available: :transparency, :consent, :privacy, :security
-Enter concerns (space-separated), or press Enter to skip:
-> transparency consent
+Welcome to Hecks.
+
+Hecks is built on the belief that software affects living beings —
+humans, animals, ecosystems. The domain you're about to model will
+touch some of them.
+
+Would you like to declare world goals for this domain?
+
+  1. Yes — walk me through them
+  2. Skip for now — I'll add them later
+  3. This doesn't apply to my project
+
+> 1
+
+Available goals: privacy, transparency, equity, sustainability, consent, security
+
+Select goals (comma-separated, or press Enter to skip):
+> privacy, consent
+
+Domain created. World goals declared.
 
 Created my_app/
-  MyAppBluebook   # includes world_concerns :transparency, :consent
+  MyAppBluebook
   app.rb
   ...
 ```
 
-## Opt-out
-
-Press Enter without typing anything to skip world concerns entirely:
-
-```
-Enter concerns (space-separated), or press Enter to skip:
->
-```
-
-The generated Bluebook will not include a `world_concerns` line.
-
-## Non-interactive / CI
-
-When stdin is not a TTY (pipes, CI), the prompt is skipped automatically
-and no concerns are included. You can always add them later by editing the
-Bluebook:
+Generated Bluebook:
 
 ```ruby
 Hecks.domain "MyApp" do
-  world_concerns :transparency, :consent
+  world_concerns :privacy, :consent
 
   aggregate "Example" do
     # ...
@@ -56,7 +59,38 @@ Hecks.domain "MyApp" do
 end
 ```
 
+## Choosing "skip for now" (option 2)
+
+The Bluebook is generated with no `world_concerns` line. You can add one
+later by editing the file directly.
+
+## Choosing "doesn't apply" (option 3)
+
+The Bluebook is generated with a commented-out stub as a reminder:
+
+```ruby
+Hecks.domain "MyApp" do
+  # world_concerns :transparency, :consent  # add when ready
+
+  aggregate "Example" do
+    # ...
+  end
+end
+```
+
+## Non-interactive / CI
+
+Use `--no-world-goals` to skip the prompt entirely:
+
+```
+$ hecks new my_app --no-world-goals
+```
+
+When stdin is not a TTY (pipes, CI), the prompt is skipped automatically.
+
+No `world_concerns` line is included in either case.
+
 ## Invalid input
 
-Unrecognized concern names are silently filtered out. Only the four valid
-concerns (`:transparency`, `:consent`, `:privacy`, `:security`) are kept.
+Unrecognized concern names are silently filtered. Only the six valid
+concern names are kept.

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -1,5 +1,19 @@
+# HecksCLI::Commands::NewProject
+#
+# Creates a new Hecks project scaffold with a Bluebook, app.rb, Gemfile,
+# spec/spec_helper.rb, .gitignore, and .rspec.
+#
+# Usage:
+#   hecks new my_domain
+#   hecks new my_domain --no-world-goals
+#
+require_relative "../world_goals_prompt"
+
 Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
-  args: ["NAME"]
+  args: ["NAME"],
+  options: {
+    "no-world-goals": { type: :boolean, default: false, desc: "Skip world goals onboarding prompt (for CI)" }
+  }
 ) do |name|
   pascal = Hecks::Utils.sanitize_constant(name)
   dir = name
@@ -9,18 +23,13 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     next
   end
 
-  available_goals = %i[transparency consent privacy security]
-  selected_goals = []
+  world_concerns = []
+  domain_mode = :skip
 
-  if $stdin.tty?
-    say ""
-    say "World concerns are opt-in ethical validation rules for your domain.", :cyan
-    say "Available: #{available_goals.map { |g| ":#{g}" }.join(", ")}"
-    say "Enter concerns (space-separated), or press Enter to skip:"
-    input = $stdin.gets&.chomp
-    if input && !input.strip.empty?
-      selected_goals = input.strip.split(/\s+/).map(&:to_sym) & available_goals
-    end
+  if !options[:"no-world-goals"] && $stdin.tty?
+    result = HecksCLI::WorldGoalsPrompt.run(shell: shell)
+    domain_mode = result[:mode]
+    world_concerns = result[:goals] || []
   end
 
   app_template = lambda do
@@ -78,7 +87,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
 
   FileUtils.mkdir_p(File.join(dir, "spec"))
 
-  write_or_diff(File.join(dir, "#{pascal}Bluebook"), domain_template(pascal, world_concerns: selected_goals))
+  write_or_diff(File.join(dir, "#{pascal}Bluebook"), domain_template(pascal, world_concerns: world_concerns, mode: domain_mode))
   write_or_diff(File.join(dir, "app.rb"), app_template.call)
   write_or_diff(File.join(dir, "Gemfile"), gemfile_template.call)
   write_or_diff(File.join(dir, "spec", "spec_helper.rb"), spec_helper_template.call)

--- a/hecksties/lib/hecks_cli/domain_helpers.rb
+++ b/hecksties/lib/hecks_cli/domain_helpers.rb
@@ -116,9 +116,11 @@ module Hecks
       result.suggestions.each { |s| say "    - #{s}", :cyan }
     end
 
-    def domain_template(name, world_concerns: [])
+    def domain_template(name, world_concerns: [], mode: :skip)
       concerns_line = if world_concerns.any?
         "\n  world_concerns #{world_concerns.map { |g| ":#{g}" }.join(", ")}\n"
+      elsif mode == :not_applicable
+        "\n  # world_concerns :transparency, :consent  # add when ready\n"
       else
         ""
       end

--- a/hecksties/lib/hecks_cli/world_goals_prompt.rb
+++ b/hecksties/lib/hecks_cli/world_goals_prompt.rb
@@ -1,0 +1,62 @@
+# HecksCLI::WorldGoalsPrompt
+#
+# Handles the interactive onboarding prompt that asks users to declare
+# world concerns (ethical commitments) for their new domain.
+#
+# Usage:
+#   result = WorldGoalsPrompt.run(shell: shell)
+#   # result is one of:
+#   #   { mode: :goals, goals: [:privacy, :consent] }
+#   #   { mode: :skip }
+#   #   { mode: :not_applicable }
+#
+module HecksCLI
+  module WorldGoalsPrompt
+    VALID_GOALS = %i[privacy transparency equity sustainability consent security].freeze
+
+    def self.run(shell:)
+      shell.say ""
+      shell.say "Welcome to Hecks."
+      shell.say ""
+      shell.say "Hecks is built on the belief that software affects living beings —"
+      shell.say "humans, animals, ecosystems. The domain you're about to model will"
+      shell.say "touch some of them."
+      shell.say ""
+      shell.say "Would you like to declare world goals for this domain?"
+      shell.say ""
+      shell.say "  1. Yes — walk me through them"
+      shell.say "  2. Skip for now — I'll add them later"
+      shell.say "  3. This doesn't apply to my project"
+      shell.say ""
+
+      choice = $stdin.gets&.chomp&.strip
+
+      case choice
+      when "1"
+        shell.say ""
+        shell.say "Available goals: #{VALID_GOALS.map(&:to_s).join(', ')}"
+        shell.say ""
+        shell.say "Select goals (comma-separated, or press Enter to skip):"
+        input = $stdin.gets&.chomp&.strip || ""
+        goals = parse_goals(input)
+        shell.say ""
+        if goals.any?
+          shell.say "Domain created. World goals declared.", :green
+        else
+          shell.say "Domain created.", :green
+        end
+        { mode: :goals, goals: goals }
+      when "3"
+        { mode: :not_applicable }
+      else
+        { mode: :skip }
+      end
+    end
+
+    def self.parse_goals(input)
+      return [] if input.empty?
+
+      input.split(/[\s,]+/).map(&:to_sym) & VALID_GOALS
+    end
+  end
+end

--- a/hecksties/spec/new_project_spec.rb
+++ b/hecksties/spec/new_project_spec.rb
@@ -8,10 +8,20 @@ RSpec.describe "hecks new CLI command" do
   let(:tmpdir) { Dir.mktmpdir("hecks-new-") }
   after { FileUtils.rm_rf(tmpdir) }
 
+  def with_stdin(text)
+    fake = StringIO.new(text)
+    allow(fake).to receive(:tty?).and_return(true)
+    original = $stdin
+    $stdin = fake
+    yield
+  ensure
+    $stdin = original
+  end
+
   it "generates project files" do
     Dir.chdir(tmpdir) do
       cli = Hecks::CLI.new
-      cli.invoke(:new_project, ["my_app"])
+      cli.invoke(:new_project, ["my_app"], { "no-world-goals": true })
 
       expect(Dir["my_app/*Bluebook"].any?).to be true
       expect(File.exist?("my_app/app.rb")).to be true
@@ -25,7 +35,7 @@ RSpec.describe "hecks new CLI command" do
   it "uses PascalCase for the domain name" do
     Dir.chdir(tmpdir) do
       cli = Hecks::CLI.new
-      cli.invoke(:new_project, ["my_cool_app"])
+      cli.invoke(:new_project, ["my_cool_app"], { "no-world-goals": true })
 
       bluebook = Dir["my_cool_app/*Bluebook"].first
       content = File.read(bluebook)
@@ -38,7 +48,7 @@ RSpec.describe "hecks new CLI command" do
       FileUtils.mkdir_p("existing")
       cli = Hecks::CLI.new
       expect {
-        cli.invoke(:new_project, ["existing"])
+        cli.invoke(:new_project, ["existing"], { "no-world-goals": true })
       }.not_to raise_error
       expect(File.exist?("existing/app.rb")).to be false
     end
@@ -47,7 +57,7 @@ RSpec.describe "hecks new CLI command" do
   it "generates a valid domain that can be booted" do
     Dir.chdir(tmpdir) do
       cli = Hecks::CLI.new
-      cli.invoke(:new_project, ["bootable"])
+      cli.invoke(:new_project, ["bootable"], { "no-world-goals": true })
     end
 
     bluebook = Dir[File.join(tmpdir, "bootable/*Bluebook")].first
@@ -58,29 +68,11 @@ RSpec.describe "hecks new CLI command" do
   end
 
   context "world goals onboarding" do
-    def with_stdin(text)
-      fake = StringIO.new(text)
-      allow(fake).to receive(:tty?).and_return(true)
-      original = $stdin
-      $stdin = fake
-      yield
-    ensure
-      $stdin = original
-    end
-
-    it "includes selected goals, filters invalid input, and skips on opt-out" do
+    it "skips prompt with --no-world-goals flag and generates domain without world_concerns" do
       Dir.chdir(tmpdir) do
-        with_stdin("transparency bogus consent\n") do
-          Hecks::CLI.new.invoke(:new_project, ["with_goals"])
-        end
-        bluebook = File.read(Dir["with_goals/*Bluebook"].first)
-        expect(bluebook).to include("world_concerns :transparency, :consent")
-        expect(bluebook).not_to include("bogus")
+        Hecks::CLI.new.invoke(:new_project, ["ci_app"], { "no-world-goals": true })
 
-        with_stdin("\n") do
-          Hecks::CLI.new.invoke(:new_project, ["no_goals"])
-        end
-        bluebook = File.read(Dir["no_goals/*Bluebook"].first)
+        bluebook = File.read(Dir["ci_app/*Bluebook"].first)
         expect(bluebook).not_to include("world_concerns")
       end
     end
@@ -92,6 +84,57 @@ RSpec.describe "hecks new CLI command" do
         Hecks::CLI.new.invoke(:new_project, ["noninteractive"])
 
         bluebook = File.read(Dir["noninteractive/*Bluebook"].first)
+        expect(bluebook).not_to include("world_concerns")
+      end
+    end
+
+    it "choice 2: generates domain without world_concerns" do
+      Dir.chdir(tmpdir) do
+        with_stdin("2\n") do
+          Hecks::CLI.new.invoke(:new_project, ["skip_app"])
+        end
+        bluebook = File.read(Dir["skip_app/*Bluebook"].first)
+        expect(bluebook).not_to include("world_concerns")
+      end
+    end
+
+    it "choice 3: generates domain with commented stub" do
+      Dir.chdir(tmpdir) do
+        with_stdin("3\n") do
+          Hecks::CLI.new.invoke(:new_project, ["na_app"])
+        end
+        bluebook = File.read(Dir["na_app/*Bluebook"].first)
+        expect(bluebook).to include("# world_concerns :transparency, :consent  # add when ready")
+      end
+    end
+
+    it "choice 1 with goals: generates domain with world_concerns" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\nprivacy, consent\n") do
+          Hecks::CLI.new.invoke(:new_project, ["goals_app"])
+        end
+        bluebook = File.read(Dir["goals_app/*Bluebook"].first)
+        expect(bluebook).to include("world_concerns :privacy, :consent")
+      end
+    end
+
+    it "choice 1 with invalid goals: silently skips invalid ones" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\nprivacy, bogus, consent\n") do
+          Hecks::CLI.new.invoke(:new_project, ["filter_app"])
+        end
+        bluebook = File.read(Dir["filter_app/*Bluebook"].first)
+        expect(bluebook).to include("world_concerns :privacy, :consent")
+        expect(bluebook).not_to include("bogus")
+      end
+    end
+
+    it "choice 1 with no goals entered: generates domain without world_concerns" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\n\n") do
+          Hecks::CLI.new.invoke(:new_project, ["empty_goals_app"])
+        end
+        bluebook = File.read(Dir["empty_goals_app/*Bluebook"].first)
         expect(bluebook).not_to include("world_concerns")
       end
     end

--- a/hecksties/spec/world_goals_prompt_spec.rb
+++ b/hecksties/spec/world_goals_prompt_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "stringio"
+require "hecks_cli"
+
+RSpec.describe HecksCLI::WorldGoalsPrompt do
+  def fake_shell
+    double("shell").tap { |s| allow(s).to receive(:say) }
+  end
+
+  def with_stdin(text, tty: true)
+    fake = StringIO.new(text)
+    allow(fake).to receive(:tty?).and_return(tty)
+    original = $stdin
+    $stdin = fake
+    yield
+  ensure
+    $stdin = original
+  end
+
+  describe ".run" do
+    it "returns skip mode for choice 2" do
+      with_stdin("2\n") do
+        result = described_class.run(shell: fake_shell)
+        expect(result[:mode]).to eq(:skip)
+      end
+    end
+
+    it "returns not_applicable mode for choice 3" do
+      with_stdin("3\n") do
+        result = described_class.run(shell: fake_shell)
+        expect(result[:mode]).to eq(:not_applicable)
+      end
+    end
+
+    it "returns goals mode for choice 1 with valid goals" do
+      with_stdin("1\nprivacy, consent\n") do
+        result = described_class.run(shell: fake_shell)
+        expect(result[:mode]).to eq(:goals)
+        expect(result[:goals]).to eq(%i[privacy consent])
+      end
+    end
+
+    it "filters invalid goal names" do
+      with_stdin("1\nprivacy, bogus, consent\n") do
+        result = described_class.run(shell: fake_shell)
+        expect(result[:goals]).to eq(%i[privacy consent])
+      end
+    end
+  end
+
+  describe ".parse_goals" do
+    it "parses comma-separated goals" do
+      expect(described_class.parse_goals("privacy, consent")).to eq(%i[privacy consent])
+    end
+
+    it "returns empty array for empty input" do
+      expect(described_class.parse_goals("")).to eq([])
+    end
+
+    it "filters goals not in VALID_GOALS" do
+      expect(described_class.parse_goals("privacy, bogus")).to eq([:privacy])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces the old space-separated goals prompt with a rich 3-choice interactive onboarding flow
- Adds `--no-world-goals` flag for CI/non-interactive use
- Extracts prompt logic to `WorldGoalsPrompt` helper to keep files under 200 lines

## Prompt interaction (choice 1 — declare goals)

```
$ hecks new my_domain

Welcome to Hecks.

Hecks is built on the belief that software affects living beings —
humans, animals, ecosystems. The domain you're about to model will
touch some of them.

Would you like to declare world goals for this domain?

  1. Yes — walk me through them
  2. Skip for now — I'll add them later
  3. This doesn't apply to my project

> 1

Available goals: privacy, transparency, equity, sustainability, consent, security

Select goals (comma-separated, or press Enter to skip):
> privacy, consent

Domain created. World goals declared.

Created my_domain/
  MyDomainBluebook
  app.rb
  ...
```

Generated DSL:

```ruby
Hecks.domain "MyDomain" do
  world_concerns :privacy, :consent

  aggregate "Example" do
    attribute :name, String
    validation :name, presence: true
    command "CreateExample" do
      attribute :name, String
    end
  end
end
```

## Choice 2 (skip) — no world_concerns line

## Choice 3 (doesn't apply) — commented stub

```ruby
Hecks.domain "MyDomain" do
  # world_concerns :transparency, :consent  # add when ready

  aggregate "Example" do
    ...
  end
end
```

## CI / non-interactive

```
$ hecks new my_domain --no-world-goals
```

No `world_concerns` line is included.

## Test plan

- [x] `--no-world-goals` flag: generates domain without world_concerns
- [x] Choice 2 (skip): generates domain without world_concerns
- [x] Choice 3 (not applicable): generates domain with commented stub
- [x] Choice 1 with goals: generates domain with `world_concerns :privacy, :consent`
- [x] Choice 1 with invalid goals: silently filters them out
- [x] Non-interactive mode (stdin not tty): skips prompt
- [x] All 2044 examples pass