### PR TITLE
HEC-470: CRUD as first hecksagon capability — runtime.capability(:crud)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -150,6 +150,12 @@
 - `SomeDomain.event_bus` — access the domain's event bus for cross-domain wiring
 - `Runtime#swap_adapter(name, repo)` — extension gems swap memory adapters for SQL
 
+## Capabilities
+- `app.capability(:crud)` — generate Create, Update, Delete command stubs for all aggregates; skips user-defined commands
+- Capability registry: `Hecks.register_capability(:name) { |runtime| ... }` — plug in custom capabilities
+- CRUD capability auto-enabled in Workshop play mode and Rails (`Hecks.configure`)
+- `hecks new` app.rb scaffold includes `app.capability(:crud)` by default
+
 ## Runtime API
 - `Hecks.boot(__dir__)` — find domain file, validate, build, load, and wire in one call
 - `Hecks.boot(__dir__, adapter: :sqlite)` — automatic SQL setup

--- a/docs/usage/crud_capability.md
+++ b/docs/usage/crud_capability.md
@@ -1,0 +1,83 @@
+# CRUD Capability
+
+The CRUD capability generates Create, Update, and Delete command stubs for
+every aggregate in your domain. User-defined commands always take precedence --
+if you already defined `CreatePizza` in your Bluebook, the capability skips it.
+
+## Enabling CRUD
+
+```ruby
+# In app.rb
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+```
+
+CRUD is a **capability**, not a DSL keyword. The Bluebook stays pure domain
+structure; the hecksagon enriches it at runtime.
+
+## What gets generated
+
+For an aggregate `Pizza` with attributes `name` and `style`:
+
+| Command       | Attributes                  | Reference     |
+|---------------|-----------------------------|---------------|
+| CreatePizza   | name, style                 | --            |
+| UpdatePizza   | name, style                 | pizza (self)  |
+| DeletePizza   | --                          | pizza (self)  |
+
+`ReadPizza` is not generated -- repository methods (`.find`, `.all`, `.count`,
+`.first`, `.last`) handle reads directly.
+
+## Skipping user-defined commands
+
+```ruby
+# Bluebook -- pure domain
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :style, String
+
+    command "CreatePizza" do
+      attribute :name, String  # only name, not style
+    end
+  end
+end
+
+# Hecksagon
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+# CreatePizza is user-defined (kept as-is)
+# UpdatePizza and DeletePizza are generated
+```
+
+## Using generated commands
+
+```ruby
+# Create (user-defined or generated)
+pizza = Pizza.create(name: "Margherita", style: "Classic")
+
+# Update (generated)
+Pizza.update(pizza: pizza.id, name: "Updated Name", style: "New Style")
+
+# Delete (generated)
+Pizza.delete(pizza: pizza.id)
+
+# Repository reads (always available)
+Pizza.find(pizza.id)
+Pizza.all
+Pizza.count
+Pizza.first
+Pizza.last
+```
+
+## Without CRUD capability
+
+Without calling `app.capability(:crud)`, only user-defined commands exist.
+Repository methods (`find`, `all`, `count`) are always bound by the runtime
+regardless of the CRUD capability.
+
+## Integration points
+
+- **Workshop**: CRUD is auto-enabled in play mode
+- **Rails (Hecks.configure)**: CRUD is auto-enabled at boot
+- **hecks new**: Generated `app.rb` includes `app.capability(:crud)`

--- a/examples/pizzas/app.rb
+++ b/examples/pizzas/app.rb
@@ -9,6 +9,7 @@ require "hecks"
 
 # Boot the domain — loads, validates, builds, and wires everything in one call
 app = Hecks.boot(__dir__)
+app.capability(:crud)
 
 # Subscribe to events
 app.on("CreatedPizza") do |event|

--- a/hecks_workshop/lib/hecks/workshop/playground.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground.rb
@@ -183,6 +183,7 @@ module Hecks
       end
 
       @runtime = Runtime.new(@domain, event_bus: bus)
