### PR TITLE
HEC-475: Custom concerns -- user-defined governance rules

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -92,6 +92,18 @@
 - **GovernanceGuard** — general-purpose governance checker (`Hecks::GovernanceGuard.new(domain).check`) returns `Result` with `passed?`, `violations`, `suggestions`; works from CLI (`--governance`), MCP (`governance_check` tool), REPL, or any entry point
 - GovernanceGuard falls back to rule-based checks when no LLM API key is present; enriches suggestions via AI when available
 
+### Custom Concerns
+- `Hecks.concern :name { }` — define user-defined governance rules that compose extensions
+- `concerns :transparency, :hipaa_compliance` — declare both world and custom concerns on a domain
+- Custom concerns have a name, description, required extensions, and validation rules
+- `requires_extension :pii` — declare extensions that must be enabled for the concern
+- `rule "description" { |aggregate| ... }` — define validation rules that check each aggregate
+- `Hecks.custom_concerns` — access the global registry of all custom concerns
+- `Hecks.find_concern(:name)` — look up a registered custom concern
+- GovernanceGuard evaluates custom concern rules alongside world concerns
+- `hecks validate` reports custom concern violations in the validation output
+- `hecks concerns` — CLI command lists all active concerns (world + custom) with status
+
 ### Access Control & Ports
 - Define access-control ports that whitelist allowed methods per consumer
 - Import domains from event storm formats (Markdown and YAML)

--- a/bluebook/lib/hecks/domain/validator.rb
+++ b/bluebook/lib/hecks/domain/validator.rb
@@ -26,6 +26,9 @@ module Hecks
   class Validator
     # Trigger autoloading of all validation rule modules so each rule
     # registers itself with Hecks.register_validation_rule.
+    # Ensure CustomConcerns rule is loaded
+    ValidationRules::CustomConcerns if defined?(ValidationRules::CustomConcerns)
+
     [ValidationRules::Naming, ValidationRules::References, ValidationRules::Structure, ValidationRules::WorldConcerns].each do |mod|
       mod.constants.each { |c| mod.const_get(c) }
     end

--- a/bluebook/lib/hecks/domain_model/structure/domain.rb
+++ b/bluebook/lib/hecks/domain_model/structure/domain.rb
@@ -71,6 +71,10 @@ module Hecks
       #   (e.g. :transparency, :consent, :privacy, :security)
       attr_reader :world_concerns
 
+      # @return [Array<Symbol>] declared custom concerns for this domain
+      #   (e.g. :hipaa_compliance, :gdpr)
+      attr_reader :custom_concerns
+
       # @return [Array<DomainModel::SubscriberRegistration>] event subscriber registrations at the domain level
       attr_reader :event_subscribers
 
@@ -102,7 +106,7 @@ module Hecks
                      workflows: [], actors: [], custom_verbs: [],
                      tenancy: nil, event_subscribers: [],
                      sagas: [], glossary_rules: [], modules: [], glossary_strict: false,
-                     version: nil, world_concerns: [], description: nil)
+                     version: nil, world_concerns: [], custom_concerns: [], description: nil)
         validate_version!(version)
         @name = name
         @version = version
@@ -120,6 +124,7 @@ module Hecks
         @tenancy = tenancy
         @event_subscribers = event_subscribers
         @world_concerns = world_concerns.map(&:to_sym)
+        @custom_concerns = custom_concerns.map(&:to_sym)
         @description = description
       end
 

--- a/bluebook/lib/hecks/dsl/domain_builder.rb
+++ b/bluebook/lib/hecks/dsl/domain_builder.rb
@@ -67,6 +67,7 @@ module Hecks
         @tenancy = nil
         @event_subscribers = []
         @world_concerns = []
+        @custom_concerns = []
       end
 
       # Declare world concerns that this domain aspires to uphold.
@@ -79,6 +80,27 @@ module Hecks
       # @return [void]
       def world_concerns(*concerns)
         @world_concerns.concat(concerns.map(&:to_sym))
