### PR TITLE
HEC-481: Audit capability with concerns-to-extension mapping

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -92,6 +92,20 @@
 - **GovernanceGuard** — general-purpose governance checker (`Hecks::GovernanceGuard.new(domain).check`) returns `Result` with `passed?`, `violations`, `suggestions`; works from CLI (`--governance`), MCP (`governance_check` tool), REPL, or any entry point
 - GovernanceGuard falls back to rule-based checks when no LLM API key is present; enriches suggestions via AI when available
 
+### Concerns-to-Capabilities Mapping
+- `Hecks::Concerns::Mapping` — shared mapping from world concerns to extensions and capabilities
+- `Hecks::Concerns::Mapping.resolve(:transparency)` — returns `{ extensions: [:audit], capabilities: [:audit] }`
+- `Hecks::Concerns::Mapping.resolve_all([:privacy, :transparency])` — deduplicates across multiple concerns
+- Hecksagon DSL: `concerns :transparency, :privacy` — declares concerns on the hecksagon IR
+- Boot resolves concerns via `ExtensionDispatch.apply_hecksagon_concerns` — activates extensions and capabilities
+
+### Audit Capability
+- `Hecks::Capabilities::Audit.apply(runtime)` — explicit programmatic wiring of audit trail
+- Idempotent: safe to call multiple times, returns existing audit instance
+- Custom resolvers: `actor_resolver:` and `tenant_resolver:` procs for request-scoped context
+- Auto-activated when `:transparency` or `:privacy` concerns are declared in hecksagon DSL
+- Reuses existing `Hecks::Audit` extension — detects if loaded, wires without duplication
+
 ### Access Control & Ports
 - Define access-control ports that whitelist allowed methods per consumer
 - Import domains from event storm formats (Markdown and YAML)

--- a/docs/usage/audit.md
+++ b/docs/usage/audit.md
@@ -1,0 +1,82 @@
+# Audit Capability
+
+The audit capability records an immutable log entry for every domain event, enriched with command name, actor, and tenant context.
+
+## Quick Start — Extension (auto-wired)
+
+The audit extension is auto-loaded at boot. Every domain event is recorded:
+
+```ruby
+require "hecks"
+
+app = Hecks.boot(__dir__)
+
+Pizza.create(name: "Margherita")
+Hecks.audit_log.last[:event_name]  # => "CreatedPizza"
+Hecks.audit_log.last[:event_data]  # => { name: "Margherita" }
+```
+
+## Capability API — Explicit Wiring
+
+Use the capability module for programmatic control:
+
+```ruby
+require "hecks"
+require "hecks/capabilities/audit"
+
+domain = Hecks.domain "Pizzas" do
+  aggregate "Pizza" do
+    attribute :name, String
+    command "CreatePizza" do
+      attribute :name, String
+    end
+  end
+end
+
+app = Hecks.load(domain)
+Hecks::Capabilities::Audit.apply(app)
+
+Pizza.create(name: "Hawaiian")
+Hecks.audit_log.size        # => 1
+Hecks.audit_log.first[:event_name]  # => "CreatedPizza"
+Hecks.audit_log.first[:timestamp]   # => 2026-04-02 ...
+```
+
+## Concerns DSL — Declarative Wiring
+
+Declare concerns in the hecksagon block and the audit capability activates automatically at boot:
+
+```ruby
+Hecks.hecksagon do
+  concerns :transparency, :privacy
+end
+
+app = Hecks.boot(__dir__)
+
+# audit is wired because :transparency and :privacy both map to the audit capability
+Hecks.audit_log  # => []
+```
+
+## Custom Actor/Tenant Resolvers
+
+Pass resolvers to control how actor and tenant are extracted:
+
+```ruby
+Hecks::Capabilities::Audit.apply(app,
+  actor_resolver:  -> { current_user.email },
+  tenant_resolver: -> { current_tenant.slug }
+)
+```
+
+## Log Entry Format
+
+Each entry in `Hecks.audit_log` is a Hash:
+
+| Key           | Type        | Description                        |
+|---------------|-------------|------------------------------------|
+| `:command`    | String/nil  | Command name (e.g., "CreatePizza") |
+| `:actor`      | String/nil  | Actor identifier                   |
+| `:tenant`     | String/nil  | Tenant identifier                  |
+| `:timestamp`  | Time        | When the event was recorded        |
+| `:event_name` | String      | Event class name (e.g., "CreatedPizza") |
+| `:event_data` | Hash        | Event attributes                   |

