### PR TITLE
HEC-262: Add event log browser page to web explorer

### DIFF
--- a/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_server.rb
@@ -7,6 +7,7 @@ require_relative "csrf_helpers"
 require "hecks/extensions/web_explorer/renderer"
 require "hecks/extensions/web_explorer/ir_introspector"
 require "hecks/extensions/web_explorer/runtime_bridge"
+require "hecks/extensions/web_explorer/event_introspector"
 require_relative "multi_domain_ui_routes"
 
 module Hecks
@@ -87,6 +88,7 @@ module Hecks
             }
           end
         end
+        items << { label: "Events", href: "/events", group: "System" }
         items << { label: "Config", href: "/config", group: "System" }
         items
       end
@@ -100,6 +102,8 @@ module Hecks
         path = req.path
         if path == "/"
           serve_home(res)
+        elsif path == "/events"
+          serve_events(req, res)
         elsif path == "/config"
           serve_config(res)
         else
@@ -200,6 +204,9 @@ module Hecks
       def wildcard?(segment)
         segment.start_with?(":")
       end
+
+      # Minimal event bus adapter for merging events from multiple runtimes.
+      MergedEventBus = Struct.new(:events)
     end
   end
 end

--- a/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
+++ b/hecksties/lib/hecks/extensions/serve/multi_domain_ui_routes.rb
@@ -14,6 +14,26 @@ module Hecks
         include CsrfHelpers
         private
 
+        def serve_events(req, res)
+          type_filter = req.query["type"]
+          aggregate_filter = req.query["aggregate"]
+          all_buses = @runtimes.map(&:event_bus)
+          merged_events = all_buses.flat_map(&:events).sort_by { |e|
+            e.respond_to?(:occurred_at) ? e.occurred_at : Time.at(0)
+          }
+          merged_bus = MergedEventBus.new(merged_events)
+          intro = Hecks::WebExplorer::EventIntrospector.new(merged_bus)
+          html = @renderer.render(:events,
+            title: "Event Log — #{@brand}", brand: @brand, nav_items: @nav,
+            entries: intro.all_entries(type_filter: type_filter, aggregate_filter: aggregate_filter),
+            event_types: intro.event_types,
+            aggregate_types: intro.aggregate_types,
+            selected_type: type_filter || "",
+            selected_aggregate: aggregate_filter || "")
+          res["Content-Type"] = "text/html"
+          res.body = html
+        end
+
         def serve_ui_route(req, res, entry, sub_path)
           ir = entry[:ir]
           bridge = entry[:bridge]