+      end
+
+      # Declare concerns (world + custom) that this domain aspires to uphold.
+      # World concerns (:transparency, :consent, :privacy, :security) activate
+      # built-in validation rules. Custom concerns (registered via Hecks.concern)
+      # activate user-defined governance checks and extension requirements.
+      #
+      #   concerns :transparency, :privacy, :hipaa_compliance
+      #
+      # @param names [Array<Symbol>] one or more concern names
+      # @return [void]
+      def concerns(*names)
+        syms = names.map(&:to_sym)
+        world = Hecks::GovernanceGuard::SUPPORTED_CONCERNS rescue %i[transparency consent privacy security]
+        syms.each do |name|
+          if world.include?(name)
+            @world_concerns << name unless @world_concerns.include?(name)
+          else
+            @custom_concerns << name unless @custom_concerns.include?(name)
+          end
+        end
       end
 
       def actor(name, description: nil)
@@ -282,6 +304,7 @@ module Hecks
           sagas: @sagas, glossary_rules: @glossary_rules, modules: @modules,
           glossary_strict: @glossary_strict || false,
           world_concerns: @world_concerns,
+          custom_concerns: @custom_concerns,
           description: @description
         )
         classify_references(domain)

--- a/bluebook/lib/hecks/validation_rules/custom_concerns.rb
+++ b/bluebook/lib/hecks/validation_rules/custom_concerns.rb
@@ -1,0 +1,39 @@
+# Hecks::ValidationRules::CustomConcerns
+#
+# Validation rule that checks declared custom concerns against aggregates.
+# When a domain declares custom concerns (via `concerns :hipaa_compliance`),
+# each concern's rules are evaluated against every aggregate. Failures are
+# reported as validation errors.
+#
+#   Hecks.concern(:hipaa) { rule("PII hidden") { |a| true } }
+#   domain = Hecks.domain("Health") { concerns :hipaa; ... }
+#   validator = Hecks::Validator.new(domain)
+#   validator.valid?
+#
+module Hecks
+  module ValidationRules
+    class CustomConcerns < BaseRule
+      def errors
+        return [] unless @domain.respond_to?(:custom_concerns)
+        return [] if @domain.custom_concerns.empty?
+
+        issues = []
+        @domain.custom_concerns.each do |name|
+          concern = Hecks.find_concern(name)
+          next unless concern
+
+          @domain.aggregates.each do |agg|
+            concern.rules.each do |rule|
+              unless rule.passes?(agg)
+                issues << error("CustomConcern[#{name}]: #{agg.name} -- #{rule.name}",
+                  hint: "Fix the aggregate to satisfy the '#{name}' concern rule")
+              end
+            end
+          end
+        end
+        issues
+      end
+    end
+    Hecks.register_validation_rule(CustomConcerns)
+  end
+end

--- a/docs/usage/custom_concerns.md
+++ b/docs/usage/custom_concerns.md
@@ -1,0 +1,89 @@
+# Custom Concerns
+
+User-defined governance rules that compose extensions. Custom concerns extend
+the built-in world concerns (`:transparency`, `:consent`, `:privacy`,
+`:security`) with domain-specific governance checks.
+
+## Defining a Custom Concern
+
+```ruby
+Hecks.concern :hipaa_compliance do
+  description "HIPAA compliance for healthcare data"
+  requires_extension :pii
+  requires_extension :audit
+
+  rule "PII fields must be hidden" do |aggregate|
+    aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+  end
+
+  rule "PII aggregates need actors on commands" do |aggregate|
+    next true unless aggregate.attributes.any?(&:pii?)
+    aggregate.commands.all? { |cmd| !cmd.actors.empty? }
+  end
+end
+```
+
+## Using Custom Concerns on a Domain
+
+Use the `concerns` keyword to declare both world and custom concerns:
+
+```ruby
+Hecks.domain "Healthcare" do
+  concerns :transparency, :privacy, :hipaa_compliance
+
+  aggregate "Patient" do
+    attribute :name, String
+    attribute :ssn, String, pii: true, visible: false
+    command "CreatePatient" do
+      attribute :name, String
+      attribute :ssn, String
+      actor "Doctor"
+    end
+  end
+end
+```
+
+The `concerns` keyword automatically splits names into world concerns and
+custom concerns. You can also use `world_concerns` and `concerns` together:
+
+```ruby
+world_concerns :transparency
+concerns :hipaa_compliance
+```
+
+## Querying the Registry
+
+```ruby
+Hecks.custom_concerns.all    # => [Concern, ...]
+Hecks.custom_concerns.names  # => [:hipaa_compliance]
+Hecks.find_concern(:hipaa_compliance)  # => Concern
+```
+
+## Governance Checks
+
+GovernanceGuard evaluates custom concerns alongside world concerns:
+
+```ruby
+domain = Hecks.domain("Health") { concerns :hipaa_compliance; ... }
+result = Hecks::GovernanceGuard.new(domain).check
+result.passed?      # => false
+result.violations   # => [{ concern: :hipaa_compliance, message: "..." }]
+```
+
+## CLI
+
+```
+hecks concerns               # list all active concerns with rules and status
+hecks validate                # includes custom concern violations
+hecks validate --governance   # full governance check including custom concerns
+```
+
+## Validation Integration
+
+Custom concern violations appear in `hecks validate` output:
+
+```
+Domain validation failed:
+  - CustomConcern[hipaa_compliance]: Patient -- PII fields must be hidden
+    Fix: Fix the aggregate to satisfy the 'hipaa_compliance' concern rule
+```

