### PR TITLE
HEC-261: Add search and filter to web explorer index pages

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -729,6 +729,13 @@
 - No `Object.const_get`, `respond_to?`, or `instance_variable_get` in the UI layer
 - Same IR structs consumed by Ruby, Go, and Rails generators now also drive the Web Explorer
 
+### Index Search and Filter (HEC-261)
+- Search box on every aggregate index page: `q=` does case-insensitive substring match across all String-typed attributes
+- Exact-match filtering via `filter[attr]=value` query params (e.g., `filter[style]=Thin`)
+- `IRIntrospector#filterable_attributes` returns String-typed, non-list visible attributes
+- `RuntimeBridge#search_and_filter` filters the in-memory collection without custom query classes
+- "Clear" link resets to the plain unfiltered index URL
+
 ### Event Log Browser (HEC-262)
 - Browse all published domain events in a filterable HTML table at `/events`
 - `EventIntrospector` reads `EventBus#events` with `all_entries(type_filter:, aggregate_filter:)`, `event_types`, `aggregate_types`

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
@@ -42,10 +42,25 @@ module Hecks
           end
         end
 
+        def parse_search_params(req)
+          q = req.query["q"].to_s.strip
+          q = nil if q.empty?
+          filters = {}
+          req.query.each do |key, value|
+            next unless key.start_with?("filter[") && key.end_with?("]")
+            attr = key[7..-2]
+            filters[attr.to_sym] = value unless value.to_s.strip.empty?
+          end
+          [q, filters]
+        end
+
         def serve_index(req, res, ir, bridge, agg, safe, p, prefix)
           token = ensure_csrf_cookie(req, res)
+          q, filters = parse_search_params(req)
           user_attrs = ir.user_attributes(agg)
-          items = bridge.find_all(agg.name).map do |obj|
+          filterable = ir.filterable_attributes(agg).map(&:name)
+          records = bridge.search_and_filter(agg.name, string_attr_names: filterable, query: q, filters: filters)
+          items = records.map do |obj|
             cells = user_attrs.map { |a|
               if ir.reference_attr?(a)
                 ref_agg = ir.find_referenced_aggregate(a)
@@ -72,7 +87,8 @@ module Hecks
           html = @renderer.render(:index,
             title: "#{safe}s — #{@brand}", brand: @brand, nav_items: @nav,
             aggregate_name: safe, items: items, columns: columns,
-            buttons: buttons, row_actions: [], csrf_token: token)
+            buttons: buttons, row_actions: [], csrf_token: token,
+            search_query: q.to_s, index_url: "#{prefix}/#{p}")
           res["Content-Type"] = "text/html"
           res.body = html
         end

--- a/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/ir_introspector.rb
@@ -100,6 +100,10 @@ module Hecks
         HecksTemplating::DisplayContract.aggregate_summary(agg)
       end
 
+      def filterable_attributes(agg)
+        user_attributes(agg).select { |a| a.type == String && !a.list? }
+      end
+
       def policy_labels
         HecksTemplating::DisplayContract.policy_labels(@domain)
       end

--- a/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/runtime_bridge.rb
@@ -25,6 +25,27 @@ module Hecks
         klass_for(agg_name).all
       end
 
+      def search_and_filter(agg_name, string_attr_names: [], query: nil, filters: {})
+        klass = klass_for(agg_name)
+        records = klass.all
+
+        unless filters.empty?
+          filters.each do |attr, value|
+            next if value.nil? || value.to_s.strip.empty?
+            records = records.select { |r| r.send(attr).to_s == value.to_s }
+          end
+        end
+
+        if query && !query.strip.empty?
+          q = query.strip.downcase
+          records = records.select do |r|
+            string_attr_names.any? { |attr| r.send(attr).to_s.downcase.include?(q) }
+          end
+        end
+
+        records
+      end
+
       def find_by_id(agg_name, id)
         klass_for(agg_name).find(id)
       end

--- a/hecksties/lib/hecks/extensions/web_explorer/views/index.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/index.erb
@@ -9,6 +9,13 @@
 <% if defined?(description) && description && !description.empty? %>
   <p style="color:#666;margin:-1rem 0 1.5rem"><%= description %></p>
 <% end %>