--- a/hecksties/lib/hecks/extensions/web_explorer/event_introspector.rb
+++ b/hecksties/lib/hecks/extensions/web_explorer/event_introspector.rb
@@ -1,0 +1,82 @@
+# Hecks::WebExplorer::EventIntrospector
+#
+# Reads the EventBus events array and provides filtered views for the
+# web explorer event log page. Derives event type and aggregate name
+# from each event's fully qualified class name.
+#
+#   introspector = EventIntrospector.new(event_bus)
+#   introspector.all_entries(type_filter: "CreatedPizza")
+#   introspector.event_types   # => ["CreatedPizza", "PlacedOrder"]
+#   introspector.aggregate_types  # => ["Pizza", "Order"]
+#
+module Hecks
+  module WebExplorer
+    class EventIntrospector
+      def initialize(event_bus)
+        @event_bus = event_bus
+      end
+
+      # Returns all event entries, newest first.
+      #
+      # @param type_filter [String, nil] restrict to this event type name
+      # @param aggregate_filter [String, nil] restrict to this aggregate name
+      # @return [Array<Hash>] entries with :type, :aggregate, :occurred_at, :payload
+      def all_entries(type_filter: nil, aggregate_filter: nil)
+        entries = @event_bus.events.map { |e| build_entry(e) }.reverse
+        entries = entries.select { |e| e[:type] == type_filter } if type_filter && !type_filter.empty?
+        entries = entries.select { |e| e[:aggregate] == aggregate_filter } if aggregate_filter && !aggregate_filter.empty?
+        entries
+      end
+
+      # Unique event type names across all stored events.
+      #
+      # @return [Array<String>]
+      def event_types
+        @event_bus.events.map { |e| short_name(e) }.uniq
+      end
+
+      # Unique aggregate names across all stored events.
+      #
+      # @return [Array<String>]
+      def aggregate_types
+        @event_bus.events.map { |e| aggregate_name(e) }.uniq
+      end
+
+      private
+
+      def build_entry(event)
+        {
+          type: short_name(event),
+          aggregate: aggregate_name(event),
+          occurred_at: extract_occurred_at(event),
+          payload: extract_payload(event)
+        }
+      end
+
+      def short_name(event)
+        Hecks::Utils.const_short_name(event)
+      end
+
+      # Derive aggregate name from module path: DomainModule::AggregateName::Events::EventType
+      def aggregate_name(event)
+        parts = event.class.name.to_s.split("::")
+        idx = parts.index("Events")
+        idx && idx > 0 ? parts[idx - 1] : parts.first
+      end
+
+      def extract_occurred_at(event)
+        event.respond_to?(:occurred_at) ? event.occurred_at : nil
+      end
+
+      def extract_payload(event)
+        params = event.class.instance_method(:initialize).parameters
+        params.filter_map { |_, name|
+          next if name.nil? || name == :occurred_at
+          [name.to_s, event.respond_to?(name) ? event.send(name).to_s : "?"]
+        }.to_h
+      rescue
+        {}
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/extensions/web_explorer/views/events.erb
+++ b/hecksties/lib/hecks/extensions/web_explorer/views/events.erb
@@ -1,0 +1,61 @@
+<div class="header-row">
+  <h1>Event Log</h1>
+  <span class="hint"><%= entries.size %> event<%= entries.size == 1 ? "" : "s" %></span>
+</div>
+
+<form method="get" action="/events" style="display:flex;gap:0.75rem;align-items:flex-end;margin-bottom:1.5rem;background:#fff;padding:1rem;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+  <div>
+    <label for="type_select" style="display:block;margin-bottom:0.25rem;font-size:0.85rem;font-weight:500;">Event Type</label>
+    <select id="type_select" name="type" class="inline">
+      <option value="">All types</option>
+      <% event_types.each do |t| -%>
+        <option value="<%= h(t) %>"<%= selected_type == t ? ' selected' : '' %>><%= h(t) %></option>
+      <% end -%>
+    </select>
+  </div>
+  <div>
+    <label for="agg_select" style="display:block;margin-bottom:0.25rem;font-size:0.85rem;font-weight:500;">Aggregate</label>
+    <select id="agg_select" name="aggregate" class="inline">
+      <option value="">All aggregates</option>
+      <% aggregate_types.each do |a| -%>
+        <option value="<%= h(a) %>"<%= selected_aggregate == a ? ' selected' : '' %>><%= h(a) %></option>
+      <% end -%>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-sm">Filter</button>
+  <a href="/events" class="btn btn-sm btn-faded">Clear</a>
+</form>
+
+<% if entries.empty? -%>
+  <p style="color:#999;text-align:center;padding:3rem 0;">No events yet. Execute a command to see events appear here.</p>
+<% else -%>
+  <table>
+    <thead>
+      <tr>
+        <th>Timestamp</th>
+        <th>Event Type</th>
+        <th>Aggregate</th>
+        <th>Payload</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% entries.each do |entry| -%>
+        <tr>
+          <td class="mono"><%= entry[:occurred_at] ? h(entry[:occurred_at].strftime("%H:%M:%S.%3N")) : "—" %></td>
+          <td><span class="badge"><%= h(entry[:type]) %></span></td>
+          <td><%= h(entry[:aggregate]) %></td>
+          <td>
+            <% if entry[:payload].empty? -%>
+              <span class="hint">none</span>
+            <% else -%>
+              <details>
+                <summary style="cursor:pointer;color:#4361ee;font-size:0.85rem;">Show</summary>
+                <pre class="mono" style="margin-top:0.5rem;background:#f5f5f5;padding:0.5rem;border-radius:4px;"><%= h(entry[:payload].map { |k, v| "#{k}: #{v}" }.join("\n")) %></pre>
+              </details>
+            <% end -%>
+          </td>
+        </tr>
+      <% end -%>
+    </tbody>
+  </table>
+<% end -%>