--- a/hecks_ai/lib/hecks_ai/governance_guard.rb
+++ b/hecks_ai/lib/hecks_ai/governance_guard.rb
@@ -29,19 +29,26 @@ module Hecks
       @api_key = api_key || ENV["ANTHROPIC_API_KEY"]
     end
 
-    # Run governance checks against all declared world concerns.
+    # Run governance checks against all declared concerns (world + custom).
     # Returns a Result with violations and suggestions.
     #
     # @return [Hecks::GovernanceGuard::Result]
     def check
-      concerns = @domain.world_concerns & SUPPORTED_CONCERNS
-      return Result.new if concerns.empty?
+      world = @domain.world_concerns & SUPPORTED_CONCERNS
+      custom_names = @domain.respond_to?(:custom_concerns) ? @domain.custom_concerns : []
+      return Result.new if world.empty? && custom_names.empty?
 
       all_violations = []
       all_suggestions = []
 
-      concerns.each do |concern|
+      world.each do |concern|
         violations, suggestions = run_concern_check(concern)
+        all_violations.concat(violations)
+        all_suggestions.concat(suggestions)
+      end
+
+      custom_names.each do |name|
+        violations, suggestions = run_custom_concern_check(name)
         all_violations.concat(violations)
         all_suggestions.concat(suggestions)
       end
@@ -55,6 +62,35 @@ module Hecks
     end
 
     private
+
+    def run_custom_concern_check(name)
+      concern = Hecks.find_concern(name)
+      return [[], []] unless concern
+
+      violations = []
+      suggestions = []
+
+      # Check required extensions are declared (hecksagon level)
+      concern.required_extensions.each do |ext|
+        unless Hecks.extension_registry.key?(ext)
+          suggestions << "Concern :#{name} requires extension :#{ext} -- ensure it is enabled"
+        end
+      end
+
+      # Run each rule against every aggregate
+      @domain.aggregates.each do |agg|
+        concern.rules.each do |rule|
+          unless rule.passes?(agg)
+            violations << {
+              concern: name,
+              message: "#{agg.name}: #{rule.name}"
+            }
+          end
+        end
+      end
+
+      [violations, suggestions]
+    end
 
     def run_concern_check(concern)
       case concern

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -22,6 +22,8 @@ require_relative "hecks/registries/adapter_registry"
 require_relative "hecks/registries/validation_registry"
 require_relative "hecks/registries/dump_format_registry"
 require_relative "hecks/registries/grammar_registry"
+require_relative "hecks/custom_concerns"
+require_relative "hecks/registries/concern_registry"
 
 # Default modules — loaded with require "hecks"
 require "bluebook"
@@ -57,6 +59,7 @@ module Hecks
   extend ValidationRegistryMethods
   extend DumpFormatRegistryMethods
   extend GrammarRegistryMethods
+  extend ConcernRegistryMethods
 
   def self.configure(&block)
     @configuration = Configuration.new

