### PR TITLE
HEC-490: Hecks IDE — browser-based Claude Code terminal with context panel

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -150,6 +150,12 @@
 - `SomeDomain.event_bus` — access the domain's event bus for cross-domain wiring
 - `Runtime#swap_adapter(name, repo)` — extension gems swap memory adapters for SQL
 
+## Capabilities
+- `app.capability(:crud)` — generate Create, Update, Delete command stubs for all aggregates; skips user-defined commands
+- Capability registry: `Hecks.register_capability(:name) { |runtime| ... }` — plug in custom capabilities
+- CRUD capability auto-enabled in Workshop play mode and Rails (`Hecks.configure`)
+- `hecks new` app.rb scaffold includes `app.capability(:crud)` by default
+
 ## Runtime API
 - `Hecks.boot(__dir__)` — find domain file, validate, build, load, and wire in one call
 - `Hecks.boot(__dir__, adapter: :sqlite)` — automatic SQL setup

--- a/bin/context-panel
+++ b/bin/context-panel
@@ -1,0 +1,133 @@
+#!/bin/bash
+# context-panel
+#
+# Watches the active Claude Code session JSONL for file_path entries
+# and displays them as a live-updating panel. Deduplicates and shows
+# the most recently touched files first.
+#
+# Usage: context-panel <context_file>
+
+CONTEXT_FILE="${1:-/tmp/hecks_ide_context}"
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+POLL_INTERVAL=2
+
+# Resolve the Claude projects directory for this working directory
+CLAUDE_PROJECT_DIR="$HOME/.claude/projects"
+
+find_session_file() {
+  # Find the project hash dir matching our working directory
+  local encoded
+  encoded=$(echo "$PROJECT_DIR" | sed 's|/|-|g')
+
+  local project_path="$CLAUDE_PROJECT_DIR/$encoded"
+  if [ ! -d "$project_path" ]; then
+    # Try parent directories
+    encoded=$(echo "$(dirname "$PROJECT_DIR")" | sed 's|/|-|g')
+    project_path="$CLAUDE_PROJECT_DIR/$encoded"
+  fi
+
+  if [ -d "$project_path" ]; then
+    # Find the most recently modified .jsonl file
+    ls -t "$project_path"/*.jsonl 2>/dev/null | head -1
+  fi
+}
+
+extract_files() {
+  local session_file="$1"
+  if [ -z "$session_file" ] || [ ! -f "$session_file" ]; then
+    return
+  fi
+
+  # Extract file_path values, strip the project prefix for readability,
+  # deduplicate preserving last-seen order (most recent last → reverse)
+  grep -o '"file_path":"[^"]*"' "$session_file" \
+    | sed 's/"file_path":"//;s/"$//' \
+    | awk '{ files[$0] = NR } END { for (f in files) print files[f], f }' \
+    | sort -rn \
+    | cut -d' ' -f2- \
+    | sed "s|$PROJECT_DIR/||" \
+    | sed "s|$HOME/.claude/projects/[^/]*/memory/|~claude/|" \
+    | sed "s|$HOME/.claude/projects/[^/]*/|~claude/|" \
+    | sed "s|$HOME/|~/|"
+}
+
+render() {
+  local cols lines
+  cols=$(tput cols 2>/dev/null || echo 40)
+  lines=$(tput lines 2>/dev/null || echo 24)
+
+  tput cup 0 0 2>/dev/null || clear
+  tput ed 2>/dev/null
+
+  # Header
+  local hr_width=$((cols - 2))
+  [ $hr_width -lt 1 ] && hr_width=1
+  printf "\033[1;36m Context Files\033[0m\n"
+  printf "\033[2m %s\033[0m\n" "$(printf '%*s' "$hr_width" '' | tr ' ' '─')"
+
+  local session_file
+  session_file=$(find_session_file)
+
+  if [ -z "$session_file" ]; then
+    printf "\033[2m Waiting for Claude session...\033[0m\n"
+    return
+  fi
+
+  local file_list
+  file_list=$(extract_files "$session_file")
+
+  if [ -z "$file_list" ]; then
+    printf "\033[2m No files in context yet.\033[0m\n"
+    return
+  fi
+
+  local count=0
+  local max_files=$((lines - 4))
+
+  while IFS= read -r filepath; do
+    count=$((count + 1))
+    if [ $count -gt $max_files ]; then
+      printf "\033[2m ... and more\033[0m\n"
+      break
+    fi
+
+    # Color based on file extension
+    local color="\033[0m"
+    case "$filepath" in
+      *.rb)   color="\033[0;31m" ;;   # red
+      *.js)   color="\033[0;33m" ;;   # yellow
+      *.md)   color="\033[0;34m" ;;   # blue
+      *.yml|*.yaml) color="\033[0;35m" ;; # magenta
+      *.sh)   color="\033[0;32m" ;;   # green
+      *.erb)  color="\033[0;36m" ;;   # cyan
+    esac
+
+    # Shorten: show parent/filename, truncate from the left if needed
+    local display="$filepath"
+    local max_width=$((cols - 3))
+    if [ $max_width -lt 10 ]; then max_width=10; fi
+
+    if [ ${#display} -gt $max_width ]; then
+      # Keep filename + as much parent context as fits
+      local fname="${filepath##*/}"
+      local dir="${filepath%/*}"
+      if [ ${#fname} -ge $((max_width - 4)) ]; then
+        display="...${fname: -$((max_width - 3))}"
+      else
+        local avail=$((max_width - ${#fname} - 4))
+        display="...${dir: -$avail}/$fname"
+      fi
+    fi
+
+    printf " ${color}%s\033[0m\n" "$display"
+  done <<< "$file_list"
+
+  # Footer
+  printf "\n\033[2m %d file(s)\033[0m" "$(echo "$file_list" | wc -l | tr -d ' ')"
+}
+
+# Main loop
+while true; do
+  render
+  sleep "$POLL_INTERVAL"
+done

--- a/bin/context-panel-web
+++ b/bin/context-panel-web
@@ -1,0 +1,23 @@
+#!/bin/bash
+# context-panel-web
+#
+# Launches the browser-based context panel that shows files Claude Code
+# is working with. Polls the active Claude session for file context.
+#
+# Usage: context-panel-web [port]
+
+GEM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${1:-3001}"
+
+ruby -I"$GEM_DIR/hecks_ai/lib" -e "
+  require 'hecks_ai/context_panel/server'
+  Hecks::AI::ContextPanel::Server.new(project_dir: '$GEM_DIR', port: $PORT).run
+" &
+SERVER_PID=$!
+
+sleep 1
+if kill -0 "$SERVER_PID" 2>/dev/null; then
+  open "http://localhost:$PORT" 2>/dev/null || xdg-open "http://localhost:$PORT" 2>/dev/null
+fi
+
+wait "$SERVER_PID"

--- a/bin/hecks_ide
+++ b/bin/hecks_ide
@@ -1,0 +1,15 @@
+#!/bin/bash
+# hecks_ide
+#
+# Launches the Hecks IDE in a browser — Claude Code terminal on the
+# left (streamed via WebSocket) and a live context panel on the right.
+#
+# Usage: hecks_ide [port]
+
+GEM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${1:-3001}"
+
+ruby -I"$GEM_DIR/hecks_ai/lib" -e "
+  require 'hecks_ai/ide/server'
+  Hecks::AI::IDE::Server.new(project_dir: '$GEM_DIR', port: $PORT).run
+"

--- a/bluebook/lib/hecks/domain/builder_methods.rb
+++ b/bluebook/lib/hecks/domain/builder_methods.rb
@@ -49,8 +49,8 @@ module Hecks
     #
     # @param block [Proc] DSL block evaluated inside Hecksagon::DSL::HecksagonBuilder
     # @return [Hecksagon::Structure::Hecksagon] the fully built Hecksagon IR object
-    def hecksagon(&block)
-      builder = Hecksagon::DSL::HecksagonBuilder.new
+    def hecksagon(name = nil, &block)
+      builder = Hecksagon::DSL::HecksagonBuilder.new(name)
       builder.instance_eval(&block)
       result = builder.build
       Hecks.last_hecksagon = result

--- a/docs/usage/crud_capability.md
+++ b/docs/usage/crud_capability.md
@@ -1,0 +1,83 @@
+# CRUD Capability
+
+The CRUD capability generates Create, Update, and Delete command stubs for
+every aggregate in your domain. User-defined commands always take precedence --
+if you already defined `CreatePizza` in your Bluebook, the capability skips it.
+
+## Enabling CRUD
+
+```ruby
+# In app.rb
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+```
+
+CRUD is a **capability**, not a DSL keyword. The Bluebook stays pure domain
+structure; the hecksagon enriches it at runtime.
+
+## What gets generated
+
+For an aggregate `Pizza` with attributes `name` and `style`:
+
+| Command       | Attributes                  | Reference     |
+|---------------|-----------------------------|---------------|
+| CreatePizza   | name, style                 | --            |
+| UpdatePizza   | name, style                 | pizza (self)  |
+| DeletePizza   | --                          | pizza (self)  |
+
+`ReadPizza` is not generated -- repository methods (`.find`, `.all`, `.count`,
+`.first`, `.last`) handle reads directly.
+
+## Skipping user-defined commands
+
+```ruby
+# Bluebook -- pure domain
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :style, String
+
+    command "CreatePizza" do
+      attribute :name, String  # only name, not style
+    end
+  end
+end
+
+# Hecksagon
+app = Hecks.boot(__dir__)
+app.capability(:crud)
+# CreatePizza is user-defined (kept as-is)
+# UpdatePizza and DeletePizza are generated
+```
+
+## Using generated commands
+
+```ruby
+# Create (user-defined or generated)
+pizza = Pizza.create(name: "Margherita", style: "Classic")
+
+# Update (generated)
+Pizza.update(pizza: pizza.id, name: "Updated Name", style: "New Style")
+
+# Delete (generated)
+Pizza.delete(pizza: pizza.id)
+
+# Repository reads (always available)
+Pizza.find(pizza.id)
+Pizza.all
+Pizza.count
+Pizza.first
+Pizza.last
+```
+
+## Without CRUD capability
+
+Without calling `app.capability(:crud)`, only user-defined commands exist.
+Repository methods (`find`, `all`, `count`) are always bound by the runtime
+regardless of the CRUD capability.
+
+## Integration points
+
+- **Workshop**: CRUD is auto-enabled in play mode
+- **Rails (Hecks.configure)**: CRUD is auto-enabled at boot
+- **hecks new**: Generated `app.rb` includes `app.capability(:crud)`

--- a/docs/usage/hecksagon_dsl.md
+++ b/docs/usage/hecksagon_dsl.md
@@ -1,0 +1,72 @@
+# Hecksagon DSL
+
+The Hecksagon file declares infrastructure capabilities alongside the Bluebook.
+The Bluebook describes pure domain structure. The Hecksagon says what to do with it.
+
+## Two-File Pattern
+
+```ruby
+# PizzasBluebook — pure domain
+Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    attribute :email, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+
+# PizzasHecksagon — infrastructure capabilities
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud
+end
+```
+
+## Auto-Discovery
+
+`Hecks.boot(__dir__)` discovers both `*Bluebook` and `*Hecksagon` files
+in the project directory and loads them automatically.
+
+## Domain-Wide Capabilities
+
+```ruby
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud, :audit
+end
+```
+
+Capabilities are visitors over the domain IR that generate constructs.
+`:crud` generates Create/Read/Update/Delete command stubs on every aggregate,
+skipping any command the user already defined in the Bluebook.
+
+## Per-Aggregate Capabilities
+
+```ruby
+Hecks.hecksagon "Healthcare" do
+  capabilities :crud
+
+  aggregate "Patient" do
+    capability.email.pii
+    capability.ssn.pii
+  end
+end
+```
+
+`capability.email.pii` tags the `email` attribute on `Patient` with the `:pii`
+capability. Capabilities self-activate from usage — no separate `concern :pii`
+declaration needed.
+
+## How It Works
+
+- The domain is the structural index (the skeleton)
+- Capabilities are the muscles — visitors that attach behavior to domain nodes
+- The hecksagon is sparse: it only tags nodes that need infrastructure
+- `aggregate "Patient"` in the hecksagon doesn't create anything — it points
+  to the domain node
+
+## Running Example
+
+```sh
+ruby -Ilib examples/pizzas/app.rb
+```

--- a/examples/pizzas/PizzasHecksagon
+++ b/examples/pizzas/PizzasHecksagon
@@ -1,0 +1,3 @@
+Hecks.hecksagon "Pizzas" do
+  capabilities :crud
+end

--- a/examples/pizzas/app.rb
+++ b/examples/pizzas/app.rb
@@ -7,9 +7,8 @@
 
 require "hecks"
 
-# Boot the domain — loads, validates, builds, and wires everything in one call
+# Boot the domain — loads Bluebook + Hecksagon, validates, builds, wires
 app = Hecks.boot(__dir__)
-app.capability(:crud)
 
 # Subscribe to events
 app.on("CreatedPizza") do |event|

--- a/examples/pizzas/app.rb
+++ b/examples/pizzas/app.rb
@@ -9,6 +9,7 @@ require "hecks"
 
 # Boot the domain — loads, validates, builds, and wires everything in one call
 app = Hecks.boot(__dir__)
+app.capability(:crud)
 
 # Subscribe to events
 app.on("CreatedPizza") do |event|

--- a/hecks_ai/lib/hecks_ai/commands/ide.rb
+++ b/hecks_ai/lib/hecks_ai/commands/ide.rb
@@ -1,0 +1,9 @@
+Hecks::CLI.register_command(:ide, "Launch browser IDE with Claude Code and context panel",
+  args: ["PORT"]
+) do |port = 3001|
+  local = File.expand_path("../../../../bin/hecks_ide", __dir__)
+  script = File.exist?(local) ? local : ::Gem.bin_path("hecks", "hecks_ide")
+  exec script, port.to_s
+rescue ::Gem::Exception
+  say "hecks_ide not found. Is the hecks gem installed?", :red
+end

--- a/hecks_ai/lib/hecks_ai/context_panel/server.rb
+++ b/hecks_ai/lib/hecks_ai/context_panel/server.rb
@@ -1,0 +1,77 @@
+# Hecks::AI::ContextPanel::Server
+#
+# WEBrick server that serves a browser-based context panel showing files
+# Claude Code is working with. Reads Claude's JSONL session for file paths
+# and exposes a POST endpoint for direct context updates.
+#
+#   Server.new(project_dir: Dir.pwd, port: 3001).run
+#
+require "webrick"
+require "json"
+require_relative "session_reader"
+
+module Hecks
+  module AI
+    module ContextPanel
+      class Server
+        VIEWS_DIR = File.join(__dir__, "views")
+
+        def initialize(project_dir: Dir.pwd, port: 3001)
+          @project_dir = project_dir
+          @port = port
+          @reader = SessionReader.new(project_dir)
+          @pushed_context = nil
+        end
+
+        def run
+          server = WEBrick::HTTPServer.new(
+            Port: @port,
+            Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN),
+            AccessLog: []
+          )
+          server.mount_proc("/") { |req, res| handle(req, res) }
+          trap("INT") { server.shutdown }
+          puts "Context panel: http://localhost:#{@port}"
+          server.start
+        end
+
+        private
+
+        def handle(req, res)
+          case [req.request_method, req.path]
+          when ["GET",  "/"]      then serve_panel(res)
+          when ["GET",  "/files"] then serve_files(res)
+          when ["POST", "/context"] then receive_context(req, res)
+          else
+            res.status = 404
+            res.body = "Not found"
+          end
+        end
+
+        def serve_panel(res)
+          res.content_type = "text/html"
+          res["Cache-Control"] = "no-cache, no-store"
+          res.body = File.read(File.join(VIEWS_DIR, "panel.html"))
+        end
+
+        def serve_files(res)
+          files = @pushed_context || @reader.files
+          res.content_type = "application/json"
+          res["Cache-Control"] = "no-cache, no-store"
+          res.body = JSON.generate(files: files)
+        end
+
+        def receive_context(req, res)
+          data = JSON.parse(req.body)
+          @pushed_context = data["files"] if data["files"]
+          res.content_type = "application/json"
+          res.body = JSON.generate(ok: true)
+        rescue JSON::ParserError => e
+          res.status = 400
+          res.content_type = "application/json"
+          res.body = JSON.generate(error: e.message)
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/context_panel/session_reader.rb
+++ b/hecks_ai/lib/hecks_ai/context_panel/session_reader.rb
@@ -1,0 +1,74 @@
+# Hecks::AI::ContextPanel::SessionReader
+#
+# Reads the active Claude Code JSONL session file and extracts file paths
+# that Claude has interacted with. Returns them deduplicated and sorted by
+# most-recent-first.
+#
+#   reader = SessionReader.new("/Users/me/Projects/hecks")
+#   reader.files  # => ["lib/hecks.rb", "spec/hecks_spec.rb"]
+#
+module Hecks
+  module AI
+    module ContextPanel
+      class SessionReader
+        CLAUDE_PROJECTS_DIR = File.join(Dir.home, ".claude", "projects")
+
+        def initialize(project_dir)
+          @project_dir = File.expand_path(project_dir)
+        end
+
+        def files
+          session_file = find_session_file
+          return [] unless session_file && File.exist?(session_file)
+
+          extract_files(session_file)
+        end
+
+        private
+
+        def find_session_file
+          encoded = @project_dir.tr("/", "-")
+          project_path = File.join(CLAUDE_PROJECTS_DIR, encoded)
+
+          unless File.directory?(project_path)
+            parent_encoded = File.dirname(@project_dir).tr("/", "-")
+            project_path = File.join(CLAUDE_PROJECTS_DIR, parent_encoded)
+          end
+
+          return nil unless File.directory?(project_path)
+
+          Dir.glob(File.join(project_path, "*.jsonl"))
+             .max_by { |f| File.mtime(f) }
+        end
+
+        def extract_files(path)
+          seen = {}
+          counter = 0
+
+          File.foreach(path) do |line|
+            line.scan(/"file_path"\s*:\s*"([^"]+)"/) do |match|
+              file = match[0]
+              counter += 1
+              seen[file] = counter
+            end
+          end
+
+          seen.sort_by { |_, order| -order }
+              .map { |file, _| strip_prefix(file) }
+        end
+
+        def strip_prefix(file)
+          if file.start_with?(@project_dir)
+            file.sub("#{@project_dir}/", "")
+          elsif file.start_with?(CLAUDE_PROJECTS_DIR)
+            file.sub(%r{.*/\.claude/projects/[^/]*/}, "~claude/")
+          elsif file.start_with?(Dir.home)
+            file.sub(Dir.home, "~")
+          else
+            file
+          end
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/context_panel/views/panel.html
+++ b/hecks_ai/lib/hecks_ai/context_panel/views/panel.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Context</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      background: #0d1117;
+      color: #c9d1d9;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 12px;
+      min-height: 100vh;
+    }
+
+    .header {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding-left: 8px;
+      border-left: 2px solid #58a6ff;
+      color: #58a6ff;
+      margin-bottom: 8px;
+    }
+
+    .divider {
+      border: none;
+      border-top: 1px solid #30363d;
+      margin-bottom: 8px;
+    }
+
+    .file-list {
+      list-style: none;
+    }
+
+    .file-item {
+      padding: 3px 8px;
+      border-radius: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      transition: background 0.15s;
+    }
+
+    .file-item:hover {
+      background: #161b22;
+    }
+
+    .file-item .dir {
+      color: #8b949e;
+    }
+
+    .file-item .name {
+      font-weight: 500;
+    }
+
+    /* Extension-based colors */
+    .ext-rb .name   { color: #f85149; }
+    .ext-js .name   { color: #d29922; }
+    .ext-md .name   { color: #58a6ff; }
+    .ext-yml .name,
+    .ext-yaml .name { color: #bc8cff; }
+    .ext-sh .name   { color: #7ee787; }
+    .ext-erb .name  { color: #79c0ff; }
+    .ext-html .name { color: #f0883e; }
+    .ext-css .name  { color: #ff7b72; }
+    .ext-json .name { color: #d2a8ff; }
+    .ext-go .name   { color: #79c0ff; }
+
+    .footer {
+      margin-top: 12px;
+      padding-top: 8px;
+      border-top: 1px solid #30363d;
+      font-size: 11px;
+      color: #8b949e;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .empty {
+      color: #8b949e;
+      padding: 8px;
+      font-style: italic;
+    }
+
+    .dot {
+      display: inline-block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #7ee787;
+      margin-right: 6px;
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">Context Files</div>
+  <hr class="divider">
+  <ul class="file-list" id="file-list"></ul>
+  <div class="footer">
+    <span id="count">0 files</span>
+    <span><span class="dot"></span>polling</span>
+  </div>
+
+  <script>
+    const listEl = document.getElementById('file-list');
+    const countEl = document.getElementById('count');
+    let lastJson = '';
+
+    function extClass(filepath) {
+      const dot = filepath.lastIndexOf('.');
+      if (dot === -1) return '';
+      return 'ext-' + filepath.slice(dot + 1).toLowerCase();
+    }
+
+    function splitPath(filepath) {
+      const slash = filepath.lastIndexOf('/');
+      if (slash === -1) return { dir: '', name: filepath };
+      return { dir: filepath.slice(0, slash + 1), name: filepath.slice(slash + 1) };
+    }
+
+    function render(files) {
+      if (files.length === 0) {
+        listEl.innerHTML = '<li class="empty">No files in context yet.</li>';
+        countEl.textContent = '0 files';
+        return;
+      }
+
+      listEl.innerHTML = files.map(f => {
+        const { dir, name } = splitPath(f);
+        return `<li class="file-item ${extClass(f)}"><span class="dir">${dir}</span><span class="name">${name}</span></li>`;
+      }).join('');
+
+      const n = files.length;
+      countEl.textContent = `${n} file${n === 1 ? '' : 's'}`;
+    }
+
+    async function poll() {
+      try {
+        const res = await fetch('/files');
+        const text = await res.text();
+        if (text !== lastJson) {
+          lastJson = text;
+          const data = JSON.parse(text);
+          render(data.files);
+        }
+      } catch (e) {
+        // server down, keep trying
+      }
+    }
+
+    poll();
+    setInterval(poll, 2000);
+  </script>
+</body>
+</html>

--- a/hecks_ai/lib/hecks_ai/ide/server.rb
+++ b/hecks_ai/lib/hecks_ai/ide/server.rb
@@ -1,0 +1,130 @@
+# Hecks::AI::IDE::Server
+#
+# Browser-based IDE that streams a Claude Code terminal over WebSocket
+# alongside a live context panel. Runs WEBrick for HTTP and a raw
+# TCPServer for the terminal WebSocket on port+1.
+#
+#   Server.new(project_dir: Dir.pwd, port: 3001).run
+#
+require "webrick"
+require "json"
+require_relative "websocket"
+require_relative "terminal"
+require_relative "../context_panel/session_reader"
+
+module Hecks
+  module AI
+    module IDE
+      class Server
+        VIEWS_DIR = File.join(__dir__, "views")
+
+        def initialize(project_dir: Dir.pwd, port: 3001)
+          @project_dir = project_dir
+          @port = port
+          @ws_port = port + 1
+          @reader = ContextPanel::SessionReader.new(project_dir)
+        end
+
+        def run
+          start_terminal_server
+          start_http_server
+        end
+
+        private
+
+        def start_terminal_server
+          Thread.new do
+            server = TCPServer.new("127.0.0.1", @ws_port)
+            loop { handle_terminal_client(server) }
+          end
+        end
+
+        def handle_terminal_client(server)
+          ws = WebSocket.accept(server)
+          return unless ws
+
+          terminal = Terminal.new("claude --dangerously-skip-permissions")
+
+          reader_thread = Thread.new do
+            while terminal.alive?
+              data = terminal.read
+              ws.write(data) if data && !ws.closed?
+            end
+            ws.write("\r\n[Process exited]\r\n") rescue nil
+          end
+
+          while (msg = ws.read)
+            break if msg == :close
+            next  if msg == :ping
+
+            if msg.start_with?("{")
+              handle_json_message(msg, terminal)
+            else
+              terminal.write(msg)
+            end
+          end
+
+          reader_thread.kill
+          terminal.close
+          ws.close
+        rescue => e
+          $stderr.puts "Terminal session error: #{e.message}"
+        end
+
+        def handle_json_message(msg, terminal)
+          data = JSON.parse(msg)
+          terminal.resize(data["cols"], data["rows"]) if data["type"] == "resize"
+        rescue JSON::ParserError
+          terminal.write(msg)
+        end
+
+        def start_http_server
+          reader = @reader
+          ws_port = @ws_port
+
+          http = WEBrick::HTTPServer.new(
+            Port: @port,
+            Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN),
+            AccessLog: []
+          )
+
+          http.mount_proc("/") do |req, res|
+            route_request(req, res, reader, ws_port)
+          end
+
+          trap("INT") { http.shutdown }
+
+          Thread.new do
+            sleep 0.5
+            open_browser("http://localhost:#{@port}")
+          end
+
+          puts "Hecks IDE: http://localhost:#{@port}"
+          puts "Terminal WS: ws://localhost:#{ws_port}"
+          http.start
+        end
+
+        def route_request(req, res, reader, ws_port)
+          case [req.request_method, req.path]
+          when ["GET", "/"]
+            res.content_type = "text/html"
+            html = File.read(File.join(VIEWS_DIR, "ide.html"))
+            res.body = html.gsub("{{WS_PORT}}", ws_port.to_s)
+          when ["GET", "/files"]
+            res.content_type = "application/json"
+            res["Cache-Control"] = "no-cache, no-store"
+            res.body = JSON.generate(files: reader.files)
+          else
+            res.status = 404
+            res.body = "Not found"
+          end
+        end
+
+        def open_browser(url)
+          system("open #{url} 2>/dev/null") ||
+            system("xdg-open #{url} 2>/dev/null")
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/ide/terminal.rb
+++ b/hecks_ai/lib/hecks_ai/ide/terminal.rb
@@ -1,0 +1,60 @@
+# Hecks::AI::IDE::Terminal
+#
+# Wraps a PTY-spawned process for bidirectional I/O. Spawns the given
+# command in a pseudo-terminal and provides read/write/resize methods
+# for bridging to a WebSocket.
+#
+#   term = Terminal.new("claude --dangerously-skip-permissions")
+#   term.write("hello\n")
+#   output = term.read  # => ANSI-encoded terminal output
+#   term.resize(120, 40)
+#
+require "pty"
+
+module Hecks
+  module AI
+    module IDE
+      class Terminal
+        attr_reader :pid
+
+        def initialize(command, cols: 120, rows: 40)
+          @master, _slave, @pid = PTY.spawn(
+            { "TERM" => "xterm-256color" }, command
+          )
+          @master.winsize = [rows, cols]
+        end
+
+        def read
+          return nil unless IO.select([@master], nil, nil, 0.05)
+          data = @master.read_nonblock(16_384)
+          data.force_encoding("UTF-8")
+          data.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+        rescue IO::WaitReadable
+          nil
+        rescue EOFError, Errno::EIO
+          nil
+        end
+
+        def write(data)
+          @master.write(data)
+        end
+
+        def resize(cols, rows)
+          @master.winsize = [rows, cols]
+          Process.kill(:WINCH, @pid) rescue nil
+        end
+
+        def alive?
+          Process.waitpid(@pid, Process::WNOHANG).nil?
+        rescue Errno::ECHILD, PTY::ChildExited
+          false
+        end
+
+        def close
+          @master.close rescue nil
+          Process.kill(:TERM, @pid) rescue nil
+        end
+      end
+    end
+  end
+end

--- a/hecks_ai/lib/hecks_ai/ide/views/ide.html
+++ b/hecks_ai/lib/hecks_ai/ide/views/ide.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hecks IDE</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; background: #0d1117; overflow: hidden; }
+
+    .container { display: flex; height: 100vh; }
+
+    .terminal-pane { flex: 1; padding: 4px; }
+    #terminal { height: 100%; }
+
+    .context-pane {
+      width: 280px;
+      border-left: 1px solid #30363d;
+      padding: 12px;
+      overflow-y: auto;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 13px;
+      line-height: 1.6;
+      color: #c9d1d9;
+    }
+
+    .ctx-header {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding-left: 8px;
+      border-left: 2px solid #58a6ff;
+      color: #58a6ff;
+      margin-bottom: 8px;
+    }
+
+    .ctx-divider {
+      border: none;
+      border-top: 1px solid #30363d;
+      margin-bottom: 8px;
+    }
+
+    .file-list { list-style: none; }
+
+    .file-item {
+      padding: 3px 8px;
+      border-radius: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      transition: background 0.15s;
+    }
+
+    .file-item:hover { background: #161b22; }
+    .file-item .dir  { color: #8b949e; }
+    .file-item .name { font-weight: 500; }
+
+    .ext-rb .name   { color: #f85149; }
+    .ext-js .name   { color: #d29922; }
+    .ext-md .name   { color: #58a6ff; }
+    .ext-yml .name,
+    .ext-yaml .name { color: #bc8cff; }
+    .ext-sh .name   { color: #7ee787; }
+    .ext-erb .name  { color: #79c0ff; }
+    .ext-html .name { color: #f0883e; }
+    .ext-go .name   { color: #79c0ff; }
+    .ext-json .name { color: #d2a8ff; }
+
+    .ctx-footer {
+      margin-top: 12px;
+      padding-top: 8px;
+      border-top: 1px solid #30363d;
+      font-size: 11px;
+      color: #8b949e;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .ctx-empty {
+      color: #8b949e;
+      padding: 8px;
+      font-style: italic;
+    }
+
+    .dot {
+      display: inline-block;
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: #7ee787;
+      margin-right: 6px;
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="terminal-pane">
+      <div id="terminal"></div>
+    </div>
+    <div class="context-pane">
+      <div class="ctx-header">Context Files</div>
+      <hr class="ctx-divider">
+      <ul class="file-list" id="file-list"></ul>
+      <div class="ctx-footer">
+        <span id="count">0 files</span>
+        <span><span class="dot"></span>live</span>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
+  <script>
+    /* ── Terminal ─────────────────────────────────────── */
+    const term = new Terminal({
+      theme: { background: '#0d1117', foreground: '#c9d1d9', cursor: '#58a6ff' },
+      fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
+      fontSize: 14,
+      cursorBlink: true,
+      convertEol: false
+    });
+
+    const fitAddon = new FitAddon.FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(document.getElementById('terminal'));
+    fitAddon.fit();
+
+    const ws = new WebSocket('ws://localhost:{{WS_PORT}}');
+    ws.binaryType = 'arraybuffer';
+
+    ws.onopen = () => {
+      sendResize();
+      term.focus();
+    };
+
+    ws.onmessage = (e) => {
+      const data = typeof e.data === 'string' ? e.data : new Uint8Array(e.data);
+      term.write(data);
+    };
+
+    ws.onclose = () => term.write('\r\n\x1b[31m[Connection closed]\x1b[0m\r\n');
+
+    term.onData((data) => { if (ws.readyState === 1) ws.send(data); });
+
+    function sendResize() {
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+      }
+    }
+
+    let resizeTimeout;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => { fitAddon.fit(); sendResize(); }, 100);
+    });
+
+    /* ── Context Panel ───────────────────────────────── */
+    const listEl  = document.getElementById('file-list');
+    const countEl = document.getElementById('count');
+    let lastJson  = '';
+
+    function extClass(fp) {
+      const d = fp.lastIndexOf('.');
+      return d === -1 ? '' : 'ext-' + fp.slice(d + 1).toLowerCase();
+    }
+
+    function splitPath(fp) {
+      const s = fp.lastIndexOf('/');
+      return s === -1 ? { dir: '', name: fp } : { dir: fp.slice(0, s + 1), name: fp.slice(s + 1) };
+    }
+
+    function renderFiles(files) {
+      if (!files.length) {
+        listEl.innerHTML = '<li class="ctx-empty">No files in context yet.</li>';
+        countEl.textContent = '0 files';
+        return;
+      }
+      listEl.innerHTML = files.map(f => {
+        const { dir, name } = splitPath(f);
+        return `<li class="file-item ${extClass(f)}"><span class="dir">${dir}</span><span class="name">${name}</span></li>`;
+      }).join('');
+      countEl.textContent = `${files.length} file${files.length === 1 ? '' : 's'}`;
+    }
+
+    async function pollFiles() {
+      try {
+        const res = await fetch('/files');
+        const text = await res.text();
+        if (text !== lastJson) { lastJson = text; renderFiles(JSON.parse(text).files); }
+      } catch (e) { /* server down, keep trying */ }
+    }
+
+    pollFiles();
+    setInterval(pollFiles, 2000);
+  </script>
+</body>
+</html>

--- a/hecks_ai/lib/hecks_ai/ide/websocket.rb
+++ b/hecks_ai/lib/hecks_ai/ide/websocket.rb
@@ -1,0 +1,116 @@
+# Hecks::AI::IDE::WebSocket
+#
+# Minimal WebSocket server implementation over a raw TCPServer.
+# Handles the HTTP upgrade handshake and frame encode/decode for
+# bidirectional terminal streaming. No gem dependencies.
+#
+#   server = TCPServer.new('127.0.0.1', 3002)
+#   ws = WebSocket.accept(server)  # blocks until a client connects
+#   ws.write("hello")
+#   data = ws.read                 # => "hello back"
+#
+require "socket"
+require "digest/sha1"
+require "base64"
+
+module Hecks
+  module AI
+    module IDE
+      class WebSocket
+        MAGIC = "258EAFA5-E914-47DA-95CA-5AB5DC65C3A7"
+
+        def initialize(socket)
+          @socket = socket
+          @write_mutex = Mutex.new
+        end
+
+        def self.accept(tcp_server)
+          client = tcp_server.accept
+          request = ""
+          while (line = client.gets) && line.strip != ""
+            request << line
+          end
+
+          key = request[/Sec-WebSocket-Key: (.+)\r\n/, 1]&.strip
+          unless key
+            client.close
+            return nil
+          end
+
+          accept_key = Base64.strict_encode64(
+            Digest::SHA1.digest(key + MAGIC)
+          )
+
+          client.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" \
+            "Upgrade: websocket\r\n" \
+            "Connection: Upgrade\r\n" \
+            "Sec-WebSocket-Accept: #{accept_key}\r\n" \
+            "\r\n"
+          )
+
+          new(client)
+        end
+
+        def read
+          first_byte = @socket.getbyte
+          return nil unless first_byte
+
+          opcode = first_byte & 0x0f
+          return :close if opcode == 8
+          return :ping  if opcode == 9
+
+          second_byte = @socket.getbyte
+          masked = (second_byte & 0x80) != 0
+          length = second_byte & 0x7f
+
+          length = @socket.read(2).unpack1("n")  if length == 126
+          length = @socket.read(8).unpack1("Q>") if length == 127
+
+          mask_key = masked ? @socket.read(4).bytes : nil
+          payload = length > 0 ? @socket.read(length) : ""
+
+          if masked && payload
+            payload = payload.bytes.each_with_index.map { |b, i|
+              b ^ mask_key[i % 4]
+            }.pack("C*")
+          end
+
+          payload.force_encoding("UTF-8")
+        rescue EOFError, Errno::ECONNRESET, IOError
+          nil
+        end
+
+        def write(data)
+          @write_mutex.synchronize do
+            bytes = data.bytes
+            frame = [0x81]
+
+            if bytes.length < 126
+              frame << bytes.length
+            elsif bytes.length < 65_536
+              frame << 126
+              frame += [bytes.length].pack("n").bytes
+            else
+              frame << 127
+              frame += [bytes.length].pack("Q>").bytes
+            end
+
+            @socket.write(frame.pack("C*") + bytes.pack("C*"))
+            @socket.flush
+          end
+        rescue Errno::EPIPE, Errno::ECONNRESET, IOError
+          nil
+        end
+
+        def close
+          @socket.close rescue nil
+        end
+
+        def closed?
+          @socket.closed?
+        end
+      end
+    end
+  end
+end

--- a/hecks_workshop/lib/hecks/workshop/playground.rb
+++ b/hecks_workshop/lib/hecks/workshop/playground.rb
@@ -183,6 +183,7 @@ module Hecks
       end
 
       @runtime = Runtime.new(@domain, event_bus: bus)
+      @runtime.capability(:crud)
     end
   end
   end

--- a/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
@@ -19,6 +19,8 @@ module Hecksagon
         @extensions = []
         @subscriptions = []
         @tenancy = nil
+        @capabilities = []
+        @aggregate_capabilities = {}
       end
 
       # Declare a gate (access control) for an aggregate + role.
@@ -59,6 +61,32 @@ module Hecksagon
         @subscriptions << domain_name.to_s
       end
 
+      # Declare domain-wide capabilities.
+      #
+      #   capabilities :crud, :audit
+      #
+      # @param names [Array<Symbol>] capability names
+      # @return [void]
+      def capabilities(*names)
+        @capabilities.concat(names.map(&:to_sym))
+      end
+
+      # Declare per-aggregate capabilities via a block. The block
+      # receives an AggregateCapabilityBuilder for fluent tagging.
+      #
+      #   aggregate "Pizza" do
+      #     capability.email.pii
+      #   end
+      #
+      # @param name [String] the aggregate name (must exist in domain)
+      # @yield block evaluated in AggregateCapabilityBuilder context
+      # @return [void]
+      def aggregate(name, &block)
+        builder = AggregateCapabilityBuilder.new(name)
+        builder.instance_eval(&block) if block
+        @aggregate_capabilities[name.to_s] = builder.tags
+      end
+
       # Set the multi-tenancy strategy.
       #
       # @param strategy [Symbol] tenancy strategy (:row, :schema, etc.)
@@ -77,8 +105,62 @@ module Hecksagon
           adapter: @adapter,
           extensions: @extensions,
           subscriptions: @subscriptions,
-          tenancy: @tenancy
+          tenancy: @tenancy,
+          capabilities: @capabilities,
+          aggregate_capabilities: @aggregate_capabilities
         )
+      end
+    end
+
+    # Fluent builder for per-aggregate capability tags.
+    #
+    #   builder = AggregateCapabilityBuilder.new("Pizza")
+    #   builder.capability.email.pii
+    #   builder.tags  # => [{ attribute: "email", tag: :pii }]
+    #
+    class AggregateCapabilityBuilder
+      attr_reader :tags
+
+      def initialize(aggregate_name)
+        @aggregate_name = aggregate_name
+        @tags = []
+      end
+
+      # Start a capability chain. Returns an AttributeSelector.
+      #
+      #   capability.email.pii
+      #
+      # @return [AttributeSelector]
+      def capability
+        AttributeSelector.new(@tags)
+      end
+
+      # Fluent attribute selector for capability tagging.
+      class AttributeSelector
+        def initialize(tags)
+          @tags = tags
+        end
+
+        def method_missing(attr_name, *args)
+          TagApplier.new(@tags, attr_name.to_s)
+        end
+
+        def respond_to_missing?(_, _ = false) = true
+      end
+
+      # Applies a tag to the selected attribute.
+      class TagApplier
+        def initialize(tags, attribute)
+          @tags = tags
+          @attribute = attribute
+        end
+
+        def method_missing(tag_name, *args)
+          @tags << { attribute: @attribute, tag: tag_name.to_sym }
+          self
+        end
+
+        def respond_to_missing?(_, _ = false) = true
       end
     end
   end

--- a/hecksagon/lib/hecksagon/structure/hecksagon.rb
+++ b/hecksagon/lib/hecksagon/structure/hecksagon.rb
@@ -19,15 +19,19 @@ module Hecksagon
     #   )
     #
     class Hecksagon
-      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy
+      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy,
+                  :capabilities, :aggregate_capabilities
 
-      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [], tenancy: nil)
+      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [],
+                     tenancy: nil, capabilities: [], aggregate_capabilities: {})
         @name = name
         @gates = gates
         @adapter = adapter
         @extensions = extensions
         @subscriptions = subscriptions
         @tenancy = tenancy
+        @capabilities = capabilities
+        @aggregate_capabilities = aggregate_capabilities
       end
 
       # Returns gates for a specific aggregate.

--- a/hecksagon/spec/dsl/hecksagon_capabilities_spec.rb
+++ b/hecksagon/spec/dsl/hecksagon_capabilities_spec.rb
@@ -1,0 +1,77 @@
+# Hecksagon DSL capabilities spec
+#
+# Tests the capabilities keyword and aggregate-level capability
+# tagging in the Hecksagon DSL.
+#
+require "spec_helper"
+
+RSpec.describe "Hecksagon DSL capabilities" do
+  describe "domain-wide capabilities" do
+    it "stores capabilities on the IR" do
+      hex = Hecks.hecksagon do
+        capabilities :crud, :audit
+      end
+
+      expect(hex.capabilities).to eq([:crud, :audit])
+    end
+  end
+
+  describe "aggregate capability tags" do
+    it "stores attribute-level tags via fluent chain" do
+      hex = Hecks.hecksagon do
+        aggregate "Customer" do
+          capability.email.pii
+          capability.ssn.pii
+        end
+      end
+
+      tags = hex.aggregate_capabilities["Customer"]
+      expect(tags).to include({ attribute: "email", tag: :pii })
+      expect(tags).to include({ attribute: "ssn", tag: :pii })
+    end
+
+    it "supports multiple tags on different aggregates" do
+      hex = Hecks.hecksagon do
+        capabilities :crud
+
+        aggregate "Customer" do
+          capability.email.pii
+        end
+
+        aggregate "Order" do
+          capability.total.audit
+        end
+      end
+
+      expect(hex.capabilities).to eq([:crud])
+      expect(hex.aggregate_capabilities["Customer"]).to eq([{ attribute: "email", tag: :pii }])
+      expect(hex.aggregate_capabilities["Order"]).to eq([{ attribute: "total", tag: :audit }])
+    end
+  end
+
+  describe "wired into boot" do
+    it "applies domain-wide capabilities at boot" do
+      domain = Hecks.domain "CapTest" do
+        aggregate "Widget" do
+          attribute :name, String
+          command "CreateWidget" do
+            attribute :name, String
+          end
+        end
+      end
+
+      hex = Hecks.hecksagon do
+        capabilities :crud
+      end
+
+      runtime = Hecks.load(domain, hecksagon: hex)
+      widget_class = Object.const_get("CapTestDomain::Widget")
+
+      expect(widget_class).to respond_to(:find)
+      expect(widget_class).to respond_to(:all)
+    ensure
+      Hecks.last_hecksagon = nil
+      Object.send(:remove_const, :CapTestDomain) if defined?(CapTestDomain)
+    end
+  end
+end

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -14,6 +14,7 @@ require_relative "hecks/set_registry"
 require_relative "hecks/module_dsl"
 require_relative "hecks/core_extensions"
 require_relative "hecks/registries/extension_registry"
+require_relative "hecks/registries/capability_registry"
 require_relative "hecks/registries/domain_registry"
 require_relative "hecks/registries/cross_domain"
 require_relative "hecks/registries/thread_context"
@@ -49,6 +50,7 @@ module Hecks
   extend DomainVisualizerMethods
   extend Boot
   extend ExtensionRegistryMethods
+  extend CapabilityRegistryMethods
   extend DomainRegistryMethods
   extend CrossDomainMethods
   extend ThreadContextMethods

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -36,7 +36,7 @@ module Hecks
 
           agg.commands.concat(new_commands)
           agg.events.concat(new_events)
-          load_command_classes(agg, new_commands, new_events, mod_name)
+          CommandLoader.load(agg, new_commands, new_events, mod_name)
           rewire_aggregate(runtime, agg, mod)
         end
       end
@@ -119,64 +119,8 @@ module Hecks
         )
       end
 
-      # Generate and eval Ruby command classes for the new stubs.
-      #
-      # @param agg [Structure::Aggregate] the aggregate
-      # @param commands [Array<Behavior::Command>] new commands
-      # @param events [Array<Behavior::DomainEvent>] corresponding events
-      # @param mod_name [String] the domain module name
-      # @return [void]
-      def self.load_command_classes(agg, commands, events, mod_name)
-        commands.each_with_index do |cmd, i|
-          event = events[i]
-          event_source = Generators::Domain::EventGenerator.new(
-            event, domain_module: mod_name, aggregate_name: agg.name
-          ).generate
-          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
-
-          source = if cmd.name.start_with?("Delete")
-            delete_command_source(cmd, event, agg, mod_name)
-          else
-            Generators::Domain::CommandGenerator.new(
-              cmd, domain_module: mod_name, aggregate_name: agg.name,
-              aggregate: agg, event: event
-            ).generate
-          end
-          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
-        end
-      end
-
-      # Generate source for a delete command that removes from the repository.
-      #
-      # @return [String] Ruby source code
-      def self.delete_command_source(cmd, event, agg, mod_name)
-        ref_name = cmd.references.first.name
-        <<~RUBY
-          module #{mod_name}
-            class #{agg.name}
-              module Commands
-                class #{cmd.name}
-                  include Hecks::Command
-                  emits "#{event.name}"
-                  attr_reader :#{ref_name}
-                  def initialize(#{ref_name}: nil)
-                    @#{ref_name} = #{ref_name}
-                  end
-                  def call
-                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
-                    existing = repository.find(_id)
-                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
-                    repository.delete(_id)
-                    existing
-                  end
-                  private
-                  def persist_aggregate; end # already deleted in call
-                end
-              end
-            end
-          end
-        RUBY
-      end
+      # Load is delegated to CommandLoader (extracted for file size).
+      require_relative "crud/command_loader"
 
       # Re-wire command and persistence ports after injecting new commands.
       #

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -1,0 +1,210 @@
+# Hecks::Capabilities::Crud
+#
+# CRUD capability for the hecksagon. Generates Create, Read, Update, and
+# Delete command stubs for each aggregate, skipping any command whose name
+# the user already defined. Also binds repository methods (.find, .all,
+# .create, .update, .delete, .count, .first, .last) via Persistence.
+#
+# Applied via:
+#   runtime.capability(:crud)
+#
+# User-defined commands always take precedence -- if a "CreatePizza" already
+# exists in the Bluebook, the capability will not generate a duplicate.
+#
+module Hecks
+  module Capabilities
+    module Crud
+      extend HecksTemplating::NamingHelpers
+      Structure = DomainModel::Structure
+      Behavior  = DomainModel::Behavior
+
+      CRUD_PREFIXES = %w[Create Read Update Delete].freeze
+
+      # Apply CRUD to all aggregates in the runtime's domain.
+      #
+      # @param runtime [Hecks::Runtime] the booted runtime
+      # @return [void]
+      def self.apply(runtime)
+        domain = runtime.domain
+        mod_name = HecksTemplating::NamingHelpers.instance_method(:domain_module_name)
+          .bind_call(self, domain.name)
+        mod = Object.const_get(mod_name)
+
+        domain.aggregates.each do |agg|
+          new_commands, new_events = generate_stubs(agg)
+          next if new_commands.empty?
+
+          agg.commands.concat(new_commands)
+          agg.events.concat(new_events)
+          load_command_classes(agg, new_commands, new_events, mod_name)
+          rewire_aggregate(runtime, agg, mod)
+        end
+      end
+
+      # Build CRUD command + event IR objects for missing verbs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate to enrich
+      # @return [Array<Array>] [new_commands, new_events]
+      def self.generate_stubs(agg)
+        existing = agg.commands.map(&:name).to_set
+        commands = []
+        events   = []
+
+        CRUD_PREFIXES.each do |verb|
+          cmd_name = "#{verb}#{agg.name}"
+          next if existing.include?(cmd_name)
+          next if verb == "Read" # Read is handled by repository, not a command
+
+          cmd_attrs, cmd_refs = attrs_for(verb, agg)
+          cmd = Behavior::Command.new(name: cmd_name, attributes: cmd_attrs, references: cmd_refs)
+          event = build_event(cmd, agg)
+          commands << cmd
+          events << event
+        end
+
+        [commands, events]
+      end
+
+      # Determine attributes and references for a generated CRUD command.
+      #
+      # @param verb [String] "Create", "Update", or "Delete"
+      # @param agg [Structure::Aggregate] the aggregate
+      # @return [Array] [attributes, references]
+      def self.attrs_for(verb, agg)
+        case verb
+        when "Create"
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, []]
+        when "Update"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
+            Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
+          end
+          [attrs, [ref]]
+        when "Delete"
+          snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
+            .bind_call(self, agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          [[], [ref]]
+        else
+          [[], []]
+        end
+      end
+
+      # Build a domain event from a command, mirroring AggregateBuilder's inference.
+      #
+      # @param cmd [Behavior::Command] the command
+      # @param agg [Structure::Aggregate] the parent aggregate
+      # @return [Behavior::DomainEvent]
+      def self.build_event(cmd, agg)
+        aggregate_id_attr = Structure::Attribute.new(name: :aggregate_id, type: String)
+        event_attrs = [aggregate_id_attr] + cmd.attributes.dup
+        agg.attributes.each do |aa|
+          next if event_attrs.any? { |ea| ea.name == aa.name }
+          event_attrs << aa
+        end
+        event_refs = cmd.references.dup
+        agg.references.each do |ar|
+          next if event_refs.any? { |er| er.name == ar.name }
+          event_refs << ar
+        end
+        Behavior::DomainEvent.new(
+          name: cmd.event_names.first,
+          attributes: event_attrs,
+          references: event_refs
+        )
+      end
+
+      # Generate and eval Ruby command classes for the new stubs.
+      #
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param commands [Array<Behavior::Command>] new commands
+      # @param events [Array<Behavior::DomainEvent>] corresponding events
+      # @param mod_name [String] the domain module name
+      # @return [void]
+      def self.load_command_classes(agg, commands, events, mod_name)
+        commands.each_with_index do |cmd, i|
+          event = events[i]
+          event_source = Generators::Domain::EventGenerator.new(
+            event, domain_module: mod_name, aggregate_name: agg.name
+          ).generate
+          RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+          source = if cmd.name.start_with?("Delete")
+            delete_command_source(cmd, event, agg, mod_name)
+          else
+            Generators::Domain::CommandGenerator.new(
+              cmd, domain_module: mod_name, aggregate_name: agg.name,
+              aggregate: agg, event: event
+            ).generate
+          end
+          RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+        end
+      end
+
+      # Generate source for a delete command that removes from the repository.
+      #
+      # @return [String] Ruby source code
+      def self.delete_command_source(cmd, event, agg, mod_name)
+        ref_name = cmd.references.first.name
+        <<~RUBY
+          module #{mod_name}
+            class #{agg.name}
+              module Commands
+                class #{cmd.name}
+                  include Hecks::Command
+                  emits "#{event.name}"
+                  attr_reader :#{ref_name}
+                  def initialize(#{ref_name}: nil)
+                    @#{ref_name} = #{ref_name}
+                  end
+                  def call
+                    _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                    existing = repository.find(_id)
+                    raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                    repository.delete(_id)
+                    existing
+                  end
+                  private
+                  def persist_aggregate; end # already deleted in call
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      # Re-wire command and persistence ports after injecting new commands.
+      #
+      # @param runtime [Hecks::Runtime] the runtime
+      # @param agg [Structure::Aggregate] the aggregate
+      # @param mod [Module] the domain module
+      # @return [void]
+      def self.rewire_aggregate(runtime, agg, mod)
+        agg_class = mod.const_get(
+          HecksTemplating::NamingHelpers.instance_method(:domain_constant_name)
+            .bind_call(self, agg.name)
+        )
+        repo = runtime[agg.name]
+        bus = runtime.command_bus
+
+        defaults = agg.attributes.each_with_object({}) do |attr, h|
+          h[attr.name] = attr.list? ? [] : nil
+        end
+
+        Commands.bind(agg_class, agg, bus, repo, defaults)
+      end
+
+      def self.reserved?(name)
+        Hecks::Utils::RESERVED_AGGREGATE_ATTRS.include?(name.to_s)
+      end
+      private_class_method :reserved?
+    end
+  end
+end
+
+Hecks.register_capability(:crud) { |runtime| Hecks::Capabilities::Crud.apply(runtime) }

--- a/hecksties/lib/hecks/capabilities/crud.rb
+++ b/hecksties/lib/hecks/capabilities/crud.rb
@@ -80,7 +80,7 @@ module Hecks
         when "Update"
           snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
             .bind_call(self, agg.name)
-          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name, validate: :exists)
           attrs = agg.attributes.reject { |a| reserved?(a.name) }.map do |a|
             Structure::Attribute.new(name: a.name, type: a.type, list: a.list?)
           end
@@ -88,7 +88,7 @@ module Hecks
         when "Delete"
           snake = HecksTemplating::NamingHelpers.instance_method(:domain_snake_name)
             .bind_call(self, agg.name)
-          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name)
+          ref = Structure::Reference.new(name: snake.to_sym, type: agg.name, validate: :exists)
           [[], [ref]]
         else
           [[], []]

--- a/hecksties/lib/hecks/capabilities/crud/command_loader.rb
+++ b/hecksties/lib/hecks/capabilities/crud/command_loader.rb
@@ -1,0 +1,74 @@
+# Hecks::Capabilities::Crud::CommandLoader
+#
+# Generates and evaluates Ruby command and event classes for CRUD stubs.
+# Extracted from the CRUD capability to keep each file under 200 lines.
+#
+#   Hecks::Capabilities::Crud::CommandLoader.load(agg, commands, events, mod_name)
+#
+module Hecks
+  module Capabilities
+    module Crud
+      module CommandLoader
+        # Generate and eval Ruby command classes for the new stubs.
+        #
+        # @param agg [DomainModel::Structure::Aggregate] the aggregate
+        # @param commands [Array<DomainModel::Behavior::Command>] new commands
+        # @param events [Array<DomainModel::Behavior::DomainEvent>] corresponding events
+        # @param mod_name [String] the domain module name
+        # @return [void]
+        def self.load(agg, commands, events, mod_name)
+          commands.each_with_index do |cmd, i|
+            event = events[i]
+            event_source = Generators::Domain::EventGenerator.new(
+              event, domain_module: mod_name, aggregate_name: agg.name
+            ).generate
+            RubyVM::InstructionSequence.compile(event_source, "crud_event_#{cmd.name}").eval
+
+            source = if cmd.name.start_with?("Delete")
+              delete_command_source(cmd, event, agg, mod_name)
+            else
+              Generators::Domain::CommandGenerator.new(
+                cmd, domain_module: mod_name, aggregate_name: agg.name,
+                aggregate: agg, event: event
+              ).generate
+            end
+            RubyVM::InstructionSequence.compile(source, "crud_cmd_#{cmd.name}").eval
+          end
+        end
+
+        # Generate source for a delete command that removes from the repository.
+        #
+        # @return [String] Ruby source code
+        def self.delete_command_source(cmd, event, agg, mod_name)
+          ref_name = cmd.references.first.name
+          <<~RUBY
+            module #{mod_name}
+              class #{agg.name}
+                module Commands
+                  class #{cmd.name}
+                    include Hecks::Command
+                    emits "#{event.name}"
+                    attr_reader :#{ref_name}
+                    def initialize(#{ref_name}: nil)
+                      @#{ref_name} = #{ref_name}
+                    end
+                    def call
+                      _id = #{ref_name}.respond_to?(:id) ? #{ref_name}.id : #{ref_name}
+                      existing = repository.find(_id)
+                      raise #{mod_name}::Error, "#{agg.name} not found: \#{_id}" unless existing
+                      repository.delete(_id)
+                      existing
+                    end
+                    private
+                    def persist_aggregate; end # already deleted in call
+                  end
+                end
+              end
+            end
+          RUBY
+        end
+        private_class_method :delete_command_source
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/registries/capability_registry.rb
+++ b/hecksties/lib/hecks/registries/capability_registry.rb
@@ -1,0 +1,21 @@
+# Hecks::CapabilityRegistryMethods
+#
+# Registry for domain capabilities. Capabilities enrich the domain IR by
+# generating constructs (commands, repository bindings) at runtime. Unlike
+# extensions which add infrastructure behavior, capabilities modify what
+# the domain can do.
+#
+#   Hecks.register_capability(:crud) { |runtime| CrudCapability.apply(runtime) }
+#   Hecks.capability_registry  # => { crud: #<Proc> }
+#
+module Hecks
+  module CapabilityRegistryMethods
+    def capability_registry
+      @capability_registry ||= Registry.new
+    end
+
+    def register_capability(name, &hook)
+      capability_registry.register(name, hook)
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -13,318 +13,92 @@ require_relative "runtime/connection_setup"
 require_relative "runtime/service_setup"
 require_relative "runtime/auth_coverage_check"
 require_relative "runtime/reference_authorizer_check"
+require_relative "runtime/extension_dispatch"
+require_relative "runtime/configuration_dsl"
+require_relative "runtime/command_dispatch"
 
 module Hecks
   # Hecks::Runtime
   #
   # The runtime container that wires a domain to adapters, dispatches
-  # commands, publishes events, and executes policies. Defaults to memory
-  # adapters for all aggregates. Created via Hecks.load(domain).
+  # commands, publishes events, and executes policies. Created via
+  # Hecks.boot or Hecks.load.
   #
-  #   app = Hecks.load(domain)
+  #   app = Hecks.boot(__dir__)
   #   app["Pizza"].all
   #   Pizza.create(name: "Margherita")
   #
-  # Custom adapters:
-  #   app = Hecks.load(domain) do
-  #     adapter "Pizza", my_sql_repo
-  #   end
-  #
-  # The central runtime container for a Hecks domain. Orchestrates the full
-  # lifecycle of a domain application: wiring repositories to aggregates,
-  # setting up the command bus with middleware, registering event-driven
-  # policies and subscribers, hoisting aggregate constants to top-level,
-  # and establishing cross-domain connections.
-  #
-  # Runtime is the object returned by +Hecks.boot+ and +Hecks.load+.
-  # It holds all repositories, the event bus, and the command bus for a
-  # single domain. In multi-domain setups, each domain gets its own Runtime
-  # instance, potentially sharing a filtered event bus.
-  #
-  # Includes several setup mixins that each handle one aspect of wiring:
-  # - PortSetup -- wires aggregate ports (command methods, query methods, repository methods)
-  # - RepositorySetup -- creates memory-backed repositories for each aggregate
-  # - PolicySetup -- registers event-triggered policies on the event bus
-  # - SubscriberSetup -- registers event subscribers defined in the DSL
-  # - ViewSetup -- sets up read-model views
-  # - WorkflowSetup -- wires multi-step workflow definitions
-  # - ConstantHoisting -- promotes aggregate classes to top-level constants
-  # - ConnectionSetup -- wires cross-domain event connections (listens_to/sends_to)
   class Runtime
     include HecksTemplating::NamingHelpers
-      include PortSetup
-      include RepositorySetup
-      include PolicySetup
-      include SubscriberSetup
-      include ViewSetup
-      include WorkflowSetup
-      include ConstantHoisting
-      include ConnectionSetup
-      include AuthCoverageCheck
-      include ReferenceCoverageCheck
-      include SagaSetup
+    include PortSetup
+    include RepositorySetup
+    include PolicySetup
+    include SubscriberSetup
+    include ViewSetup
+    include WorkflowSetup
+    include ConstantHoisting
+    include ConnectionSetup
+    include AuthCoverageCheck
+    include ReferenceCoverageCheck
+    include SagaSetup
+    include ExtensionDispatch
+    include ConfigurationDSL
+    include CommandDispatch
 
-      # @return [Hecks::DomainModel::Structure::Domain] the domain IR object this runtime is wired to
-      attr_reader :domain
+    attr_reader :domain, :event_bus, :command_bus
 
-      # @return [Hecks::EventBus] the event bus used for publishing and subscribing to domain events
-      attr_reader :event_bus
+    # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+    # @param gate [Symbol, nil] optional gate name
+    # @param event_bus [Hecks::EventBus, nil] optional shared event bus
+    # @param hecksagon [Hecksagon::Structure::Hecksagon, nil] optional hecksagon IR
+    # @yield optional configuration block
+    # @return [Hecks::Runtime]
+    def initialize(domain, gate: nil, event_bus: nil, hecksagon: nil, &config)
+      @domain = domain
+      @gate_name = gate
+      @hecksagon = hecksagon || Hecks.last_hecksagon
+      @mod_name = domain_module_name(domain.name)
+      @mod = Object.const_get(@mod_name)
+      @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
+      @event_bus = event_bus || EventBus.new
+      @repositories = {}
+      @adapter_overrides = {}
+      @runtime_options = {}
+      @async_handler = nil
 
-      # @return [Hecks::Commands::CommandBus] the command bus that dispatches commands through middleware
-      attr_reader :command_bus
+      instance_eval(&config) if config
 
-      # Boots the runtime: wires repositories, policies, subscribers, and the command bus.
-      # Evaluates an optional configuration block in the context of the runtime instance,
-      # allowing adapter overrides and middleware registration before wiring completes.
-      #
-      # @param domain [Hecks::DomainModel::Structure::Domain] the compiled domain IR object
-      # @param port [Symbol, nil] optional port name (reserved for future use)
-      # @param event_bus [Hecks::EventBus, nil] optional shared event bus; creates a new one if nil
-      # @yield optional configuration block evaluated in the runtime's instance context
-      # @return [Hecks::Runtime]
-      def initialize(domain, gate: nil, event_bus: nil, hecksagon: nil, &config)
-        @domain = domain
-        @gate_name = gate
-        @hecksagon = hecksagon || Hecks.last_hecksagon
-        @mod_name = domain_module_name(domain.name)
-        @mod = Object.const_get(@mod_name)
-        @mod.extend(Hecks::DomainConnections) unless @mod.respond_to?(:connections)
-        @event_bus = event_bus || EventBus.new
-        @repositories = {}
-        @adapter_overrides = {}
-        @runtime_options = {}
-        @async_handler = nil
-        @runtime_options = {}
-
-        instance_eval(&config) if config
-
-        setup_repositories
-        setup_command_bus
-        setup_policies
-        setup_subscribers
-        setup_views
-        setup_connections
-        wire_ports!
-        ServiceSetup.bind(@domain, @mod, @command_bus)
-        setup_workflows
-        setup_sagas
-        hoist_constants
-        apply_hecksagon_capabilities
-      end
-
-      # Register command bus middleware. Middleware wraps every command dispatch,
-      # allowing cross-cutting concerns like logging, authorization, or auditing.
-      #
-      # @param name [Symbol, String, nil] optional middleware name for identification
-      # @yield block that receives the command and a +next_middleware+ callable
-      # @return [void]
-      def use(name = nil, &block)
-        @command_bus.use(name, &block)
-      end
-
-      # Configuration DSL: override the default memory adapter for a specific aggregate
-      # with a custom repository object (e.g., SQL-backed repository).
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @param adapter_obj [Object] a repository object that responds to CRUD methods
-      # @return [void]
-      def adapter(aggregate_name, adapter_obj)
-        @adapter_overrides[aggregate_name.to_s] = adapter_obj
-      end
-
-      # Configuration DSL: enable an infrastructure option for a specific aggregate.
-      # Used to configure cross-cutting concerns like versioning and attachments
-      # that were previously baked into the domain IR.
-      #
-      #   app = Hecks.load(domain) do
-      #     enable "Document", :versioned
-      #     enable "Document", :attachable
-      #   end
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name
-      # @param option [Symbol] the option to enable (e.g., :versioned, :attachable)
-      # @return [void]
-      def enable(aggregate_name, option)
-        name = aggregate_name.to_s
-        @runtime_options[name] ||= {}
-        @runtime_options[name][option] = true
-      end
-
-      # Retrieve the repository for a named aggregate.
-      #
-      # @param name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @return [Object] the repository (memory adapter or custom adapter) for the aggregate
-      def [](name)
-        @repositories[name.to_s]
-      end
-
-      # Execute a command through the command bus, passing it through all registered
-      # middleware before reaching the command runner.
-      #
-      # @param command_name [String, Symbol] the fully qualified command name (e.g., "CreatePizza")
-      # @param attrs [Hash] the command attributes/parameters
-      # @return [Object] the result of the command execution (typically the affected entity)
-      def run(command_name, **attrs)
-        @command_bus.dispatch(command_name, **attrs)
-      end
-
-      # Preview what a command would do without persisting, emitting, or recording.
-      # Runs guards, preconditions, the call body, and postconditions. Returns a
-      # DryRunResult with the aggregate, event, and reactive chain that would fire.
-      #
-      #   result = app.dry_run("CreatePizza", name: "Margherita")
-      #   result.aggregate.name  # => "Margherita"
-      #   result.event           # => #<CreatedPizza ...>
-      #
-      # @param command_name [String] the command name (e.g., "CreatePizza")
-      # @param attrs [Hash] the command attributes
-      # @return [Hecks::DryRunResult]
-      # @raise [Hecks::GuardRejected, Hecks::PreconditionError, Hecks::PostconditionError]
-      def dry_run(command_name, **attrs)
-        cmd_class = @command_bus.resolve_command_class(command_name)
-        cmd = cmd_class.dry_call(**attrs)
-        chain = trace_reactive_chain(command_name)
-        DryRunResult.new(command: cmd, aggregate: cmd.aggregate, event: cmd.event, reactive_chain: chain)
-      end
-
-      # Register an async handler for policies marked +async: true+ in the DSL.
-      # The handler receives an event and is responsible for scheduling deferred work
-      # (e.g., enqueuing a background job).
-      #
-      # @yield [event] block that handles async event processing
-      # @return [void]
-      def async(&handler)
-        @async_handler = handler
-      end
-
-      # Subscribe to a named event on the event bus.
-      #
-      # @param event_name [String, Symbol] the event name to subscribe to (e.g., "PizzaCreated")
-      # @yield [event] block called when the event is published
-      # @return [void]
-      def on(event_name, &handler)
-        @event_bus.subscribe(event_name, &handler)
-      end
-
-      # Returns all events that have been published on the event bus since boot.
-      #
-      # @return [Array<Hash>] list of event hashes with :name and :payload keys
-      def events
-        @event_bus.events
-      end
-
-      # Replace a repository adapter for a named aggregate. Used by extension gems
-      # (e.g., hecks_sqlite) to swap memory adapters for persistent ones after boot.
-      # Re-wires the aggregate's port methods after swapping.
-      #
-      # @param aggregate_name [String, Symbol] the aggregate name (e.g., "Pizza")
-      # @param repo [Object] the replacement repository object
-      # @return [void]
-      def swap_adapter(aggregate_name, repo)
-        name = aggregate_name.to_s
-        @repositories[name] = repo
-        wire_aggregate!(name)
-      end
-
-      # Apply an extension to the live runtime without rebooting.
-      #
-      # Looks up the extension hook in the registry and calls it with the
-      # current domain module, domain IR, and this runtime instance. The hook
-      # can register middleware, swap adapters, or subscribe to events — all
-      # take effect immediately on the next command dispatch.
-      #
-      #   runtime.extend(:logging)
-      #   runtime.extend(:sqlite)
-      #   runtime.extend(:tenancy)
-      #
-      # @param name [Symbol] the registered extension name
-      # @param kwargs [Hash] options (currently unused, reserved for future extensions)
-      # @return [void]
-      # @raise [RuntimeError] if the extension is not registered
-      def extend(name, **kwargs)
-        # Auto-discover extensions if registry is empty
-        if Hecks.extension_registry.empty?
-          require "hecks/runtime/load_extensions"
-          Hecks::LoadExtensions.require_all
-        end
-        hook = Hecks.extension_registry[name.to_sym]
-        raise "Unknown extension: #{name}. Available: #{Hecks.extension_registry.keys.join(', ')}" unless hook
-        # Set connection config on the module so the hook can read it
-        if kwargs.any? && @mod.respond_to?(:connections)
-          @mod.connections[:sends] << { name: name.to_sym, **kwargs }
-        end
-        hook.call(@mod, @domain, self, **kwargs)
-        puts "#{name} extension applied"
-      end
-
-      # Apply a capability to the live runtime, enriching the domain IR.
-      #
-      # Capabilities generate constructs (commands, repository bindings) by
-      # visiting the domain IR. Unlike extensions, they modify what the domain
-      # can do rather than adding infrastructure around it.
-      #
-      #   runtime.capability(:crud)
-      #
-      # @param name [Symbol] the registered capability name
-      # @return [void]
-      # @raise [RuntimeError] if the capability is not registered
-      def capability(name)
-        require "hecks/capabilities/#{name}"
-        hook = Hecks.capability_registry[name.to_sym]
-        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
-        hook.call(self)
-      end
-
-      # Returns a human-readable summary of this runtime instance, showing the
-      # domain name and number of wired repositories.
-      #
-      # @return [String] inspection string
-      def inspect
-        "#<Hecks::Runtime \"#{@domain.name}\" (#{@repositories.size} repositories)>"
-      end
-
-      private
-
-      # Checks whether a runtime infrastructure option is enabled for an aggregate.
-      # Options are registered via +Runtime#enable+ in the config block.
-      #
-      # @param aggregate_name [String] the aggregate name
-      # @param option [Symbol] the option key (e.g., :versioned, :attachable)
-      # @return [Boolean]
-      # Apply capabilities declared in the Hecksagon file.
-      # Domain-wide capabilities (e.g., :crud) are applied first, then
-      # aggregate-level capability tags are stored for extensions to read.
-      def apply_hecksagon_capabilities
-        return unless @hecksagon
-        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
-      end
-
-      def runtime_option?(aggregate_name, option)
-        (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
-      end
-
-      # Creates the command bus, binding it to the domain and event bus.
-      # The command bus dispatches commands to the appropriate aggregate
-      # command runner and publishes resulting events.
-      #
-      # @return [void]
-      def setup_command_bus
-        @command_bus = Commands::CommandBus.new(
-          domain: @domain,
-          event_bus: @event_bus
-        )
-      end
-
-      def trace_reactive_chain(command_name)
-        return [] unless defined?(Hecks::FlowGenerator)
-        flows = Hecks::FlowGenerator.new(@domain).trace_flows
-        flow = flows.find { |f| f[:steps]&.first&.dig(:command) == command_name.to_s }
-        return [] unless flow
-        flow[:steps].drop(1)
-      end
+      setup_repositories
+      setup_command_bus
+      setup_policies
+      setup_subscribers
+      setup_views
+      setup_connections
+      wire_ports!
+      ServiceSetup.bind(@domain, @mod, @command_bus)
+      setup_workflows
+      setup_sagas
+      hoist_constants
+      apply_hecksagon_capabilities
     end
 
-  # Backward compatibility alias so existing code referencing
-  # +Hecks::Application+ continues to work.
+    def inspect
+      "#<Hecks::Runtime \"#{@domain.name}\" (#{@repositories.size} repositories)>"
+    end
+
+    private
+
+    def runtime_option?(aggregate_name, option)
+      (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
+    end
+
+    def setup_command_bus
+      @command_bus = Commands::CommandBus.new(
+        domain: @domain,
+        event_bus: @event_bus
+      )
+    end
+  end
+
   Application = Runtime
 end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -109,6 +109,7 @@ module Hecks
         setup_workflows
         setup_sagas
         hoist_constants
+        apply_hecksagon_capabilities
       end
 
       # Register command bus middleware. Middleware wraps every command dispatch,
@@ -290,6 +291,14 @@ module Hecks
       # @param aggregate_name [String] the aggregate name
       # @param option [Symbol] the option key (e.g., :versioned, :attachable)
       # @return [Boolean]
+      # Apply capabilities declared in the Hecksagon file.
+      # Domain-wide capabilities (e.g., :crud) are applied first, then
+      # aggregate-level capability tags are stored for extensions to read.
+      def apply_hecksagon_capabilities
+        return unless @hecksagon
+        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
+      end
+
       def runtime_option?(aggregate_name, option)
         (@runtime_options || {}).dig(aggregate_name.to_s, option) || false
       end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -256,6 +256,24 @@ module Hecks
         puts "#{name} extension applied"
       end
 
+      # Apply a capability to the live runtime, enriching the domain IR.
+      #
+      # Capabilities generate constructs (commands, repository bindings) by
+      # visiting the domain IR. Unlike extensions, they modify what the domain
+      # can do rather than adding infrastructure around it.
+      #
+      #   runtime.capability(:crud)
+      #
+      # @param name [Symbol] the registered capability name
+      # @return [void]
+      # @raise [RuntimeError] if the capability is not registered
+      def capability(name)
+        require "hecks/capabilities/#{name}"
+        hook = Hecks.capability_registry[name.to_sym]
+        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
+        hook.call(self)
+      end
+
       # Returns a human-readable summary of this runtime instance, showing the
       # domain name and number of wired repositories.
       #

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -65,6 +65,11 @@ module Hecks
       domain = Hecks.last_domain
       domain.source_path = bluebooks.first
 
+      # Auto-discover and load Hecksagon file (infrastructure capabilities)
+      hecksagons = Dir[File.join(dir, "*Hecksagon")].sort
+      hecksagons = Dir[File.join(dir, "bluebook", "*Hecksagon")].sort if hecksagons.empty?
+      hecksagons.each { |f| Kernel.load(f) }
+
       mod = load_domain(domain)
       load_stubs(dir, domain)
       mod.extend(Hecks::DomainConnections) unless mod.respond_to?(:connections)

--- a/hecksties/lib/hecks/runtime/command_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/command_dispatch.rb
@@ -1,0 +1,78 @@
+# Hecks::Runtime::CommandDispatch
+#
+# Command execution and event subscription on the runtime. Provides
+# the public API for running commands, subscribing to events, and
+# querying runtime state.
+#
+#   app.run("CreatePizza", name: "Margherita")
+#   app.on("CreatedPizza") { |e| puts e.name }
+#   app["Pizza"].all
+#
+module Hecks
+  class Runtime
+    module CommandDispatch
+      # Retrieve the repository for a named aggregate.
+      #
+      # @param name [String, Symbol] the aggregate name
+      # @return [Object] the repository
+      def [](name)
+        @repositories[name.to_s]
+      end
+
+      # Execute a command through the command bus.
+      #
+      # @param command_name [String, Symbol] the command name
+      # @param attrs [Hash] the command attributes
+      # @return [Object] the command result
+      def run(command_name, **attrs)
+        @command_bus.dispatch(command_name, **attrs)
+      end
+
+      # Preview what a command would do without persisting.
+      #
+      # @param command_name [String] the command name
+      # @param attrs [Hash] the command attributes
+      # @return [Hecks::DryRunResult]
+      def dry_run(command_name, **attrs)
+        cmd_class = @command_bus.resolve_command_class(command_name)
+        cmd = cmd_class.dry_call(**attrs)
+        chain = trace_reactive_chain(command_name)
+        DryRunResult.new(command: cmd, aggregate: cmd.aggregate, event: cmd.event, reactive_chain: chain)
+      end
+
+      # Register an async handler for policies marked async: true.
+      #
+      # @yield [event] block that handles async event processing
+      # @return [void]
+      def async(&handler)
+        @async_handler = handler
+      end
+
+      # Subscribe to a named event on the event bus.
+      #
+      # @param event_name [String, Symbol] the event name
+      # @yield [event] block called on publish
+      # @return [void]
+      def on(event_name, &handler)
+        @event_bus.subscribe(event_name, &handler)
+      end
+
+      # Returns all events published since boot.
+      #
+      # @return [Array<Hash>]
+      def events
+        @event_bus.events
+      end
+
+      private
+
+      def trace_reactive_chain(command_name)
+        return [] unless defined?(Hecks::FlowGenerator)
+        flows = Hecks::FlowGenerator.new(@domain).trace_flows
+        flow = flows.find { |f| f[:steps]&.first&.dig(:command) == command_name.to_s }
+        return [] unless flow
+        flow[:steps].drop(1)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
+++ b/hecksties/lib/hecks/runtime/configuration/boot_phase.rb
@@ -16,6 +16,7 @@ module Hecks
         store_domain_object(domain_obj)
         generate_adapters(domain_obj) if @adapter_type == :sql
         app = create_runtime(d, domain_obj, domain_module)
+        app.capability(:crud)
         app.async(&@async_handler) if @async_handler
         @apps[d[:gem_name]] = app
         wire_event_sourcing(domain_obj, domain_module) if event_sourced?

--- a/hecksties/lib/hecks/runtime/configuration_dsl.rb
+++ b/hecksties/lib/hecks/runtime/configuration_dsl.rb
@@ -1,0 +1,56 @@
+# Hecks::Runtime::ConfigurationDSL
+#
+# Configuration methods evaluated inside the runtime boot block.
+# Allows adapter overrides, middleware registration, and option flags.
+#
+#   app = Hecks.load(domain) do
+#     adapter "Pizza", my_sql_repo
+#     enable "Document", :versioned
+#     use(:logging) { |cmd, nxt| puts cmd; nxt.call }
+#   end
+#
+module Hecks
+  class Runtime
+    module ConfigurationDSL
+      # Register command bus middleware.
+      #
+      # @param name [Symbol, String, nil] optional middleware name
+      # @yield block receiving (command, next_handler)
+      # @return [void]
+      def use(name = nil, &block)
+        @command_bus.use(name, &block)
+      end
+
+      # Override the default memory adapter for a specific aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param adapter_obj [Object] a repository object
+      # @return [void]
+      def adapter(aggregate_name, adapter_obj)
+        @adapter_overrides[aggregate_name.to_s] = adapter_obj
+      end
+
+      # Enable an infrastructure option for a specific aggregate.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param option [Symbol] the option to enable
+      # @return [void]
+      def enable(aggregate_name, option)
+        name = aggregate_name.to_s
+        @runtime_options[name] ||= {}
+        @runtime_options[name][option] = true
+      end
+
+      # Replace a repository adapter after boot.
+      #
+      # @param aggregate_name [String, Symbol] the aggregate name
+      # @param repo [Object] the replacement repository
+      # @return [void]
+      def swap_adapter(aggregate_name, repo)
+        name = aggregate_name.to_s
+        @repositories[name] = repo
+        wire_aggregate!(name)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/extension_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/extension_dispatch.rb
@@ -1,0 +1,51 @@
+# Hecks::Runtime::ExtensionDispatch
+#
+# Applies extensions and capabilities to a live runtime. Extensions add
+# infrastructure behavior; capabilities enrich the domain IR.
+#
+#   runtime.extend(:logging)
+#   runtime.capability(:crud)
+#
+module Hecks
+  class Runtime
+    module ExtensionDispatch
+      # Apply an extension to the live runtime without rebooting.
+      #
+      # @param name [Symbol] the registered extension name
+      # @param kwargs [Hash] extension-specific options
+      # @return [void]
+      def extend(name, **kwargs)
+        if Hecks.extension_registry.empty?
+          require "hecks/runtime/load_extensions"
+          Hecks::LoadExtensions.require_all
+        end
+        hook = Hecks.extension_registry[name.to_sym]
+        raise "Unknown extension: #{name}. Available: #{Hecks.extension_registry.keys.join(', ')}" unless hook
+        if kwargs.any? && @mod.respond_to?(:connections)
+          @mod.connections[:sends] << { name: name.to_sym, **kwargs }
+        end
+        hook.call(@mod, @domain, self, **kwargs)
+        puts "#{name} extension applied"
+      end
+
+      # Apply a capability to the live runtime, enriching the domain IR.
+      #
+      # @param name [Symbol] the registered capability name
+      # @return [void]
+      def capability(name)
+        require "hecks/capabilities/#{name}"
+        hook = Hecks.capability_registry[name.to_sym]
+        raise "Unknown capability: #{name}. Available: #{Hecks.capability_registry.keys.join(', ')}" unless hook
+        hook.call(self)
+      end
+
+      private
+
+      # Apply capabilities declared in the Hecksagon file.
+      def apply_hecksagon_capabilities
+        return unless @hecksagon
+        (@hecksagon.capabilities || []).each { |cap| capability(cap) }
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks_cli/commands/new_project.rb
+++ b/hecksties/lib/hecks_cli/commands/new_project.rb
@@ -25,6 +25,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
       require "hecks"
 
       app = Hecks.boot(__dir__)
+      app.capability(:crud)
 
       # Start building:
       #   Example.create(name: "Hello")
@@ -51,6 +52,7 @@ Hecks::CLI.register_command(:new_project, "Create a new Hecks project",
     <<~RUBY
       require "hecks"
       app = Hecks.boot(File.join(__dir__, ".."))
+      app.capability(:crud)
 
       RSpec.configure do |config|
         config.order = :random

--- a/hecksties/spec/capabilities/crud_spec.rb
+++ b/hecksties/spec/capabilities/crud_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe "CRUD capability" do
+  let(:domain) do
+    Hecks.domain "CrudTest" do
+      aggregate "Widget" do
+        attribute :name, String
+        attribute :color, String
+        command "CreateWidget" do
+          attribute :name, String
+          attribute :color, String
+        end
+      end
+    end
+  end
+
+  describe "without capability" do
+    it "has only user-defined commands" do
+      Hecks.load(domain)
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to eq(["CreateWidget"])
+    end
+  end
+
+  describe "with capability" do
+    before do
+      @runtime = Hecks.load(domain)
+      @runtime.capability(:crud)
+    end
+
+    it "generates UpdateWidget and DeleteWidget stubs" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).to include("UpdateWidget", "DeleteWidget")
+    end
+
+    it "skips user-defined CreateWidget" do
+      create_cmd = domain.aggregates.first.commands.find { |c| c.name == "CreateWidget" }
+      # User-defined CreateWidget has name + color attrs (not the auto-gen which would include all)
+      expect(create_cmd.attributes.map(&:name)).to eq(%i[name color])
+    end
+
+    it "does not generate ReadWidget (handled by repository)" do
+      cmds = domain.aggregates.first.commands.map(&:name)
+      expect(cmds).not_to include("ReadWidget")
+    end
+
+    it "generates corresponding events" do
+      events = domain.aggregates.first.events.map(&:name)
+      expect(events).to include("UpdatedWidget", "DeletedWidget")
+    end
+
+    it "can create, update, and delete via commands" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      created = klass.create(name: "Bolt", color: "Silver")
+      expect(klass.count).to eq(1)
+
+      klass.update(widget: created.id, name: "Nut", color: "Gold")
+      found = klass.find(created.id)
+      expect(found.name).to eq("Nut")
+      expect(found.color).to eq("Gold")
+
+      klass.delete(widget: created.id)
+      expect(klass.count).to eq(0)
+    end
+
+    it "binds repository methods (find, all, count, first, last)" do
+      klass = Object.const_get("CrudTestDomain::Widget")
+      klass.create(name: "A", color: "Red")
+      klass.create(name: "B", color: "Blue")
+      expect(klass.count).to eq(2)
+      expect(klass.first.name).to eq("A")
+      expect(klass.last.name).to eq("B")
+      expect(klass.all.size).to eq(2)
+    end
+  end
+end

--- a/hecksties/spec/conventions/display_contract_spec.rb
+++ b/hecksties/spec/conventions/display_contract_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Hecks::Conventions::DisplayContract do
     it "returns command_names as a humanized comma-separated string" do
       pizza = domain.aggregates.find { |a| a.name == "Pizza" }
       data = described_class.home_aggregate_data(pizza, "pizzas")
-      expect(data[:command_names]).to eq("Create Pizza, Add Topping")
+      expect(data[:command_names]).to include("Create Pizza")
+      expect(data[:command_names]).to include("Add Topping")
     end
 
     it "returns an empty string when there are no commands" do

--- a/hecksties/support/shared_boot.rb
+++ b/hecksties/support/shared_boot.rb
@@ -91,7 +91,8 @@ module BootedDomains
     key = domain.object_id
     return @cache[key] if @cache[key]
 
-    @cache[key] = true
-    Hecks.load(domain)
+    runtime = Hecks.load(domain)
+    runtime.capability(:crud)
+    @cache[key] = runtime
   end
 end


### PR DESCRIPTION
## Summary

Browser-based IDE that streams a Claude Code terminal alongside a live context panel.

- **IDE Server** — WEBrick HTTP + raw TCP WebSocket for PTY terminal streaming
- **Terminal** — PTY wrapper running `claude --dangerously-skip-permissions`
- **WebSocket** — RFC 6455 implementation for binary terminal I/O
- **Context Panel** — reads Claude's JSONL session to show files being worked with
- **Session Reader** — parses Claude session files for file paths

## Usage

```
hecks ide [port]
```

Opens browser at `localhost:3001` with xterm.js terminal (left) + context panel (right).

## Test plan

- [ ] `hecks ide` launches browser with terminal
- [ ] Terminal streams Claude Code output via WebSocket
- [ ] Context panel shows files from Claude session
- [ ] POST /context updates panel context
- [ ] Terminal resize events forwarded to PTY