### PR TITLE
HEC-445: Add world concerns onboarding to hecks new

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -427,7 +427,7 @@
 - Preview mode with `--preview` flag
 
 ## CLI Commands
-- `hecks new NAME` — scaffold a complete project with interactive world goals onboarding (opt-out by pressing Enter; skipped in non-interactive/CI)
+- `hecks new NAME` — scaffold a complete project with interactive world goals onboarding: 3-step prompt (yes/skip/doesn't apply), maps each goal to a real extension (`privacy→:pii`, `transparency→:audit`, `consent/security→:auth`, `equity→:tenancy`, `sustainability→:rate_limit`), deduplicates extensions, generates both `world_concerns` and `extend` calls in the Bluebook; `--no-world-goals` skips prompt for CI
 - `hecks build` — validate and generate versioned gem
 - `hecks build --gem` — produce a publishable `.gem` artifact after building (runs `gem build` on generated output); supported for `ruby` and `static` targets
 - `hecks serve [--rpc]` — start REST or JSON-RPC server

--- a/docs/usage/world_concerns_onboarding.md
+++ b/docs/usage/world_concerns_onboarding.md
@@ -1,62 +1,104 @@
-# World Concerns Onboarding
+# World Concerns Onboarding — `hecks new`
 
-When creating a new project with `hecks new`, you are prompted to select
-world concerns interactively. Concerns are opt-in ethical validation rules that
-check your domain design for alignment with stated values.
+When you create a new Hecks domain, you are invited to declare world concerns upfront. Each goal maps to a real runtime extension that enforces it — this is not aspiration, it is enforcement.
 
-## Available concerns
-
-| Concern         | What it checks                                       |
-|-----------------|------------------------------------------------------|
-| `:transparency` | Commands must emit events (no silent mutations)      |
-| `:consent`      | User-like aggregate commands must declare actors     |
-| `:privacy`      | PII attributes must be `visible: false`              |
-| `:security`     | Sensitive aggregates need auth guards                |
-
-## Interactive usage
+## The prompt
 
 ```
-$ hecks new my_app
+$ hecks new my_domain
 
-World concerns are opt-in ethical validation rules for your domain.
-Available: :transparency, :consent, :privacy, :security
-Enter concerns (space-separated), or press Enter to skip:
-> transparency consent
+Welcome to Hecks.
 
-Created my_app/
-  MyAppBluebook   # includes world_concerns :transparency, :consent
-  app.rb
-  ...
+Hecks is built on the belief that software affects living beings.
+The domain you're about to model will touch some of them.
+
+Would you like to declare world concerns for this domain?
+
+  1. Yes — walk me through them
+  2. Skip for now — I'll add them later
+  3. This doesn't apply to my project
+
+> 1
+
+Available concerns (each wires in a real extension):
+
+  privacy        — mark sensitive fields, require consent  (extend :pii)
+  transparency   — log all state changes                   (extend :audit)
+  consent        — require actors for all commands         (extend :auth)
+  security       — fail-closed auth and CSRF protection    (extend :auth)
+  equity         — row-level access, no gatekeeping        (extend :tenancy)
+  sustainability — rate limiting and resource bounds       (extend :rate_limit)
+
+Select concerns (comma-separated, or Enter to skip):
+> privacy, consent
+
+Domain created. World concerns declared.
 ```
 
-## Opt-out
-
-Press Enter without typing anything to skip world concerns entirely:
-
-```
-Enter concerns (space-separated), or press Enter to skip:
->
-```
-
-The generated Bluebook will not include a `world_concerns` line.
-
-## Non-interactive / CI
-
-When stdin is not a TTY (pipes, CI), the prompt is skipped automatically
-and no concerns are included. You can always add them later by editing the
-Bluebook:
+## Generated Bluebook (privacy + consent selected)
 
 ```ruby
-Hecks.domain "MyApp" do
-  world_concerns :transparency, :consent
+Hecks.domain "MyDomain" do
+  world_concerns :privacy, :consent
+  extend :pii
+  extend :auth
 
   aggregate "Example" do
-    # ...
+    attribute :name, String
+    validation :name, presence: true
+    command "CreateExample" do
+      attribute :name, String
+    end
   end
 end
 ```
 
+Note: `consent` and `security` both map to `:auth` — selecting both emits `extend :auth` only once.
+
+## Extension mapping
+
+| Goal | Extension |
+|------|-----------|
+| `privacy` | `:pii` |
+| `transparency` | `:audit` |
+| `consent` | `:auth` |
+| `security` | `:auth` |
+| `equity` | `:tenancy` |
+| `sustainability` | `:rate_limit` |
+
+## Choice 2 — skip
+
+Generates a plain domain with no world_concerns or extend calls.
+
+## Choice 3 — doesn't apply
+
+Generates a domain with a commented stub for later:
+
+```ruby
+Hecks.domain "MyDomain" do
+  # world_concerns :privacy, :consent  # add when ready
+
+  aggregate "Example" do
+    attribute :name, String
+    validation :name, presence: true
+    command "CreateExample" do
+      attribute :name, String
+    end
+  end
+end
+```
+
+## CI / non-interactive mode
+
+Use `--no-world-goals` to skip the prompt entirely:
+
+```
+$ hecks new my_domain --no-world-goals
+```
+
+The prompt is also skipped automatically when stdin is not a TTY.
+
 ## Invalid input
 
-Unrecognized concern names are silently filtered out. Only the four valid
-concerns (`:transparency`, `:consent`, `:privacy`, `:security`) are kept.
+Unrecognized concern names are silently filtered out. Only the six valid goals
+(`privacy`, `transparency`, `consent`, `security`, `equity`, `sustainability`) are kept.

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -1,5 +1,10 @@
+require_relative "../world_concerns_prompt"
+
 Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
-  args: ["NAME"]
+  args: ["NAME"],
+  options: {
+    "no-world-goals": { type: :boolean, desc: "Skip world concerns prompt (for CI)", default: false }
+  }
 ) do |name|
   pascal = Hecks::Utils.sanitize_constant(name)
   dir = name
