### PR TITLE
HEC-480: Hecksagon DSL — declarative infrastructure capabilities file

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -150,6 +150,12 @@
 - `SomeDomain.event_bus` — access the domain's event bus for cross-domain wiring
 - `Runtime#swap_adapter(name, repo)` — extension gems swap memory adapters for SQL
 
+## Capabilities
+- `app.capability(:crud)` — generate Create, Update, Delete command stubs for all aggregates; skips user-defined commands
+- Capability registry: `Hecks.register_capability(:name) { |runtime| ... }` — plug in custom capabilities
+- CRUD capability auto-enabled in Workshop play mode and Rails (`Hecks.configure`)
+- `hecks new` app.rb scaffold includes `app.capability(:crud)` by default
+
 ## Runtime API
 - `Hecks.boot(__dir__)` — find domain file, validate, build, load, and wire in one call
 - `Hecks.boot(__dir__, adapter: :sqlite)` — automatic SQL setup

--- a/bluebook/lib/hecks/domain/builder_methods.rb
+++ b/bluebook/lib/hecks/domain/builder_methods.rb
@@ -49,8 +49,8 @@ module Hecks
     #
     # @param block [Proc] DSL block evaluated inside Hecksagon::DSL::HecksagonBuilder
     # @return [Hecksagon::Structure::Hecksagon] the fully built Hecksagon IR object
-    def hecksagon(&block)
-      builder = Hecksagon::DSL::HecksagonBuilder.new
+    def hecksagon(name = nil, &block)
+      builder = Hecksagon::DSL::HecksagonBuilder.new(name)
       builder.instance_eval(&block)
       result = builder.build
       Hecks.last_hecksagon = result

--- a/docs/usage/crud_capability.md
+++ b/docs/usage/crud_capability.md
@@ -1,0 +1,83 @@
+# CRUD Capability
+
+The CRUD capability generates Create, Update, and Delete command stubs for
+every aggregate in your domain. User-defined commands always take precedence --
+if you already defined `CreatePizza` in your Bluebook, the capability skips it.
+
+## Enabling CRUD
+
+```ruby
+# In app.rb
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+```
+
+CRUD is a **capability**, not a DSL keyword. The Bluebook stays pure domain
+structure; the hecksagon enriches it at runtime.
+
+## What gets generated
+
+For an aggregate `Pizza` with attributes `name` and `style`:
+
+| Command       | Attributes                  | Reference     |
+|---------------|-----------------------------|---------------|
+| CreatePizza   | name, style                 | --            |
+| UpdatePizza   | name, style                 | pizza (self)  |
+| DeletePizza   | --                          | pizza (self)  |
+
+`ReadPizza` is not generated -- repository methods (`.find`, `.all`, `.count`,
+`.first`, `.last`) handle reads directly.
+
+## Skipping user-defined commands
+
+```ruby
+# Bluebook -- pure domain
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :style, String
+
+    command "CreatePizza" do
+      attribute :name, String  # only name, not style
+    end
+  end
+end
+
+# Hecksagon
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+# CreatePizza is user-defined (kept as-is)
+# UpdatePizza and DeletePizza are generated
+```
+
+## Using generated commands
+
+```ruby
+# Create (user-defined or generated)
+pizza = Pizza.create(name: "Margherita", style: "Classic")
+
+# Update (generated)
+Pizza.update(pizza: pizza.id, name: "Updated Name", style: "New Style")
+
+# Delete (generated)
+Pizza.delete(pizza: pizza.id)
+
+# Repository reads (always available)
+Pizza.find(pizza.id)
+Pizza.all
+Pizza.count
+Pizza.first
+Pizza.last
+```
+
+## Without CRUD capability
+
+Without calling `app.capability(:crud)`, only user-defined commands exist.
+Repository methods (`find`, `all`, `count`) are always bound by the runtime
+regardless of the CRUD capability.
+
+## Integration points
+
+- **Workshop**: CRUD is auto-enabled in play mode
+- **Rails (Hecks.configure)**: CRUD is auto-enabled at boot
+- **hecks new**: Generated `app.rb` includes `app.capability(:crud)`

--- a/docs/usage/hecksagon_dsl.md
+++ b/docs/usage/hecksagon_dsl.md
@@ -1,0 +1,72 @@
+# Hecksagon DSL
+
+The Hecksagon file declares infrastructure capabilities alongside the Bluebook.
+The Bluebook describes pure domain structure. The Hecksagon says what to do with it.
+
+## Two-File Pattern
+
+```ruby
+# PizzasBluebook — pure domain
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :email, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+
+# PizzasHecksagon — infrastructure capabilities
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud
+end
+```
+
+## Auto-Discovery
+
+`Hecks.boot(__dir__)` discovers both `*Bluebook` and `*Hecksagon` files
+in the project directory and loads them automatically.
+
+## Domain-Wide Capabilities
+
+```ruby
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud, :audit
+end
+```
+
+Capabilities are visitors over the domain IR that generate constructs.
+`:crud` generates Create/Read/Update/Delete command stubs on every aggregate,
+skipping any command the user already defined in the Bluebook.
+
+## Per-Aggregate Capabilities
+
+```ruby
+Hecks.hecksagon "Healthcare" do
+  capabilities :crud
+
+  aggregate "Patient" do
+    capability.email.pii
+    capability.ssn.pii
+  end
+end
+```
+
+`capability.email.pii` tags the `email` attribute on `Patient` with the `:pii`
+capability. Capabilities self-activate from usage — no separate `concern :pii`
+declaration needed.
+
+## How It Works
+
+- The domain is the structural index (the skeleton)
+- Capabilities are the muscles — visitors that attach behavior to domain nodes
+- The hecksagon is sparse: it only tags nodes that need infrastructure
+- `aggregate "Patient"` in the hecksagon doesn't create anything — it points
+  to the domain node
+
+## Running Example
+
+```sh
+ruby -Ilib examples/pizzas/app.rb
+```

--- a/examples/pizzas/PizzasHecksagon
+++ b/examples/pizzas/PizzasHecksagon
@@ -1,0 +1,3 @@
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud
+end

--- a/examples/pizzas/app.rb
+++ b/examples/pizzas/app.rb
@@ -7,9 +7,8 @@
 
 require "hecks"
 
-# Boot the domain — loads, validates, builds, and wires everything in one call
+# Boot the domain — loads Bluebook + Hecksagon, validates, builds, wires
 app = Hecks.boot(__dir__)
-app.capability(:crud)
 
 # Subscribe to events
 app.on("CreatedPizza") do |event|

--- a/examples/pizzas/app.rb
+++ b/examples/pizzas/app.rb
@@ -9,6 +9,7 @@ require "hecks"
 
 # Boot the domain — loads, validates, builds, and wires everything in one call
 app = Hecks.boot(__dir__)
+app.capability(:crud)
 
 # Subscribe to events
 app.on("CreatedPizza") do |event|