--- a/hecksties/lib/hecks/autoloads.rb
+++ b/hecksties/lib/hecks/autoloads.rb
@@ -65,7 +65,8 @@ module Hecks
     autoload :Naming,      "hecks/validation_rules/naming"
     autoload :References,  "hecks/validation_rules/references"
     autoload :Structure,   "hecks/validation_rules/structure"
-    autoload :WorldConcerns, "hecks/validation_rules/world_concerns"
+    autoload :WorldConcerns,  "hecks/validation_rules/world_concerns"
+    autoload :CustomConcerns, "hecks/validation_rules/custom_concerns"
   end
 
   # = Hecks::DomainModel

--- a/hecksties/lib/hecks/custom_concerns.rb
+++ b/hecksties/lib/hecks/custom_concerns.rb
@@ -1,0 +1,26 @@
+# Hecks::CustomConcerns
+#
+# User-defined governance rules that compose extensions. Custom concerns
+# extend the built-in world concerns (:transparency, :consent, :privacy,
+# :security) with domain-specific governance checks.
+#
+# Define a custom concern with `Hecks.concern`, then declare it on domains
+# alongside world concerns using the `concerns` keyword.
+#
+#   Hecks.concern :hipaa_compliance do
+#     description "HIPAA compliance for healthcare data"
+#     requires_extension :pii
+#     requires_extension :audit
+#     rule "PII must be hidden" do |aggregate|
+#       aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+#     end
+#   end
+#
+module Hecks
+  module CustomConcerns
+    autoload :Rule,             "hecks/custom_concerns/rule"
+    autoload :Concern,          "hecks/custom_concerns/concern"
+    autoload :ConcernBuilder,   "hecks/custom_concerns/concern_builder"
+    autoload :ConcernRegistry,  "hecks/custom_concerns/concern_registry"
+  end
+end