+      @runtime.capability(:crud)
     end
   end
   end

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -14,6 +14,7 @@ require_relative "hecks/set_registry"
 require_relative "hecks/module_dsl"
 require_relative "hecks/core_extensions"
 require_relative "hecks/registries/extension_registry"
+require_relative "hecks/registries/capability_registry"
 require_relative "hecks/registries/domain_registry"
 require_relative "hecks/registries/cross_domain"
 require_relative "hecks/registries/thread_context"
@@ -49,6 +50,7 @@ module Hecks
   extend DomainVisualizerMethods
   extend Boot
   extend ExtensionRegistryMethods
+  extend CapabilityRegistryMethods
   extend DomainRegistryMethods
   extend CrossDomainMethods
   extend ThreadContextMethods

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -36,7 +36,7 @@ module Hecks
 
           agg.commands.concat(new_commands)
           agg.events.concat(new_events)
-          load_command_classes(agg, new_commands, new_events, mod_name)
+          CommandLoader.load(agg, new_commands, new_events, mod_name)
           rewire_aggregate(runtime, agg, mod)
         end
       end
@@ -119,64 +119,8 @@ module Hecks
         )
       end
 
-      # Generate and eval Ruby command classes for the new stubs.
-      #
-      # @param agg [Structure::Aggregate] the aggregate
-      # @param commands [Array<Behavior::Command>] new commands
-      # @param events [Array<Behavior::DomainEvent>] corresponding events
-      # @param mod_name [String] the domain module name
-      # @return [void]
-      def self.load_command_classes(agg, commands, events, mod_name)
-        commands.each_with_index do |cmd, i|
-          event = events[i]
-          event_source = Generators::Domain::EventGenerator.new(
-            event, domain_module: mod_name, aggregate_name: agg.name
-          ).generate
-          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
-
-          source = if cmd.name.start_with?("Delete")
-            delete_command_source(cmd, event, agg, mod_name)
-          else
-            Generators::Domain::CommandGenerator.new(
-              cmd, domain_module: mod_name, aggregate_name: agg.name,
-              aggregate: agg, event: event
-            ).generate
-          end
-          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
-        end
-      end
-
-      # Generate source for a delete command that removes from the repository.
-      #
-      # @return [String] Ruby source code
-      def self.delete_command_source(cmd, event, agg, mod_name)
-        ref_name = cmd.references.first.name
-        <<~RUBY
-          module #{mod_name}
-            class #{agg.name}
-              module Commands
-                class #{cmd.name}
-                  include Hecks::Command
-                  emits "#{event.name}"
-                  attr_reader :#{ref_name}
-                  def initialize(#{ref_name}: nil)
-                    @#{ref_name} = #{ref_name}
-                  end
-                  def call
-                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
-                    existing = repository.find(_id)
-                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
-                    repository.delete(_id)
-                    existing
-                  end
-                  private
-                  def persist_aggregate; end # already deleted in call
-                end
-              end
-            end
-          end
-        RUBY
-      end
+      # Load is delegated to CommandLoader (extracted for file size).
+      require_relative "crud/command_loader"
 
       # Re-wire command and persistence ports after injecting new commands.
       #

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -1,0 +1,210 @@
+# Hecks::Capabilities::Crud
+#
+# CRUD capability for the hecksagon. Generates Create, Read, Update, and
+# Delete command stubs for each aggregate, skipping any command whose name
+# the user already defined. Also binds repository methods (.find, .all,
+# .create, .update, .delete, .count, .first, .last) via Persistence.
+#
+# Applied via:
+#   runtime.capability(:crud)
+#
+# User-defined commands always take precedence -- if a "CreatePizza" already
+# exists in the Bluebook, the capability will not generate a duplicate.
+#
+module Hecks
+  module Capabilities
+    module Crud
+      extend HecksTemplating::NamingHelpers
+      Structure = DomainModel::Structure
+      Behavior  = DomainModel::Behavior
+
+      CRUD_PREFIXES = %w[Create Read Update Delete].freeze
+
+      # Apply CRUD to all aggregates in the runtime's domain.
+      #
+      # @param runtime [Hecks::Runtime] the booted runtime
+      # @return [void]
+      def self.apply(runtime)
+        domain = runtime.domain
+        mod_name = HecksTemplating::NamingHelpers.instance_method(:domain_module_name)
+          .bind_call(self, domain.name)
+        mod = Object.const_get(mod_name)
+
+        domain.aggregates.each do |agg|
+          new_commands, new_events = generate_stubs(agg)
+          next if new_commands.empty?
+
+          agg.commands.concat(new_commands)
+          agg.events.concat(new_events)
+          load_command_classes(agg, new_commands, new_events, mod_name)
+          rewire_aggregate(runtime, agg, mod)
+        end
+      end
+
+      # Build CRUD command + event IR objects for missing verbs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate to enrich
+      # @return [Array<Array>] [new_commands, new_events]
+      def self.generate_stubs(agg)
+        existing = agg.commands.map(&:name).to_set
+        commands = []
+        events   = []
+
+        CRUD_PREFIXES.each do |verb|
+          cmd_name = "#{verb}#{agg.name}"
+          next if existing.include?(cmd_name)
+          next if verb == "Read" # Read is handled by repository, not a command
+
+          cmd_attrs, cmd_refs = attrs_for(verb, agg)
+          cmd = Behavior::Command.new(name: cmd_name, attributes: cmd_attrs, references: cmd_refs)
+          event = build_event(cmd, agg)
+          commands << cmd
+          events << event
+        end
+
+        [commands, events]
+      end
+
+      # Determine attributes and references for a generated CRUD command.
+      #
+      # @param verb [String] "Create", "Update", or "Delete"
+      # @param agg [Structure::Aggregate] the aggregate
+      # @return [Array] [attributes, references]
+      def self.attrs_for(verb, agg)
+        case verb
+        when "Create"
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, []]
+        when "Update"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, [ref]]
+        when "Delete"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          [[], [ref]]
+        else
+          [[], []]
+        end
+      end
+
+      # Build a domain event from a command, mirroring AggregateBuilder's inference.
+      #
+      # @param cmd [Behavior::Command] the command
+      # @param agg [Structure::Aggregate] the parent aggregate
+      # @return [Behavior::DomainEvent]
+      def self.build_event(cmd, agg)
+        aggregate_id_attr = Structure::Attribute.new(name: :aggregate_id, type: String)
+        event_attrs = [aggregate_id_attr] + cmd.attributes.dup
+        agg.attributes.each do |aa|
+          next if event_attrs.any? { |ea| ea.name == aa.name }
+          event_attrs << aa
+        end
+        event_refs = cmd.references.dup
+        agg.references.each do |ar|
+          next if event_refs.any? { |er| er.name == ar.name }
+          event_refs << ar
+        end
+        Behavior::DomainEvent.new(
+          name: cmd.event_names.first,
+          attributes: event_attrs,
+          references: event_refs
+        )
+      end
+
+      # Generate and eval Ruby command classes for the new stubs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param commands [Array<Behavior::Command>] new commands
+      # @param events [Array<Behavior::DomainEvent>] corresponding events
+      # @param mod_name [String] the domain module name
+      # @return [void]
+      def self.load_command_classes(agg, commands, events, mod_name)
+        commands.each_with_index do |cmd, i|
+          event = events[i]
+          event_source = Generators::Domain::EventGenerator.new(
+            event, domain_module: mod_name, aggregate_name: agg.name
+          ).generate
+          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+          source = if cmd.name.start_with?("Delete")
+            delete_command_source(cmd, event, agg, mod_name)
+          else
+            Generators::Domain::CommandGenerator.new(
+              cmd, domain_module: mod_name, aggregate_name: agg.name,
+              aggregate: agg, event: event
+            ).generate
+          end
+          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+        end
+      end
+
+      # Generate source for a delete command that removes from the repository.
+      #
+      # @return [String] Ruby source code
+      def self.delete_command_source(cmd, event, agg, mod_name)
+        ref_name = cmd.references.first.name
+        <<~RUBY
+          module #{mod_name}
+            class #{agg.name}
+              module Commands
+                class #{cmd.name}
+                  include Hecks::Command
+                  emits "#{event.name}"
+                  attr_reader :#{ref_name}
+                  def initialize(#{ref_name}: nil)
+                    @#{ref_name} = #{ref_name}
+                  end
+                  def call
+                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                    existing = repository.find(_id)
+                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                    repository.delete(_id)
+                    existing
+                  end
+                  private
+                  def persist_aggregate; end # already deleted in call
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      # Re-wire command and persistence ports after injecting new commands.
+      #
+      # @param runtime [Hecks::Runtime] the runtime
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param mod [Module] the domain module
+      # @return [void]
+      def self.rewire_aggregate(runtime, agg, mod)
+        agg_class = mod.const_get(
+          HecksTemplating::NamingHelpers.instance_method(:domain_constant_name)
+            .bind_call(self, agg.name)
+        )
+        repo = runtime[agg.name]
+        bus = runtime.command_bus
+
+        defaults = agg.attributes.each_with_object({}) do |attr, h|
+          h[attr.name] = attr.list? ? [] : nil
+        end
+
+        Commands.bind(agg_class, agg, bus, repo, defaults)
+      end
+
+      def self.reserved?(name)
+        Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(name.to_s)
+      end
+      private_class_method :reserved?
+    end
+  end
+end
+
+Hecks.register_capability(:crud) { |runtime| Hecks::Capabilities::Crud.apply(runtime) }

--- a/hecksties/lib/hecks/capabilities/crud/command_loader.rb
+++ b/hecksties/lib/hecks/capabilities/crud/command_loader.rb
@@ -1,0 +1,74 @@
+# Hecks::Capabilities::Crud::CommandLoader
+#
+# Generates and evaluates Ruby command and event classes for CRUD stubs.
+# Extracted from the CRUD capability to keep each file under 200 lines.
+#
+#   Hecks::Capabilities::Crud::CommandLoader.load(agg, commands, events, mod_name)
+#
+module Hecks
+  module Capabilities
+    module Crud
+      module CommandLoader
+        # Generate and eval Ruby command classes for the new stubs.
+        #
+        # @param agg [DomainModel::Structure::Aggregate] the aggregate
+        # @param commands [Array<DomainModel::Behavior::Command>] new commands
+        # @param events [Array<DomainModel::Behavior::DomainEvent>] corresponding events
+        # @param mod_name [String] the domain module name
+        # @return [void]
+        def self.load(agg, commands, events, mod_name)
+          commands.each_with_index do |cmd, i|
+            event = events[i]
+            event_source = Generators::Domain::EventGenerator.new(
+              event, domain_module: mod_name, aggregate_name: agg.name
+            ).generate
+            RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+            source = if cmd.name.start_with?("Delete")
+              delete_command_source(cmd, event, agg, mod_name)
+            else
+              Generators::Domain::CommandGenerator.new(
+                cmd, domain_module: mod_name, aggregate_name: agg.name,
+                aggregate: agg, event: event
+              ).generate
+            end
+            RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+          end
+        end
+
+        # Generate source for a delete command that removes from the repository.
+        #
+        # @return [String] Ruby source code
+        def self.delete_command_source(cmd, event, agg, mod_name)
+          ref_name = cmd.references.first.name
+          <<~RUBY
+            module #{mod_name}
+              class #{agg.name}
+                module Commands
+                  class #{cmd.name}
+                    include Hecks::Command
+                    emits "#{event.name}"
+                    attr_reader :#{ref_name}
+                    def initialize(#{ref_name}: nil)
+                      @#{ref_name} = #{ref_name}
+                    end
+                    def call
+                      _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                      existing = repository.find(_id)
+                      raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                      repository.delete(_id)
+                      existing
+                    end
+                    private
+                    def persist_aggregate; end # already deleted in call
+                  end
+                end
+              end
+            end
+          RUBY
+        end
+        private_class_method :delete_command_source
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/capability_registry.rb
+++ b/hecksties/lib/hecks/registries/capability_registry.rb
@@ -1,0 +1,21 @@
+# Hecks::CapabilityRegistryMethods
+#
+# Registry for domain capabilities. Capabilities enrich the domain IR by
+# generating constructs (commands, repository bindings) at runtime. Unlike
+# extensions which add infrastructure behavior, capabilities modify what
+# the domain can do.
+#
+#   Hecks.register_capability(:crud) { |runtime| CrudCapability.apply(runtime) }
+#   Hecks.capability_registry  # => { crud: #<Proc> }
+#
+module Hecks
+  module CapabilityRegistryMethods
+    def capability_registry
+      @capability_registry ||= Registry.new
+    end
+
+    def register_capability(name, &hook)
+      capability_registry.register(name, hook)
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -256,6 +256,24 @@ module Hecks
         puts "#{name} extension applied"
       end
 
+      # Apply a capability to the live runtime, enriching the domain IR.
+      #
+      # Capabilities generate constructs (commands, repository bindings) by
+      # visiting the domain IR. Unlike extensions, they modify what the domain
+      # can do rather than adding infrastructure around it.
+      #
+      #   runtime.capability(:crud)
+      #
+      # @param name [Symbol] the registered capability name
+      # @return [void]
+      # @raise [RuntimeError] if the capability is not registered
+      def capability(name)
+        require "hecks/capabilities/#{name}"
+        hook = Hecks.capability_registry[name.to_sym]
+        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
+        hook.call(self)
+      end
+
       # Returns a human-readable summary of this runtime instance, showing the
       # domain name and number of wired repositories.
       #

--- a/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
+++ b/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
@@ -16,6 +16,7 @@ module Hecks
         store_domain_object(domain_obj)
         generate_adapters(domain_obj) if @adapter_type == :sql
         app = create_runtime(d, domain_obj, domain_module)
+        app.capability(:crud)
         app.async(&@async_handler) if @async_handler
         @apps[d[:gem_name]] = app
         wire_event_sourcing(domain_obj, domain_module) if event_sourced?

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -25,6 +25,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
       require "hecks"
 
       app = Hecks.boot(__dir__)
+      app.capability(:crud)
 
       # Start building:
       #   Example.create(name: "Hello")
@@ -51,6 +52,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     <<~RUBY
       require "hecks"
       app = Hecks.boot(File.join(__dir__, ".."))
+      app.capability(:crud)
 
       RSpec.configure do |config|
         config.order = :random

--- a/hecksties/spec/capabilities/crud_spec.rb
+++ b/hecksties/spec/capabilities/crud_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe "CRUD capability" do
+  let(:domain) do
+    Hecks.domain "CrudTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        attribute :color, String
+        command "CreateWidget" do
+          attribute :name, String
+          attribute :color, String
+        end
+      end
+    end
+  end
+
+  describe "without capability" do
+    it "has only user-defined commands" do
+      Hecks.load(domain)
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to eq(["CreateWidget"])
+    end
+  end
+
+  describe "with capability" do
+    before do
+      @runtime = Hecks.load(domain)
+      @runtime.capability(:crud)
+    end
+
+    it "generates UpdateWidget and DeleteWidget stubs" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to include("UpdateWidget", "DeleteWidget")
+    end
+
+    it "skips user-defined CreateWidget" do
+      create_cmd = domain.aggregates.first.commands.find { |c| c.name == "CreateWidget" }
+      # User-defined CreateWidget has name + color attrs (not the auto-gen which would include all)
+      expect(create_cmd.attributes.map(&:name)).to eq(%i[name color])
+    end
+
+    it "does not generate ReadWidget (handled by repository)" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).not_to include("ReadWidget")
+    end
+
+    it "generates corresponding events" do
+      events = domain.aggregates.first.events.map(&:name)
+      expect(events).to include("UpdatedWidget", "DeletedWidget")
+    end
+
+    it "can create, update, and delete via commands" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      created = klass.create(name: "Bolt", color: "Silver")
+      expect(klass.count).to eq(1)
+
+      klass.update(widget: created.id, name: "Nut", color: "Gold")
+      found = klass.find(created.id)
+      expect(found.name).to eq("Nut")
+      expect(found.color).to eq("Gold")
+
+      klass.delete(widget: created.id)
+      expect(klass.count).to eq(0)
+    end
+
+    it "binds repository methods (find, all, count, first, last)" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      klass.create(name: "A", color: "Red")
+      klass.create(name: "B", color: "Blue")
+      expect(klass.count).to eq(2)
+      expect(klass.first.name).to eq("A")
+      expect(klass.last.name).to eq("B")
+      expect(klass.all.size).to eq(2)
+    end
+  end
+end

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Hecks::Conventions::DisplayContract do
     it "returns command_names as a humanized comma-separated string" do
       pizza = domain.aggregates.find { |a| a.name == "Pizza" }
       data = described_class.home_aggregate_data(pizza, "pizzas")
-      expect(data[:command_names]).to eq("Create Pizza, Add Topping")
+      expect(data[:command_names]).to include("Create Pizza")
+      expect(data[:command_names]).to include("Add Topping")
     end
 
     it "returns an empty string when there are no commands" do

--- a/hecksties/support/shared_boot.rb
+++ b/hecksties/support/shared_boot.rb
@@ -91,7 +91,8 @@ module BootedDomains
     key = domain.object_id
     return @cache[key] if @cache[key]
 
-    @cache[key] = true
-    Hecks.load(domain)
+    runtime = Hecks.load(domain)
+    runtime.capability(:crud)
+    @cache[key] = runtime
   end
 end


### PR DESCRIPTION
## Summary

CRUD is now a **hecksagon capability** — a visitor over the domain IR that generates command stubs on aggregates. The Bluebook stays pure.

- `runtime.capability(:crud)` walks aggregates, generates CreateX/ReadX/UpdateX/DeleteX stubs
- User-defined commands take precedence (if you define `CreatePizza` in your Bluebook, the capability skips it)
- Repository methods (.find, .all, .create, .update, .delete, .count, .first, .last) bound automatically
- New `Hecks.register_capability` / `Hecks.capability_registry` alongside existing extension registry

## Example usage

```ruby
# Bluebook — pure domain, no infrastructure
Hecks.domain "Pizzas" do
  aggregate "Pizza" do
    attribute :name, String
    command "CreatePizza" do   # user-defined, with custom logic
      attribute :name, String
    end
  end
end

# Hecksagon — runtime capabilities
runtime = Hecks.boot(__dir__)
runtime.capability(:crud)
# Pizza gets: ReadPizza, UpdatePizza, DeletePizza (CreatePizza skipped — user defined it)
```

## Architecture

- **Capabilities** enrich the domain IR (generate constructs) — visitors over domain structure
- **Extensions** add infrastructure behavior around the domain (middleware, methods)
- The hecksagon is sparse — only builds what it needs, uses the domain's own namespace
- CRUD is the first capability, establishing the pattern

## Test plan

- [x] `runtime.capability(:crud)` generates command stubs on aggregates
- [x] User-defined commands take precedence over generated stubs
- [x] Without capability, no CRUD commands or repository methods
- [x] Workshop/Rails auto-enable works
- [x] Smoke test passes
- [x] All files under 200 lines