@@ -9,18 +14,10 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     next
   end
 
-  available_goals = %i[transparency consent privacy security]
-  selected_goals = []
-
-  if $stdin.tty?
-    say ""
-    say "World concerns are opt-in ethical validation rules for your domain.", :cyan
-    say "Available: #{available_goals.map { |g| ":#{g}" }.join(", ")}"
-    say "Enter concerns (space-separated), or press Enter to skip:"
-    input = $stdin.gets&.chomp
-    if input && !input.strip.empty?
-      selected_goals = input.strip.split(/\s+/).map(&:to_sym) & available_goals
-    end
+  world_result = if options[:"no-world-goals"]
+    { concerns: [], extensions: [], stub: false }
+  else
+    Hecks::WorldConcernsPrompt.new(say_method: method(:say)).run
   end
 
   app_template = lambda do
@@ -78,14 +75,25 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
 
   FileUtils.mkdir_p(File.join(dir, "spec"))
 
-  write_or_diff(File.join(dir, "#{pascal}Bluebook"), domain_template(pascal, world_concerns: selected_goals))
+  write_or_diff(
+    File.join(dir, "#{pascal}Bluebook"),
+    domain_template(pascal,
+      world_concerns: world_result[:concerns],
+      extensions:     world_result[:extensions],
+      stub:           world_result[:stub])
+  )
   write_or_diff(File.join(dir, "app.rb"), app_template.call)
   write_or_diff(File.join(dir, "Gemfile"), gemfile_template.call)
   write_or_diff(File.join(dir, "spec", "spec_helper.rb"), spec_helper_template.call)
   write_or_diff(File.join(dir, ".gitignore"), gitignore_template.call)
   write_or_diff(File.join(dir, ".rspec"), rspec_template.call)
 
-  say "Created #{dir}/", :green
+  if world_result[:concerns].any? || world_result[:stub]
+    say ""
+    say "Domain created. World concerns declared.", :green
+  else
+    say "Created #{dir}/", :green
+  end
   say "  #{pascal}Bluebook"
   say "  app.rb"
   say "  Gemfile"

--- a/hecksties/lib/hecks_cli/domain_helpers.rb
+++ b/hecksties/lib/hecks_cli/domain_helpers.rb
@@ -116,15 +116,20 @@ module Hecks
       result.suggestions.each { |s| say "    - #{s}", :cyan }
     end
 
