### PR TITLE
feat(autophagy): Prism-based self-hosting compiler

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -479,12 +479,19 @@
 - Skips Rails internal tables (schema_migrations, active_storage_*, etc.)
 - Preview mode with `--preview` flag
 
-## Binary Compiler (Hecks v0)
+## Autophagy: Self-Hosting Compiler (Hecks v0)
 - `hecks compile` — compile the entire Hecks framework into a single self-contained Ruby script
 - `hecks compile --plan` — show compilation plan (file count and list) without writing
 - `hecks compile --output NAME` — specify output file name (default: `hecks_v0`)
-- The compiled binary bundles all 400+ source files in load order with zero `require_relative`
-- Strips internal requires, chapter loading calls, and Dir[] glob requires
+- `hecks compile --trace` — emit auditable trace of every compiler decision to stderr
+- **Prism AST analysis** — uses Ruby's built-in Prism parser for dependency resolution
+- **Bluebook IR consultation** — resolves method-call dependencies via chapter definitions
+- **Two-layer dependency graph**: Layer 1 = Prism (constant refs, inheritance, mixins), Layer 2 = Bluebook (method-call edges)
+- **Source files are require-free** — all internal requires stripped, Bluebook defines load order
+- **SourceTransformer** — strips requires and expands compact class syntax at compile time
+- **ConstantResolver** — namespace-aware constant resolution across all source files
+- **CycleSorter** — greedy topo sort within dependency cycles, respecting wiring file order
+- The compiled binary bundles all source files in load order with zero internal requires
 - Injects forward declarations for load-order dependencies
 - Pre-registers all bundled files in `$LOADED_FEATURES` to prevent double-loading
 - The binary supports `boot`, `version`, and `self-test` commands

--- a/bluebook/lib/hecks/chapters/bluebook/tooling.rb
+++ b/bluebook/lib/hecks/chapters/bluebook/tooling.rb
@@ -59,6 +59,34 @@ module Hecks
           b.aggregate "ReadmeWriter", "Generates per-extension Markdown README files from metadata" do
             command("GenerateReadmes") { attribute :root, String }
           end
+
+          b.aggregate "SourceAnalyzer", "Prism AST analysis of source files for dependency resolution" do
+            command("Analyze") { attribute :lib_root, String }
+          end
+
+          b.aggregate "ConstantResolver", "Resolves constant references to defining files" do
+            command("Resolve") { attribute :ref, String }
+          end
+
+          b.aggregate "DependencyGraph", "Builds file-level dependency graph and topological sort" do
+            command("Sort") { attribute :lib_root, String }
+          end
+
+          b.aggregate "CycleSorter", "Greedy topological sort within dependency cycles" do
+            command("SortCycle") { attribute :files, String }
+          end
+
+          b.aggregate "SourceTransformer", "Strips requires and expands compact class syntax" do
+            command("Transform") { attribute :source, String }
+          end
+
+          b.aggregate "ReferenceExtractor", "Extracts constant references from Prism AST" do
+            command("Extract") { attribute :source, String }
+          end
+
+          b.aggregate "DefinitionExtractor", "Extracts constant definitions from Prism AST" do
+            command("Extract") { attribute :source, String }
+          end
         end
       end
     end

--- a/docs/usage/binary_compiler.md
+++ b/docs/usage/binary_compiler.md
@@ -1,8 +1,9 @@
-# Binary Compiler (Hecks v0)
+# Autophagy: Self-Hosting Compiler (Hecks v0)
 
-Compile the entire Hecks framework into a single self-contained Ruby script.
-The output binary boots Hecks with zero `require_relative` -- all 400+ source
-files are concatenated in load order.
+Hecks compiles itself into a single dependency-free Ruby script. The pipeline
+uses Prism AST analysis to build a file-level dependency graph, topologically
+sorts it, and concatenates all source into one file. No gems, no bundler,
+no require infrastructure — just `ruby hecks_v0`.
 
 ## Quick Start
 
@@ -14,6 +15,9 @@ hecks compile
 ./hecks_v0 version
 ./hecks_v0 boot examples/pizzas
 ./hecks_v0 self-test
+
+# Debug compilation with trace output
+hecks compile --trace
 ```
 
 ## CLI Options
@@ -24,6 +28,9 @@ hecks compile
 
 # Custom output name
 hecks compile --output my_hecks
+
+# Trace mode — emits [AUTOPHAGY] decisions to stderr
+hecks compile --trace
 
 # Show what would be compiled (no file written)
 hecks compile --plan
@@ -47,24 +54,39 @@ require "hecks/compiler"
 compiler = Hecks::Compiler::BinaryCompiler.new
 compiler.compile(output: "hecks_v0")
 
-# Check compilation plan
-plan = compiler.plan
-puts "Files: #{plan[:file_count]}"
-plan[:files].each { |f| puts "  #{f}" }
+# Compile with trace output
+compiler.compile(output: "hecks_v0", trace: true)
 ```
 
 ## How It Works
 