--- a/hecks_workshop/lib/hecks/workshop/playground.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground.rb
@@ -183,6 +183,7 @@ module Hecks
       end
 
       @runtime = Runtime.new(@domain, event_bus: bus)
+      @runtime.capability(:crud)
     end
   end
   end

--- a/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
@@ -19,6 +19,8 @@ module Hecksagon
         @extensions = []
         @subscriptions = []
         @tenancy = nil
+        @capabilities = []
+        @aggregate_capabilities = {}
       end
 
       # Declare a gate (access control) for an aggregate + role.
@@ -59,6 +61,32 @@ module Hecksagon
         @subscriptions << domain_name.to_s
       end
 
+      # Declare domain-wide capabilities.
+      #
+      #   capabilities :crud, :audit
+      #
+      # @param names [Array<Symbol>] capability names
+      # @return [void]
+      def capabilities(*names)
+        @capabilities.concat(names.map(&:to_sym))
+      end
+
+      # Declare per-aggregate capabilities via a block. The block
+      # receives an AggregateCapabilityBuilder for fluent tagging.
+      #
+      #   aggregate "Pizza" do
+      #     capability.email.pii
+      #   end
+      #
+      # @param name [String] the aggregate name (must exist in domain)
+      # @yield block evaluated in AggregateCapabilityBuilder context
+      # @return [void]
+      def aggregate(name, &block)
+        builder = AggregateCapabilityBuilder.new(name)
+        builder.instance_eval(&block) if block
+        @aggregate_capabilities[name.to_s] = builder.tags
+      end
+
       # Set the multi-tenancy strategy.
       #
       # @param strategy [Symbol] tenancy strategy (:row, :schema, etc.)
@@ -77,8 +105,62 @@ module Hecksagon
           adapter: @adapter,
           extensions: @extensions,
           subscriptions: @subscriptions,
-          tenancy: @tenancy
+          tenancy: @tenancy,
+          capabilities: @capabilities,
+          aggregate_capabilities: @aggregate_capabilities
         )
+      end
+    end
+
+    # Fluent builder for per-aggregate capability tags.
+    #
+    #   builder = AggregateCapabilityBuilder.new("Pizza")
+    #   builder.capability.email.pii
+    #   builder.tags  # => [{ attribute: "email", tag: :pii }]
+    #
+    class AggregateCapabilityBuilder
+      attr_reader :tags
+
+      def initialize(aggregate_name)
+        @aggregate_name = aggregate_name
+        @tags = []
+      end
+
+      # Start a capability chain. Returns an AttributeSelector.
+      #
+      #   capability.email.pii
+      #
+      # @return [AttributeSelector]
+      def capability
+        AttributeSelector.new(@tags)
+      end
+
+      # Fluent attribute selector for capability tagging.
+      class AttributeSelector
+        def initialize(tags)
+          @tags = tags
+        end
+
+        def method_missing(attr_name, *args)
+          TagApplier.new(@tags, attr_name.to_s)
+        end
+
+        def respond_to_missing?(_, _ = false) = true
+      end
+
+      # Applies a tag to the selected attribute.
+      class TagApplier
+        def initialize(tags, attribute)
+          @tags = tags
+          @attribute = attribute
+        end
+
+        def method_missing(tag_name, *args)
+          @tags << { attribute: @attribute, tag: tag_name.to_sym }
+          self
+        end
+
+        def respond_to_missing?(_, _ = false) = true
       end
     end
   end

--- a/hecksagon/lib/hecksagon/structure/hecksagon.rb
+++ b/hecksagon/lib/hecksagon/structure/hecksagon.rb
@@ -19,15 +19,19 @@ module Hecksagon
     #   )
     #
     class Hecksagon
-      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy
+      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy,
+                  :capabilities, :aggregate_capabilities
 
-      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [], tenancy: nil)
+      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [],
+                     tenancy: nil, capabilities: [], aggregate_capabilities: {})
         @name = name
         @gates = gates
         @adapter = adapter
         @extensions = extensions
         @subscriptions = subscriptions
         @tenancy = tenancy
+        @capabilities = capabilities
+        @aggregate_capabilities = aggregate_capabilities
       end
 
       # Returns gates for a specific aggregate.

--- a/hecksagon/spec/dsl/hecksagon_capabilities_spec.rb
+++ b/hecksagon/spec/dsl/hecksagon_capabilities_spec.rb
@@ -1,0 +1,77 @@
+# Hecksagon DSL capabilities spec
+#
+# Tests the capabilities keyword and aggregate-level capability
+# tagging in the Hecksagon DSL.
+#
+require "spec_helper"
+
+RSpec.describe "Hecksagon DSL capabilities" do
+  describe "domain-wide capabilities" do
+    it "stores capabilities on the IR" do
+      hex = Hecks.hecksagon do
+        capabilities :crud, :audit
+      end
+
+      expect(hex.capabilities).to eq([:crud, :audit])
+    end
+  end
+
+  describe "aggregate capability tags" do
+    it "stores attribute-level tags via fluent chain" do
+      hex = Hecks.hecksagon do
+        aggregate "Customer" do
+          capability.email.pii
+          capability.ssn.pii
+        end
+      end
+
+      tags = hex.aggregate_capabilities["Customer"]
+      expect(tags).to include({ attribute: "email", tag: :pii })
+      expect(tags).to include({ attribute: "ssn", tag: :pii })
+    end
+
+    it "supports multiple tags on different aggregates" do
+      hex = Hecks.hecksagon do
+        capabilities :crud
+
+        aggregate "Customer" do
+          capability.email.pii
+        end
+
+        aggregate "Order" do
+          capability.total.audit
+        end
+      end
+
+      expect(hex.capabilities).to eq([:crud])
+      expect(hex.aggregate_capabilities["Customer"]).to eq([{ attribute: "email", tag: :pii }])
+      expect(hex.aggregate_capabilities["Order"]).to eq([{ attribute: "total", tag: :audit }])
+    end
+  end
+
+  describe "wired into boot" do
+    it "applies domain-wide capabilities at boot" do
+      domain = Hecks.domain "CapTest" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      hex = Hecks.hecksagon do
+        capabilities :crud
+      end
+
+      runtime = Hecks.load(domain, hecksagon: hex)
+      widget_class = Object.const_get("CapTestDomain::Widget")
+
+      expect(widget_class).to respond_to(:find)
+      expect(widget_class).to respond_to(:all)
+    ensure
+      Hecks.last_hecksagon = nil
+      Object.send(:remove_const, :CapTestDomain) if defined?(CapTestDomain)
+    end
+  end
+end

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -14,6 +14,7 @@ require_relative "hecks/set_registry"
 require_relative "hecks/module_dsl"
 require_relative "hecks/core_extensions"
 require_relative "hecks/registries/extension_registry"
