### PR TITLE
HEC-483: Encrypted attribute tag with transparent encrypt/decrypt

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,7 @@
 - References hold live objects in memory — IDs are purely a persistence concern
 - Enum constraints: `attribute :category, String, enum: %w[low medium high]` — validated at runtime, dropdown in UI
 - Computed attributes: `computed :lot_size do; area / 43560.0; end` — derived values not stored in the database, shown in UI with "(computed)" hint, visible in `hecks inspect`, and available as MCP `add_computed` tool
+- Encrypted attributes: `attribute :ssn, String, encrypted: true` — transparently encrypted at rest via EncryptingRepository decorator; AES-256-GCM in production, reversible Base64 in tests; nil values pass through unencrypted
 
 ### Commands
 - Define commands with attributes, handlers, guards, read models, actors, and external system docs

--- a/bluebook/lib/hecks/domain_model/structure/attribute.rb
+++ b/bluebook/lib/hecks/domain_model/structure/attribute.rb
@@ -40,6 +40,8 @@ module Hecks
       # @param list [Boolean] if true, this attribute holds a collection (Array) of the given type.
       # @param pii [Boolean] if true, this attribute contains personally identifiable information
       #   and should be handled according to PII policies (encryption, masking, etc.).
+      # @param encrypted [Boolean] if true, this attribute is encrypted at rest in the repository.
+      #   The EncryptingRepository decorator handles transparent encrypt/decrypt on save and find.
       # @param enum [Array<String>, nil] optional list of allowed string values. When present,
       #   generated code will validate that the attribute value is one of these.
       # @param visible [Boolean] if false, this attribute is hidden from the web explorer
@@ -47,12 +49,13 @@ module Hecks
       #   like passwords, tokens, or raw foreign keys that should not be displayed to users.
       #
       # @return [Attribute] a new Attribute instance
-      def initialize(name:, type:, default: nil, list: false, pii: false, enum: nil, visible: true)
+      def initialize(name:, type:, default: nil, list: false, pii: false, encrypted: false, enum: nil, visible: true)
         @name = name.to_sym
         @type = type
         @default = default
         @list = list
         @pii = pii
+        @encrypted = encrypted
         @enum = enum
         @visible = visible
       end
@@ -73,6 +76,15 @@ module Hecks
       # @return [Boolean] true if this attribute holds PII data
       def pii?
         @pii
+      end
+
+      # Returns true if this attribute is encrypted at rest.
+      # Encrypted attributes are transparently encrypted on save and decrypted
+      # on find by the EncryptingRepository decorator.
+      #
+      # @return [Boolean] true if this attribute is encrypted at rest
+      def encrypted?
+        @encrypted
       end
 
       # Returns true if this attribute should appear in the web explorer

--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -537,6 +537,7 @@ attribute :name, String                          # required, no default
 attribute :status, String, default: "draft"      # with default
 attribute :role, String, enum: ["admin", "user"] # constrained values
 attribute :email, String, pii: true              # PII flag