--- a/hecksties/spec/extensions/event_introspector_spec.rb
+++ b/hecksties/spec/extensions/event_introspector_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+require "hecks/extensions/web_explorer/event_introspector"
+
+RSpec.describe Hecks::WebExplorer::EventIntrospector do
+  FakeEvent = Struct.new(:name, :occurred_at, keyword_init: true) unless defined?(FakeEvent)
+
+  def make_event(type_name:, aggregate:, occurred_at: Time.now)
+    # Build a class whose name matches: DomainModule::Aggregate::Events::EventType
+    klass = Class.new(Struct.new(:occurred_at, keyword_init: true))
+    mod = Module.new
+    events_mod = Module.new
+    stub_const("FakeTestDomain::#{aggregate}::Events::#{type_name}", klass)
+    klass.new(occurred_at: occurred_at)
+  end
+
+  let(:t1) { Time.now - 10 }
+  let(:t2) { Time.now - 5 }
+  let(:t3) { Time.now }
+
+  let(:pizza_event)  { make_event(type_name: "CreatedPizza",  aggregate: "Pizza",  occurred_at: t1) }
+  let(:order_event1) { make_event(type_name: "PlacedOrder",   aggregate: "Order",  occurred_at: t2) }
+  let(:order_event2) { make_event(type_name: "CancelledOrder", aggregate: "Order", occurred_at: t3) }
+
+  let(:bus) do
+    b = Hecks::EventBus.new
+    b.publish(pizza_event)
+    b.publish(order_event1)
+    b.publish(order_event2)
+    b
+  end
+
+  subject(:intro) { described_class.new(bus) }
+
+  describe "#all_entries" do
+    it "returns all events when no filter given" do
+      expect(intro.all_entries.size).to eq(3)
+    end
+
+    it "returns newest first" do
+      entries = intro.all_entries
+      expect(entries.first[:type]).to eq("CancelledOrder")
+      expect(entries.last[:type]).to eq("CreatedPizza")
+    end
+
+    it "filters by event type" do
+      entries = intro.all_entries(type_filter: "PlacedOrder")
+      expect(entries.size).to eq(1)
+      expect(entries.first[:type]).to eq("PlacedOrder")
+    end
+
+    it "filters by aggregate" do
+      entries = intro.all_entries(aggregate_filter: "Order")
+      expect(entries.size).to eq(2)
+      entries.each { |e| expect(e[:aggregate]).to eq("Order") }
+    end
+
+    it "returns empty array when bus has no events" do
+      empty_bus = Hecks::EventBus.new
+      expect(described_class.new(empty_bus).all_entries).to eq([])
+    end
+
+    it "includes occurred_at in each entry" do
+      entries = intro.all_entries
+      entries.each { |e| expect(e[:occurred_at]).to be_a(Time) }
+    end
+
+    it "ignores blank type_filter" do
+      entries = intro.all_entries(type_filter: "")
+      expect(entries.size).to eq(3)
+    end
+  end
+
+  describe "#event_types" do
+    it "returns unique event type names" do
+      types = intro.event_types
+      expect(types).to include("CreatedPizza", "PlacedOrder", "CancelledOrder")
+      expect(types.uniq).to eq(types)
+    end
+  end
+
+  describe "#aggregate_types" do
+    it "returns unique aggregate names" do
+      aggs = intro.aggregate_types
+      expect(aggs).to include("Pizza", "Order")
+      expect(aggs.uniq).to eq(aggs)
+    end
+  end
+end