--- a/hecksties/lib/hecks/custom_concerns/concern.rb
+++ b/hecksties/lib/hecks/custom_concerns/concern.rb
@@ -1,0 +1,44 @@
+# Hecks::CustomConcerns::Concern
+#
+# Immutable value object representing a user-defined governance concern.
+# A concern has a name, description, required extensions, and validation
+# rules. Custom concerns compose extensions and add domain-specific
+# governance checks.
+#
+#   concern = Concern.new(
+#     name: :hipaa_compliance,
+#     description: "HIPAA compliance for healthcare data",
+#     required_extensions: [:pii, :audit, :auth],
+#     rules: [Rule.new("PII must be hidden") { |agg| ... }]
+#   )
+#   concern.name                # => :hipaa_compliance
+#   concern.required_extensions # => [:pii, :audit, :auth]
+#
+module Hecks
+  module CustomConcerns
+    class Concern
+      # @return [Symbol] the concern name
+      attr_reader :name
+
+      # @return [String] human-readable description
+      attr_reader :description
+
+      # @return [Array<Symbol>] extensions this concern requires
+      attr_reader :required_extensions
+
+      # @return [Array<Rule>] validation rules for this concern
+      attr_reader :rules
+
+      # @param name [Symbol] concern identifier
+      # @param description [String] what this concern enforces
+      # @param required_extensions [Array<Symbol>] extensions that must be enabled
+      # @param rules [Array<Rule>] validation rules
+      def initialize(name:, description: "", required_extensions: [], rules: [])
+        @name = name.to_sym
+        @description = description
+        @required_extensions = required_extensions.map(&:to_sym).freeze
+        @rules = rules.freeze
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/custom_concerns/concern_builder.rb
+++ b/hecksties/lib/hecks/custom_concerns/concern_builder.rb
@@ -1,0 +1,68 @@
+# Hecks::CustomConcerns::ConcernBuilder
+#
+# DSL builder for defining custom concerns. Parses the block passed to
+# `Hecks.concern` and builds a Concern value object with name, description,
+# required extensions, and validation rules.
+#
+#   builder = ConcernBuilder.new(:hipaa_compliance)
+#   builder.instance_eval do
+#     description "HIPAA compliance for healthcare data"
+#     requires_extension :pii
+#     requires_extension :audit
+#     rule "All PII fields must be encrypted" do |aggregate|
+#       aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+#     end
+#   end
+#   concern = builder.build
+#
+module Hecks
+  module CustomConcerns
+    class ConcernBuilder
+      def initialize(name)
+        @name = name.to_sym
+        @description = ""
+        @required_extensions = []
+        @rules = []
+      end
+
+      # Set the concern description.
+      #
+      # @param text [String] human-readable description
+      # @return [void]
+      def description(text)
+        @description = text
+      end
+
+      # Declare a required extension for this concern.
+      #
+      # @param name [Symbol] extension name (e.g., :pii, :audit, :auth)
+      # @return [void]
+      def requires_extension(name)
+        @required_extensions << name.to_sym
+      end
+
+      # Define a validation rule for this concern.
+      #
+      # @param name [String] human-readable rule description
+      # @yield [aggregate] block that validates an aggregate
+      # @yieldparam aggregate [Hecks::DomainModel::Structure::Aggregate]
+      # @yieldreturn [Boolean] true if the rule passes
+      # @return [void]
+      def rule(name, &block)
+        @rules << Rule.new(name, &block)
+      end
+
+      # Build and return the Concern value object.
+      #
+      # @return [Concern]
+      def build
+        Concern.new(
+          name: @name,
+          description: @description,
+          required_extensions: @required_extensions,
+          rules: @rules
+        )
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/custom_concerns/concern_registry.rb
+++ b/hecksties/lib/hecks/custom_concerns/concern_registry.rb
@@ -1,0 +1,65 @@
+# Hecks::CustomConcerns::ConcernRegistry
+#
+# Stores custom concern definitions registered via `Hecks.concern`.
+# Provides lookup by name and enumeration of all registered concerns.
+#
+#   registry = ConcernRegistry.new
+#   registry.register(concern)
+#   registry.find(:hipaa_compliance) # => Concern
+#   registry.all                     # => [Concern, ...]
+#   registry.names                   # => [:hipaa_compliance, ...]
+#
+module Hecks
+  module CustomConcerns
+    class ConcernRegistry
+      def initialize
+        @concerns = {}
+      end
+
+      # Register a concern. Overwrites any existing concern with the same name.
+      #
+      # @param concern [Concern] the concern to register
+      # @return [void]
+      def register(concern)
+        @concerns[concern.name] = concern
+      end
+
+      # Look up a concern by name.
+      #
+      # @param name [Symbol] the concern name
+      # @return [Concern, nil]
+      def find(name)
+        @concerns[name.to_sym]
+      end
+
+      # All registered concern names.
+      #
+      # @return [Array<Symbol>]
+      def names
+        @concerns.keys
+      end
+
+      # All registered concerns.
+      #
+      # @return [Array<Concern>]
+      def all
+        @concerns.values
+      end
+
+      # True if a concern with this name is registered.
+      #
+      # @param name [Symbol] the concern name
+      # @return [Boolean]
+      def registered?(name)
+        @concerns.key?(name.to_sym)
+      end
+
+      # Remove all registered concerns (useful for test cleanup).
+      #
+      # @return [void]
+      def clear!
+        @concerns.clear
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/custom_concerns/rule.rb
+++ b/hecksties/lib/hecks/custom_concerns/rule.rb
@@ -1,0 +1,37 @@
+# Hecks::CustomConcerns::Rule
+#
+# A named validation rule within a custom concern. Holds a human-readable
+# name and a validation proc that receives an aggregate and returns true
+# when the rule passes.
+#
+#   rule = Rule.new("All PII fields must be encrypted") { |agg|
+#     agg.attributes.select(&:pii?).all? { |a| a.metadata[:encrypted] }
+#   }
+#   rule.passes?(aggregate) # => true/false
+#   rule.name               # => "All PII fields must be encrypted"
+#
+module Hecks
+  module CustomConcerns
+    class Rule
+      # @return [String] human-readable rule description
+      attr_reader :name
+
+      # @param name [String] the rule description
+      # @param block [Proc] validation proc that takes an aggregate, returns Boolean
+      def initialize(name, &block)
+        @name = name
+        @block = block
+      end
+
+      # Evaluate this rule against an aggregate.
+      #
+      # @param aggregate [Hecks::DomainModel::Structure::Aggregate]
+      # @return [Boolean] true if the rule passes
+      def passes?(aggregate)
+        @block.call(aggregate)
+      rescue => _e
+        false
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/concern_registry.rb
+++ b/hecksties/lib/hecks/registries/concern_registry.rb
@@ -1,0 +1,40 @@
+# Hecks::ConcernRegistryMethods
+#
+# Module-level methods for registering and retrieving custom concerns.
+# Extended into the Hecks module so concerns are available globally.
+#
+#   Hecks.concern(:hipaa) { description "HIPAA"; requires_extension :pii }
+#   Hecks.custom_concerns         # => ConcernRegistry
+#   Hecks.find_concern(:hipaa)    # => Concern
+#
+module Hecks
+  module ConcernRegistryMethods
+    # Access the global custom concern registry.
+    #
+    # @return [CustomConcerns::ConcernRegistry]
+    def custom_concerns
+      @custom_concern_registry ||= CustomConcerns::ConcernRegistry.new
+    end
+
+    # Define and register a custom concern using the DSL block.
+    #
+    # @param name [Symbol] concern identifier
+    # @yield DSL block evaluated in ConcernBuilder context
+    # @return [CustomConcerns::Concern] the registered concern
+    def concern(name, &block)
+      builder = CustomConcerns::ConcernBuilder.new(name)
+      builder.instance_eval(&block) if block
+      concern = builder.build
+      custom_concerns.register(concern)
+      concern
+    end
+
+    # Look up a custom concern by name.
+    #
+    # @param name [Symbol] the concern name
+    # @return [CustomConcerns::Concern, nil]
+    def find_concern(name)
+      custom_concerns.find(name)
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/concerns.rb
+++ b/hecksties/lib/hecks_cli/commands/concerns.rb
@@ -1,0 +1,67 @@
+# Hecks::CLI -- concerns command
+#
+# Lists all active concerns (world + custom) for a domain, shows their
+# status, and reports any violations from custom concern rules.
+#
+#   hecks concerns
+#   hecks concerns --domain path/to/domain
+#
+Hecks::CLI.register_command(:concerns, "List active concerns (world + custom)",
+  options: {
+    domain: { type: :string, desc: "Domain gem name or path" }
+  }
+) do
+  domain = resolve_domain_option
+  next unless domain
+
+  world = domain.world_concerns
+  custom = domain.respond_to?(:custom_concerns) ? domain.custom_concerns : []
+
+  if world.empty? && custom.empty?
+    say "No concerns declared for #{domain.name}", :yellow
+    next
+  end
+
+  say "Concerns for #{domain.name}:", :bold
+  say ""
+
+  if world.any?
+    say "World Concerns:", :green
+    world.each { |c| say "  [world] :#{c}" }
+    say ""
+  end
+
+  if custom.any?
+    say "Custom Concerns:", :green
+    custom.each do |name|
+      concern = Hecks.find_concern(name)
+      if concern
+        say "  [custom] :#{name} -- #{concern.description}"
+        concern.required_extensions.each do |ext|
+          say "    requires: :#{ext}"
+        end
+        concern.rules.each do |rule|
+          say "    rule: #{rule.name}"
+        end
+      else
+        say "  [custom] :#{name} (not registered)", :red
+      end
+    end
+    say ""
+  end
+
+  # Run validation and show results
+  validator = Hecks::Validator.new(domain)
+  validator.valid?
+
+  print_world_concerns_report(validator)
+
+  custom_errors = validator.errors.select { |e| e.to_s.start_with?("CustomConcern") }
+  if custom_errors.any?
+    say ""
+    say "Custom Concern Violations:", :red
+    custom_errors.each { |e| say "  - #{e}", :red }
+  elsif custom.any?
+    say "Custom concerns: all rules passing", :green
+  end
+end

