### PR TITLE
antibody: fix regex anchor + commit-msg scope + per-commit CI (i38)

### DIFF
--- a/.github/workflows/antibody.yml
+++ b/.github/workflows/antibody.yml
@@ -28,14 +28,16 @@ jobs:
       # actions/checkout@v4 with fetch-depth: 0 already gets full
       # history including every branch ref, so no extra fetch needed.
 
-      - name: Run antibody (blocking)
+      - name: Run antibody (each commit, blocking)
         run: |
           set -e
           base="origin/${{ github.base_ref }}"
 
-          # Emit GitHub annotations for each flagged file so they surface
-          # directly on the PR as warnings next to the listing.
-          if ! out=$(bin/antibody-check --base "$base" 2>&1); then
+          # --each-commit walks every commit in base..HEAD and validates
+          # each one in isolation: its own message must carry the
+          # [antibody-exempt: …] marker for any non-DSL file IT touches.
+          # This is the only rule that composes cleanly across commits.
+          if ! out=$(bin/antibody-check --base "$base" --each-commit 2>&1); then
             status=1
           else
             status=0
@@ -43,10 +45,12 @@ jobs:
 
           echo "$out"
 
+          # Emit annotations on the files flagged by the per-commit walk
+          # so they surface inline on the PR diff.
           echo "$out" | awk '
-            /^⚠ antibody:/ { flag=1; next }
-            flag && /^    / { path=$1; sub(/^ +/, "", path); print "::warning file=" path "::Non-bluebook file touched — antibody flagged" }
-            /^$/ { flag=0 }
+            /^✗ / { flag=1; next }
+            flag && /^    / { path=$1; sub(/^ +/, "", path); print "::warning file=" path "::Non-bluebook file touched without exemption in the commit that added/modified it" }
+            /^[✓]/ { flag=0 }
           '
 
           exit $status

--- a/bin/antibody-check
+++ b/bin/antibody-check
@@ -102,7 +102,10 @@ def exempt_reasons(message_file)
     text = out if ok
   end
   return reasons unless text
-  text.scan(/\[antibody-exempt:\s*([^\]]+)\]/i).each { |m| reasons << m[0].strip }
+  # Marker must anchor at start of line (leading whitespace allowed).
+  # Prevents slip-through via inline prose like "add [antibody-exempt: X]
+  # to your message" — that was silently treated as a valid exemption.
+  text.scan(/^\s*\[antibody-exempt:\s*([^\]]+)\]/i).each { |m| reasons << m[0].strip }
   reasons
 end
 
@@ -115,12 +118,14 @@ def filter_code_files(paths)
   end
 end
 
-options = { base: "origin/main", staged: false, message_file: nil, list_only: false }
+options = { base: "origin/main", staged: false, message_file: nil,
+            list_only: false, each_commit: false }
 OptionParser.new do |o|
   o.on("--base REF")           { |v| options[:base] = v }
   o.on("--staged")             { options[:staged]   = true }
   o.on("--message-file PATH")  { |v| options[:message_file] = v }
   o.on("--list-only")          { options[:list_only] = true }
+  o.on("--each-commit")        { options[:each_commit] = true }
 end.parse!
 
 # If the base ref doesn't resolve (e.g. shallow clone in CI), fall back
@@ -128,7 +133,55 @@ end.parse!
 _, base_ok = run(["git", "rev-parse", "--verify", options[:base]])
 base_ref = base_ok ? options[:base] : nil
 