--- a/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
@@ -19,6 +19,7 @@ module Hecksagon
         @extensions = []
         @subscriptions = []
         @tenancy = nil
+        @concerns = []
       end
 
       # Declare a gate (access control) for an aggregate + role.
@@ -67,6 +68,17 @@ module Hecksagon
         @tenancy = strategy.to_sym
       end
 
+      # Declare world concerns for this hecksagon.
+      #
+      # Concerns are resolved at boot time to extensions and capabilities
+      # via Hecks::Concerns::Mapping.
+      #
+      # @param names [Array<Symbol>] concern names (e.g., :transparency, :privacy)
+      # @return [void]
+      def concerns(*names)
+        @concerns = names.flatten.map(&:to_sym)
+      end
+
       # Build and return the Hecksagon IR object.
       #
       # @return [Hecksagon::Structure::Hecksagon]
@@ -77,7 +89,8 @@ module Hecksagon
           adapter: @adapter,
           extensions: @extensions,
           subscriptions: @subscriptions,
-          tenancy: @tenancy
+          tenancy: @tenancy,
+          concerns: @concerns
         )
       end
     end

--- a/hecksagon/lib/hecksagon/structure/hecksagon.rb
+++ b/hecksagon/lib/hecksagon/structure/hecksagon.rb
@@ -19,15 +19,16 @@ module Hecksagon
     #   )
     #
     class Hecksagon
-      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy
+      attr_reader :name, :gates, :adapter, :extensions, :subscriptions, :tenancy, :concerns
 
-      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [], tenancy: nil)
+      def initialize(name:, gates: [], adapter: nil, extensions: [], subscriptions: [], tenancy: nil, concerns: [])
         @name = name
         @gates = gates
         @adapter = adapter
         @extensions = extensions
         @subscriptions = subscriptions
         @tenancy = tenancy
+        @concerns = concerns
       end
 
       # Returns gates for a specific aggregate.