-1. **Source Collection** -- introspects `$LOADED_FEATURES` after requiring
-   `hecks` and booting a domain, capturing all source files in load order
-2. **Forward Declarations** -- injects module stubs for load-order
-   dependencies (e.g., `HecksDeprecations`) and extends registry methods
-3. **Line Stripping** -- comments out `require_relative`, internal `require`,
-   `Chapters.load_chapter/load_aggregates` calls, and `Dir[]` glob requires
-4. **Feature Registration** -- pre-registers all bundled file paths in
-   `$LOADED_FEATURES` so Ruby's `require` skips them
-5. **Entrypoint** -- appends a CLI dispatcher for `boot`, `version`, and
-   `self-test` commands
+The compiler pipeline has five stages:
+
+1. **Prism AST Analysis** (`SourceAnalyzer`) — discovers all `.rb` files under
+   `lib/`, parses each with Prism, and extracts constant definitions, references,
+   inheritance, mixins, and namespace scopes
+2. **Dependency Graph** (`DependencyGraph` + `ConstantResolver`) — builds
+   file-level edges from constant references. Two resolution layers:
+   - Layer 1: Prism AST (direct constant refs, superclass, include/extend)
+   - Layer 2: Bluebook IR (method-call deps like `Hecks.describe_extension`)
+3. **Topological Sort** — Kahn's algorithm with `CycleSorter` for cycles.
+   Wiring files (`foo.rb` with `foo/` directory) load after their children
+4. **Source Transform** (`SourceTransformer`) — strips all require/autoload
+   calls and expands compact class syntax (`class Hecks::Foo::Bar` → nested
+   `module Hecks; module Foo; class Bar`)
+5. **Bundle Write** (`BundleWriter`) — concatenates transformed source with
+   forward declarations, stdlib requires, and a CLI entrypoint
+
+## Trace Mode
+
+The `--trace` flag emits every compiler decision to stderr:
+
+```
+[AUTOPHAGY] EDGE hecks/dsl/domain_builder.rb → hecks/dsl/aggregate_builder.rb (ref: AggregateBuilder)
+[AUTOPHAGY] EDGE hecks/runtime.rb → hecks/ports/commands.rb (method)
+[AUTOPHAGY] EDGE hecks/conventions.rb → hecks/conventions/naming.rb (wiring)
+[AUTOPHAGY] CYCLE: hecks/foo.rb, hecks/bar.rb
+```
 
 ## Self-Hosting Verification
 
@@ -75,6 +97,6 @@ ruby -Ilib -e 'require "hecks"; require "hecks/compiler"; Hecks::Compiler::Binar
 # Run v0 on the pizzas example
 ./hecks_v0 boot examples/pizzas
 
