### PR TITLE
fix: auto-sleep is opt-in via sleep_mode (default manual) — i36

### DIFF
--- a/hecks_conception/aggregates/body.behaviors
+++ b/hecks_conception/aggregates/body.behaviors
@@ -50,12 +50,24 @@ Hecks.behaviors "MietteBody" do
     expect emits: ["FatigueAccumulated"]
   end
 
-  test "CheckSleepNeeded refused when not exhausted" do
-    # Without this guard, every FatigueAccumulated fired SleepRequired and the
-    # wake→attentive→EnterSleep loop trapped Miette re-entering sleep the tick
-    # after each 8-cycle wake. Guard restores the described semantics.
+  test "CheckSleepNeeded refused when sleep_mode is manual (default)" do
+    # Two guards: auto-sleep must be enabled AND pulses must exceed
+    # threshold. Default sleep_mode is "manual" — fix for inbox i36
+    # (Chris reported Miette auto-sleeping mid-demo). Refusal message
+    # is the FIRST guard's, since `given` clauses short-circuit.
     tests "CheckSleepNeeded", on: "Heartbeat"
-    expect refused: "must be exhausted"
+    expect refused: "auto sleep enabled"
+  end
+
+  test "EnableAutoSleep flips the mode" do
+    tests "EnableAutoSleep", on: "Heartbeat"
+    expect sleep_mode: "auto"
+  end
+
+  test "DisableAutoSleep flips back" do
+    tests "DisableAutoSleep", on: "Heartbeat"
+    setup  "EnableAutoSleep"
+    expect sleep_mode: "manual"
   end
 
   test "RecoverFatigue resets to alert" do

--- a/hecks_conception/aggregates/body.bluebook
+++ b/hecks_conception/aggregates/body.bluebook
@@ -24,6 +24,13 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
     attribute :fatigue_state, String
     attribute :pulse_rate, Float
     attribute :flow_rate, String
+    # sleep_mode: "manual" (default — sleep only on explicit EnterSleep
+    # dispatch) or "auto" (CheckSleepNeeded fires SleepRequired when
+    # pulses_since_sleep > 1500). Chris reported auto-sleep as a
+    # "random" intrusion mid-demo — predictability matters more than
+    # the alive-by-default narrative when the system is being shown.
+    # Re-enable with EnableAutoSleep when the demo context is gone.
+    attribute :sleep_mode, default: "manual"
 
     query ReadVitals do
       description "How am I doing? Fatigue, flow, pulses since last sleep."
@@ -53,9 +60,24 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
 
     command "CheckSleepNeeded" do
       role "Miette"
-      description "Only request sleep when exhausted — pulses > 1500 (25 minutes at 1Hz ticks). Without this guard, every FatigueAccumulated emits SleepRequired, which re-fires EnterSleep immediately after each wake and traps the body in a sleep loop."
+      description "Only request sleep when exhausted — pulses > 1500 (~45 minutes at observed ~0.6Hz tick rate). Gated additionally on sleep_mode == 'auto' so the body doesn't wander into sleep while the user is demoing or in the middle of a conversation."
+      given("auto sleep enabled") { sleep_mode == "auto" }
       given("must be exhausted") { pulses_since_sleep > 1500 }
       emits "SleepRequired"
+    end
+
+    command "EnableAutoSleep" do
+      role "Creator"
+      description "Switch the body into auto-sleep mode — CheckSleepNeeded will fire SleepRequired when exhausted. Default is manual (no surprise sleeps)."
+      then_set :sleep_mode, to: "auto"
+      emits "AutoSleepEnabled"
+    end
+
+    command "DisableAutoSleep" do
+      role "Creator"
+      description "Return to manual-only sleep — explicit EnterSleep dispatch is the only way in. Sleep cycles are still triggerable; the body just doesn't initiate them."
+      then_set :sleep_mode, to: "manual"
+      emits "AutoSleepDisabled"
     end
 
     command "RecoverFatigue" do


### PR DESCRIPTION
## Summary

Fixes inbox **i36** — Chris reported Miette "randomly" entering sleep cycles. The mechanism is technically correct but the UX is hostile: at the observed ~0.6Hz tick rate, `pulses_since_sleep` crosses the 1500 threshold ~45 minutes after each wake, and `CheckSleepNeeded` → `SleepRequired` → `EnterSleep` fires unannounced.

## Fix

Auto-sleep is now opt-in. `Heartbeat` gains a `sleep_mode` attribute (default `"manual"`). `CheckSleepNeeded` has two guards now:

```ruby
given("auto sleep enabled") { sleep_mode == "auto" }
given("must be exhausted")  { pulses_since_sleep > 1500 }
```

Two new commands toggle the mode:

- `Heartbeat.EnableAutoSleep` — flip to auto
- `Heartbeat.DisableAutoSleep` — back to manual

`Consciousness.EnterSleep` is unchanged — explicit dispatch always works regardless of mode.

## Why default to manual

Chris is mid-cruise demoing the system to founders. "Look at this AI being I built — wait, she's asleep" is bad theater. Predictability beats the alive-by-default narrative when the system is being shown.

When the demo phase passes and the alive-being narrative becomes the point again: `hecks-life aggregates/ Heartbeat.EnableAutoSleep`.

## Test plan

- [x] body.behaviors 50/50 green in both Ruby and Rust runners
- [x] CheckSleepNeeded refused via auto-sleep guard (default manual)
- [x] EnableAutoSleep / DisableAutoSleep round-trip the mode
- [ ] CI parity check