--- a/hecksties/lib/hecks/capabilities/audit.rb
+++ b/hecksties/lib/hecks/capabilities/audit.rb
@@ -1,0 +1,113 @@
+# Hecks::Capabilities::Audit
+#
+# Audit capability that wires the Hecks::Audit extension as an opt-in
+# hecksagon concern. Follows the capability pattern: detects whether the
+# audit extension is already loaded, wires it idempotently, and adds
+# command bus middleware for actor/tenant context enrichment.
+#
+# Usage:
+#   Hecks::Capabilities::Audit.apply(runtime)
+#
+#   # Or via concerns DSL in hecksagon:
+#   Hecks.hecksagon do
+#     concerns :transparency, :privacy
+#   end
+#
+require_relative "../concerns/mapping"
+
+module Hecks
+  module Capabilities
+    module Audit
+      # Apply the audit capability to a runtime. Loads the audit extension
+      # if not already present, subscribes to the event bus, and registers
+      # command bus middleware for context enrichment.
+      #
+      # Idempotent: if Hecks.audit_log already exists, skips wiring.
+      #
+      # @param runtime [Hecks::Runtime] the runtime to wire audit into
+      # @param actor_resolver [Proc, nil] optional proc that returns the actor
+      #   string for the current request context
+      # @param tenant_resolver [Proc, nil] optional proc that returns the tenant
+      #   string for the current request context
+      # @return [Hecks::Audit] the audit instance
+      def self.apply(runtime, actor_resolver: nil, tenant_resolver: nil)
+        return Hecks.instance_variable_get(:@_audit) if Hecks.respond_to?(:audit_log)
+
+        load_extension
+        audit = Hecks::Audit.new(runtime.event_bus)
+        store_audit(audit)
+        register_middleware(runtime, audit, actor_resolver: actor_resolver, tenant_resolver: tenant_resolver)
+        audit
+      end
+
+      # Check whether the audit capability is already active.
+      #
+      # @return [Boolean]
+      def self.active?
+        Hecks.respond_to?(:audit_log)
+      end
+
+      private
+
+      # Load the audit extension file if Hecks::Audit is not yet defined.
+      #
+      # @return [void]
+      def self.load_extension
+        return if defined?(Hecks::Audit)
+
+        require "hecks/extensions/audit"
+      end
+
+      # Store the audit instance on Hecks and expose audit_log.
+      #
+      # @param audit [Hecks::Audit] the audit instance
+      # @return [void]
+      def self.store_audit(audit)
+        Hecks.instance_variable_set(:@_audit, audit)
+        return if Hecks.respond_to?(:audit_log)
+
+        Hecks.define_singleton_method(:audit_log) { @_audit.log }
+      end
+
+      # Register command bus middleware that enriches audit entries with
+      # actor and tenant context from the current request.
+      #
+      # @param runtime [Hecks::Runtime] the runtime
+      # @param audit [Hecks::Audit] the audit instance
+      # @param actor_resolver [Proc, nil] optional actor resolver
+      # @param tenant_resolver [Proc, nil] optional tenant resolver
+      # @return [void]
+      def self.register_middleware(runtime, audit, actor_resolver: nil, tenant_resolver: nil)
+        runtime.use(:audit_capability) do |cmd, nxt|
+          actor = resolve_actor(actor_resolver)
+          tenant = resolve_tenant(tenant_resolver)
+          audit.around_command(cmd, nxt, actor: actor, tenant: tenant)
+        end
+      end
+
+      # Resolve the current actor from the resolver or Hecks.actor.
+      #
+      # @param resolver [Proc, nil]
+      # @return [String, nil]
+      def self.resolve_actor(resolver)
+        return resolver.call if resolver
+
+        actor = Hecks.respond_to?(:actor) ? Hecks.actor : nil
+        actor.respond_to?(:role) ? actor.role : nil
+      end
+
+      # Resolve the current tenant from the resolver or Hecks.tenant.
+      #
+      # @param resolver [Proc, nil]
+      # @return [String, nil]
+      def self.resolve_tenant(resolver)
+        return resolver.call if resolver
+
+        Hecks.respond_to?(:tenant) ? Hecks.tenant : nil
+      end
+
+      private_class_method :load_extension, :store_audit, :register_middleware,
+                           :resolve_actor, :resolve_tenant
+    end
+  end
+end

--- a/hecksties/lib/hecks/concerns/mapping.rb
+++ b/hecksties/lib/hecks/concerns/mapping.rb
@@ -1,0 +1,83 @@
+# Hecks::Concerns::Mapping
+#
+# Shared mapping from world concerns to extensions and capabilities.
+# Extracted from WorldConcernsPrompt so that both the onboarding CLI
+# and the runtime boot sequence share a single source of truth.
+#
+# Usage:
+#   Hecks::Concerns::Mapping.extensions_for(:privacy)    # => [:pii]
+#   Hecks::Concerns::Mapping.capabilities_for(:privacy)  # => [:audit]
+#   Hecks::Concerns::Mapping.resolve(:transparency)
+#   # => { extensions: [:audit], capabilities: [:audit] }
+#
+module Hecks
+  module Concerns
+    module Mapping
+      # Maps a world concern to the extension that enforces it.
+      CONCERN_TO_EXTENSION = {
+        privacy:        :pii,
+        transparency:   :audit,
+        consent:        :auth,
+        security:       :auth,
+        equity:         :tenancy,
+        sustainability: :rate_limit
+      }.freeze
+
+      # Maps a world concern to capabilities that should be activated.
+      # Capabilities are higher-level behaviors composed from extensions.
+      CONCERN_TO_CAPABILITIES = {
+        privacy:      [:audit],
+        transparency: [:audit],
+        consent:      [],
+        security:     [],
+        equity:       [],
+        sustainability: []
+      }.freeze
+
+      VALID_CONCERNS = CONCERN_TO_EXTENSION.keys.freeze
+
+      # Returns the extensions needed for a single concern.
+      #
+      # @param concern [Symbol] a world concern name
+      # @return [Array<Symbol>] extension names
+      def self.extensions_for(concern)
+        ext = CONCERN_TO_EXTENSION[concern.to_sym]
+        ext ? [ext] : []
+      end
+
+      # Returns the capabilities needed for a single concern.
+      #
+      # @param concern [Symbol] a world concern name
+      # @return [Array<Symbol>] capability names
+      def self.capabilities_for(concern)
+        CONCERN_TO_CAPABILITIES.fetch(concern.to_sym, [])
+      end
+
+      # Resolves a concern to both its extensions and capabilities.
+      #
+      # @param concern [Symbol] a world concern name
+      # @return [Hash] with :extensions and :capabilities arrays
+      def self.resolve(concern)
+        {
+          extensions: extensions_for(concern),
+          capabilities: capabilities_for(concern)
+        }
+      end
+
+      # Resolves multiple concerns, deduplicating results.
+      #
+      # @param concerns [Array<Symbol>] concern names
+      # @return [Hash] with :extensions and :capabilities arrays
+      def self.resolve_all(concerns)
+        exts = []
+        caps = []
+        concerns.each do |c|
+          r = resolve(c)
+          exts.concat(r[:extensions])
+          caps.concat(r[:capabilities])
+        end
+        { extensions: exts.uniq, capabilities: caps.uniq }
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/boot.rb
+++ b/hecksties/lib/hecks/runtime/boot.rb
@@ -103,6 +103,9 @@ module Hecks
       driven, driving, untyped = partition_by_adapter_type(eligible)
       (driven + untyped + driving).each { |_name, hook| hook.call(mod, domain, runtime) }
 
