### PR TITLE
HEC-487: Attachable attribute tag extension

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -138,6 +138,7 @@
 - `hecks_transactions` — DB transaction wrapping when SQL adapter present
 - `hecks_retry` — exponential backoff for transient errors
 - `hecks_bubble` — anti-corruption layer (ACL) for legacy data translation; context DSL with `map_aggregate`, `from_legacy` (field renaming + transforms), `map_out` (reverse mapping); API: `context.translate(:Pizza, :create, legacy_data)` and `context.reverse(:Pizza, :create, domain_data)`
+- `hecks_attachable` — file attachment metadata for aggregate attributes; tag attributes with `:attachable` in the Hecksagon DSL (`avatar.attachable`), generates `attach_<attr>` and `<attr>_attachments` methods; introspection via `DomainMod.attachable_fields`; auto-activates from hecksagon IR tags
 
 ### Domain Connections DSL
 - `extend :sqlite` — declare persistence adapter

--- a/docs/usage/attachable.md
+++ b/docs/usage/attachable.md
@@ -1,0 +1,74 @@
+# Attachable Attribute Tag
+
+Tag aggregate attributes as `:attachable` in your Hecksagon file to get
+per-attribute attachment methods generated at boot time.
+
+## Hecksagon DSL
+
+```ruby
+# PatientsHecksagon
+Hecks.hecksagon do
+  aggregate "Patient" do
+    avatar.attachable
+    scan.attachable
+  end
+end
+```
+
+The bare `avatar.attachable` syntax works inside the `aggregate` block.
+You can also use the longer `capability.avatar.attachable` form.
+
+## Domain Setup
+
+```ruby
+Hecks.domain "Patients" do
+  aggregate "Patient" do
+    attribute :name, String
+    command "CreatePatient" do
+      attribute :name, String
+    end
+  end
+end
+```
+
+## Generated Methods
+
+Once booted, the aggregate class gains:
+
+```ruby
+patient = Patient.create(name: "Alice")
+
+# Attach metadata (filename, content_type, size, etc.)
+entry = Patient.attach_avatar(patient.id, filename: "photo.jpg", content_type: "image/jpeg")
+# => { filename: "photo.jpg", content_type: "image/jpeg", ref_id: "abc-123..." }
+
+# List all attachments for the attribute
+Patient.avatar_attachments(patient.id)
+# => [{ filename: "photo.jpg", content_type: "image/jpeg", ref_id: "abc-123..." }]
+```
+
+## Introspection
+
+```ruby
+PatientsDomain.attachable_fields
+# => { "Patient" => [:avatar, :scan] }
+```
+
+## Storage
+
+The default store is `MemoryAttachmentStore` (in-memory, suitable for
+tests). The store exposes `store`, `list`, `delete`, and `clear` methods.
+
+Access the store via the runtime:
+
+```ruby
+app = Hecks.boot(__dir__)
+app.attachment_store.clear
+```
+
+## Notes
+
+- Attachments store **metadata only** (filename, content type, size).
+  Actual file bytes are handled by your storage adapter (S3, local disk, etc.).
+- The `:attachable` extension auto-activates when any aggregate has
+  an `attachable` tag in the hecksagon IR.

--- a/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
+++ b/hecksagon/lib/hecksagon/dsl/hecksagon_builder.rb
@@ -135,6 +135,17 @@ module Hecksagon
         AttributeSelector.new(@tags)
       end
 
+      # Bare attribute shorthand: avatar.attachable (without leading capability.)
+      #
+      #   avatar.attachable
+      #
+      # @return [TagApplier]
+      def method_missing(attr_name, *args)
+        TagApplier.new(@tags, attr_name.to_s)
+      end
+
+      def respond_to_missing?(_, _ = false) = true
+
       # Fluent attribute selector for capability tagging.
       class AttributeSelector
         def initialize(tags)