--- a/hecksties/spec/custom_concerns_spec.rb
+++ b/hecksties/spec/custom_concerns_spec.rb
@@ -1,0 +1,186 @@
+require "spec_helper"
+
+RSpec.describe "Custom Concerns" do
+  after { Hecks.custom_concerns.clear! }
+
+  describe "Hecks.concern DSL" do
+    it "registers a custom concern with the ConcernBuilder" do
+      Hecks.concern :hipaa_compliance do
+        description "HIPAA compliance for healthcare data"
+        requires_extension :pii
+        requires_extension :audit
+        rule "PII must be hidden" do |aggregate|
+          aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+        end
+      end
+
+      concern = Hecks.find_concern(:hipaa_compliance)
+      expect(concern).not_to be_nil
+      expect(concern.name).to eq(:hipaa_compliance)
+      expect(concern.description).to eq("HIPAA compliance for healthcare data")
+      expect(concern.required_extensions).to eq([:pii, :audit])
+      expect(concern.rules.size).to eq(1)
+      expect(concern.rules.first.name).to eq("PII must be hidden")
+    end
+
+    it "overwrites an existing concern with the same name" do
+      Hecks.concern(:test) { description "v1" }
+      Hecks.concern(:test) { description "v2" }
+
+      expect(Hecks.find_concern(:test).description).to eq("v2")
+      expect(Hecks.custom_concerns.all.size).to eq(1)
+    end
+  end
+
+  describe "ConcernRegistry" do
+    let(:registry) { Hecks::CustomConcerns::ConcernRegistry.new }
+
+    it "stores and retrieves concerns" do
+      concern = Hecks::CustomConcerns::Concern.new(name: :gdpr, description: "GDPR")
+      registry.register(concern)
+
+      expect(registry.find(:gdpr)).to eq(concern)
+      expect(registry.names).to eq([:gdpr])
+      expect(registry.registered?(:gdpr)).to be true
+      expect(registry.registered?(:unknown)).to be false
+    end
+
+    it "clears all concerns" do
+      registry.register(Hecks::CustomConcerns::Concern.new(name: :a))
+      registry.register(Hecks::CustomConcerns::Concern.new(name: :b))
+      registry.clear!
+
+      expect(registry.all).to be_empty
+    end
+  end
+
+  describe "ConcernBuilder" do
+    it "builds a Concern value object" do
+      builder = Hecks::CustomConcerns::ConcernBuilder.new(:gdpr)
+      builder.instance_eval do
+        description "GDPR compliance"
+        requires_extension :pii
+        rule("Rule 1") { |_| true }
+        rule("Rule 2") { |_| false }
+      end
+
+      concern = builder.build
+      expect(concern.name).to eq(:gdpr)
+      expect(concern.description).to eq("GDPR compliance")
+      expect(concern.required_extensions).to eq([:pii])
+      expect(concern.rules.size).to eq(2)
+    end
+  end
+
+  describe "Rule" do
+    it "evaluates against an aggregate" do
+      passing = Hecks::CustomConcerns::Rule.new("always passes") { |_| true }
+      failing = Hecks::CustomConcerns::Rule.new("always fails") { |_| false }
+      erroring = Hecks::CustomConcerns::Rule.new("raises") { |_| raise "boom" }
+
+      aggregate = double("aggregate")
+      expect(passing.passes?(aggregate)).to be true
+      expect(failing.passes?(aggregate)).to be false
+      expect(erroring.passes?(aggregate)).to be false
+    end
+  end
+
+  describe "concerns DSL keyword" do
+    it "splits world and custom concerns" do
+      Hecks.concern(:hipaa) { description "HIPAA" }
+
+      domain = Hecks.domain "Health" do
+        concerns :transparency, :hipaa
+        aggregate "Patient" do
+          attribute :name, String
+          command("CreatePatient") { attribute :name, String }
+        end
+      end
+
+      expect(domain.world_concerns).to include(:transparency)
+      expect(domain.custom_concerns).to include(:hipaa)
+    end
+
+    it "works alongside world_concerns keyword" do
+      Hecks.concern(:sox) { description "SOX" }
+
+      domain = Hecks.domain "Finance" do
+        world_concerns :transparency
+        concerns :sox
+        aggregate "Account" do
+          attribute :name, String
+          command("CreateAccount") { attribute :name, String }
+        end
+      end
+
+      expect(domain.world_concerns).to eq([:transparency])
+      expect(domain.custom_concerns).to eq([:sox])
+    end
+  end
+
+  describe "GovernanceGuard integration" do
+    it "checks custom concern rules against aggregates" do
+      Hecks.concern :pii_hidden do
+        description "PII must not be visible"
+        rule "PII fields must be hidden" do |aggregate|
+          aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+        end
+      end
+
+      domain = Hecks.domain "Health" do
+        concerns :pii_hidden
+        aggregate "Patient" do
+          attribute :ssn, String, pii: true
+          command("CreatePatient") { attribute :ssn, String }
+        end
+      end
+
+      result = Hecks::GovernanceGuard.new(domain).check
+      expect(result.passed?).to be false
+      expect(result.violations.first[:concern]).to eq(:pii_hidden)
+      expect(result.violations.first[:message]).to include("Patient")
+    end
+
+    it "passes when all custom concern rules pass" do
+      Hecks.concern :pii_hidden do
+        rule "PII fields must be hidden" do |aggregate|
+          aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
+        end
+      end
+
+      domain = Hecks.domain "Health" do
+        concerns :pii_hidden
+        aggregate "Patient" do
+          attribute :ssn, String, pii: true, visible: false
+          command("CreatePatient") { attribute :ssn, String }
+        end
+      end
+
+      expect(Hecks::GovernanceGuard.new(domain).check.passed?).to be true
+    end
+  end
+
+  describe "Validator integration" do
+    it "includes custom concern violations in validation errors" do
+      Hecks.concern :must_have_commands do
+        rule "Aggregate must have at least two commands" do |aggregate|
+          aggregate.commands.size >= 2
+        end
+      end
+
+      domain = Hecks.domain "Simple" do
+        concerns :must_have_commands
+        aggregate "Widget" do
+          attribute :name, String
+          command("CreateWidget") { attribute :name, String }
+        end
+      end
+
+      validator = Hecks::Validator.new(domain)
+      validator.valid?
+      custom_errors = validator.errors.select { |e| e.to_s.include?("CustomConcern") }
+      expect(custom_errors).not_to be_empty
+      expect(custom_errors.first.to_s).to include("must_have_commands")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds custom concerns: user-defined governance rules that compose extensions, extending the built-in world concerns system
- New `Hecks.concern` DSL for defining concerns with descriptions, required extensions, and validation rules
- `concerns` keyword on domains accepts both world and custom concern names
- GovernanceGuard evaluates custom concern rules alongside world concerns
- `hecks concerns` CLI command lists all active concerns with status
- Custom concern violations surface in `hecks validate` output

