### PR TITLE
fixup: stale bluebook.hec in .claude/commands/bluebook.md

### DIFF
--- a/.claude/commands/bluebook.md
+++ b/.claude/commands/bluebook.md
@@ -25,7 +25,7 @@ policy "NotifyKitchen" do
 end
 ```
 
-5. After modifying a bluebook.hec, verify it parses:
+5. After modifying a `.bluebook` file, verify it parses:
 
 ```bash
 ruby -Ilib -e "require 'hecks'; Hecks.boot('path/to/project')"


### PR DESCRIPTION
One stale `bluebook.hec` reference the rename agent on PR #245 couldn't edit (permission-denied on `.claude/` from within its worktree). Fixed here — the slash command now says "a `.bluebook` file" generically, matching the post-rename vocabulary.

## Verification ran on merged #245

- Rust parses all 11 `.hecksagon` files (`hecks-life dump`) ✓
- Rust parses all 7 `.world` files ✓
- Pizzas example boots + smoke-tests green ✓
- Multi-domain example boots green ✓
- 4 nursery hecksagons fail Ruby load — pre-existing i1/i2 Ruby DSL gap, not caused by rename (content unchanged, only path)
- Governance example boot failure — pre-existing `autoload_services` bug in `lib/hecks/runtime/boot.rb:113` (uses `require` where `require_relative` is needed); confirmed identical code existed in main pre-rename. Filing as separate inbox item.

## Test plan

- [x] grep confirms no remaining `bluebook.hec` references in `.claude/`