+<% base_url = defined?(index_url) ? index_url : "" %>
+<form method="get" action="<%= base_url %>" style="margin-bottom:1rem;display:flex;gap:0.5rem;align-items:center">
+  <label for="q" style="font-weight:600">Search</label>
+  <input id="q" name="q" type="text" value="<%= h(defined?(search_query) ? search_query : "") %>" placeholder="Search all text fields…" style="flex:1;padding:0.3rem 0.5rem">
+  <button type="submit" class="btn">Go</button>
+  <a class="btn btn-faded" href="<%= base_url %>">Clear</a>
+</form>
 <table>
   <thead>
     <tr>

--- a/hecksties/spec/extensions/web_explorer_ir_spec.rb
+++ b/hecksties/spec/extensions/web_explorer_ir_spec.rb
@@ -209,5 +209,52 @@ RSpec.describe "Web Explorer IR introspection" do
       expect(bridge).to respond_to(:find_by_id)
       expect(bridge).not_to respond_to(:klass_for)
     end
+
+    it "search_and_filter: substring, exact-match, case-insensitive, and blank-filter" do
+      bridge.execute_command("Widget", :create, { label: "Alpha" })
+      bridge.execute_command("Widget", :create, { label: "Beta" })
+      bridge.execute_command("Widget", :create, { label: "Gamma" })
+
+      all = bridge.search_and_filter("Widget", string_attr_names: [:label])
+      expect(all.size).to be >= 3
+
+      by_q = bridge.search_and_filter("Widget", string_attr_names: [:label], query: "alph")
+      expect(by_q.map(&:label)).to include("Alpha")
+      expect(by_q.map(&:label)).not_to include("Beta")
+
+      case_insensitive = bridge.search_and_filter("Widget", string_attr_names: [:label], query: "BETA")
+      expect(case_insensitive.map(&:label)).to include("Beta")
+
+      exact = bridge.search_and_filter("Widget", string_attr_names: [:label], filters: { label: "Gamma" })
+      expect(exact.map(&:label)).to eq(["Gamma"])
+
+      no_match = bridge.search_and_filter("Widget", string_attr_names: [:label], filters: { label: "NoMatch" })
+      expect(no_match).to be_empty
+
+      blank_filter = bridge.search_and_filter("Widget", string_attr_names: [:label], filters: { label: "" })
+      expect(blank_filter.size).to be >= 3
+    end
+  end
+
+  describe "IRIntrospector#filterable_attributes" do
+    it "returns only string-typed, non-list user attributes" do
+      domain = Hecks.domain "FilterableTest" do
+        aggregate "Item" do
+          attribute :title, String
+          attribute :count, Integer
+          attribute :tags, list_of("String")
+          attribute :price, Float
+          attribute :secret, String, visible: false
+          command "CreateItem" do
+            attribute :title, String
+          end
+        end
+      end
+      ir = Hecks::WebExplorer::IRIntrospector.new(domain)
+      agg = ir.find_aggregate("Item")
+      names = ir.filterable_attributes(agg).map(&:name)
+      expect(names).to include(:title)
+      expect(names).not_to include(:count, :price, :secret)
+    end
   end
 end


### PR DESCRIPTION
## Why

The web explorer index pages show all records with no way to find specific ones. On any domain with more than a handful of records, this is unusable — you have to eyeball a flat list. Search and filter turn the explorer from a debugging toy into a useful development tool.

## What changed

- **`RuntimeBridge#search_and_filter`** — filters the in-memory collection with substring search across String attrs and exact-match filters
- **`IRIntrospector#filterable_attributes`** — returns String-typed, non-list visible attributes (the set eligible for `q=` search)
- **`UIRoutes#parse_search_params`** — parses `q=` and `filter[attr]=value` from query params
- **`serve_index`** — calls `search_and_filter` instead of `find_all`; passes `search_query` and `index_url` to the template
- **`index.erb`** — search box above the table with a "Clear" link

## URL patterns

```
GET /pizzas_domain/pizzas?q=marg           # substring search across all String fields
GET /pizzas_domain/pizzas?filter[style]=Thin  # exact match on style
GET /pizzas_domain/pizzas                  # unfiltered (Clear link target)
```

## Search box behavior

A single "Search" text input appears above the table. Submitting the form adds `?q=<value>` to the current page URL. The "Clear" link navigates back to the bare index URL with no query params, resetting the view.

## Specs

- `RuntimeBridge#search_and_filter`: substring, exact-match, case-insensitive, blank-filter-ignored
- `IRIntrospector#filterable_attributes`: returns only String non-list visible attrs
- All 2034 existing specs still pass