+      require_relative "extension_dispatch"
+      ExtensionDispatch.apply_hecksagon_concerns(runtime)
+
       runtime.check_auth_coverage!
       runtime.check_reference_coverage!
     end

--- a/hecksties/lib/hecks/runtime/extension_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/extension_dispatch.rb
@@ -1,0 +1,68 @@
+# Hecks::ExtensionDispatch
+#
+# Resolves hecksagon concerns into extensions and capabilities at boot
+# time. Called by the boot sequence after extensions are fired, so that
+# concern-driven capabilities layer on top of explicitly declared
+# extensions without conflicting.
+#
+# Usage:
+#   Hecks::ExtensionDispatch.apply_hecksagon_concerns(runtime)
+#
+require_relative "../concerns/mapping"
+require_relative "../capabilities/audit"
+
+module Hecks
+  module ExtensionDispatch
+    # Reads concerns from the hecksagon IR attached to the runtime and
+    # activates the corresponding extensions and capabilities.
+    #
+    # Extensions are loaded via LoadExtensions.require_one and fired
+    # through the extension registry. Capabilities are activated via
+    # their own apply method.
+    #
+    # @param runtime [Hecks::Runtime] a booted runtime with @hecksagon set
+    # @return [void]
+    def self.apply_hecksagon_concerns(runtime)
+      hecksagon = runtime.instance_variable_get(:@hecksagon)
+      return unless hecksagon
+      return if hecksagon.concerns.empty?
+
+      resolved = Concerns::Mapping.resolve_all(hecksagon.concerns)
+      activate_extensions(resolved[:extensions], runtime)
+      activate_capabilities(resolved[:capabilities], runtime)
+    end
+
+    # Load and fire extensions that are not yet registered.
+    #
+    # @param extension_names [Array<Symbol>] extension names
+    # @param runtime [Hecks::Runtime] the runtime
+    # @return [void]
+    def self.activate_extensions(extension_names, runtime)
+      mod = runtime.instance_variable_get(:@mod)
+      domain = runtime.domain
+
+      extension_names.each do |name|
+        LoadExtensions.require_one(name)
+        hook = Hecks.extension_registry[name]
+        next unless hook
+        hook.call(mod, domain, runtime)
+      end
+    end
+
+    # Activate capabilities by name.
+    #
+    # @param capability_names [Array<Symbol>] capability names
+    # @param runtime [Hecks::Runtime] the runtime
+    # @return [void]
+    def self.activate_capabilities(capability_names, runtime)
+      capability_names.each do |name|
+        case name
+        when :audit
+          Capabilities::Audit.apply(runtime)
+        end
+      end
+    end
+
+    private_class_method :activate_extensions, :activate_capabilities
+  end
+end