--- a/hecksties/spec/extensions/event_log_route_spec.rb
+++ b/hecksties/spec/extensions/event_log_route_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+require "hecks/extensions/web_explorer/event_introspector"
+require "hecks/extensions/web_explorer/renderer"
+
+RSpec.describe "Event log page rendering" do
+  let(:views_dir) { File.expand_path("../../lib/hecks/extensions/web_explorer/views", __dir__) }
+  let(:renderer)  { Hecks::WebExplorer::Renderer.new(views_dir) }
+
+  # Build fake events without loading a domain.
+  def make_fake_event(mod_path, type_name)
+    klass = stub_const(mod_path, Class.new(Struct.new(:occurred_at, keyword_init: true)))
+    klass.new(occurred_at: Time.now)
+  end
+
+  let(:alpha_event) { make_fake_event("EventPageTest::Widget::Events::CreatedWidget", "CreatedWidget") }
+  let(:beta_event)  { make_fake_event("EventPageTest::Widget::Events::UpdatedWidget", "UpdatedWidget") }
+
+  let(:bus) do
+    b = Hecks::EventBus.new
+    b.publish(alpha_event)
+    b.publish(beta_event)
+    b
+  end
+
+  let(:intro) { Hecks::WebExplorer::EventIntrospector.new(bus) }
+
+  it "renders the events page with event type names" do
+    html = renderer.render(:events,
+      title: "Event Log", brand: "Test", nav_items: [],
+      entries: intro.all_entries,
+      event_types: intro.event_types,
+      aggregate_types: intro.aggregate_types,
+      selected_type: "",
+      selected_aggregate: "")
+    expect(html).to include("CreatedWidget")
+  end
+
+  it "renders 'No events yet' when the bus is empty" do
+    empty_bus = Hecks::EventBus.new
+    empty_intro = Hecks::WebExplorer::EventIntrospector.new(empty_bus)
+    html = renderer.render(:events,
+      title: "Event Log", brand: "Test", nav_items: [],
+      entries: empty_intro.all_entries,
+      event_types: [],
+      aggregate_types: [],
+      selected_type: "",
+      selected_aggregate: "")
+    expect(html).to include("No events yet")
+  end
+
+  it "shows event count in heading" do
+    html = renderer.render(:events,
+      title: "Event Log", brand: "Test", nav_items: [],
+      entries: intro.all_entries,
+      event_types: intro.event_types,
+      aggregate_types: intro.aggregate_types,
+      selected_type: "",
+      selected_aggregate: "")
+    expect(html).to include("2 events")
+  end
+end


### PR DESCRIPTION
## Why

The web explorer had no way to see what events had actually been published across domains. Debugging event-driven workflows meant adding puts statements or inspecting the Ruby REPL — there was no browser-visible event history.

## What changed

- **`EventIntrospector`** — reads a merged event bus and exposes `all_entries`, `event_types`, `aggregate_types` with optional type/aggregate filtering
- **`events.erb`** — filterable HTML table at `/events` with type badge, aggregate name, timestamp, and expandable payload `<details>` toggle; empty state when no events published
- **`MultiDomainServer`** — `MergedEventBus` struct, `require event_introspector`, Events nav link, `/events` route dispatch
- **`MultiDomainUIRoutes#serve_events`** — merges all runtime event buses, builds introspector, renders the events page

## URL

```
GET /events                            # all events, newest first
GET /events?type=PizzaCreated          # filter by event type
GET /events?aggregate=Pizza            # filter by aggregate
GET /events?type=PizzaCreated&aggregate=Pizza
```

## Specs

- `event_introspector_spec.rb` — 9 examples: filtering, ordering, edge cases
- `event_log_route_spec.rb` — 3 rendering examples using stub_const fake events

Supersedes #203 (conflict resolution).