+require_relative "hecks/registries/capability_registry"
 require_relative "hecks/registries/domain_registry"
 require_relative "hecks/registries/cross_domain"
 require_relative "hecks/registries/thread_context"
@@ -49,6 +50,7 @@ module Hecks
   extend DomainVisualizerMethods
   extend Boot
   extend ExtensionRegistryMethods
+  extend CapabilityRegistryMethods
   extend DomainRegistryMethods
   extend CrossDomainMethods
   extend ThreadContextMethods

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -36,7 +36,7 @@ module Hecks
 
           agg.commands.concat(new_commands)
           agg.events.concat(new_events)
-          load_command_classes(agg, new_commands, new_events, mod_name)
+          CommandLoader.load(agg, new_commands, new_events, mod_name)
           rewire_aggregate(runtime, agg, mod)
         end
       end
@@ -119,64 +119,8 @@ module Hecks
         )
       end
 
-      # Generate and eval Ruby command classes for the new stubs.
-      #
-      # @param agg [Structure::Aggregate] the aggregate
-      # @param commands [Array<Behavior::Command>] new commands
-      # @param events [Array<Behavior::DomainEvent>] corresponding events
-      # @param mod_name [String] the domain module name
-      # @return [void]
-      def self.load_command_classes(agg, commands, events, mod_name)
-        commands.each_with_index do |cmd, i|
-          event = events[i]
-          event_source = Generators::Domain::EventGenerator.new(
-            event, domain_module: mod_name, aggregate_name: agg.name
-          ).generate
-          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
-
-          source = if cmd.name.start_with?("Delete")
-            delete_command_source(cmd, event, agg, mod_name)
-          else
-            Generators::Domain::CommandGenerator.new(
-              cmd, domain_module: mod_name, aggregate_name: agg.name,
-              aggregate: agg, event: event
-            ).generate
-          end
-          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
-        end
-      end
-
-      # Generate source for a delete command that removes from the repository.
-      #
-      # @return [String] Ruby source code
-      def self.delete_command_source(cmd, event, agg, mod_name)
-        ref_name = cmd.references.first.name
-        <<~RUBY
-          module #{mod_name}
-            class #{agg.name}
-              module Commands
-                class #{cmd.name}
-                  include Hecks::Command
-                  emits "#{event.name}"
-                  attr_reader :#{ref_name}
-                  def initialize(#{ref_name}: nil)
-                    @#{ref_name} = #{ref_name}
-                  end
-                  def call
-                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
-                    existing = repository.find(_id)
-                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
-                    repository.delete(_id)
-                    existing
-                  end
-                  private
-                  def persist_aggregate; end # already deleted in call
-                end
-              end
-            end
-          end
-        RUBY
-      end
+      # Load is delegated to CommandLoader (extracted for file size).
+      require_relative "crud/command_loader"
 
       # Re-wire command and persistence ports after injecting new commands.
       #

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -1,0 +1,210 @@
+# Hecks::Capabilities::Crud
+#
+# CRUD capability for the hecksagon. Generates Create, Read, Update, and
+# Delete command stubs for each aggregate, skipping any command whose name
+# the user already defined. Also binds repository methods (.find, .all,
+# .create, .update, .delete, .count, .first, .last) via Persistence.
+#
+# Applied via:
+#   runtime.capability(:crud)
+#
+# User-defined commands always take precedence -- if a "CreatePizza" already
+# exists in the Bluebook, the capability will not generate a duplicate.
+#
+module Hecks
+  module Capabilities
+    module Crud
+      extend HecksTemplating::NamingHelpers
+      Structure = DomainModel::Structure
+      Behavior  = DomainModel::Behavior
+
+      CRUD_PREFIXES = %w[Create Read Update Delete].freeze
+
+      # Apply CRUD to all aggregates in the runtime's domain.
+      #
+      # @param runtime [Hecks::Runtime] the booted runtime
+      # @return [void]
+      def self.apply(runtime)
+        domain = runtime.domain
+        mod_name = HecksTemplating::NamingHelpers.instance_method(:domain_module_name)
+          .bind_call(self, domain.name)
+        mod = Object.const_get(mod_name)
+
+        domain.aggregates.each do |agg|
+          new_commands, new_events = generate_stubs(agg)
+          next if new_commands.empty?
+
+          agg.commands.concat(new_commands)
+          agg.events.concat(new_events)
+          load_command_classes(agg, new_commands, new_events, mod_name)
+          rewire_aggregate(runtime, agg, mod)
+        end
+      end
+
+      # Build CRUD command + event IR objects for missing verbs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate to enrich
+      # @return [Array<Array>] [new_commands, new_events]
+      def self.generate_stubs(agg)
+        existing = agg.commands.map(&:name).to_set
+        commands = []
+        events   = []
+
+        CRUD_PREFIXES.each do |verb|
+          cmd_name = "#{verb}#{agg.name}"
+          next if existing.include?(cmd_name)
+          next if verb == "Read" # Read is handled by repository, not a command
+
+          cmd_attrs, cmd_refs = attrs_for(verb, agg)
+          cmd = Behavior::Command.new(name: cmd_name, attributes: cmd_attrs, references: cmd_refs)
+          event = build_event(cmd, agg)
+          commands << cmd
+          events << event
+        end
+
+        [commands, events]
+      end
+
+      # Determine attributes and references for a generated CRUD command.
+      #
+      # @param verb [String] "Create", "Update", or "Delete"
+      # @param agg [Structure::Aggregate] the aggregate
+      # @return [Array] [attributes, references]
+      def self.attrs_for(verb, agg)
+        case verb
+        when "Create"
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, []]
+        when "Update"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, [ref]]
+        when "Delete"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          [[], [ref]]
+        else
+          [[], []]
+        end
+      end
+
+      # Build a domain event from a command, mirroring AggregateBuilder's inference.
+      #
+      # @param cmd [Behavior::Command] the command
+      # @param agg [Structure::Aggregate] the parent aggregate
+      # @return [Behavior::DomainEvent]
+      def self.build_event(cmd, agg)
+        aggregate_id_attr = Structure::Attribute.new(name: :aggregate_id, type: String)
+        event_attrs = [aggregate_id_attr] + cmd.attributes.dup
+        agg.attributes.each do |aa|
+          next if event_attrs.any? { |ea| ea.name == aa.name }
+          event_attrs << aa
+        end
+        event_refs = cmd.references.dup
+        agg.references.each do |ar|
+          next if event_refs.any? { |er| er.name == ar.name }
+          event_refs << ar
+        end
+        Behavior::DomainEvent.new(
+          name: cmd.event_names.first,
+          attributes: event_attrs,
+          references: event_refs
+        )
+      end
+
+      # Generate and eval Ruby command classes for the new stubs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param commands [Array<Behavior::Command>] new commands
+      # @param events [Array<Behavior::DomainEvent>] corresponding events
+      # @param mod_name [String] the domain module name
+      # @return [void]
+      def self.load_command_classes(agg, commands, events, mod_name)
+        commands.each_with_index do |cmd, i|
+          event = events[i]
+          event_source = Generators::Domain::EventGenerator.new(
+            event, domain_module: mod_name, aggregate_name: agg.name
+          ).generate
+          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+          source = if cmd.name.start_with?("Delete")
+            delete_command_source(cmd, event, agg, mod_name)
+          else
+            Generators::Domain::CommandGenerator.new(
+              cmd, domain_module: mod_name, aggregate_name: agg.name,
+              aggregate: agg, event: event
+            ).generate
+          end
+          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+        end
+      end
+
+      # Generate source for a delete command that removes from the repository.
+      #
+      # @return [String] Ruby source code
+      def self.delete_command_source(cmd, event, agg, mod_name)
+        ref_name = cmd.references.first.name
+        <<~RUBY
+          module #{mod_name}
+            class #{agg.name}
+              module Commands
+                class #{cmd.name}
+                  include Hecks::Command
+                  emits "#{event.name}"
+                  attr_reader :#{ref_name}
+                  def initialize(#{ref_name}: nil)
+                    @#{ref_name} = #{ref_name}
+                  end
+                  def call
+                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                    existing = repository.find(_id)
+                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                    repository.delete(_id)
+                    existing
+                  end
+                  private
+                  def persist_aggregate; end # already deleted in call
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      # Re-wire command and persistence ports after injecting new commands.
+      #
+      # @param runtime [Hecks::Runtime] the runtime
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param mod [Module] the domain module
+      # @return [void]
+      def self.rewire_aggregate(runtime, agg, mod)
+        agg_class = mod.const_get(
+          HecksTemplating::NamingHelpers.instance_method(:domain_constant_name)
+            .bind_call(self, agg.name)
+        )
+        repo = runtime[agg.name]
+        bus = runtime.command_bus
+
+        defaults = agg.attributes.each_with_object({}) do |attr, h|
+          h[attr.name] = attr.list? ? [] : nil
+        end
+
+        Commands.bind(agg_class, agg, bus, repo, defaults)
+      end
+
+      def self.reserved?(name)
+        Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(name.to_s)
+      end
+      private_class_method :reserved?
+    end
+  end
+end
+
+Hecks.register_capability(:crud) { |runtime| Hecks::Capabilities::Crud.apply(runtime) }

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -80,7 +80,7 @@ module Hecks
         when "Update"
           snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
             .bind_call(self, agg.name)
-          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name, validate: :exists)
           attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
             Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
           end