--- a/hecksties/lib/hecks_cli/world_concerns_prompt.rb
+++ b/hecksties/lib/hecks_cli/world_concerns_prompt.rb
@@ -4,22 +4,20 @@
 # for a new domain. Each concern maps to a real Hecks extension that enforces
 # the goal at runtime. Extracted from new_project.rb to keep that file small.
 #
+# Delegates concern-to-extension mapping to Hecks::Concerns::Mapping so
+# that the CLI and runtime boot share a single source of truth.
+#
 # Usage:
 #   result = WorldConcernsPrompt.run(say_method: method(:say))
 #   result[:concerns]   # => [:privacy, :consent]
 #   result[:extensions] # => [:pii, :auth]
 #   result[:stub]       # => false
 #
+require_relative "../hecks/concerns/mapping"
+
 module Hecks
   class WorldConcernsPrompt
-    GOAL_TO_EXTENSION = {
-      privacy:       :pii,
-      transparency:  :audit,
-      consent:       :auth,
-      security:      :auth,
-      equity:        :tenancy,
-      sustainability: :rate_limit
-    }.freeze
+    GOAL_TO_EXTENSION = Hecks::Concerns::Mapping::CONCERN_TO_EXTENSION
 
     VALID_GOALS = GOAL_TO_EXTENSION.keys.freeze
 

--- a/hecksties/spec/capabilities/audit_spec.rb
+++ b/hecksties/spec/capabilities/audit_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+require "hecks/capabilities/audit"
+
+RSpec.describe Hecks::Capabilities::Audit do
+  let(:domain) do
+    Hecks.domain "AuditCapTest" do
+      aggregate "Widget" do
+        attribute :name, String
+
+        command "CreateWidget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  before do
+    # Clean up singleton state left by other specs (e.g., extensions/audit_spec)
+    if Hecks.respond_to?(:audit_log)
+      Hecks.singleton_class.remove_method(:audit_log)
+    end
+    Hecks.instance_variable_set(:@_audit, nil)
+  end
+
+  after do
+    if Hecks.respond_to?(:audit_log)
+      Hecks.singleton_class.remove_method(:audit_log)
+    end
+    Hecks.instance_variable_set(:@_audit, nil)
+  end
+
+  describe ".apply" do
+    it "wires audit to the runtime and exposes Hecks.audit_log" do
+      app = Hecks.load(domain)
+      described_class.apply(app)
+
+      AuditCapTestDomain::Widget.create(name: "Sprocket")
+
+      expect(Hecks.audit_log.size).to eq(1)
+      expect(Hecks.audit_log.first[:event_name]).to eq("CreatedWidget")
+    end
+
+    it "is idempotent — second call returns existing audit" do
+      app = Hecks.load(domain)
+      first = described_class.apply(app)
+      second = described_class.apply(app)
+
+      expect(first).to equal(second)
+    end
+
+    it "enriches entries with actor context from Hecks.actor" do
+      app = Hecks.load(domain)
+      described_class.apply(app)
+
+      AuditCapTestDomain::Widget.create(name: "Bolt")
+
+      entry = Hecks.audit_log.first
+      expect(entry[:timestamp]).to be_a(Time)
+      expect(entry[:event_data][:name]).to eq("Bolt")
+    end
+  end
+
+  describe ".active?" do
+    it "returns false before apply" do
+      expect(described_class.active?).to be false
+    end
+
+    it "returns true after apply" do
+      app = Hecks.load(domain)
+      described_class.apply(app)
+      expect(described_class.active?).to be true
+    end
+  end
+end