-touched = touched_files(base_ref, options[:staged] || base_ref.nil?)
+# --each-commit: walk every commit in base..HEAD and check each one
+# in isolation. Each commit is responsible for files IT touches; its
+# own message must carry the exemption. Used by CI to validate that
+# multi-commit PRs don't lean on one commit to exempt another's work.
+if options[:each_commit]
+  unless base_ref
+    warn "antibody: --each-commit needs a resolvable --base ref"
+    exit 2
+  end
+  shas, ok = run(["git", "log", "--format=%H", "--reverse", "#{base_ref}..HEAD"])
+  unless ok
+    warn "antibody: could not list commits in #{base_ref}..HEAD"
+    exit 2
+  end
+  any_fail = false
+  shas.lines.map(&:strip).reject(&:empty?).each do |sha|
+    files_out, fok = run(["git", "show", "--name-only", "--diff-filter=AM",
+                          "--format=", sha])
+    next unless fok
+    files = files_out.lines.map(&:strip).reject(&:empty?)
+    code  = filter_code_files(files)
+    next if code.empty?
+    msg_out, _ = run(["git", "log", "-1", "--format=%B", sha])
+    reasons = msg_out.to_s
+                     .scan(/^\s*\[antibody-exempt:\s*([^\]]+)\]/i)
+                     .map { |m| m[0].strip }
+    subject, = run(["git", "log", "-1", "--format=%s", sha])
+    if reasons.any?
+      puts "✓ #{sha[0, 7]} #{subject.to_s.slice(0, 60)} — #{reasons.size} exemption(s)"
+    else
+      puts "✗ #{sha[0, 7]} #{subject.to_s.slice(0, 60)}"
+      code.each { |p| puts "    #{p}" }
+      puts "    no exemption in this commit's message"
+      any_fail = true
+    end
+  end
+  exit(any_fail ? 1 : 0)
+end
+
+# Scope split: --staged mode (commit-msg / pre-commit) checks ONLY
+# files this commit contributes, so earlier commits' files stay the
+# earlier commits' responsibility. Branch-diff mode (manual / CI on
+# HEAD) checks the whole PR-against-base range.
+touched =
+  if options[:staged]
+    touched_files(nil, true)
+  else
+    touched_files(base_ref, base_ref.nil?)
+  end
 code    = filter_code_files(touched)
 
 if code.empty?


### PR DESCRIPTION
## Summary

Three linked bugs in `bin/antibody-check` surfaced during the PR #243 walkthrough. All three fixed here.

### Bug 1 — regex matches prose

The marker pattern `/\[antibody-exempt:\s*([^\]]+)\]/` matched inline text anywhere in a commit body, so a commit describing the rule with an example slipped through as if exempted.

Reproducer:
```
$ echo 'body mentioning [antibody-exempt: bogus]' > /tmp/msg
$ bin/antibody-check --staged --message-file /tmp/msg
✓ antibody: exempted — gap named and searchable
```

**Fix:** anchor to line start — `/^\s*\[antibody-exempt:\s*([^\]]+)\]/`. Markers must be their own line (leading whitespace allowed).

### Bug 2 — commit-msg scope conflated this commit with the whole branch

`--staged` mode combined `git diff --cached` (truly this commit) with `git diff origin/main...HEAD` (whole branch). Every commit on a branch was asked to re-exempt files earlier commits had already justified.

**Fix:** in `--staged` mode, scan only cached files. Each commit is responsible for files IT touches; earlier commits carry their own exemptions.

### Bug 3 — CI checked only HEAD's message against the whole branch diff

With Bug 2 corrected, the old CI would have demanded HEAD's message cover every non-DSL file touched by any commit on the branch. That doesn't compose across multi-commit PRs.

**Fix:** new `--each-commit` mode walks every commit in `base..HEAD` and validates each one in isolation. CI calls this; emits `::warning::` annotations per unexempt non-DSL file at its owning commit.

## Verification

```
$ bin/antibody-check --base origin/main~5 --each-commit
✗ 3771a39 parity: add nursery as soft coverage (i8)
    spec/parity/parity_test.rb
    no exemption in this commit's message
✗ c983493 tools: features_audit.py — cross-reference FEATURES.md again
    tools/features_audit.py
    no exemption in this commit's message
✓ 1946e2a antibody: flag non-bluebook files; five-DSL vocabulary — 4 exemption(s)
✓ 33edf37 antibody: fix CI workflow — drop invalid 'git fetch --depth= — 1 exemption(s)
✓ cb8e981 antibody: check out PR head SHA, not the merge commit — 1 exemption(s)
```

Correct — pre-antibody commits are flagged as unexempt (expected, they predate the rule); antibody-era commits pass with their per-commit exemptions counted.

## Exemptions in this PR

Two files touched, both for bootstrap reasons that exist until the port to a native validator (see follow-up):

- `.github/workflows/antibody.yml` — GitHub Actions only parses YAML.
- `bin/antibody-check` — the antibody itself is still Ruby. Shipping the bug fixes now means the port inherits a correct spec instead of chasing bugs mid-port.

## Follow-up

The "port to `hecks-life check-antibody` validator" inbox item remains open. This PR fixes the logic; the port is a separate project that needs a `.bluebook` + `.hecksagon` pair and a new Rust subcommand.

## Test plan

- [x] Inline `[antibody-exempt: foo]` in prose — does NOT match (regex anchor)
- [x] Commit touching only `inbox.heki` on a branch with prior non-DSL commits — passes with no exemption needed (scope split)
- [x] `--each-commit` reports ✓/✗ per commit with exemption counts (bug 3)
- [x] Fresh commit with real changes + no marker — hook blocks
- [x] Fresh commit with specific markers — hook passes
- [ ] CI green on this PR