--- a/hecksties/lib/hecks/extensions/attachable.rb
+++ b/hecksties/lib/hecks/extensions/attachable.rb
@@ -1,0 +1,81 @@
+# Hecks::Attachable
+#
+# File attachment extension for Hecks domains. Reads +:attachable+ tags
+# from the hecksagon IR's aggregate_capabilities and generates per-attribute
+# attachment methods on domain aggregate classes.
+#
+# When registered, this extension:
+# - Adds +attach_<attr>(metadata)+ methods for storing attachment metadata
+# - Adds +<attr>_attachments+ methods for listing attachments
+# - Adds +attachable_fields+ introspection on the domain module
+#
+# Future gem: hecks_attachable
+#
+#   # Hecksagon DSL
+#   aggregate "Patient" do
+#     avatar.attachable
+#   end
+#
+#   # Usage
+#   patient = Patient.create(name: "Alice")
+#   Patient.attach_avatar(patient.id, filename: "photo.jpg")
+#   Patient.avatar_attachments(patient.id)  # => [{ filename: "photo.jpg", ref_id: "..." }]
+#   PatientsDomain.attachable_fields         # => { "Patient" => [:avatar] }
+#
+require "securerandom"
+require_relative "../runtime/attachment_store"
+
+module Hecks; end
+module Hecks::Attachable
+  # Extract attachable fields from hecksagon aggregate_capabilities tags.
+  #
+  # @param hecksagon [Hecksagon::Structure::Hecksagon] the hecksagon IR
+  # @return [Hash{String => Array<Symbol>}] aggregate name to attachable attribute names
+  def self.attachable_fields(hecksagon)
+    return {} unless hecksagon&.aggregate_capabilities
+    hecksagon.aggregate_capabilities.each_with_object({}) do |(agg_name, tags), result|
+      attrs = tags.select { |t| t[:tag] == :attachable }.map { |t| t[:attribute].to_sym }
+      result[agg_name] = attrs unless attrs.empty?
+    end
+  end
+end
+
+Hecks.describe_extension(:attachable,
+  description: "File attachment metadata for aggregate attributes",
+  adapter_type: :driven,
+  config: {},
+  wires_to: :repository)
+
+Hecks.register_extension(:attachable) do |domain_mod, domain, runtime|
+  hecksagon = runtime.hecksagon
+  fields = Hecks::Attachable.attachable_fields(hecksagon)
+  store = Hecks::Runtime::MemoryAttachmentStore.new
+
+  # Expose the attachment store on the runtime for testing/access.
+  runtime.instance_variable_set(:@attachment_store, store)
+  runtime.define_singleton_method(:attachment_store) { @attachment_store }
+
+  # Generate per-attribute methods on aggregate classes.
+  fields.each do |agg_name, attrs|
+    agg_class = domain_mod.const_get(agg_name)
+
+    attrs.each do |attr|
+      # attach_<attr>(entity_id, metadata) — store attachment metadata
+      agg_class.define_singleton_method(:"attach_#{attr}") do |entity_id, **metadata|
+        store.store(entity_id.to_s, attr, metadata)
+      end
+
+      # <attr>_attachments(entity_id) — list all attachments for the attribute
+      agg_class.define_singleton_method(:"#{attr}_attachments") do |entity_id|
+        store.list(entity_id.to_s, attr)
+      end
+    end
+  end
+
+  # Introspection: domain_mod.attachable_fields
+  #
+  # @return [Hash{String => Array<Symbol>}] aggregate name to attachable field names
+  domain_mod.define_singleton_method(:attachable_fields) do
+    fields
+  end
+end

--- a/hecksties/lib/hecks/runtime.rb
+++ b/hecksties/lib/hecks/runtime.rb
@@ -45,7 +45,7 @@ module Hecks
     include ConfigurationDSL
     include CommandDispatch
 
-    attr_reader :domain, :event_bus, :command_bus
+    attr_reader :domain, :event_bus, :command_bus, :hecksagon
 
     # @param domain [Hecks::DomainModel::Structure::Domain] the domain IR
     # @param gate [Symbol, nil] optional gate name