## Example Usage

**Define a custom concern:**
```ruby
Hecks.concern :hipaa_compliance do
  description "HIPAA compliance for healthcare data"
  requires_extension :pii
  requires_extension :audit

  rule "PII fields must be hidden" do |aggregate|
    aggregate.attributes.select(&:pii?).all? { |a| !a.visible? }
  end
end
```

**Declare on a domain (mixed with world concerns):**
```ruby
Hecks.domain "Healthcare" do
  concerns :transparency, :privacy, :hipaa_compliance

  aggregate "Patient" do
    attribute :ssn, String, pii: true, visible: false
    command("CreatePatient") { attribute :ssn, String; actor "Doctor" }
  end
end
```

**Check governance:**
```ruby
result = Hecks::GovernanceGuard.new(domain).check
result.passed?      # => true
result.violations   # => []
```

**CLI:**
```
$ hecks concerns
Concerns for Healthcare:

World Concerns:
  [world] :transparency
  [world] :privacy

Custom Concerns:
  [custom] :hipaa_compliance -- HIPAA compliance for healthcare data
    requires: :pii
    requires: :audit
    rule: PII fields must be hidden
```

## Test plan

- [x] Unit: ConcernBuilder creates valid Concern objects
- [x] Unit: ConcernRegistry stores and retrieves concerns
- [x] Unit: Rule evaluates against aggregates (passing, failing, error cases)
- [x] Integration: `concerns` DSL splits world and custom concerns correctly
- [x] Integration: GovernanceGuard evaluates custom concern rules
- [x] Integration: Validator reports custom concern violations
- [x] All 2091 specs pass, 0 failures
- [x] Smoke test (`ruby -Ilib examples/pizzas/app.rb`) passes

Generated with [Claude Code](https://claude.com/claude-code)