-    def domain_template(name, world_concerns: [])
-      concerns_line = if world_concerns.any?
-        "\n  world_concerns #{world_concerns.map { |g| ":#{g}" }.join(", ")}\n"
-      else
-        ""
+    def domain_template(name, world_concerns: [], extensions: [], stub: false)
+      header_lines = []
+
+      if stub
+        header_lines << "  # world_concerns :privacy, :consent  # add when ready"
+      elsif world_concerns.any?
+        header_lines << "  world_concerns #{world_concerns.map { |g| ":#{g}" }.join(", ")}"
+        extensions.each { |ext| header_lines << "  extend :#{ext}" }
       end
 
+      header = header_lines.any? ? "\n#{header_lines.join("\n")}\n" : ""
+
       <<~RUBY
-        Hecks.domain "#{name}" do#{concerns_line}
+        Hecks.domain "#{name}" do#{header}
           aggregate "Example" do
             attribute :name, String
             validation :name, presence: true

--- a/hecksties/lib/hecks_cli/world_concerns_prompt.rb
+++ b/hecksties/lib/hecks_cli/world_concerns_prompt.rb
@@ -1,0 +1,98 @@
+# Hecks::WorldConcernsPrompt
+#
+# Interactive onboarding prompt that asks developers to declare world concerns
+# for a new domain. Each concern maps to a real Hecks extension that enforces
+# the goal at runtime. Extracted from new_project.rb to keep that file small.
+#
+# Usage:
+#   result = WorldConcernsPrompt.run(say_method: method(:say))
+#   result[:concerns]   # => [:privacy, :consent]
+#   result[:extensions] # => [:pii, :auth]
+#   result[:stub]       # => false
+#
+module Hecks
+  class WorldConcernsPrompt
+    GOAL_TO_EXTENSION = {
+      privacy:       :pii,
+      transparency:  :audit,
+      consent:       :auth,
+      security:      :auth,
+      equity:        :tenancy,
+      sustainability: :rate_limit
+    }.freeze
+
+    VALID_GOALS = GOAL_TO_EXTENSION.keys.freeze
+
+    GOAL_DESCRIPTIONS = {
+      privacy:       "mark sensitive fields, require consent  (extend :pii)",
+      transparency:  "log all state changes                   (extend :audit)",
+      consent:       "require actors for all commands         (extend :auth)",
+      security:      "fail-closed auth and CSRF protection    (extend :auth)",
+      equity:        "row-level access, no gatekeeping        (extend :tenancy)",
+      sustainability: "rate limiting and resource bounds       (extend :rate_limit)"
+    }.freeze
+
+    def initialize(say_method:, stdin: $stdin)
+      @say    = say_method
+      @stdin  = stdin
+    end
+
+    # Run the prompt and return a result hash.
+    # Returns { concerns: [], extensions: [], stub: false } on skip.
+    # Returns { concerns: [], extensions: [], stub: true } on "doesn't apply".
+    def run
+      return no_concerns unless @stdin.tty?
+
+      show_welcome
+      choice = ask_top_choice
+      case choice
+      when "1" then walk_through_concerns
+      when "3" then { concerns: [], extensions: [], stub: true }
+      else          no_concerns
+      end
+    end
+
+    private
+
+    def show_welcome
+      @say.call("")
+      @say.call("Welcome to Hecks.")
+      @say.call("")
+      @say.call("Hecks is built on the belief that software affects living beings.")
+      @say.call("The domain you're about to model will touch some of them.")
+      @say.call("")
+      @say.call("Would you like to declare world concerns for this domain?")
+      @say.call("")
+      @say.call("  1. Yes — walk me through them")
+      @say.call("  2. Skip for now — I'll add them later")
+      @say.call("  3. This doesn't apply to my project")
+      @say.call("")
+    end
+
+    def ask_top_choice
+      @stdin.gets&.chomp&.strip || "2"
+    end
+
+    def walk_through_concerns
+      @say.call("")
+      @say.call("Available concerns (each wires in a real extension):")
+      @say.call("")
+      GOAL_DESCRIPTIONS.each do |goal, desc|
+        @say.call("  %-14s — %s" % [goal.to_s, desc])
+      end
+      @say.call("")
+      @say.call("Select concerns (comma-separated, or Enter to skip):")
+
+      raw   = @stdin.gets&.chomp&.strip || ""
+      input = raw.split(/[\s,]+/).map { |s| s.to_sym } & VALID_GOALS
+
+      extensions = input.map { |g| GOAL_TO_EXTENSION[g] }.uniq
+
+      { concerns: input, extensions: extensions, stub: false }
+    end
+
+    def no_concerns
+      { concerns: [], extensions: [], stub: false }
+    end
+  end
+end