--- a/hecksties/spec/concerns/mapping_spec.rb
+++ b/hecksties/spec/concerns/mapping_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "hecks/concerns/mapping"
+
+RSpec.describe Hecks::Concerns::Mapping do
+  describe ".extensions_for" do
+    it "returns the extension for a known concern" do
+      expect(described_class.extensions_for(:privacy)).to eq([:pii])
+      expect(described_class.extensions_for(:transparency)).to eq([:audit])
+    end
+
+    it "returns empty array for an unknown concern" do
+      expect(described_class.extensions_for(:bogus)).to eq([])
+    end
+  end
+
+  describe ".capabilities_for" do
+    it "returns capabilities for a concern that has them" do
+      expect(described_class.capabilities_for(:transparency)).to eq([:audit])
+      expect(described_class.capabilities_for(:privacy)).to eq([:audit])
+    end
+
+    it "returns empty array for a concern with no capabilities" do
+      expect(described_class.capabilities_for(:security)).to eq([])
+    end
+  end
+
+  describe ".resolve" do
+    it "returns both extensions and capabilities for a concern" do
+      result = described_class.resolve(:transparency)
+      expect(result[:extensions]).to eq([:audit])
+      expect(result[:capabilities]).to eq([:audit])
+    end
+  end
+
+  describe ".resolve_all" do
+    it "deduplicates extensions and capabilities across multiple concerns" do
+      result = described_class.resolve_all([:privacy, :transparency])
+      expect(result[:extensions]).to eq([:pii, :audit])
+      expect(result[:capabilities]).to eq([:audit])
+    end
+
+    it "returns empty arrays for empty input" do
+      result = described_class.resolve_all([])
+      expect(result[:extensions]).to eq([])
+      expect(result[:capabilities]).to eq([])
+    end
+  end
+
+  describe "VALID_CONCERNS" do
+    it "includes all six world concerns" do
+      expect(described_class::VALID_CONCERNS).to contain_exactly(
+        :privacy, :transparency, :consent, :security, :equity, :sustainability
+      )
+    end
+  end
+end

--- a/hecksties/spec/runtime/extension_dispatch_spec.rb
+++ b/hecksties/spec/runtime/extension_dispatch_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "hecks/runtime/extension_dispatch"
+
+RSpec.describe Hecks::ExtensionDispatch do
+  let(:domain) do
+    Hecks.domain "DispatchTest" do
+      aggregate "Gadget" do
+        attribute :name, String
+
+        command "CreateGadget" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  before do
+    if Hecks.respond_to?(:audit_log)
+      Hecks.singleton_class.remove_method(:audit_log)
+    end
+    Hecks.instance_variable_set(:@_audit, nil)
+  end
+
+  after do
+    if Hecks.respond_to?(:audit_log)
+      Hecks.singleton_class.remove_method(:audit_log)
+    end
+    Hecks.instance_variable_set(:@_audit, nil)
+  end
+
+  describe ".apply_hecksagon_concerns" do
+    it "activates audit capability when hecksagon has :transparency concern" do
+      Hecks.hecksagon do
+        concerns :transparency
+      end
+
+      app = Hecks.load(domain)
+      described_class.apply_hecksagon_concerns(app)
+
+      DispatchTestDomain::Gadget.create(name: "Widget")
+      expect(Hecks.audit_log.size).to eq(1)
+      expect(Hecks.audit_log.first[:event_name]).to eq("CreatedGadget")
+    end
+
+    it "does nothing when hecksagon has no concerns" do
+      Hecks.hecksagon do
+        # no concerns declared
+      end
+
+      app = Hecks.load(domain)
+      described_class.apply_hecksagon_concerns(app)
+
+      expect(Hecks.respond_to?(:audit_log)).to be false
+    end
+
+    it "does nothing when no hecksagon is set" do
+      Hecks.last_hecksagon = nil
+      app = Hecks.load(domain)
+      app.instance_variable_set(:@hecksagon, nil)
+
+      expect { described_class.apply_hecksagon_concerns(app) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extracts concern-to-extension mapping into shared `Hecks::Concerns::Mapping` module
- Adds `:audit` capability following the CRUD pattern — reuses existing audit extension idempotently
- Adds `concerns` DSL method to HecksagonBuilder with concern resolution at boot
- `ExtensionDispatch.apply_hecksagon_concerns` wires concerns into the runtime

## Example usage

```ruby
Hecks.hecksagon "Healthcare" do
  concerns :privacy  # implicitly activates :audit capability
end
```

## Test plan
- [x] Concern mapping resolves extensions and capabilities correctly
- [x] Audit capability applies idempotently
- [x] Extension dispatch activates concerns at boot
- [x] All specs pass, smoke test passes

Generated with [Claude Code](https://claude.com/claude-code)