### PR TITLE
spike: executable .bluebook with shebang (proof + first-obstacle doc)

### DIFF
--- a/examples/shebang_demo/README.md
+++ b/examples/shebang_demo/README.md
@@ -1,0 +1,80 @@
+# Shebang Demo — executable `.bluebook`
+
+A minimum-viable spike proving that the `hecks-life` parser already
+tolerates a leading `#!` line in a `.bluebook` file, so a Bluebook
+can be chmod +x'd and invoked as a script.
+
+## What this spike proves
+
+- `hecks_life/src/parser.rs` silently skips any top-level line it
+  doesn't recognize (the main loop only activates on `Hecks.bluebook`,
+  `category`, `vision`, `aggregate`, `policy`, `fixture`). A `#!…`
+  line is "unknown" and falls through — no parser change required.
+- With `hecks-life` on `PATH`, running `./hello.bluebook` directly
+  produces the same JSON IR as calling `hecks-life dump` on the file.
+- No repurposing of `hecks-life run` (the interactive REPL) was
+  needed for this spike — `dump` and `parse` already work.
+
+## How to run
+
+**Direct path (bypasses shebang):**
+
+```
+$ hecks_life/target/release/hecks-life dump examples/shebang_demo/hello.bluebook
+$ hecks_life/target/release/hecks-life parse examples/shebang_demo/hello.bluebook
+```
+
+Both print the domain IR (JSON and tree view respectively). The
+`#!/usr/bin/env hecks-life dump` line is silently ignored by the
+parser.
+
+**Shebang path (requires `hecks-life` on `PATH`):**
+
+```
+$ PATH="$(pwd)/hecks_life/target/release:$PATH" ./examples/shebang_demo/hello.bluebook
+```
+
+This invokes the binary via `/usr/bin/env hecks-life dump
+<script-path>` and emits the full JSON IR.
+
+## First obstacle
+
+**`hecks-life` is not on `PATH` by default.** Out of the box:
+
+```
+$ ./examples/shebang_demo/hello.bluebook
+env: hecks-life: No such file or directory
+```
+
+Nothing in the repo installs a binary, symlink, or wrapper into
+`~/.cargo/bin`, `~/.local/bin`, `/usr/local/bin`, or `~/bin`. Users
+must either:
+
+1. Add `hecks_life/target/release` to `PATH`, or
+2. Symlink `hecks_life/target/release/hecks-life` into a directory
+   already on `PATH` (e.g. `ln -s
+   $(pwd)/hecks_life/target/release/hecks-life ~/.local/bin/`), or
+3. `cargo install --path hecks_life` to drop it into
+   `~/.cargo/bin/hecks-life`.
+
+Once `hecks-life` is resolvable by `/usr/bin/env`, the shebang works
+with no further changes. macOS `env` (Darwin 24+) handles
+multi-arg shebangs (`hecks-life dump`) correctly; no `env -S` needed.
+
+## What this spike does NOT do
+
+- No parser changes (the `#!` tolerance is incidental, not
+  intentional — a follow-up may want to handle it explicitly).
+- No new subcommand. `hecks-life dump` and `hecks-life parse`
+  already exist.
+- No repurposing of `hecks-life run` — that still drops into the
+  interactive REPL. Making `run` execute a `.bluebook` as a script
+  (the ergonomic end-state where the shebang just says
+  `#!/usr/bin/env hecks-life`) is the follow-up.
+
+## Forward link
+
+See agent `a8c80e90`'s shebang runtime plan for the follow-up:
+teaching `hecks-life run <file>` to execute a Bluebook non-interactively
+and wiring `hecks-life` onto `PATH` as part of repo setup. This spike
+is the minimal proof that the parser is already ready for it.

--- a/examples/shebang_demo/hello.bluebook
+++ b/examples/shebang_demo/hello.bluebook
@@ -1,0 +1,17 @@
+#!/usr/bin/env hecks-life dump
+Hecks.bluebook "ShebangDemo" do
+  vision "Proof that a shebang line is tolerated by the parser"
+  category "example"
+
+  aggregate "Greeting" do
+    attribute :text, String
+
+    command "Greet" do
+      role "User"
+      description "Emit a greeting"
+      attribute :text, String
+      emits "Greeted"
+      then_set :text, to: :text
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Minimum-viable spike proving `hecks_life/src/parser.rs` already tolerates a leading `#!` line — the top-level parse loop only activates on known keywords (`Hecks.bluebook`, `category`, `vision`, `aggregate`, `policy`, `fixture`) and silently skips everything else, so no parser change is required to make a `.bluebook` executable.
- `examples/shebang_demo/hello.bluebook` is `chmod +x` with `#!/usr/bin/env hecks-life dump`. Running `hecks-life dump` or `hecks-life parse` directly on the file emits the expected JSON IR / aggregate tree. Running the script via its shebang works end-to-end once `hecks-life` is on `PATH`.
- First obstacle documented: `hecks-life` is not installed on `PATH` by default. README lists the three workarounds (PATH export, symlink, `cargo install`) and links forward to agent `a8c80e90`'s shebang runtime plan for the real follow-up (teach `hecks-life run <file>` to execute non-interactively and wire the binary onto PATH as part of repo setup).

No parser changes, no new subcommands, no repurposing of `run`.

## Example usage

```
$ hecks_life/target/release/hecks-life parse examples/shebang_demo/hello.bluebook
ShebangDemo
└── Greeting —
    └── Greet -> Greeted

$ PATH="$(pwd)/hecks_life/target/release:$PATH" ./examples/shebang_demo/hello.bluebook
{
  "aggregates": [...],
  "category": "example",
  "name": "ShebangDemo",
  "vision": "Proof that a shebang line is tolerated by the parser"
}
```

Without `hecks-life` on PATH:
```
$ ./examples/shebang_demo/hello.bluebook
env: hecks-life: No such file or directory
```

## Test plan

- [x] `hecks-life dump` on the file emits full JSON IR
- [x] `hecks-life parse` on the file prints clean aggregate tree
- [x] `./hello.bluebook` works when `hecks-life` is on PATH
- [x] `./hello.bluebook` fails cleanly with `env: hecks-life: No such file or directory` when it isn't (documented as first obstacle)
- [x] Antibody check passed (only `.bluebook` + `.md` files touched)