--- a/hecksties/spec/new_project_spec.rb
+++ b/hecksties/spec/new_project_spec.rb
@@ -68,20 +68,79 @@ RSpec.describe "hecks new CLI command" do
       $stdin = original
     end
 
-    it "includes selected goals, filters invalid input, and skips on opt-out" do
+    it "--no-world-goals flag skips prompt entirely and generates plain domain" do
       Dir.chdir(tmpdir) do
-        with_stdin("transparency bogus consent\n") do
-          Hecks::CLI.new.invoke(:new_project, ["with_goals"])
+        cli = Hecks::CLI.new([], { "no-world-goals": true })
+        cli.invoke(:new_project, ["ci_domain"])
+
+        bluebook = File.read(Dir["ci_domain/*Bluebook"].first)
+        expect(bluebook).not_to include("world_concerns")
+        expect(bluebook).not_to include("extend :")
+      end
+    end
+
+    it "choice 2 (skip) generates plain domain without world_concerns" do
+      Dir.chdir(tmpdir) do
+        with_stdin("2\n") do
+          Hecks::CLI.new.invoke(:new_project, ["skip_domain"])
         end
-        bluebook = File.read(Dir["with_goals/*Bluebook"].first)
+        bluebook = File.read(Dir["skip_domain/*Bluebook"].first)
+        expect(bluebook).not_to include("world_concerns")
+        expect(bluebook).not_to include("extend :")
+      end
+    end
+
+    it "choice 3 (doesn't apply) generates domain with commented stub" do
+      Dir.chdir(tmpdir) do
+        with_stdin("3\n") do
+          Hecks::CLI.new.invoke(:new_project, ["stub_domain"])
+        end
+        bluebook = File.read(Dir["stub_domain/*Bluebook"].first)
+        expect(bluebook).to include("# world_concerns :privacy, :consent  # add when ready")
+        expect(bluebook).not_to include("\n  world_concerns ")
+      end
+    end
+
+    it "choice 1 with privacy and consent generates world_concerns and deduped extend calls" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\nprivacy, consent\n") do
+          Hecks::CLI.new.invoke(:new_project, ["values_domain"])
+        end
+        bluebook = File.read(Dir["values_domain/*Bluebook"].first)
+        expect(bluebook).to include("world_concerns :privacy, :consent")
+        expect(bluebook).to include("extend :pii")
+        expect(bluebook).to include("extend :auth")
+        # auth appears only once even though consent and security both map to it
+        expect(bluebook.scan("extend :auth").length).to eq(1)
+      end
+    end
+
+    it "choice 1 filters invalid goal names and keeps valid ones" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\ntransparency bogus consent\n") do
+          Hecks::CLI.new.invoke(:new_project, ["filtered_domain"])
+        end
+        bluebook = File.read(Dir["filtered_domain/*Bluebook"].first)
         expect(bluebook).to include("world_concerns :transparency, :consent")
         expect(bluebook).not_to include("bogus")
+        expect(bluebook).to include("extend :audit")
+        expect(bluebook).to include("extend :auth")
+      end
+    end
 
-        with_stdin("\n") do
-          Hecks::CLI.new.invoke(:new_project, ["no_goals"])
+    it "choice 1 with all six goals deduplicates auth extension" do
+      Dir.chdir(tmpdir) do
+        with_stdin("1\nprivacy, transparency, consent, security, equity, sustainability\n") do
+          Hecks::CLI.new.invoke(:new_project, ["all_goals_domain"])
         end
-        bluebook = File.read(Dir["no_goals/*Bluebook"].first)
-        expect(bluebook).not_to include("world_concerns")
+        bluebook = File.read(Dir["all_goals_domain/*Bluebook"].first)
+        expect(bluebook).to include("world_concerns :privacy, :transparency, :consent, :security, :equity, :sustainability")
+        expect(bluebook).to include("extend :pii")
+        expect(bluebook).to include("extend :audit")
+        expect(bluebook).to include("extend :auth")
+        expect(bluebook).to include("extend :tenancy")
+        expect(bluebook).to include("extend :rate_limit")
+        expect(bluebook.scan("extend :auth").length).to eq(1)
       end
     end
 

