### PR TITLE
HEC-258: Regenerate Go static examples with cross-aggregate command buttons

### DIFF
--- a/examples/pizzas/pizzas_static_go/server/server.go
+++ b/examples/pizzas/pizzas_static_go/server/server.go
@@ -1,3 +1,5 @@
+// Domain: Pizzas
+// Version: unversioned
 package server
 
 import (
@@ -376,7 +378,8 @@ func (app *App) Start(port int) error {
 	})
 
 	mux.HandleFunc("GET /pizzas/queries/by_description", func(w http.ResponseWriter, r *http.Request) {
-		results, _ := domain.PizzaByDescription(app.PizzaRepo, r.URL.Query().Get("desc"))
+		qp_desc := r.URL.Query().Get("desc")
+		results, _ := domain.PizzaByDescription(app.PizzaRepo, qp_desc)
 		jsonResponse(w, results)
 	})
 

--- a/examples/pizzas_static_go/server/server.go
+++ b/examples/pizzas_static_go/server/server.go
@@ -1,3 +1,5 @@
+// Domain: Pizzas
+// Version: unversioned
 package server
 
 import (
@@ -376,7 +378,8 @@ func (app *App) Start(port int) error {
 	})
 
 	mux.HandleFunc("GET /pizzas/queries/by_description", func(w http.ResponseWriter, r *http.Request) {
-		results, _ := domain.PizzaByDescription(app.PizzaRepo, r.URL.Query().Get("desc"))
+		qp_desc := r.URL.Query().Get("desc")
+		results, _ := domain.PizzaByDescription(app.PizzaRepo, qp_desc)
 		jsonResponse(w, results)
 	})
 


### PR DESCRIPTION
## Why

When the Go server generator produces a show page, it wires up **cross-aggregate command buttons** — buttons for commands in other aggregates that reference the current one. For example, `Order.PlaceOrder` has a `reference_to "Pizza"`, so the Pizza show page gets a "Place Order" button that links to the Order form pre-filled with the current pizza's ID.

The generator logic at `html_routes.rb` lines 83-97 was already correct and the specs in `data_routes_spec.rb` (including the new HEC-258 negative-case spec) were already passing. But the static example files (`examples/pizzas_static_go/server/server.go`) had drifted from the current generator output and needed to be regenerated.

## What changed

Two diffs between the stale static examples and current generator output:

1. **Domain/Version header** — the generator now emits `// Domain: Pizzas` and `// Version: unversioned` at the top of `server.go`

2. **Query parameter variable** — the generator now assigns query params to a named variable before passing to the domain function (HEC-257 coercion pattern):

```go
// Before (stale)
results, _ := domain.PizzaByDescription(app.PizzaRepo, r.URL.Query().Get("desc"))

// After (current generator output)
qp_desc := r.URL.Query().Get("desc")
results, _ := domain.PizzaByDescription(app.PizzaRepo, qp_desc)
```

The cross-aggregate button itself was already correct in both the generator and the static example:

```go
// Pizza show page — cross-aggregate button wired by html_routes.rb lines 83-97
buttons := []PizzaButton{PizzaButton{Label: "Add Topping", Href: "/pizzas/add_topping/new?id=" + obj.ID, Allowed: true}}
buttons = append(buttons, PizzaButton{Label: "Place Order", Href: "/orders/place_order/new?id=" + obj.ID, Allowed: true})
```

## Test plan

- [x] `bundle exec rspec hecks_targets/go/spec/` — all pass (2042 examples, 0 failures)
- [x] Cross-aggregate spec: `renders cross-aggregate Create Review button on Product show page`
- [x] Negative-case spec (HEC-258): `does not add cross-aggregate buttons when no references exist`
- [x] Static examples regenerated and match current generator output exactly