### PR TITLE
HEC-263: Strip _id suffix from reference column headers in UI

### DIFF
--- a/hecksties/lib/hecks/conventions/display_contract.rb
+++ b/hecksties/lib/hecks/conventions/display_contract.rb
@@ -30,6 +30,16 @@ module Hecks::Conventions
       UILabelContract.label(base)
     end
 
+    # Strip the _id suffix from a name string.
+    #   strip_id_suffix("pizza_id") # => "pizza"
+    #   strip_id_suffix("name")     # => "name"
+    #
+    # @param name [String, Symbol] the name to strip
+    # @return [String] name without _id suffix
+    def self.strip_id_suffix(name)
+      name.to_s.sub(/_id\z/, "")
+    end
+
     # Find the aggregate referenced by a _id attribute within a domain.
     #
     # @param attr [Attribute] a reference attribute

--- a/hecksties/lib/hecks/conventions/ui_label_contract.rb
+++ b/hecksties/lib/hecks/conventions/ui_label_contract.rb
@@ -5,6 +5,7 @@
 # names, aggregate names). Pure Ruby — no ActiveSupport dependency.
 #
 #   Hecks::Conventions::UILabelContract.label(:effective_date)    # => "Effective Date"
+#   Hecks::Conventions::UILabelContract.label(:pizza_id)          # => "Pizza"
 #   Hecks::Conventions::UILabelContract.label("ReportIncident")   # => "Report Incident"
 #   Hecks::Conventions::UILabelContract.plural_label("GovernancePolicy")  # => "Governance Policies"
 #
@@ -12,11 +13,13 @@
 module Hecks::Conventions
   module UILabelContract
     # Convert any name (snake_case or PascalCase) to a display label.
+    # Strips trailing " Id" to remove foreign-key persistence leaks from UI.
     def self.label(name)
       s = name.to_s
       s = s.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
            .gsub(/([a-z\d])([A-Z])/, '\1 \2')
-      s.split(/[_ ]+/).map(&:capitalize).join(" ")
+      result = s.split(/[_ ]+/).map(&:capitalize).join(" ")
+      result.sub(/ Id$/, "")
     end
 
     # Humanized plural label for an aggregate or entity name.

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe Hecks::Conventions::DisplayContract do
     end
   end
 
+  describe ".strip_id_suffix" do
+    it "removes _id from a reference field name" do
+      expect(described_class.strip_id_suffix("pizza_id")).to eq("pizza")
+    end
+
+    it "leaves non-_id names unchanged" do
+      expect(described_class.strip_id_suffix("name")).to eq("name")
+    end
+  end
+
   describe ".cell_expression with domain" do
     it "returns short-id fallback when no domain given for reference attr" do
       attr = attr_class.new(name: :model_id, type: String)

--- a/hecksties/spec/conventions/ui_label_contract_spec.rb
+++ b/hecksties/spec/conventions/ui_label_contract_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Hecks::Conventions::UILabelContract do
     it "handles consecutive capitals (e.g. UILabel)" do
       expect(described_class.label("UILabel")).to eq("Ui Label")
     end
+
+    it "strips trailing _id — pizza_id becomes Pizza" do
+      expect(described_class.label(:pizza_id)).to eq("Pizza")
+    end
+
+    it "strips trailing _id — restaurant_id becomes Restaurant" do
+      expect(described_class.label(:restaurant_id)).to eq("Restaurant")
+    end
+
+    it "strips trailing _id — multi-word pizza_topping_id becomes Pizza Topping" do
+      expect(described_class.label(:pizza_topping_id)).to eq("Pizza Topping")
+    end
+
+    it "does not strip Id in the middle of a name" do
+      expect(described_class.label("Provider")).to eq("Provider")
+    end
   end
 
   describe ".plural_label" do


### PR DESCRIPTION
## Why

When an aggregate has a `reference_to "Pizza"`, the web explorer was showing a column headed **"Pizza Id"** displaying a raw UUID. This leaks persistence concerns (foreign-key naming) into the UI. End users want to see **"Pizza"**, not a foreign key label.

## What changed

- `UILabelContract.label` now strips a trailing ` Id` from humanized names, so `pizza_id` → `"Pizza Id"` → `"Pizza"`
- `DisplayContract.strip_id_suffix` added as an explicit helper for stripping `_id` from field name strings
- Both Ruby and Go generators already route reference attributes through `DisplayContract.reference_column_label`, which uses `UILabelContract.label` — so the fix flows through automatically
- New specs: `pizza_id` → `"Pizza"`, `restaurant_id` → `"Restaurant"`, `pizza_topping_id` → `"Pizza Topping"`, and `strip_id_suffix` tests

## Before / After

```
# Before
| Pizza Id        | Name    |
| abc-123-uuid    | Marg    |

# After
| Pizza           | Name    |
| abc-123-uuid    | Marg    |
```

## Test plan

- [x] `bundle exec rspec` — 2038 examples, 0 failures
- [x] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes
- [x] File sizes within 200-line limit (`display_contract.rb` at 188 lines)