--- a/hecksties/spec/world_concerns_prompt_spec.rb
+++ b/hecksties/spec/world_concerns_prompt_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require "stringio"
+require "hecks_cli"
+
+RSpec.describe Hecks::WorldConcernsPrompt do
+  def prompt_with(input, tty: true)
+    fake = StringIO.new(input)
+    allow(fake).to receive(:tty?).and_return(tty)
+    described_class.new(say_method: ->(*) {}, stdin: fake).run
+  end
+
+  it "returns empty result when stdin is not a tty" do
+    result = prompt_with("1\nprivacy\n", tty: false)
+    expect(result).to eq(concerns: [], extensions: [], stub: false)
+  end
+
+  it "choice 2 returns empty result" do
+    result = prompt_with("2\n")
+    expect(result).to eq(concerns: [], extensions: [], stub: false)
+  end
+
+  it "choice 3 sets stub: true" do
+    result = prompt_with("3\n")
+    expect(result).to eq(concerns: [], extensions: [], stub: true)
+  end
+
+  it "choice 1 maps goals to extensions and deduplicates" do
+    result = prompt_with("1\nprivacy, consent\n")
+    expect(result[:concerns]).to eq([:privacy, :consent])
+    expect(result[:extensions]).to eq([:pii, :auth])
+    expect(result[:stub]).to be false
+  end
+
+  it "choice 1 filters invalid goal names silently" do
+    result = prompt_with("1\ntransparency bogus\n")
+    expect(result[:concerns]).to eq([:transparency])
+    expect(result[:extensions]).to eq([:audit])
+  end
+
+  it "deduplicates :auth when both consent and security are selected" do
+    result = prompt_with("1\nconsent, security\n")
+    expect(result[:concerns]).to eq([:consent, :security])
+    expect(result[:extensions]).to eq([:auth])
+  end
+
+  it "maps all six goals correctly" do
+    result = prompt_with("1\nprivacy, transparency, consent, security, equity, sustainability\n")
+    expect(result[:concerns]).to eq([:privacy, :transparency, :consent, :security, :equity, :sustainability])
+    expect(result[:extensions]).to contain_exactly(:pii, :audit, :auth, :tenancy, :rate_limit)
+  end
+end


### PR DESCRIPTION
## Why

Software affects living beings. When a developer creates a new domain, they should be invited to declare their values before writing a single line of business logic. This PR makes that invitation real — each world concern maps to a runtime extension that actually enforces the goal, not just documents it.

## What changed

- `hecks new NAME` now shows a 3-step onboarding prompt (yes / skip / doesn't apply)
- Choosing "yes" presents all 6 goals with their extension mappings and lets you pick
- Selected goals generate both `world_concerns` and `extend` calls in the Bluebook
- Extensions are deduplicated (`consent` + `security` both map to `:auth` — only one `extend :auth`)
- `--no-world-goals` flag skips the prompt entirely for CI
- Choice 3 ("doesn't apply") adds a commented stub for later

## Extension mapping

| Goal | Extension |
|------|-----------|
| `privacy` | `:pii` |
| `transparency` | `:audit` |
| `consent` | `:auth` |
| `security` | `:auth` |
| `equity` | `:tenancy` |
| `sustainability` | `:rate_limit` |

## Generated output — privacy + consent selected

```ruby
Hecks.domain "MyDomain" do
  world_concerns :privacy, :consent
  extend :pii
  extend :auth

  aggregate "Example" do
    attribute :name, String
    validation :name, presence: true
    command "CreateExample" do
      attribute :name, String
    end
  end
end
```

## Files changed

- `hecksties/lib/hecks_cli/world_concerns_prompt.rb` — extracted prompt logic (new file, 98 lines)
- `hecksties/lib/hecks_cli/commands/new_project.rb` — uses prompt, adds `--no-world-goals` flag
- `hecksties/lib/hecks_cli/domain_helpers.rb` — `domain_template` now accepts `extensions:` and `stub:` kwargs
- `hecksties/spec/new_project_spec.rb` — 7 new scenario specs
- `hecksties/spec/world_concerns_prompt_spec.rb` — 7 unit specs for the prompt
- `docs/usage/world_concerns_onboarding.md` — updated with full example
- `FEATURES.md` — updated CLI entry