-# Check v0 self-test
+# Check v0 self-test (modules, targets, status)
 ./hecks_v0 self-test
 ```

--- a/lib/hecks/chapters/bluebook/tooling.rb
+++ b/lib/hecks/chapters/bluebook/tooling.rb
@@ -75,6 +75,34 @@ module Hecks
           b.aggregate "BinaryCompiler", "Orchestrates compilation into a self-contained Ruby script" do
             command("Compile") { attribute :output, String }
           end
+
+          b.aggregate "SourceAnalyzer", "Prism AST analysis of source files for dependency resolution" do
+            command("Analyze") { attribute :lib_root, String }
+          end
+
+          b.aggregate "ConstantResolver", "Resolves constant references to defining files" do
+            command("Resolve") { attribute :ref, String }
+          end
+
+          b.aggregate "DependencyGraph", "Builds file-level dependency graph and topological sort" do
+            command("Sort") { attribute :lib_root, String }
+          end
+
+          b.aggregate "CycleSorter", "Greedy topological sort within dependency cycles" do
+            command("SortCycle") { attribute :files, String }
+          end
+
+          b.aggregate "SourceTransformer", "Strips requires and expands compact class syntax" do
+            command("Transform") { attribute :source, String }
+          end
+
+          b.aggregate "ReferenceExtractor", "Extracts constant references from Prism AST" do
+            command("Extract") { attribute :source, String }
+          end
+
+          b.aggregate "DefinitionExtractor", "Extracts constant definitions from Prism AST" do
+            command("Extract") { attribute :source, String }
+          end
         end
       end
     end

--- a/lib/hecks/compiler/binary_compiler.rb
+++ b/lib/hecks/compiler/binary_compiler.rb
@@ -1,8 +1,8 @@
 # Hecks::Compiler::BinaryCompiler
 #
 # Orchestrates compilation of the Hecks framework into a single
-# self-contained Ruby script. Collects all loaded source files,
-# concatenates them in load order, and writes a bundled executable.
+# self-contained Ruby script. Uses SourceAnalyzer for Prism-based
+# dependency resolution and topological file ordering.
 #
 #   compiler = Hecks::Compiler::BinaryCompiler.new
 #   compiler.compile(output: "hecks_v0")
@@ -14,19 +14,19 @@ module Hecks
 
       # @param lib_root [String] path to the lib/ directory
       def initialize(lib_root: nil)
-        @lib_root = lib_root || SourceCollector.default_lib_root
+        @lib_root = lib_root || default_lib_root
       end
 
-      # Compiles all loaded Hecks source into a bundled executable.
+      # Compiles all Hecks source into a bundled executable using
+      # static analysis for file ordering (no runtime introspection).
       #
       # @param output [String] output file path (default: "hecks_v0")
       # @return [String] absolute path to the compiled binary
-      def compile(output: "hecks_v0")
-        files = SourceCollector.collect(lib_root: lib_root)
+      def compile(output: "hecks_v0", trace: false)
+        files = SourceAnalyzer.analyze(lib_root: lib_root, trace: trace)
 
         if files.empty?
-          raise "No Hecks source files found under #{lib_root}. " \
-                "Is Hecks loaded? (require 'hecks' first)"
+          raise "No Hecks source files found under #{lib_root}."
         end
 
         output_path = File.expand_path(output)
@@ -38,12 +38,18 @@ module Hecks
       #
       # @return [Hash] compilation plan with file count and paths
       def plan
-        files = SourceCollector.collect(lib_root: lib_root)
+        files = SourceAnalyzer.analyze(lib_root: lib_root)
         {
           lib_root: lib_root,
           file_count: files.size,
           files: files.map { |f| f.sub("#{lib_root}/", "") }
         }
+      end
+
+      private
+
+      def default_lib_root
+        File.expand_path("../..", __dir__)
       end
     end
   end

--- a/lib/hecks/compiler/bundle_writer.rb
+++ b/lib/hecks/compiler/bundle_writer.rb
@@ -1,8 +1,9 @@
 # Hecks::Compiler::BundleWriter
 #
 # Takes an ordered list of source files and concatenates them into a
-# single self-contained Ruby script. Strips require_relative calls,
-# neutralizes chapter loading, and guards require via $LOADED_FEATURES.
+# single self-contained Ruby script. Strips all require/require_relative
+# calls, neutralizes chapter loading, and guards external class
+# inheritance with defined?() checks.
 #
 #   Hecks::Compiler::BundleWriter.write(files, output: "hecks_v0")
 #
@@ -22,17 +23,17 @@ module Hecks
 
       # Writes the bundled script to the output path.
       def self.write(files, output:, lib_root:)
+        last_registry_idx = find_last_registry_index(files)
+
         File.open(output, "w") do |f|
           write_header(f, files.size)
           write_stdlib_requires(f)
           ForwardDeclarations.write(f)
           write_loaded_features(f, files)
-          registry_injected = false
-          files.each do |path|
+          files.each_with_index do |path, idx|
             write_file(f, path, lib_root)
-            if !registry_injected && path.include?("grammar_registry")
+            if idx == last_registry_idx
               ForwardDeclarations.write_registry_extends(f)
-              registry_injected = true
             end
           end
           write_entrypoint(f)
@@ -41,9 +42,19 @@ module Hecks
         output
       end
 
+      # Finds the index of the last registries/ file so we inject
+      # extends after all registry modules are defined.
+      def self.find_last_registry_index(files)
+        last = nil
+        files.each_with_index do |path, idx|
+          last = idx if path.include?("/registries/")
+        end
+        last
+      end
+
       def self.write_header(io, count)
         io.puts SHEBANG
-        io.puts format(BANNER, timestamp: Time.now.iso8601, count: count)
+        io.puts format(BANNER, timestamp: Time.now.strftime("%Y-%m-%dT%H:%M:%S%z"), count: count)
       end
 
       def self.write_stdlib_requires(io)
@@ -63,7 +74,6 @@ module Hecks
         io.puts "$LOAD_PATH.reject! { |p| p.include?(\"hecks\") }"
         io.puts ""
         io.puts "# Pre-register bundled files so require() skips them."
-        io.puts "# Add both absolute and lib-relative paths."
         files.each do |f|
           io.puts "$LOADED_FEATURES << #{f.inspect}"
           rel = f.sub(%r{.*/lib/}, "")
@@ -76,57 +86,8 @@ module Hecks
         rel = path.sub("#{lib_root}/", "")
         io.puts "# --- #{rel} ---"
         content = File.read(path)
-        cleaned = strip_bundled_lines(content)
-        io.puts cleaned
+        io.puts SourceTransformer.transform(content)
         io.puts
-      end
-
-      # Comments out require_relative, internal require, chapter loading,
-      # and Dir[] loading calls that reference bundled code.
-      def self.strip_bundled_lines(source)
-        lines = source.lines
-        result = []
-        skip_depth = 0
-
-        lines.each do |line|
-          stripped = line.strip
-          if skip_depth > 0
-            skip_depth += line.count("(") - line.count(")")
-            result << "# [v0] #{line.chomp}\n"
-            skip_depth = 0 if skip_depth <= 0
-          elsif should_strip?(stripped)
-            result << "# [v0] #{stripped}\n"
-            if multiline_call?(stripped)
-              skip_depth = stripped.count("(") - stripped.count(")")
-            end
-          else
-            result << line
-          end
-        end
-        result.join
-      end
-
-      def self.should_strip?(line)
-        line.match?(/\Arequire_relative\s/) ||
-          hecks_require?(line) ||
-          chapter_load?(line) ||
-          dir_glob_require?(line)
-      end
-
-      def self.hecks_require?(line)
-        line.match?(/\Arequire\s+["'](?:hecks|bluebook|hecksagon|hecks_cli|hecks_persist|hecks_mongodb|hecksul|heckscode|hecks_serve|hecks_multidomain|hecks_targets|go_hecks|node_hecks|hecks_ai|active_hecks|hecks_live|hecks_static)/)
-      end
-
-      def self.chapter_load?(line)
-        line.match?(/(?:Hecks::)?Chapters\.(load_chapter|load_aggregates|require_paragraphs)\b/)
-      end
-
-      def self.dir_glob_require?(line)
-        line.match?(/\ADir\[.*\].*\.each\s*\{.*require/)
-      end
-
-      def self.multiline_call?(line)
-        line.include?("(") && line.count("(") > line.count(")")
       end
 
       def self.write_entrypoint(io)
@@ -162,10 +123,7 @@ module Hecks
 
       private_class_method :write_header, :write_stdlib_requires,
                            :write_loaded_features, :write_file,
-                           :strip_bundled_lines, :should_strip?,
-                           :hecks_require?, :chapter_load?,
-                           :dir_glob_require?, :multiline_call?,
-                           :write_entrypoint
+                           :write_entrypoint, :find_last_registry_index
     end
   end
 end

--- a/lib/hecks/compiler/constant_resolver.rb
+++ b/lib/hecks/compiler/constant_resolver.rb
@@ -1,0 +1,99 @@
+# Hecks::Compiler::ConstantResolver
+#
+# Builds an index of Ruby constant definitions across files and
+# resolves constant references to their defining file. Handles
+# fully-qualified paths, suffix matching, and namespace-aware
+# resolution for bare references inside enclosing scopes.
+#
+#   resolver = ConstantResolver.new(file_definitions, file_namespaces)
+#   resolver.resolve("Hecks::DSL::DomainBuilder")
+#     # => "/path/to/lib/hecks/dsl/domain_builder.rb"
+#
+module Hecks
+  module Compiler
+    class ConstantResolver
+      def initialize(file_definitions, file_namespaces)
+        @file_definitions = file_definitions
+        @file_namespaces  = file_namespaces
+        @index = build_index
+      end
+
+      # Resolves a constant reference to the file that defines it.
+      # Tries full path first, then progressively shorter prefixes.
+      #
+      # @param ref [String] constant path (e.g. "Hecks::DSL::DomainBuilder")
+      # @param exclude [String, nil] file to exclude from results
+      # @return [String, nil] file path or nil
+      def resolve(ref, exclude: nil)
+        parts = ref.split("::")
+        parts.length.downto(1) do |n|
+          candidate = parts[0...n].join("::")
+          provider = @index[candidate]
+          return provider if provider && provider != exclude
+        end
+        nil
+      end
+
+      # Qualifies a reference with enclosing namespaces and resolves.
+      #
+      # @param ref [String] bare or partial constant name
+      # @param scopes [Set<String>] enclosing namespace paths
+      # @param exclude [String, nil] file to exclude
+      # @return [String, nil] file path or nil
+      def resolve_in_scope(ref, scopes, exclude: nil)
+        scopes.each do |ns|
+          provider = @index["#{ns}::#{ref}"]
+          return provider if provider && provider != exclude
+        end
+        nil
+      end
+
+      # Checks if a bare reference matches any locally defined constant.
+      # E.g., "DomainVisualizer" matches "Hecks::DomainVisualizer".
+      def defined_locally?(ref, scopes)
+        suffix = "::#{ref}"
+        scopes.any? { |s| s == ref || s.end_with?(suffix) }
+      end
+
+      private
+
+      def build_index
+        all_namespaces = @file_namespaces.values.flatten.to_set
+        index = {}
+
+        @file_definitions.each do |file, constants|
+          constants.each do |const|
+            next if all_namespaces.include?(const)
+            index[const] = file unless index.key?(const)
+          end
+        end
+
+        @file_namespaces.each do |file, namespaces|
+          namespaces.each do |ns|
+            index[ns] = file unless index.key?(ns)
+          end
+        end
+
+        build_suffix_entries(index, all_namespaces)
+        index
+      end
+
+      # Suffix-derived entries for qualified refs (3+ segments).
+      # Avoids false edges from bare names like "Names" or "Utils".
+      def build_suffix_entries(index, all_namespaces)
+        @file_definitions.each do |file, constants|
+          constants.each do |const|
+            next if all_namespaces.include?(const)
+            parts = const.split("::")
+            next if parts.length < 3
+            (1...parts.length).each do |i|
+              suffix = parts[i..].join("::")
+              next if suffix.split("::").length < 2
+              index[suffix] = file unless index.key?(suffix)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hecks/compiler/cycle_sorter.rb
+++ b/lib/hecks/compiler/cycle_sorter.rb
@@ -1,0 +1,76 @@
+# Hecks::Compiler::CycleSorter
+#
+# Orders files within a dependency cycle using a greedy topological
+# approach. Repeatedly selects files whose cycle-internal dependencies
+# are satisfied, breaking deadlocks by choosing files with the fewest
+# unsatisfied deps. Wiring files are deferred until their children
+# are emitted.
+#
+#   sorter = CycleSorter.new(files, edges, wiring_files: Set.new)
+#   sorter.sorted  # => ["/path/to/a.rb", "/path/to/b.rb"]
+#
+module Hecks
+  module Compiler
+    class CycleSorter
+      # @param files [Array<String>] files in the cycle
+      # @param edges [Hash{String => Set<String>}] full edge map
+      # @param wiring_files [Set<String>] files that load after children
+      def initialize(files, edges, wiring_files: Set.new)
+        @files = files
+        @edges = edges
+        @wiring_files = wiring_files
+        @file_set = files.to_set
+        @cycle_deps = build_cycle_deps
+      end
+
+      # Returns files ordered so cycle-internal deps are respected
+      # as much as possible.
+      #
+      # @return [Array<String>] ordered file paths
+      def sorted
+        result = []
+        emitted = Set.new
+        remaining = @files.dup
+
+        loop do
+          ready = remaining.select { |f|
+            @cycle_deps[f].all? { |d| emitted.include?(d) }
+          }
+          ready = pick_deadlock_breakers(remaining, emitted) if ready.empty?
+          non_wiring = ready.reject { |f| @wiring_files.include?(f) }
+          pick = non_wiring.min || ready.min
+          break unless pick
+          result << pick
+          emitted << pick
+          remaining.delete(pick)
+          break if remaining.empty?
+        end
+
+        result
+      end
+
+      private
+
+      def build_cycle_deps
+        deps = {}
+        @files.each do |f|
+          deps[f] = (@edges[f] || Set.new).select { |d| @file_set.include?(d) }
+        end
+        deps
+      end
+
+      # Picks files with fewest unsatisfied cycle deps to break deadlocks.
+      def pick_deadlock_breakers(remaining, emitted)
+        remaining_set = remaining.to_set
+        unsatisfied = {}
+        remaining.each do |f|
+          unsatisfied[f] = @cycle_deps[f].count { |d|
+            remaining_set.include?(d) && !emitted.include?(d)
+          }
+        end
+        min_unsat = unsatisfied.values.min
+        remaining.select { |f| unsatisfied[f] == min_unsat }
+      end
+    end
+  end
+end

--- a/lib/hecks/compiler/definition_extractor.rb
+++ b/lib/hecks/compiler/definition_extractor.rb
@@ -1,0 +1,115 @@
+# Hecks::Compiler::DefinitionExtractor
+#
+# Prism AST visitor that extracts class and module definitions from
+# a Ruby source file. Tracks the full constant path (e.g. Hecks::Compiler)
+# and distinguishes namespace-only modules from real definitions.
+#
+#   result = DefinitionExtractor.extract(source)
+#   result.definitions  # => ["Hecks::Compiler::SourceAnalyzer"]
+#   result.namespaces   # => ["Hecks", "Hecks::Compiler"]
+#
+require "prism"
+
+module Hecks
+  module Compiler
+    class DefinitionExtractor < Prism::Visitor
+      Result = Struct.new(:definitions, :namespaces, keyword_init: true)
+
+      # Extracts definitions from Ruby source code.
+      #
+      # @param source [String] Ruby source code
+      # @return [Result] definitions and namespaces found
+      def self.extract(source)
+        tree = Prism.parse(source).value
+        visitor = new
+        visitor.visit(tree)
+        Result.new(
+          definitions: visitor.definitions.uniq,
+          namespaces: visitor.namespaces.uniq
+        )
+      end
+
+      attr_reader :definitions, :namespaces
+
+      def initialize
+        @definitions = []
+        @namespaces  = []
+        @scope_stack = []
+      end
+
+      def visit_module_node(node)
+        name = resolve_constant_path(node.constant_path)
+        return super unless name
+
+        full_name = scoped_name(name)
+        if namespace_only?(node)
+          @namespaces << full_name
+        else
+          @definitions << full_name
+        end
+
+        @scope_stack.push(full_name)
+        super
+        @scope_stack.pop
+      end
+
+      def visit_class_node(node)
+        name = resolve_constant_path(node.constant_path)
+        return super unless name
+
+        full_name = scoped_name(name)
+        @definitions << full_name
+
+        @scope_stack.push(full_name)
+        super
+        @scope_stack.pop
+      end
+
+      private
+
+      def scoped_name(name)
+        if name.include?("::")
+          name
+        elsif @scope_stack.any?
+          "#{@scope_stack.last}::#{name}"
+        else
+          name
+        end
+      end
+
+      def resolve_constant_path(node)
+        case node
+        when Prism::ConstantReadNode
+          node.name.to_s
+        when Prism::ConstantPathNode
+          parts = []
+          current = node
+          while current.is_a?(Prism::ConstantPathNode)
+            parts.unshift(current.name.to_s)
+            current = current.parent
+          end
+          parts.unshift(current.name.to_s) if current.is_a?(Prism::ConstantReadNode)
+          parts.join("::")
+        end
+      end
+
+      # A module is namespace-only if its body contains only other
+      # class/module nodes — no method defs, no constant assignments,
+      # no include/extend calls.
+      def namespace_only?(node)
+        body = node.body
+        return true unless body
+
+        statements = case body
+                     when Prism::StatementsNode then body.body
+                     else [body]
+                     end
+
+        statements.all? { |s|
+          s.is_a?(Prism::ModuleNode) ||
+          s.is_a?(Prism::ClassNode)
+        }
+      end
+    end
+  end
+end

--- a/lib/hecks/compiler/dependency_graph.rb
+++ b/lib/hecks/compiler/dependency_graph.rb
@@ -1,0 +1,141 @@
+# Hecks::Compiler::DependencyGraph
+#
+# Builds a file-level dependency graph from definition and reference
+# data, then topologically sorts it using Kahn's algorithm. Handles
+# cycles via CycleSorter. Wiring files (foo.rb with foo/ directory)
+# are forced to load after their children.
+#
+#   graph = DependencyGraph.new(file_defs, file_refs, file_ns,
+#     method_edges: {}, wiring_files: Set.new)
+#   graph.sorted_files  # => ["/path/to/a.rb", "/path/to/b.rb"]
+#
+module Hecks
+  module Compiler
+    class DependencyGraph
+      def initialize(file_definitions, file_references, file_namespaces = {},
+                     method_edges: {}, wiring_files: Set.new,
+                     mixin_refs: {}, trace: false, lib_root: "")
+        @file_definitions = file_definitions
+        @file_references  = file_references
+        @file_namespaces  = file_namespaces
+        @method_edges     = method_edges
+        @wiring_files     = wiring_files
+        @mixin_refs       = mixin_refs
+        @files            = file_definitions.keys
+        @trace            = trace
+        @lib_root         = lib_root
+        @resolver = ConstantResolver.new(file_definitions, file_namespaces)
+      end
+
+      # Returns files in topological order (dependencies first).
+      #
+      # @return [Array<String>] sorted file paths
+      def sorted_files
+        edges = build_edges
+        inject_method_edges(edges)
+        inject_wiring_edges(edges)
+        kahn_sort(edges)
+      end
+
+      private
+
+      def build_edges
+        edges = Hash.new { |h, k| h[k] = Set.new }
+        @files.each { |f| edges[f] }
+
+        @file_references.each do |file, refs|
+          own_namespaces = (@file_namespaces[file] || []).to_set
+          own_defs = (@file_definitions[file] || []).to_set
+          scopes = own_namespaces | own_defs
+
+          refs.each do |ref|
+            next if own_namespaces.include?(ref) || own_defs.include?(ref)
+            next if @resolver.defined_locally?(ref, scopes)
+            provider = @resolver.resolve(ref, exclude: file)
+            provider ||= @resolver.resolve_in_scope(ref, scopes, exclude: file)
+            next unless provider
+            trace_edge(file, provider, "ref: #{ref}") if @trace
+            edges[file] << provider
+          end
+        end
+
+        inject_mixin_edges(edges)
+        edges
+      end
+
+      # Resolves bare mixin refs (include Foo) using enclosing scopes.
+      def inject_mixin_edges(edges)
+        @mixin_refs.each do |file, mixins|
+          scopes = ((@file_namespaces[file] || []) + (@file_definitions[file] || [])).to_set
+          mixins.each do |ref|
+            next if ref.include?("::")
+            next if @resolver.resolve(ref, exclude: file)
+            provider = @resolver.resolve_in_scope(ref, scopes, exclude: file)
+            next unless provider
+            trace_edge(file, provider, "mixin-ns") if @trace
+            edges[file] << provider
+          end
+        end
+      end
+
+      def inject_method_edges(edges)
+        @method_edges.each do |caller_file, deps|
+          deps.each do |dep|
+            next if dep == caller_file
+            trace_edge(caller_file, dep, "method") if @trace
+            (edges[caller_file] ||= Set.new) << dep
+          end
+        end
+      end
+
+      # Wiring files depend on all files in their corresponding directory.
+      def inject_wiring_edges(edges)
+        @wiring_files.each do |wiring_file|
+          dir = wiring_file.sub(/\.rb$/, "")
+          @files.select { |f| f.start_with?("#{dir}/") }.each do |child|
+            trace_edge(wiring_file, child, "wiring") if @trace
+            (edges[wiring_file] ||= Set.new) << child
+          end
+        end
+      end
+
+      def kahn_sort(edges)
+        in_degree = {}
+        edges.each_key { |f| in_degree[f] = edges[f].size }
+        edges.each_value { |deps| deps.each { |d| in_degree[d] ||= 0 } }
+
+        queue = in_degree.select { |_, d| d == 0 }.keys.sort
+        result = []
+        removed = Set.new
+
+        while queue.any?
+          file = queue.shift
+          result << file
+          removed << file
+          edges.each do |dependent, deps|
+            next if removed.include?(dependent) || !deps.include?(file)
+            in_degree[dependent] -= 1
+            queue.push(dependent).sort! if in_degree[dependent] == 0
+          end
+        end
+
+        remaining = @files - result
+        ordered = CycleSorter.new(remaining, edges, wiring_files: @wiring_files).sorted
+        trace_cycle(remaining) if @trace && remaining.any?
+        result + ordered
+      end
+
+      def rel(path)
+        path.sub("#{@lib_root}/", "")
+      end
+
+      def trace_edge(from, to, kind)
+        $stderr.puts "[AUTOPHAGY] EDGE #{rel(from)} → #{rel(to)} (#{kind})"
+      end
+
+      def trace_cycle(remaining)
+        $stderr.puts "[AUTOPHAGY] CYCLE: #{remaining.map { |f| rel(f) }.join(', ')}"
+      end
+    end
+  end
+end

--- a/lib/hecks/compiler/reference_extractor.rb
+++ b/lib/hecks/compiler/reference_extractor.rb
@@ -1,0 +1,155 @@
+# Hecks::Compiler::ReferenceExtractor
+#
+# Prism AST visitor that extracts constant references from Ruby source.
+# Captures inheritance (superclass), include/extend mixins, and general
+# constant path reads. Used by SourceAnalyzer to build dependency edges.
+#
+#   refs = ReferenceExtractor.extract(source)
+#   refs  # => ["Hecks::Compiler", "Prism::Visitor", "JSON"]
+#
+require "prism"
+
+module Hecks
+  module Compiler
+    class ReferenceExtractor < Prism::Visitor
+      # Ruby stdlib constants that should never create dependency edges.
+      STDLIB = %w[
+        String Integer Float Numeric Symbol Array Hash Set
+        Object BasicObject Kernel Module Class Struct
+        Comparable Enumerable Enumerator
+        IO File Dir FileUtils Pathname
+        Regexp MatchData Range
+        Time Date DateTime
+        Proc Method UnboundMethod
+        Thread Mutex Monitor
+        Exception StandardError RuntimeError
+        ArgumentError TypeError NameError NoMethodError
+        LoadError IOError Errno SystemCallError
+        NilClass TrueClass FalseClass
+        Math Process Signal ENV ARGV STDIN STDOUT STDERR
+        Marshal ObjectSpace GC
+        JSON OpenStruct Psych YAML
+        Gem Bundler
+        Data
+      ].to_set.freeze
+
+      # Result struct holding constant references, mixin refs, and method calls.
+      Result = Struct.new(:references, :mixin_refs, :method_calls, keyword_init: true)
+
+      # Extracts all constant references and Hecks.method calls from source.
+      #
+      # @param source [String] Ruby source code
+      # @return [Result] references and method_calls found
+      def self.extract(source)
+        tree = Prism.parse(source).value
+        visitor = new
+        visitor.visit(tree)
+        Result.new(
+          references: visitor.references.uniq,
+          mixin_refs: visitor.mixin_refs.uniq,
+          method_calls: visitor.method_calls.uniq
+        )
+      end
+
+      attr_reader :references, :mixin_refs, :method_calls
+
+      def initialize
+        @references = []
+        @mixin_refs = []
+        @method_calls = []
+        @scope_stack = []
+      end
+
+      def visit_class_node(node)
+        name = resolve_constant_path(node.constant_path)
+        @scope_stack.push(name) if name
+
+        if node.superclass
+          ref = resolve_constant_path(node.superclass)
+          if ref
+            record(ref)
+            @mixin_refs << ref
+          end
+        end
+
+        super
+        @scope_stack.pop if name
+      end
+
+      def visit_module_node(node)
+        name = resolve_constant_path(node.constant_path)
+        @scope_stack.push(name) if name
+        super
+        @scope_stack.pop if name
+      end
+
+      def visit_call_node(node)
+        if mixin_call?(node)
+          node.arguments&.arguments&.each do |arg|
+            ref = resolve_constant_path(arg)
+            if ref
+              record(ref)
+              @mixin_refs << ref
+            end
+          end
+        end
+
+        # Detect Hecks.method_name calls for Bluebook IR resolution
+        if hecks_method_call?(node)
+          @method_calls << node.name.to_s
+        end
+
+        super
+      end
+
+      def visit_constant_path_node(node)
+        ref = resolve_constant_path(node)
+        record(ref) if ref
+        # Don't call super — we've already walked the path
+      end
+
+      def visit_constant_read_node(node)
+        record(node.name.to_s)
+      end
+
+      private
+
+      def mixin_call?(node)
+        return false unless node.receiver.nil?
+        %i[include extend prepend].include?(node.name)
+      end
+
+      # Detects calls like Hecks.describe_extension, Hecks.register_xxx
+      def hecks_method_call?(node)
+        return false unless node.receiver
+        receiver_name = resolve_constant_path(node.receiver)
+        receiver_name == "Hecks" && node.name.to_s != "new"
+      end
+
+      def record(name)
+        root = name.split("::").first
+        return if STDLIB.include?(root)
+        return if STDLIB.include?(name)
+        @references << name
+      end
+
+      def resolve_constant_path(node)
+        case node
+        when Prism::ConstantReadNode
+          node.name.to_s
+        when Prism::ConstantPathNode
+          parts = []
+          current = node
+          while current.is_a?(Prism::ConstantPathNode)
+            parts.unshift(current.name.to_s)
+            current = current.parent
+          end
+          if current.is_a?(Prism::ConstantReadNode)
+            parts.unshift(current.name.to_s)
+          end
+          parts.join("::")
+        end
+      end
+    end
+  end
+end

--- a/lib/hecks/compiler/source_analyzer.rb
+++ b/lib/hecks/compiler/source_analyzer.rb
@@ -1,0 +1,206 @@
+# Hecks::Compiler::SourceAnalyzer
+#
+# Orchestrates static analysis of Hecks Ruby source files using
+# Prism AST (Layer 1) and Bluebook IR method-call resolution (Layer 2)
+# to build a real dependency graph and topologically sort files into
+# correct load order for the binary compiler.
+#
+#   files = SourceAnalyzer.analyze(lib_root: "lib")
+#   files.each { |path| puts path }
+#
+require "prism"
+
+module Hecks
+  module Compiler
+    module SourceAnalyzer
+      # Analyzes all Ruby files under lib_root, builds a dependency
+      # graph via Prism AST analysis and Bluebook IR consultation,
+      # and returns files in load order.
+      #
+      # @param lib_root [String] path to the lib/ directory
+      # @return [Array<String>] absolute file paths in load order
+      def self.analyze(lib_root:, trace: false)
+        lib_root = File.expand_path(lib_root)
+        files = discover_files(lib_root)
+
+        file_defs = {}
+        file_refs = {}
+        file_ns   = {}
+        file_method_calls = {}
+        file_mixin_refs = {}
+
+        files.each do |path|
+          source = File.read(path)
+          defs = DefinitionExtractor.extract(source)
+          refs = ReferenceExtractor.extract(source)
+
+          file_defs[path] = defs.definitions
+          file_refs[path] = refs.references
+          file_ns[path]   = defs.namespaces
+          file_method_calls[path] = refs.method_calls
+          file_mixin_refs[path] = refs.mixin_refs
+        end
+
+        method_map = build_method_map(file_method_calls, files)
+        wiring     = detect_wiring_files(files, lib_root)
+
+        if trace
+          wiring.each do |w|
+            rel = w.sub("#{lib_root}/", "")
+            $stderr.puts "[AUTOPHAGY] CLASSIFY #{rel} → WIRING"
+          end
+        end
+
+        graph = DependencyGraph.new(
+          file_defs, file_refs, file_ns,
+          method_edges: method_map,
+          wiring_files: wiring,
+          mixin_refs: file_mixin_refs,
+          trace: trace,
+          lib_root: lib_root
+        )
+        sorted = graph.sorted_files
+        apply_priority_ordering(sorted, lib_root, trace: trace)
+      end
+
+      # Ensures infrastructure files (errors, conventions, registries)
+      # load before all other files.
+      PRIORITY_PATTERNS = %w[
+        /errors.rb
+        /conventions
+        /autoloads.rb
+        /version.rb
+        /registry.rb
+        /set_registry.rb
+        /module_dsl.rb
+        /core_extensions.rb
+        /registries/
+        /naming_helpers.rb
+        hecks/generator.rb
+        hecks/dry_run_result.rb
+      ].freeze
+
+      def self.apply_priority_ordering(files, lib_root, trace: false)
+        priority, rest = files.partition { |f|
+          rel = f.sub("#{lib_root}/", "")
+          PRIORITY_PATTERNS.any? { |pat| rel.include?(pat.delete_prefix("/")) }
+        }
+        if trace
+          priority.each_with_index do |f, i|
+            $stderr.puts "[AUTOPHAGY] PRIORITY ##{i} #{f.sub("#{lib_root}/", "")}"
+          end
+        end
+        result = priority + rest
+        if trace
+          result.each_with_index do |f, i|
+            $stderr.puts "[AUTOPHAGY] ORDER ##{i} #{f.sub("#{lib_root}/", "")}"
+          end
+        end
+        result
+      end
+
+      # Discovers all Ruby source files under lib_root, excluding
+      # templates, spec files, and generated output directories.
+      #
+      # @param lib_root [String] absolute path to lib/
+      # @return [Array<String>] discovered file paths
+      # External-dependency directories excluded from binary output.
+      EXCLUDED_DIRS = %w[
+        /templates/ /spec/ /examples/ /compiler/
+        /hecks_cli/ /hecks_serve/ /hecks_mongodb/
+        /hecks_ai/
+      ].freeze
+
+      def self.discover_files(lib_root)
+        Dir.glob(File.join(lib_root, "**", "*.rb")).select { |f|
+          EXCLUDED_DIRS.none? { |d| f.include?(d) } &&
+          !excluded_file?(f)
+        }.sort
+      end
+
+      # Checks if a file should be excluded from the binary: either it
+      # inherits from an external gem or is a CLI command registration.
+      EXTERNAL_SUPERCLASSES = /class\s+\w+\s*<\s*::?(Thor|Sinatra::Base|Rails::Railtie|Rails::Generators::Base)\b/
+      CLI_REGISTRATION = /\AHecks::CLI\.register_command\b/
+
+      def self.excluded_file?(path)
+        File.foreach(path).any? { |line|
+          line.match?(EXTERNAL_SUPERCLASSES) || line.match?(CLI_REGISTRATION)
+        }
+      rescue
+        false
+      end
+
+      # Layer 2: Bluebook IR consultation.
+      # Maps Hecks.method_name calls to the registry files that define them.
+      # Scans file_method_calls to build edges from callers to registries.
+      #
+      # @return [Hash{String => String}] caller_file => depended_file
+      def self.build_method_map(file_method_calls, files)
+        registry_methods = build_registry_method_index(files)
+        edges = {}
+
+        file_method_calls.each do |file, methods|
+          methods.each do |method_name|
+            provider = registry_methods[method_name]
+            next unless provider && provider != file
+            edges[file] ||= []
+            edges[file] << provider
+          end
+        end
+
+        edges
+      end
+
+      # Builds an index of method_name => file for registry methods.
+      # Registry files define methods that get extended onto Hecks.
+      #
+      # @return [Hash{String => String}] method_name => file_path
+      def self.build_registry_method_index(files)
+        index = {}
+        registry_files = files.select { |f| f.include?("/registries/") }
+
+        registry_files.each do |path|
+          source = File.read(path)
+          tree = Prism.parse(source).value
+          extract_defined_methods(tree, index, path)
+        end
+
+        index
+      end
+
+      # Walk AST to find method definitions (def self.xxx or def xxx)
+      def self.extract_defined_methods(node, index, path)
+        if node.is_a?(Prism::DefNode)
+          index[node.name.to_s] = path
+        end
+        node.child_nodes.compact.each do |child|
+          extract_defined_methods(child, index, path)
+        end
+      end
+
+      # Detects wiring files: foo.rb that has a corresponding foo/ directory
+      # AND contains extend/include referencing constants from foo/.
+      # These must load after all their children.
+      #
+      # @return [Set<String>] paths of wiring files
+      def self.detect_wiring_files(files, lib_root)
+        wiring = Set.new
+        files.each do |path|
+          dir = path.sub(/\.rb$/, "")
+          next unless File.directory?(dir)
+          source = File.read(path)
+          if source.match?(/\b(extend|include|prepend)\b/)
+            wiring << path
+          end
+        end
+        wiring
+      end
+
+      private_class_method :apply_priority_ordering, :discover_files,
+                           :excluded_file?,
+                           :build_method_map, :build_registry_method_index,
+                           :extract_defined_methods, :detect_wiring_files
+    end
+  end
+end

--- a/lib/hecks/compiler/source_transformer.rb
+++ b/lib/hecks/compiler/source_transformer.rb
@@ -1,0 +1,113 @@
+# Hecks::Compiler::SourceTransformer
+#
+# Transforms Ruby source for binary bundling: strips require/require_relative
+# calls, neutralizes chapter loading, and expands compact class syntax
+# (class Hecks::Foo::Bar) into nested module form.
+#
+#   cleaned = SourceTransformer.transform(source)
+#
+module Hecks
+  module Compiler
+    module SourceTransformer
+      # Transforms source for binary inclusion: strips loading
+      # infrastructure and expands compact class syntax.
+      #
+      # @param source [String] Ruby source code
+      # @return [String] transformed source
+      def self.transform(source)
+        expand_compact_classes(strip_bundled_lines(source))
+      end
+
+      # Converts compact class syntax (class Hecks::Foo::Bar) to nested
+      # module form so namespaces exist before classes reference them.
+      COMPACT_CLASS = /^class\s+((?:\w+::)+)(\w+)(.*)/
+
+      def self.expand_compact_classes(source)
+        extra_ends = 0
+        result = source.gsub(COMPACT_CLASS) do
+          parts = $1.split("::").reject(&:empty?)
+          class_name = $2
+          rest = $3
+          extra_ends += parts.size
+          parts.map { |mod| "module #{mod}" }.join("\n") +
+            "\nclass #{class_name}#{rest}"
+        end
+        result + ("end\n" * extra_ends)
+      end
+
+      # Strips require, require_relative, chapter loading, Dir[] loading,
+      # and require_paragraphs calls from bundled source.
+      def self.strip_bundled_lines(source)
+        lines = source.lines
+        result = []
+        skip_depth = 0
+
+        lines.each do |line|
+          stripped = line.strip
+          if skip_depth > 0
+            skip_depth += line.count("(") - line.count(")")
+            result << "# [v0] #{line.chomp}\n"
+            skip_depth = 0 if skip_depth <= 0
+          elsif should_strip?(stripped)
+            result << "# [v0] #{stripped}\n"
+            if multiline_call?(stripped)
+              skip_depth = stripped.count("(") - stripped.count(")")
+            end
+          else
+            result << line
+          end
+        end
+        result.join
+      end
+
+      def self.should_strip?(line)
+        require_line?(line) ||
+          chapter_load?(line) ||
+          dir_glob_require?(line) ||
+          require_paragraphs?(line) ||
+          hecks_autoload?(line)
+      end
+
+      HECKS_GEMS = %w[
+        hecks bluebook hecksagon hecks_cli hecks_persist hecks_mongodb
+        hecksul heckscode hecks_serve hecks_multidomain hecks_targets
+        go_hecks node_hecks hecks_ai active_hecks hecks_live hecks_static
+      ].freeze
+
+      HECKS_REQUIRE = /\Arequire\s+["'](?:#{HECKS_GEMS.join("|")})/
+      HECKS_AUTOLOAD = /\A\s*autoload\s+:\w+,\s+["'](?:#{HECKS_GEMS.join("|")})/
+
+      def self.hecks_autoload?(line)
+        line.match?(HECKS_AUTOLOAD)
+      end
+
+      def self.require_line?(line)
+        line.match?(/\Arequire_relative\s/) || line.match?(HECKS_REQUIRE)
+      end
+
+      def self.chapter_load?(line)
+        return false if line.match?(/\bdef\s/)
+        line.match?(/\A\s*(?:Hecks::)?Chapters\.(load_chapter|load_aggregates|define_paragraphs)\b/)
+      end
+
+      def self.require_paragraphs?(line)
+        line.match?(/\A\s*require_paragraphs\(/) ||
+          line.match?(/\A\s*Chapters\.require_paragraphs\b/)
+      end
+
+      def self.dir_glob_require?(line)
+        line.match?(/\ADir\[.*\].*\.each\s*\{.*require/)
+      end
+
+      def self.multiline_call?(line)
+        line.include?("(") && line.count("(") > line.count(")")
+      end
+
+      private_class_method :strip_bundled_lines, :expand_compact_classes,
+                           :should_strip?, :require_line?,
+                           :hecks_autoload?, :chapter_load?,
+                           :require_paragraphs?, :dir_glob_require?,
+                           :multiline_call?
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **7 new compiler modules**: SourceAnalyzer, ConstantResolver, DependencyGraph, CycleSorter, SourceTransformer, ReferenceExtractor, DefinitionExtractor
- **Two-layer dependency resolution**: Prism AST (constant refs, inheritance, mixins) + Bluebook IR (method-call deps like `Hecks.describe_extension`)
- **`--trace` flag**: emits `[AUTOPHAGY]` decisions to stderr for debugging compilation order
- **SourceTransformer**: strips requires and expands compact class syntax at compile time only — source files keep requires for the interpreted dev workflow

## Example usage

```bash
# Compile Hecks into a single-file binary
hecks compile

# Debug compilation order
hecks compile --trace

# Run the binary
./hecks_v0 self-test    # 118 modules, 6 targets
./hecks_v0 boot examples/pizzas
```

## Test plan

- [x] `bin/verify` — 24835 examples, 0 failures
- [x] `ruby -Ilib examples/pizzas/app.rb` — smoke test passes
- [x] `./hecks_v0 self-test` — 118 modules, 6 targets, OK
- [x] `./hecks_v0 boot examples/pizzas` — boots Pizzas domain
- [x] All compiler files under 200 code lines