+attribute :ssn, String, encrypted: true          # encrypted at rest
 ```
 
 ### Identity (natural key)

--- a/docs/usage/encrypted_attributes.md
+++ b/docs/usage/encrypted_attributes.md
@@ -1,0 +1,87 @@
+# Encrypted Attributes
+
+Mark sensitive attributes with `encrypted: true` to encrypt them at rest in the repository. Values are transparently encrypted on save and decrypted on find/all/query.
+
+## DSL
+
+```ruby
+Hecks.domain "Health" do
+  aggregate "Patient" do
+    attribute :name, String
+    attribute :ssn, String, encrypted: true
+    attribute :email, String, encrypted: true
+
+    command "RegisterPatient" do
+      attribute :name, String
+      attribute :ssn, String
+      attribute :email, String
+    end
+  end
+end
+```
+
+## How it works
+
+When an aggregate has any `encrypted: true` attributes, the runtime automatically wraps its repository in an `EncryptingRepository` decorator. This decorator:
+
+- **On save**: encrypts marked fields before passing the aggregate to the inner repo
+- **On find/all/query**: decrypts marked fields in the returned aggregates
+- **Nil values**: pass through without encryption
+
+## Encryption backends
+
+### Test (default)
+
+When `Hecks.encryption_key` is nil (the default), a reversible Base64 encryptor is used. This is fast and deterministic -- ideal for tests.
+
+### AES-256-GCM (production)
+
+Set a 32-byte key to enable real encryption:
+
+```ruby
+require "openssl"
+Hecks.encryption_key = OpenSSL::Random.random_bytes(32)
+
+# Or from an environment variable:
+Hecks.encryption_key = [ENV.fetch("ENCRYPTION_KEY")].pack("H*")
+```
+
+Each encrypted value includes a random IV and auth tag, Base64-encoded for safe storage in text columns.
+
+## Runtime example
+
+```ruby
+app = Hecks.load(domain)
+
+patient = Patient.create(name: "Alice", ssn: "123-45-6789", email: "alice@example.com")
+
+# Decrypted transparently on find
+found = Patient.find(patient.id)
+found.ssn   # => "123-45-6789"
+found.email # => "alice@example.com"
+
+# Encrypted in the underlying storage
+inner = Patient.instance_variable_get(:@__hecks_repo__).instance_variable_get(:@inner)
+raw = inner.find(patient.id)
+raw.ssn  # => Base64-encoded ciphertext
+```
+
+## Hecksagon concern expansion
+
+The `:privacy` concern automatically enables the `:encrypted` extension alongside `:pii`:
+
+```ruby
+builder = Hecksagon::DSL::HecksagonBuilder.new("Health")
+builder.concern(:privacy)
+hex = builder.build
+hex.extensions.map { |e| e[:name] }  # => [:pii, :encrypted]
+```
+
+## IR query
+
+Query which attributes are encrypted on any aggregate:
+
+```ruby
+hex = Hecksagon::Structure::Hecksagon.new(name: "Health")
+hex.encrypted_attributes("Patient", domain: domain)  # => [:ssn, :email]
+```

--- a/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
@@ -67,6 +67,21 @@ module Hecksagon
         @tenancy = strategy.to_sym
       end
 
+      # Expand a world concern into hecksagon-level configuration.
+      # The :privacy concern enables the :pii extension and the :encrypted
+      # attribute tag support (wires EncryptingRepository for aggregates
+      # with encrypted fields).
+      #
+      # @param concern [Symbol] the concern name (e.g., :privacy)
+      # @return [void]
+      def concern(concern)
+        case concern.to_sym
+        when :privacy
+          extension(:pii) unless @extensions.any? { |e| e[:name] == :pii }
+          extension(:encrypted) unless @extensions.any? { |e| e[:name] == :encrypted }
+        end
+      end
+
       # Build and return the Hecksagon IR object.
       #
       # @return [Hecksagon::Structure::Hecksagon]

--- a/hecksagon/lib/hecksagon/structure/hecksagon.rb
+++ b/hecksagon/lib/hecksagon/structure/hecksagon.rb
@@ -39,6 +39,19 @@ module Hecksagon
       def gate_for(aggregate_name, role)
         @gates.find { |g| g.aggregate == aggregate_name.to_s && g.role == role.to_sym }
       end
+
+      # Returns encrypted attribute names for a given aggregate, queried from
+      # the domain IR. Returns an empty array if the domain is not set or the
+      # aggregate has no encrypted attributes.
+      #
+      # @param aggregate_name [String] the aggregate name
+      # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
+      # @return [Array<Symbol>] names of encrypted attributes
+      def encrypted_attributes(aggregate_name, domain:)
+        agg = domain.aggregates.find { |a| a.name == aggregate_name.to_s }
+        return [] unless agg
+        agg.attributes.select(&:encrypted?).map(&:name)
+      end
     end
   end
 end

--- a/hecksagon/spec/dsl/hecksagon_concerns_spec.rb
+++ b/hecksagon/spec/dsl/hecksagon_concerns_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe "Hecksagon concern expansion" do
+  describe ":privacy concern" do
+    it "expands to :pii and :encrypted extensions" do
+      builder = Hecksagon::DSL::HecksagonBuilder.new("TestDomain")
+      builder.concern(:privacy)
+      hex = builder.build
+
+      extension_names = hex.extensions.map { |e| e[:name] }
+      expect(extension_names).to include(:pii)
+      expect(extension_names).to include(:encrypted)
+    end
+
+    it "does not duplicate extensions on repeated concern calls" do
+      builder = Hecksagon::DSL::HecksagonBuilder.new("TestDomain")
+      builder.concern(:privacy)
+      builder.concern(:privacy)
+      hex = builder.build
+
+      extension_names = hex.extensions.map { |e| e[:name] }
+      expect(extension_names.count(:pii)).to eq(1)
+      expect(extension_names.count(:encrypted)).to eq(1)
+    end
+  end
+
+  describe "encrypted_attributes query" do
+    it "returns encrypted field names from domain IR" do
+      domain = Hecks.domain "EncAttrQuery" do
+        aggregate "Secret" do
+          attribute :label, String
+          attribute :token, String, encrypted: true
+          attribute :key, String, encrypted: true
+        end
+      end
+
+      hex = Hecksagon::Structure::Hecksagon.new(name: "EncAttrQuery")
+      names = hex.encrypted_attributes("Secret", domain: domain)
+      expect(names).to eq([:token, :key])
+    end
+
+    it "returns empty array when no encrypted attributes" do
+      domain = Hecks.domain "PlainQuery" do
+        aggregate "Open" do
+          attribute :label, String
+        end
+      end
+
+      hex = Hecksagon::Structure::Hecksagon.new(name: "PlainQuery")
+      expect(hex.encrypted_attributes("Open", domain: domain)).to eq([])
+    end
+  end
+end

--- a/hecksties/lib/hecks.rb
+++ b/hecksties/lib/hecks.rb
@@ -58,6 +58,16 @@ module Hecks
   extend DumpFormatRegistryMethods
   extend GrammarRegistryMethods
 
+  # 32-byte encryption key for attribute-level encryption at rest.
+  # When nil (default), the TestEncryptor (Base64) is used.
+  # Set to a 32-byte binary string to enable AES-256-GCM encryption.
+  #
+  #   Hecks.encryption_key = OpenSSL::Random.random_bytes(32)
+  #
+  class << self
+    attr_accessor :encryption_key
+  end
+
   def self.configure(&block)
     @configuration = Configuration.new
     @configuration.instance_eval(&block)

--- a/hecksties/lib/hecks/adapters/aes_encryptor.rb
+++ b/hecksties/lib/hecks/adapters/aes_encryptor.rb
@@ -1,0 +1,65 @@
+# Hecks::Adapters::AesEncryptor
+#
+# AES-256-GCM encryption backend for attribute-level encryption at rest.
+# Each encrypted value includes a random IV prepended to the ciphertext,
+# Base64-encoded for safe storage in any text column.
+#
+#   key = OpenSSL::Random.random_bytes(32)
+#   enc = Hecks::Adapters::AesEncryptor.new(key)
+#   cipher = enc.encrypt("secret")
+#   enc.decrypt(cipher)  # => "secret"
+#
+require "openssl"
+require "base64"
+
+module Hecks
+  module Adapters
+    class AesEncryptor
+      ALGO = "aes-256-gcm".freeze
+      IV_LEN = 12
+      TAG_LEN = 16
+
+      # @param key [String] 32-byte encryption key (binary)
+      def initialize(key)
+        raise ArgumentError, "Key must be 32 bytes" unless key.bytesize == 32
+        @key = key
+      end
+
+      # Encrypt a plaintext string. Returns a Base64-encoded string containing
+      # the IV, auth tag, and ciphertext.
+      #
+      # @param value [String] the plaintext to encrypt
+      # @return [String] Base64-encoded ciphertext with embedded IV and tag
+      def encrypt(value)
+        cipher = OpenSSL::Cipher.new(ALGO)
+        cipher.encrypt
+        iv = cipher.random_iv
+        cipher.key = @key
+
+        ciphertext = cipher.update(value.to_s) + cipher.final
+        tag = cipher.auth_tag(TAG_LEN)
+
+        Base64.strict_encode64(iv + tag + ciphertext)
+      end
+
+      # Decrypt a Base64-encoded ciphertext produced by +encrypt+.
+      #
+      # @param value [String] Base64-encoded ciphertext
+      # @return [String] the original plaintext
+      def decrypt(value)
+        raw = Base64.strict_decode64(value.to_s)
+        iv = raw[0, IV_LEN]
+        tag = raw[IV_LEN, TAG_LEN]
+        ciphertext = raw[(IV_LEN + TAG_LEN)..]
+
+        decipher = OpenSSL::Cipher.new(ALGO)
+        decipher.decrypt
+        decipher.iv = iv
+        decipher.key = @key
+        decipher.auth_tag = tag
+
+        decipher.update(ciphertext) + decipher.final
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/adapters/encrypting_repository.rb
+++ b/hecksties/lib/hecks/adapters/encrypting_repository.rb
@@ -1,0 +1,107 @@
+# Hecks::Adapters::EncryptingRepository
+#
+# Repository decorator that transparently encrypts marked attributes on
+# save and decrypts them on find/all/query. Wraps any inner repository
+# (memory, SQL, etc.) using the same decorator pattern as
+# OwnershipScopedRepository.
+#
+# Fields to encrypt are determined by the aggregate IR (attributes with
+# +encrypted: true+). Nil values pass through without encryption.
+#
+#   repo = Hecks::Adapters::EncryptingRepository.new(
+#     inner_repo,
+#     aggregate: pizza_agg,
+#     encryptor: Hecks::Adapters::TestEncryptor.new,
+#     aggregate_class: Pizza
+#   )
+#   repo.save(Pizza.new(name: "Margherita", ssn: "123-45-6789"))
+#   repo.find(id).ssn  # => "123-45-6789" (decrypted transparently)
+#
+module Hecks
+  module Adapters
+    class EncryptingRepository
+      # @param inner_repo [Object] the underlying repository to wrap
+      # @param aggregate [Hecks::DomainModel::Structure::Aggregate] the aggregate IR
+      # @param encryptor [#encrypt, #decrypt] encryption backend
+      # @param aggregate_class [Class] the runtime aggregate class for rebuilding
+      def initialize(inner_repo, aggregate:, encryptor:, aggregate_class:)
+        @inner = inner_repo
+        @encryptor = encryptor
+        @aggregate_class = aggregate_class
+        @encrypted_fields = aggregate.attributes
+          .select(&:encrypted?)
+          .map(&:name)
+      end
+
+      # Find a record by ID and decrypt encrypted fields.
+      def find(id)
+        record = @inner.find(id)
+        decrypt_record(record)
+      end
+
+      # Return all records with encrypted fields decrypted.
+      def all
+        @inner.all.map { |r| decrypt_record(r) }
+      end
+
+      # Encrypt marked fields and persist to the inner repository.
+      def save(aggregate)
+        @inner.save(encrypt_record(aggregate))
+      end
+
+      # Delete a record by ID (delegates directly).
+      def delete(id)
+        @inner.delete(id)
+      end
+
+      # Return count of records (delegates directly).
+      def count
+        @inner.count
+      end
+
+      # Remove all records (delegates directly).
+      def clear
+        @inner.clear
+      end
+
+      # Query records with encrypted fields decrypted in results.
+      def query(**kwargs)
+        @inner.query(**kwargs).map { |r| decrypt_record(r) }
+      end
+
+      private
+
+      def encrypt_record(aggregate)
+        return aggregate if @encrypted_fields.empty?
+
+        attrs = extract_attrs(aggregate)
+        @encrypted_fields.each do |field|
+          val = attrs[field]
+          attrs[field] = @encryptor.encrypt(val) unless val.nil?
+        end
+        @aggregate_class.new(**attrs)
+      end
+
+      def decrypt_record(record)
+        return record if record.nil? || @encrypted_fields.empty?
+
+        attrs = extract_attrs(record)
+        @encrypted_fields.each do |field|
+          val = attrs[field]
+          attrs[field] = @encryptor.decrypt(val) unless val.nil?
+        end
+        @aggregate_class.new(**attrs)
+      end
+
+      def extract_attrs(aggregate)
+        hash = {}
+        hash[:id] = aggregate.id if aggregate.respond_to?(:id)
+        @aggregate_class.hecks_attributes.each do |attr_def|
+          name = attr_def.respond_to?(:name) ? attr_def.name : attr_def.to_sym
+          hash[name] = aggregate.public_send(name) if aggregate.respond_to?(name)
+        end
+        hash
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/adapters/test_encryptor.rb
+++ b/hecksties/lib/hecks/adapters/test_encryptor.rb
@@ -1,0 +1,25 @@
+# Hecks::Adapters::TestEncryptor
+#
+# Reversible Base64 encryptor for fast tests. Produces visibly different
+# ciphertext without requiring an encryption key, so specs can verify
+# that encryption/decryption round-trips without needing OpenSSL.
+#
+#   enc = Hecks::Adapters::TestEncryptor.new
+#   cipher = enc.encrypt("secret")   # => "c2VjcmV0"
+#   enc.decrypt(cipher)              # => "secret"
+#
+require "base64"
+
+module Hecks
+  module Adapters
+    class TestEncryptor
+      def encrypt(value)
+        Base64.strict_encode64(value.to_s)
+      end
+
+      def decrypt(value)
+        Base64.strict_decode64(value.to_s)
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/port_setup.rb
+++ b/hecksties/lib/hecks/runtime/port_setup.rb
@@ -55,6 +55,7 @@ module Hecks
       def wire_aggregate(agg)
         agg_class = @mod.const_get(domain_constant_name(agg.name))
         repo = ownership_scoped_repo(agg, @repositories[agg.name])
+        repo = encrypting_repo(agg, repo, agg_class)
         defaults = build_defaults(agg)
 
         Persistence.bind(agg_class, agg, repo)
@@ -92,6 +93,35 @@ module Hecks
         else
           repo
         end
+      end
+
+      # Wraps the repository with an EncryptingRepository when the aggregate
+      # has attributes tagged with +encrypted: true+.
+      #
+      # @param agg [Hecks::DomainModel::Aggregate] the aggregate definition
+      # @param repo [Object] the inner repository instance
+      # @param agg_class [Class] the runtime aggregate class
+      # @return [Object] the repo, possibly wrapped with encryption
+      def encrypting_repo(agg, repo, agg_class)
+        encrypted_fields = agg.attributes.select(&:encrypted?)
+        return repo if encrypted_fields.empty?
+
+        require "hecks/adapters/encrypting_repository"
+        require "hecks/adapters/test_encryptor"
+
+        encryptor = if Hecks.encryption_key
+                      require "hecks/adapters/aes_encryptor"
+                      Hecks::Adapters::AesEncryptor.new(Hecks.encryption_key)
+                    else
+                      Hecks::Adapters::TestEncryptor.new
+                    end
+
+        Hecks::Adapters::EncryptingRepository.new(
+          repo,
+          aggregate: agg,
+          encryptor: encryptor,
+          aggregate_class: agg_class
+        )
       end
 
       # Builds a default values hash for the aggregate's attributes.

--- a/hecksties/spec/adapters/aes_encryptor_spec.rb
+++ b/hecksties/spec/adapters/aes_encryptor_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require "openssl"
+require "hecks/adapters/aes_encryptor"
+
+RSpec.describe Hecks::Adapters::AesEncryptor do
+  let(:key) { OpenSSL::Random.random_bytes(32) }
+  subject(:enc) { described_class.new(key) }
+
+  it "round-trips a string" do
+    cipher = enc.encrypt("hello")
+    expect(enc.decrypt(cipher)).to eq("hello")
+  end
+
+  it "produces different ciphertext each time (random IV)" do
+    a = enc.encrypt("same")
+    b = enc.encrypt("same")
+    expect(a).not_to eq(b)
+  end
+
+  it "rejects keys that are not 32 bytes" do
+    expect { described_class.new("short") }.to raise_error(ArgumentError, /32 bytes/)
+  end
+
+  it "handles empty strings" do
+    cipher = enc.encrypt("")
+    expect(enc.decrypt(cipher)).to eq("")
+  end
+end

--- a/hecksties/spec/adapters/encrypting_repository_spec.rb
+++ b/hecksties/spec/adapters/encrypting_repository_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+RSpec.describe "EncryptingRepository" do
+  let(:domain) do
+    Hecks.domain "EncryptTest" do
+      aggregate "Patient" do
+        attribute :name, String
+        attribute :ssn, String, encrypted: true
+        attribute :email, String, encrypted: true
+
+        command "RegisterPatient" do
+          attribute :name, String
+          attribute :ssn, String
+          attribute :email, String
+        end
+      end
+    end
+  end
+
+  before { @app = Hecks.load(domain) }
+
+  describe "DSL" do
+    it "marks attributes as encrypted" do
+      agg = domain.aggregates.first
+      encrypted = agg.attributes.select(&:encrypted?)
+      expect(encrypted.map(&:name)).to eq([:ssn, :email])
+    end
+
+    it "non-encrypted attributes are not marked" do
+      agg = domain.aggregates.first
+      name_attr = agg.attributes.find { |a| a.name == :name }
+      expect(name_attr.encrypted?).to be false
+    end
+  end
+
+  describe "round-trip encrypt/decrypt" do
+    it "transparently encrypts and decrypts on save/find" do
+      patient = Patient.create(name: "Alice", ssn: "123-45-6789", email: "alice@example.com")
+
+      found = Patient.find(patient.id)
+      expect(found.name).to eq("Alice")
+      expect(found.ssn).to eq("123-45-6789")
+      expect(found.email).to eq("alice@example.com")
+    end
+
+    it "encrypts values in the inner repository" do
+      patient = Patient.create(name: "Bob", ssn: "987-65-4321", email: "bob@example.com")
+
+      # The class-level repo is the EncryptingRepository; reach into its inner repo
+      encrypting_repo = Patient.instance_variable_get(:@__hecks_repo__)
+      inner_repo = encrypting_repo.instance_variable_get(:@inner)
+      raw = inner_repo.find(patient.id)
+
+      # With TestEncryptor, values should be Base64-encoded
+      expect(raw.ssn).not_to eq("987-65-4321")
+      expect(raw.email).not_to eq("bob@example.com")
+      # Unencrypted field should be unchanged
+      expect(raw.name).to eq("Bob")
+    end
+
+    it "returns all records decrypted" do
+      Patient.create(name: "Carol", ssn: "111-22-3333", email: "carol@example.com")
+      Patient.create(name: "Dave", ssn: "444-55-6666", email: "dave@example.com")
+
+      all = Patient.all
+      expect(all.size).to eq(2)
+      expect(all.map(&:ssn)).to contain_exactly("111-22-3333", "444-55-6666")
+    end
+  end
+
+  describe "nil passthrough" do
+    it "does not encrypt nil values" do
+      patient = Patient.create(name: "Eve", ssn: nil, email: nil)
+
+      found = Patient.find(patient.id)
+      expect(found.ssn).to be_nil
+      expect(found.email).to be_nil
+    end
+  end
+
+  describe "delegation" do
+    it "delegates delete to inner repository" do
+      patient = Patient.create(name: "Frank", ssn: "000-00-0000", email: "frank@example.com")
+      Patient.delete(patient.id)
+      expect(Patient.find(patient.id)).to be_nil
+    end
+
+    it "delegates count to inner repository" do
+      Patient.create(name: "Grace", ssn: "111-11-1111", email: "grace@example.com")
+      expect(Patient.count).to eq(1)
+    end
+  end
+end

--- a/hecksties/spec/adapters/test_encryptor_spec.rb
+++ b/hecksties/spec/adapters/test_encryptor_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "hecks/adapters/test_encryptor"
+
+RSpec.describe Hecks::Adapters::TestEncryptor do
+  subject(:enc) { described_class.new }
+
+  it "round-trips a string" do
+    cipher = enc.encrypt("hello")
+    expect(enc.decrypt(cipher)).to eq("hello")
+  end
+
+  it "produces visibly different ciphertext" do
+    expect(enc.encrypt("secret")).not_to eq("secret")
+  end
+
+  it "handles empty strings" do
+    cipher = enc.encrypt("")
+    expect(enc.decrypt(cipher)).to eq("")
+  end
+end


### PR DESCRIPTION
## Summary
- `EncryptingRepository` decorator wraps any inner repo (mirrors `OwnershipScopedRepository` pattern)
- AES-256-GCM backend (`AesEncryptor`) + reversible Base64 (`TestEncryptor`) for fast tests
- `Hecks.encryption_key` accessor — nil uses TestEncryptor, 32-byte key uses AES
- `:privacy` concern expansion includes `:encrypted`
- Wired in `port_setup.rb` alongside ownership scoping

## Example usage

```ruby
Hecks.hecksagon "Healthcare" do
  concerns :privacy
  aggregate "Patient" do
    ssn.privacy      # .privacy expands to include .encrypted
  end
end

# Raw store has encrypted value, find returns plaintext
patient = Patient.find(id)
patient.ssn  # => "123-45-6789" (decrypted transparently)
```

## Test plan
- [x] Round-trip encrypt/decrypt through repository
- [x] Nil values pass through unchanged
- [x] Inner repo stores encrypted (non-plaintext) values
- [x] Concern expansion adds `:encrypted` for `:privacy`
- [x] AES and test encryptor unit tests
- [x] All specs pass, smoke test passes

Generated with [Claude Code](https://claude.com/claude-code)