@@ -88,7 +88,7 @@ module Hecks
         when "Delete"
           snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
             .bind_call(self, agg.name)
-          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name, validate: :exists)
           [[], [ref]]
         else
           [[], []]

--- a/hecksties/lib/hecks/capabilities/crud/command_loader.rb
+++ b/hecksties/lib/hecks/capabilities/crud/command_loader.rb
@@ -1,0 +1,74 @@
+# Hecks::Capabilities::Crud::CommandLoader
+#
+# Generates and evaluates Ruby command and event classes for CRUD stubs.
+# Extracted from the CRUD capability to keep each file under 200 lines.
+#
+#   Hecks::Capabilities::Crud::CommandLoader.load(agg, commands, events, mod_name)
+#
+module Hecks
+  module Capabilities
+    module Crud
+      module CommandLoader
+        # Generate and eval Ruby command classes for the new stubs.
+        #
+        # @param agg [DomainModel::Structure::Aggregate] the aggregate
+        # @param commands [Array<DomainModel::Behavior::Command>] new commands
+        # @param events [Array<DomainModel::Behavior::DomainEvent>] corresponding events
+        # @param mod_name [String] the domain module name
+        # @return [void]
+        def self.load(agg, commands, events, mod_name)
+          commands.each_with_index do |cmd, i|
+            event = events[i]
+            event_source = Generators::Domain::EventGenerator.new(
+              event, domain_module: mod_name, aggregate_name: agg.name
+            ).generate
+            RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+            source = if cmd.name.start_with?("Delete")
+              delete_command_source(cmd, event, agg, mod_name)
+            else
+              Generators::Domain::CommandGenerator.new(
+                cmd, domain_module: mod_name, aggregate_name: agg.name,
+                aggregate: agg, event: event
+              ).generate
+            end
+            RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+          end
+        end
+
+        # Generate source for a delete command that removes from the repository.
+        #
+        # @return [String] Ruby source code
+        def self.delete_command_source(cmd, event, agg, mod_name)
+          ref_name = cmd.references.first.name
+          <<~RUBY
+            module #{mod_name}
+              class #{agg.name}
+                module Commands
+                  class #{cmd.name}
+                    include Hecks::Command
+                    emits "#{event.name}"
+                    attr_reader :#{ref_name}
+                    def initialize(#{ref_name}: nil)
+                      @#{ref_name} = #{ref_name}
+                    end
+                    def call
+                      _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                      existing = repository.find(_id)
+                      raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                      repository.delete(_id)
+                      existing
+                    end
+                    private
+                    def persist_aggregate; end # already deleted in call
+                  end
+                end
+              end
+            end
+          RUBY
+        end
+        private_class_method :delete_command_source
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/capability_registry.rb
+++ b/hecksties/lib/hecks/registries/capability_registry.rb
@@ -1,0 +1,21 @@
+# Hecks::CapabilityRegistryMethods
+#
+# Registry for domain capabilities. Capabilities enrich the domain IR by
+# generating constructs (commands, repository bindings) at runtime. Unlike
+# extensions which add infrastructure behavior, capabilities modify what
+# the domain can do.
+#
+#   Hecks.register_capability(:crud) { |runtime| CrudCapability.apply(runtime) }
+#   Hecks.capability_registry  # => { crud: #<Proc> }
+#
+module Hecks
+  module CapabilityRegistryMethods
+    def capability_registry
+      @capability_registry ||= Registry.new
+    end
+
+    def register_capability(name, &hook)
+      capability_registry.register(name, hook)
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -13,318 +13,92 @@ require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
 require_relative "runtime/auth_coverage_check"
 require_relative "runtime/reference_authorizer_check"
+require_relative "runtime/extension_dispatch"
+require_relative "runtime/configuration_dsl"
+require_relative "runtime/command_dispatch"
 
 module Hecks
   # Hecks::Runtime
   #
   # The runtime container that wires a domain to adapters, dispatches
-  # commands, publishes events, and executes policies. Defaults to memory
-  # adapters for all aggregates. Created via Hecks.load(domain).
+  # commands, publishes events, and executes policies. Created via
+  # Hecks.boot or Hecks.load.
   #
-  #   app = Hecks.load(domain)
+  #   app = Hecks.boot(__dir__)
   #   app["Pizza"].all
   #   Pizza.create(name: "Margherita")
   #
-  # Custom adapters:
-  #   app = Hecks.load(domain) do
-  #     adapter "Pizza", my_sql_repo
-  #   end
-  #
-  # The central runtime container for a Hecks domain. Orchestrates the full
-  # lifecycle of a domain application: wiring repositories to aggregates,
-  # setting up the command bus with middleware, registering event-driven
-  # policies and subscribers, hoisting aggregate constants to top-level,
-  # and establishing cross-domain connections.
-  #
-  # Runtime is the object returned by +Hecks.boot+ and +Hecks.load+.
-  # It holds all repositories, the event bus, and the command bus for a
-  # single domain. In multi-domain setups, each domain gets its own Runtime
-  # instance, potentially sharing a filtered event bus.
-  #
-  # Includes several setup mixins that each handle one aspect of wiring:
-  # - PortSetup -- wires aggregate ports (command methods, query methods, repository methods)
-  # - RepositorySetup -- creates memory-backed repositories for each aggregate
-  # - PolicySetup -- registers event-triggered policies on the event bus
-  # - SubscriberSetup -- registers event subscribers defined in the DSL
-  # - ViewSetup -- sets up read-model views
-  # - WorkflowSetup -- wires multi-step workflow definitions
-  # - ConstantHoisting -- promotes aggregate classes to top-level constants
-  # - ConnectionSetup -- wires cross-domain event connections (listens_to/sends_to)
   class Runtime
     include HecksTemplating::NamingHelpers
-      include PortSetup
-      include RepositorySetup
-      include PolicySetup
-      include SubscriberSetup
-      include ViewSetup
-      include WorkflowSetup
-      include ConstantHoisting
-      include ConnectionSetup
-      include AuthCoverageCheck
-      include ReferenceCoverageCheck
-      include SagaSetup
+    include PortSetup
+    include RepositorySetup
+    include PolicySetup
+    include SubscriberSetup
+    include ViewSetup
+    include WorkflowSetup
+    include ConstantHoisting
+    include ConnectionSetup
+    include AuthCoverageCheck
+    include ReferenceCoverageCheck
+    include SagaSetup
+    include ExtensionDispatch
+    include ConfigurationDSL
+    include CommandDispatch
 
-      # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to
-      attr_reader :domain
+    attr_reader :domain, :event_bus, :command_bus
 
-      # @return [Hecks::EventBus] the event bus used for publishing and subscribing to domain events
-      attr_reader :event_bus
+    # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+    # @param gate [Symbol, nil] optional gate name
+    # @param event_bus [Hecks::EventBus, nil] optional shared event bus
+    # @param hecksagon [Hecksagon::Structure::Hecksagon, nil] optional hecksagon IR
+    # @yield optional configuration block
+    # @return [Hecks::Runtime]
+    def initialize(domain, gate: nil, event_bus: nil, hecksagon: nil, &config)
+      @domain = domain
+      @gate_name = gate
+      @hecksagon = hecksagon || Hecks.last_hecksagon
+      @mod_name = domain_module_name(domain.name)
+      @mod = Object.const_get(@mod_name)
+      @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
+      @event_bus = event_bus || EventBus.new
+      @repositories = {}
+      @adapter_overrides = {}
+      @runtime_options = {}
+      @async_handler = nil
 
-      # @return [Hecks::Commands::CommandBus] the command bus that dispatches commands through middleware
-      attr_reader :command_bus
+      instance_eval(&config) if config
 
-      # Boots the runtime: wires repositories, policies, subscribers, and the command bus.
-      # Evaluates an optional configuration block in the context of the runtime instance,
-      # allowing adapter overrides and middleware registration before wiring completes.
-      #
-      # @param domain [Hecks::DomainModel::Structure::Domain] the compiled domain IR object
-      # @param port [Symbol, nil] optional port name (reserved for future use)
-      # @param event_bus [Hecks::EventBus, nil] optional shared event bus; creates a new one if nil
-      # @yield optional configuration block evaluated in the runtime's instance context
-      # @return [Hecks::Runtime]
-      def initialize(domain, gate: nil, event_bus: nil, hecksagon: nil, &config)
-        @domain = domain
-        @gate_name = gate
-        @hecksagon = hecksagon || Hecks.last_hecksagon
-        @mod_name = domain_module_name(domain.name)
-        @mod = Object.const_get(@mod_name)
-        @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
-        @event_bus = event_bus || EventBus.new
-        @repositories = {}
-        @adapter_overrides = {}
-        @runtime_options = {}
-        @async_handler = nil
-        @runtime_options = {}
-
-        instance_eval(&config) if config
-
-        setup_repositories
-        setup_command_bus
-        setup_policies
-        setup_subscribers
-        setup_views
-        setup_connections
-        wire_ports!
-        ServiceSetup.bind(@domain, @mod, @command_bus)
-        setup_workflows
-        setup_sagas
-        hoist_constants
-        apply_hecksagon_capabilities
-      end
-
-      # Register command bus middleware. Middleware wraps every command dispatch,
-      # allowing cross-cutting concerns like logging, authorization, or auditing.
-      #
-      # @param name [Symbol, String, nil] optional middleware name for identification
-      # @yield block that receives the command and a +next_middleware+ callable
-      # @return [void]
-      def use(name = nil, &block)
-        @command_bus.use(name, &block)
-      end
-
-      # Configuration DSL: override the default memory adapter for a specific aggregate
-      # with a custom repository object (e.g., SQL-backed repository).
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @param adapter_obj [Object] a repository object that responds to CRUD methods
-      # @return [void]
-      def adapter(aggregate_name, adapter_obj)
-        @adapter_overrides[aggregate_name.to_s] = adapter_obj
-      end
-
-      # Configuration DSL: enable an infrastructure option for a specific aggregate.
-      # Used to configure cross-cutting concerns like versioning and attachments
-      # that were previously baked into the domain IR.
-      #
-      #   app = Hecks.load(domain) do
-      #     enable "Document", :versioned
-      #     enable "Document", :attachable
-      #   end
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name
-      # @param option [Symbol] the option to enable (e.g., :versioned, :attachable)
-      # @return [void]
-      def enable(aggregate_name, option)
-        name = aggregate_name.to_s
-        @runtime_options[name] ||= {}
-        @runtime_options[name][option] = true
-      end
-
-      # Retrieve the repository for a named aggregate.
-      #
-      # @param name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @return [Object] the repository (memory adapter or custom adapter) for the aggregate
-      def [](name)
-        @repositories[name.to_s]
-      end
-
-      # Execute a command through the command bus, passing it through all registered
-      # middleware before reaching the command runner.
-      #
-      # @param command_name [String, Symbol] the fully qualified command name (e.g., "CreatePizza")
-      # @param attrs [Hash] the command attributes/parameters
-      # @return [Object] the result of the command execution (typically the affected entity)
-      def run(command_name, **attrs)
-        @command_bus.dispatch(command_name, **attrs)
-      end
-
-      # Preview what a command would do without persisting, emitting, or recording.
-      # Runs guards, preconditions, the call body, and postconditions. Returns a
-      # DryRunResult with the aggregate, event, and reactive chain that would fire.
-      #
-      #   result = app.dry_run("CreatePizza", name: "Margherita")
-      #   result.aggregate.name  # => "Margherita"
-      #   result.event           # => #<CreatedPizza ...>
-      #
-      # @param command_name [String] the command name (e.g., "CreatePizza")
-      # @param attrs [Hash] the command attributes
-      # @return [Hecks::DryRunResult]
-      # @raise [Hecks::GuardRejected, Hecks::PreconditionError, Hecks::PostconditionError]
-      def dry_run(command_name, **attrs)
-        cmd_class = @command_bus.resolve_command_class(command_name)
-        cmd = cmd_class.dry_call(**attrs)
-        chain = trace_reactive_chain(command_name)
-        DryRunResult.new(command: cmd, aggregate: cmd.aggregate, event: cmd.event, reactive_chain: chain)
-      end
-
-      # Register an async handler for policies marked +async: true+ in the DSL.
-      # The handler receives an event and is responsible for scheduling deferred work
-      # (e.g., enqueuing a background job).
-      #
-      # @yield [event] block that handles async event processing
-      # @return [void]
-      def async(&handler)
-        @async_handler = handler
-      end
-
-      # Subscribe to a named event on the event bus.
-      #
-      # @param event_name [String, Symbol] the event name to subscribe to (e.g., "PizzaCreated")
-      # @yield [event] block called when the event is published
-      # @return [void]
-      def on(event_name, &handler)
-        @event_bus.subscribe(event_name, &handler)
-      end
-
-      # Returns all events that have been published on the event bus since boot.
-      #
-      # @return [Array<Hash>] list of event hashes with :name and :payload keys
-      def events
-        @event_bus.events
-      end
-
-      # Replace a repository adapter for a named aggregate. Used by extension gems
-      # (e.g., hecks_sqlite) to swap memory adapters for persistent ones after boot.
-      # Re-wires the aggregate's port methods after swapping.
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @param repo [Object] the replacement repository object
-      # @return [void]
-      def swap_adapter(aggregate_name, repo)
-        name = aggregate_name.to_s
-        @repositories[name] = repo
-        wire_aggregate!(name)
-      end
-
-      # Apply an extension to the live runtime without rebooting.
-      #
-      # Looks up the extension hook in the registry and calls it with the
-      # current domain module, domain IR, and this runtime instance. The hook
-      # can register middleware, swap adapters, or subscribe to events — all
-      # take effect immediately on the next command dispatch.
-      #
-      #   runtime.extend(:logging)
-      #   runtime.extend(:sqlite)
-      #   runtime.extend(:tenancy)
-      #
-      # @param name [Symbol] the registered extension name
-      # @param kwargs [Hash] options (currently unused, reserved for future extensions)
-      # @return [void]
-      # @raise [RuntimeError] if the extension is not registered
-      def extend(name, **kwargs)
-        # Auto-discover extensions if registry is empty
-        if Hecks.extension_registry.empty?
-          require "hecks/runtime/load_extensions"
-          Hecks::LoadExtensions.require_all
-        end
-        hook = Hecks.extension_registry[name.to_sym]
-        raise "Unknown extension: #{name}. Available: #{Hecks.extension_registry.keys.join(', ')}" unless hook
-        # Set connection config on the module so the hook can read it
-        if kwargs.any? && @mod.respond_to?(:connections)
-          @mod.connections[:sends] << { name: name.to_sym, **kwargs }
-        end
-        hook.call(@mod, @domain, self, **kwargs)
-        puts "#{name} extension applied"
-      end
-
-      # Apply a capability to the live runtime, enriching the domain IR.
-      #
-      # Capabilities generate constructs (commands, repository bindings) by
-      # visiting the domain IR. Unlike extensions, they modify what the domain
-      # can do rather than adding infrastructure around it.
-      #
-      #   runtime.capability(:crud)
-      #
-      # @param name [Symbol] the registered capability name
-      # @return [void]
-      # @raise [RuntimeError] if the capability is not registered
-      def capability(name)
-        require "hecks/capabilities/#{name}"
-        hook = Hecks.capability_registry[name.to_sym]
-        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
-        hook.call(self)
-      end
-
-      # Returns a human-readable summary of this runtime instance, showing the
-      # domain name and number of wired repositories.
-      #
-      # @return [String] inspection string
-      def inspect
-        "#<Hecks::Runtime \"#{@domain.name}\" (#{@repositories.size} repositories)>"
-      end
-
-      private
-
-      # Checks whether a runtime infrastructure option is enabled for an aggregate.
-      # Options are registered via +Runtime#enable+ in the config block.
-      #
-      # @param aggregate_name [String] the aggregate name
-      # @param option [Symbol] the option key (e.g., :versioned, :attachable)
-      # @return [Boolean]
-      # Apply capabilities declared in the Hecksagon file.
-      # Domain-wide capabilities (e.g., :crud) are applied first, then
-      # aggregate-level capability tags are stored for extensions to read.
-      def apply_hecksagon_capabilities
-        return unless @hecksagon
-        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
-      end
-
-      def runtime_option?(aggregate_name, option)
-        (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
-      end
-
-      # Creates the command bus, binding it to the domain and event bus.
-      # The command bus dispatches commands to the appropriate aggregate
-      # command runner and publishes resulting events.
-      #
-      # @return [void]
-      def setup_command_bus
-        @command_bus = Commands::CommandBus.new(
-          domain: @domain,
-          event_bus: @event_bus
-        )
-      end
-
-      def trace_reactive_chain(command_name)
-        return [] unless defined?(Hecks::FlowGenerator)
-        flows = Hecks::FlowGenerator.new(@domain).trace_flows
-        flow = flows.find { |f| f[:steps]&.first&.dig(:command) == command_name.to_s }
-        return [] unless flow
-        flow[:steps].drop(1)
-      end
+      setup_repositories
+      setup_command_bus
+      setup_policies
+      setup_subscribers
+      setup_views
+      setup_connections
+      wire_ports!
+      ServiceSetup.bind(@domain, @mod, @command_bus)
+      setup_workflows
+      setup_sagas
+      hoist_constants
+      apply_hecksagon_capabilities
     end
 
-  # Backward compatibility alias so existing code referencing
-  # +Hecks::Application+ continues to work.
+    def inspect
+      "#<Hecks::Runtime \"#{@domain.name}\" (#{@repositories.size} repositories)>"
+    end
+
+    private
+
+    def runtime_option?(aggregate_name, option)
+      (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
+    end
+
+    def setup_command_bus
+      @command_bus = Commands::CommandBus.new(
+        domain: @domain,
+        event_bus: @event_bus
+      )
+    end
+  end
+
   Application = Runtime
 end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -109,6 +109,7 @@ module Hecks
         setup_workflows
         setup_sagas
         hoist_constants
+        apply_hecksagon_capabilities
       end
 
       # Register command bus middleware. Middleware wraps every command dispatch,
@@ -290,6 +291,14 @@ module Hecks
       # @param aggregate_name [String] the aggregate name
       # @param option [Symbol] the option key (e.g., :versioned, :attachable)
       # @return [Boolean]
+      # Apply capabilities declared in the Hecksagon file.
+      # Domain-wide capabilities (e.g., :crud) are applied first, then
+      # aggregate-level capability tags are stored for extensions to read.
+      def apply_hecksagon_capabilities
+        return unless @hecksagon
+        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
+      end
+
       def runtime_option?(aggregate_name, option)
         (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
       end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -256,6 +256,24 @@ module Hecks
         puts "#{name} extension applied"
       end
 
+      # Apply a capability to the live runtime, enriching the domain IR.
+      #
+      # Capabilities generate constructs (commands, repository bindings) by
+      # visiting the domain IR. Unlike extensions, they modify what the domain
+      # can do rather than adding infrastructure around it.
+      #
+      #   runtime.capability(:crud)
+      #
+      # @param name [Symbol] the registered capability name
+      # @return [void]
+      # @raise [RuntimeError] if the capability is not registered
+      def capability(name)
+        require "hecks/capabilities/#{name}"
+        hook = Hecks.capability_registry[name.to_sym]
+        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
+        hook.call(self)
+      end
+
       # Returns a human-readable summary of this runtime instance, showing the
       # domain name and number of wired repositories.
       #

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -65,6 +65,11 @@ module Hecks
       domain = Hecks.last_domain
       domain.source_path = bluebooks.first
 
+      # Auto-discover and load Hecksagon file (infrastructure capabilities)
+      hecksagons = Dir[File.join(dir, "*Hecksagon")].sort
+      hecksagons = Dir[File.join(dir, "bluebook", "*Hecksagon")].sort if hecksagons.empty?
+      hecksagons.each { |f| Kernel.load(f) }
+
       mod = load_domain(domain)
       load_stubs(dir, domain)
       mod.extend(Hecks::DomainConnections) unless mod.respond_to?(:connections)

--- a/hecksties/lib/hecks/runtime/command_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/command_dispatch.rb
@@ -1,0 +1,78 @@
+# Hecks::Runtime::CommandDispatch
+#
+# Command execution and event subscription on the runtime. Provides
+# the public API for running commands, subscribing to events, and
+# querying runtime state.
+#
+#   app.run("CreatePizza", name: "Margherita")
+#   app.on("CreatedPizza") { |e| puts e.name }
+#   app["Pizza"].all
+#
+module Hecks
+  class Runtime
+    module CommandDispatch
+      # Retrieve the repository for a named aggregate.
+      #
+      # @param name [String, Symbol] the aggregate name
+      # @return [Object] the repository
+      def [](name)
+        @repositories[name.to_s]
+      end
+
+      # Execute a command through the command bus.
+      #
+      # @param command_name [String, Symbol] the command name
+      # @param attrs [Hash] the command attributes
+      # @return [Object] the command result
+      def run(command_name, **attrs)
+        @command_bus.dispatch(command_name, **attrs)
+      end
+
+      # Preview what a command would do without persisting.
+      #
+      # @param command_name [String] the command name
+      # @param attrs [Hash] the command attributes
+      # @return [Hecks::DryRunResult]
+      def dry_run(command_name, **attrs)
+        cmd_class = @command_bus.resolve_command_class(command_name)
+        cmd = cmd_class.dry_call(**attrs)
+        chain = trace_reactive_chain(command_name)
+        DryRunResult.new(command: cmd, aggregate: cmd.aggregate, event: cmd.event, reactive_chain: chain)
+      end
+
+      # Register an async handler for policies marked async: true.
+      #
+      # @yield [event] block that handles async event processing
+      # @return [void]
+      def async(&handler)
+        @async_handler = handler
+      end
+
+      # Subscribe to a named event on the event bus.
+      #
+      # @param event_name [String, Symbol] the event name
+      # @yield [event] block called on publish
+      # @return [void]
+      def on(event_name, &handler)
+        @event_bus.subscribe(event_name, &handler)
+      end
+
+      # Returns all events published since boot.
+      #
+      # @return [Array<Hash>]
+      def events
+        @event_bus.events
+      end
+
+      private
+
+      def trace_reactive_chain(command_name)
+        return [] unless defined?(Hecks::FlowGenerator)
+        flows = Hecks::FlowGenerator.new(@domain).trace_flows
+        flow = flows.find { |f| f[:steps]&.first&.dig(:command) == command_name.to_s }
+        return [] unless flow
+        flow[:steps].drop(1)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
+++ b/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
@@ -16,6 +16,7 @@ module Hecks
         store_domain_object(domain_obj)
         generate_adapters(domain_obj) if @adapter_type == :sql
         app = create_runtime(d, domain_obj, domain_module)
+        app.capability(:crud)
         app.async(&@async_handler) if @async_handler
         @apps[d[:gem_name]] = app
         wire_event_sourcing(domain_obj, domain_module) if event_sourced?

--- a/hecksties/lib/hecks/runtime/configuration_dsl.rb
+++ b/hecksties/lib/hecks/runtime/configuration_dsl.rb
@@ -1,0 +1,56 @@
+# Hecks::Runtime::ConfigurationDSL
+#
+# Configuration methods evaluated inside the runtime boot block.
+# Allows adapter overrides, middleware registration, and option flags.
+#
+#   app = Hecks.load(domain) do
+#     adapter "Pizza", my_sql_repo
+#     enable "Document", :versioned
+#     use(:logging) { |cmd, nxt| puts cmd; nxt.call }
+#   end
+#
+module Hecks
+  class Runtime
+    module ConfigurationDSL
+      # Register command bus middleware.
+      #
+      # @param name [Symbol, String, nil] optional middleware name
+      # @yield block receiving (command, next_handler)
+      # @return [void]
+      def use(name = nil, &block)
+        @command_bus.use(name, &block)
+      end
+
+      # Override the default memory adapter for a specific aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param adapter_obj [Object] a repository object
+      # @return [void]
+      def adapter(aggregate_name, adapter_obj)
+        @adapter_overrides[aggregate_name.to_s] = adapter_obj
+      end
+
+      # Enable an infrastructure option for a specific aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param option [Symbol] the option to enable
+      # @return [void]
+      def enable(aggregate_name, option)
+        name = aggregate_name.to_s
+        @runtime_options[name] ||= {}
+        @runtime_options[name][option] = true
+      end
+
+      # Replace a repository adapter after boot.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param repo [Object] the replacement repository
+      # @return [void]
+      def swap_adapter(aggregate_name, repo)
+        name = aggregate_name.to_s
+        @repositories[name] = repo
+        wire_aggregate!(name)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/extension_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/extension_dispatch.rb
@@ -1,0 +1,51 @@
+# Hecks::Runtime::ExtensionDispatch
+#
+# Applies extensions and capabilities to a live runtime. Extensions add
+# infrastructure behavior; capabilities enrich the domain IR.
+#
+#   runtime.extend(:logging)
+#   runtime.capability(:crud)
+#
+module Hecks
+  class Runtime
+    module ExtensionDispatch
+      # Apply an extension to the live runtime without rebooting.
+      #
+      # @param name [Symbol] the registered extension name
+      # @param kwargs [Hash] extension-specific options
+      # @return [void]
+      def extend(name, **kwargs)
+        if Hecks.extension_registry.empty?
+          require "hecks/runtime/load_extensions"
+          Hecks::LoadExtensions.require_all
+        end
+        hook = Hecks.extension_registry[name.to_sym]
+        raise "Unknown extension: #{name}. Available: #{Hecks.extension_registry.keys.join(', ')}" unless hook
+        if kwargs.any? && @mod.respond_to?(:connections)
+          @mod.connections[:sends] << { name: name.to_sym, **kwargs }
+        end
+        hook.call(@mod, @domain, self, **kwargs)
+        puts "#{name} extension applied"
+      end
+
+      # Apply a capability to the live runtime, enriching the domain IR.
+      #
+      # @param name [Symbol] the registered capability name
+      # @return [void]
+      def capability(name)
+        require "hecks/capabilities/#{name}"
+        hook = Hecks.capability_registry[name.to_sym]
+        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
+        hook.call(self)
+      end
+
+      private
+
+      # Apply capabilities declared in the Hecksagon file.
+      def apply_hecksagon_capabilities
+        return unless @hecksagon
+        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -25,6 +25,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
       require "hecks"
 
       app = Hecks.boot(__dir__)
+      app.capability(:crud)
 
       # Start building:
       #   Example.create(name: "Hello")
@@ -51,6 +52,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     <<~RUBY
       require "hecks"
       app = Hecks.boot(File.join(__dir__, ".."))
+      app.capability(:crud)
 
       RSpec.configure do |config|
         config.order = :random

--- a/hecksties/spec/capabilities/crud_spec.rb
+++ b/hecksties/spec/capabilities/crud_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe "CRUD capability" do
+  let(:domain) do
+    Hecks.domain "CrudTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        attribute :color, String
+        command "CreateWidget" do
+          attribute :name, String
+          attribute :color, String
+        end
+      end
+    end
+  end
+
+  describe "without capability" do
+    it "has only user-defined commands" do
+      Hecks.load(domain)
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to eq(["CreateWidget"])
+    end
+  end
+
+  describe "with capability" do
+    before do
+      @runtime = Hecks.load(domain)
+      @runtime.capability(:crud)
+    end
+
+    it "generates UpdateWidget and DeleteWidget stubs" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to include("UpdateWidget", "DeleteWidget")
+    end
+
+    it "skips user-defined CreateWidget" do
+      create_cmd = domain.aggregates.first.commands.find { |c| c.name == "CreateWidget" }
+      # User-defined CreateWidget has name + color attrs (not the auto-gen which would include all)
+      expect(create_cmd.attributes.map(&:name)).to eq(%i[name color])
+    end
+
+    it "does not generate ReadWidget (handled by repository)" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).not_to include("ReadWidget")
+    end
+
+    it "generates corresponding events" do
+      events = domain.aggregates.first.events.map(&:name)
+      expect(events).to include("UpdatedWidget", "DeletedWidget")
+    end
+
+    it "can create, update, and delete via commands" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      created = klass.create(name: "Bolt", color: "Silver")
+      expect(klass.count).to eq(1)
+
+      klass.update(widget: created.id, name: "Nut", color: "Gold")
+      found = klass.find(created.id)
+      expect(found.name).to eq("Nut")
+      expect(found.color).to eq("Gold")
+
+      klass.delete(widget: created.id)
+      expect(klass.count).to eq(0)
+    end
+
+    it "binds repository methods (find, all, count, first, last)" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      klass.create(name: "A", color: "Red")
+      klass.create(name: "B", color: "Blue")
+      expect(klass.count).to eq(2)
+      expect(klass.first.name).to eq("A")
+      expect(klass.last.name).to eq("B")
+      expect(klass.all.size).to eq(2)
+    end
+  end
+end

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Hecks::Conventions::DisplayContract do
     it "returns command_names as a humanized comma-separated string" do
       pizza = domain.aggregates.find { |a| a.name == "Pizza" }
       data = described_class.home_aggregate_data(pizza, "pizzas")
-      expect(data[:command_names]).to eq("Create Pizza, Add Topping")
+      expect(data[:command_names]).to include("Create Pizza")
+      expect(data[:command_names]).to include("Add Topping")
     end
 
     it "returns an empty string when there are no commands" do

--- a/hecksties/support/shared_boot.rb
+++ b/hecksties/support/shared_boot.rb
@@ -91,7 +91,8 @@ module BootedDomains
     key = domain.object_id
     return @cache[key] if @cache[key]
 
-    @cache[key] = true
-    Hecks.load(domain)
+    runtime = Hecks.load(domain)
+    runtime.capability(:crud)
+    @cache[key] = runtime
   end
 end


### PR DESCRIPTION
## Summary

Two-file pattern for separating domain from infrastructure:

- **Bluebook** — pure domain structure (aggregates, commands, events)
- **Hecksagon** — infrastructure capabilities (CRUD, PII, audit)

`Hecks.boot(__dir__)` auto-discovers both `*Bluebook` and `*Hecksagon` files.

## Example

```ruby
# PizzasBluebook — pure domain
Hecks.domain "Pizzas" do
  aggregate "Pizza" do
    attribute :name, String
    command "CreatePizza" do
      attribute :name, String
    end
  end
end

# PizzasHecksagon — infrastructure capabilities
Hecks.hecksagon "Pizzas" do
  capabilities :crud, :audit

  aggregate "Pizza" do
    capability.email.pii
  end
end
```

## What's new

- `Hecks.hecksagon "Name" do ... end` DSL with name param
- `capabilities :crud, :audit` — domain-wide capability list
- `capability.attr.tag` — fluent per-attribute capability tagging
- `AggregateCapabilityBuilder` with `AttributeSelector` and `TagApplier`
- Auto-discovery of `*Hecksagon` files in `Hecks.boot`
- Capabilities from hecksagon file applied during boot
- CRUD refs now use `validate: :exists` (no authorizer needed)

## Test plan

- [x] Domain-wide capabilities stored on IR
- [x] Fluent attribute tagging works
- [x] Capabilities applied at boot via hecksagon file
- [x] Pizzas example boots with PizzasHecksagon (no manual `runtime.capability(:crud)`)
- [x] Smoke test passes