--- a/hecksties/lib/hecks/runtime/attachment_store.rb
+++ b/hecksties/lib/hecks/runtime/attachment_store.rb
@@ -1,0 +1,73 @@
+# Hecks::Runtime::MemoryAttachmentStore
+#
+# In-memory storage for file attachment metadata. Implements the
+# attachment store interface used by the :attachable extension.
+# Each attachment is stored as a hash keyed by aggregate ID and
+# attribute name.
+#
+# Interface:
+#   store.store(agg_id, attr, metadata)   # => metadata with :ref_id
+#   store.list(agg_id, attr)              # => [metadata, ...]
+#   store.delete(agg_id, attr, ref_id)    # => deleted metadata or nil
+#   store.clear                           # => reset all data
+#
+# Future gem: hecks_attachments
+#
+#   store = Hecks::Runtime::MemoryAttachmentStore.new
+#   store.store("abc-123", :avatar, { filename: "photo.jpg", content_type: "image/jpeg" })
+#   store.list("abc-123", :avatar)
+#
+module Hecks
+  class Runtime
+    class MemoryAttachmentStore
+      def initialize
+        @data = {}
+      end
+
+      # Store attachment metadata for an aggregate attribute.
+      #
+      # @param agg_id [String] the aggregate instance ID
+      # @param attr [Symbol, String] the attribute name
+      # @param metadata [Hash] attachment metadata (filename, content_type, etc.)
+      # @return [Hash] the stored metadata with an assigned :ref_id
+      def store(agg_id, attr, metadata)
+        key = [agg_id.to_s, attr.to_sym]
+        @data[key] ||= []
+        entry = metadata.merge(ref_id: SecureRandom.uuid)
+        @data[key] << entry
+        entry
+      end
+
+      # List all attachments for an aggregate attribute.
+      #
+      # @param agg_id [String] the aggregate instance ID
+      # @param attr [Symbol, String] the attribute name
+      # @return [Array<Hash>] stored attachment metadata entries
+      def list(agg_id, attr)
+        key = [agg_id.to_s, attr.to_sym]
+        @data[key] || []
+      end
+
+      # Delete a specific attachment by ref_id.
+      #
+      # @param agg_id [String] the aggregate instance ID
+      # @param attr [Symbol, String] the attribute name
+      # @param ref_id [String] the attachment reference ID to remove
+      # @return [Hash, nil] the deleted entry, or nil if not found
+      def delete(agg_id, attr, ref_id)
+        key = [agg_id.to_s, attr.to_sym]
+        entries = @data[key] || []
+        idx = entries.index { |e| e[:ref_id] == ref_id }
+        return nil unless idx
+        entries.delete_at(idx)
+      end
+
+      # Clear all stored attachment data.
+      #
+      # @return [void]
+      def clear
+        @data.clear
+      end
+    end
+  end
+end

--- a/hecksties/lib/hecks/runtime/extension_dispatch.rb
+++ b/hecksties/lib/hecks/runtime/extension_dispatch.rb
@@ -45,6 +45,19 @@ module Hecks
       def apply_hecksagon_capabilities
         return unless @hecksagon
         (@hecksagon.capabilities || []).each { |cap| capability(cap) }
+        apply_hecksagon_attribute_tags
+      end
+
+      # Read aggregate_capabilities tags from the hecksagon IR and
+      # auto-activate matching extensions (e.g., :attachable, :pii).
+      def apply_hecksagon_attribute_tags
+        return unless @hecksagon&.aggregate_capabilities
+        tags = @hecksagon.aggregate_capabilities.values.flatten
+        ext_names = tags.map { |t| t[:tag] }.uniq
+        ext_names.each do |name|
+          next unless Hecks.extension_registry[name]
+          self.extend(name)
+        end
       end
     end
   end

--- a/hecksties/lib/hecks/runtime/load_extensions.rb
+++ b/hecksties/lib/hecks/runtime/load_extensions.rb
@@ -20,7 +20,7 @@ module Hecks
   # Non-persistence extensions are auto-loaded at boot time.
   module LoadExtensions
     # Extensions loaded automatically at boot (non-persistence).
-    AUTO = %i[serve ai auth audit pii validations filesystem_store].freeze
+    AUTO = %i[serve ai auth audit pii validations filesystem_store attachable].freeze
 
     # Loads a single extension by name via the load path.
     # Silently does nothing if the extension cannot be loaded

--- a/hecksties/spec/extensions/attachable_spec.rb
+++ b/hecksties/spec/extensions/attachable_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+require "hecks/extensions/attachable"
+
+RSpec.describe "Hecks::Attachable" do
+  let(:domain) do
+    Hecks.domain "AttachTest" do
+      aggregate "Patient" do
+        attribute :name, String
+        command "CreatePatient" do
+          attribute :name, String
+        end
+      end
+    end
+  end
+
+  let(:hecksagon) do
+    Hecks.hecksagon do
+      aggregate "Patient" do
+        avatar.attachable
+      end
+    end
+  end
+
+  before do
+    @app = Hecks.load(domain, hecksagon: hecksagon)
+  end
+
+  after do
+    Hecks.last_hecksagon = nil
+    Object.send(:remove_const, :AttachTestDomain) if defined?(AttachTestDomain)
+  end
+
+  describe "attach and list" do
+    it "attaches metadata and lists attachments" do
+      patient = Patient.create(name: "Alice")
+      Patient.attach_avatar(patient.id, filename: "photo.jpg", content_type: "image/jpeg")
+
+      attachments = Patient.avatar_attachments(patient.id)
+      expect(attachments.size).to eq(1)
+      expect(attachments.first[:filename]).to eq("photo.jpg")
+      expect(attachments.first[:content_type]).to eq("image/jpeg")
+      expect(attachments.first[:ref_id]).to be_a(String)
+    end
+
+    it "supports multiple attachments" do
+      patient = Patient.create(name: "Bob")
+      Patient.attach_avatar(patient.id, filename: "a.jpg")
+      Patient.attach_avatar(patient.id, filename: "b.jpg")
+
+      expect(Patient.avatar_attachments(patient.id).size).to eq(2)
+    end
+  end
+
+  describe "introspection" do
+    it "exposes attachable_fields on the domain module" do
+      mod = Object.const_get("AttachTestDomain")
+      expect(mod.attachable_fields).to eq("Patient" => [:avatar])
+    end
+  end
+
+  describe "DSL bare syntax" do
+    it "supports avatar.attachable without capability. prefix" do
+      hex = Hecks.hecksagon do
+        aggregate "Patient" do
+          avatar.attachable
+        end
+      end
+
+      tags = hex.aggregate_capabilities["Patient"]
+      expect(tags).to include({ attribute: "avatar", tag: :attachable })
+    end
+  end
+end

--- a/hecksties/spec/extensions/attachable_store_spec.rb
+++ b/hecksties/spec/extensions/attachable_store_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require "hecks/runtime/attachment_store"
+
+RSpec.describe Hecks::Runtime::MemoryAttachmentStore do
+  subject(:store) { described_class.new }
+
+  describe "#store" do
+    it "stores metadata and returns entry with ref_id" do
+      entry = store.store("agg-1", :avatar, { filename: "photo.jpg" })
+
+      expect(entry[:filename]).to eq("photo.jpg")
+      expect(entry[:ref_id]).to be_a(String)
+      expect(entry[:ref_id].length).to eq(36) # UUID
+    end
+
+    it "stores multiple attachments for the same attribute" do
+      store.store("agg-1", :avatar, { filename: "a.jpg" })
+      store.store("agg-1", :avatar, { filename: "b.jpg" })
+
+      expect(store.list("agg-1", :avatar).size).to eq(2)
+    end
+  end
+
+  describe "#list" do
+    it "returns empty array when no attachments exist" do
+      expect(store.list("agg-1", :avatar)).to eq([])
+    end
+
+    it "returns stored entries for the attribute" do
+      store.store("agg-1", :avatar, { filename: "photo.jpg" })
+      entries = store.list("agg-1", :avatar)
+
+      expect(entries.size).to eq(1)
+      expect(entries.first[:filename]).to eq("photo.jpg")
+    end
+
+    it "isolates by aggregate ID" do
+      store.store("agg-1", :avatar, { filename: "a.jpg" })
+      store.store("agg-2", :avatar, { filename: "b.jpg" })
+
+      expect(store.list("agg-1", :avatar).size).to eq(1)
+      expect(store.list("agg-2", :avatar).size).to eq(1)
+    end
+  end
+
+  describe "#delete" do
+    it "removes the entry by ref_id and returns it" do
+      entry = store.store("agg-1", :avatar, { filename: "photo.jpg" })
+      deleted = store.delete("agg-1", :avatar, entry[:ref_id])
+
+      expect(deleted[:filename]).to eq("photo.jpg")
+      expect(store.list("agg-1", :avatar)).to be_empty
+    end
+
+    it "returns nil when ref_id not found" do
+      expect(store.delete("agg-1", :avatar, "nonexistent")).to be_nil
+    end
+  end
+
+  describe "#clear" do
+    it "removes all stored data" do
+      store.store("agg-1", :avatar, { filename: "photo.jpg" })
+      store.clear
+
+      expect(store.list("agg-1", :avatar)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `MemoryAttachmentStore` with `store`, `list`, `delete`, `clear` interface
- Attachable extension follows PII pattern: reads `:attachable` tags from hecksagon IR
- Generates per-attribute methods: `attach_<attr>(metadata)`, `<attr>_attachments`
- `apply_hecksagon_attribute_tags` in extension dispatch auto-activates from tags
- Bare DSL: `avatar.attachable` via `method_missing` on `AggregateCapabilityBuilder`

## Example usage

```ruby
Hecks.hecksagon "Healthcare" do
  aggregate "Patient" do
    avatar.attachable
  end
end

patient.attach_avatar(name: "photo.jpg", url: "/uploads/photo.jpg")
patient.avatar_attachments  # => [{name: "photo.jpg", ...}]
```

## Test plan
- [x] Attach and list per-attribute attachments
- [x] Introspection: `attachable_fields` returns correct mapping
- [x] MemoryAttachmentStore unit tests
- [x] All specs pass, smoke test passes

Generated with [Claude Code](https://claude.com/claude-code)