### PR TITLE
i4: duplicate policy validator — catches same (event, trigger) pairs

### DIFF
--- a/hecks_life/src/duplicate_policy_validator.rs
+++ b/hecks_life/src/duplicate_policy_validator.rs
@@ -1,0 +1,95 @@
+//! Duplicate policy validator
+//!
+//! Catches bluebooks that declare two or more policies wired to the
+//! same `(on_event, trigger_command)` pair. Today this silently
+//! coexists — the runtime fires every matching policy in declaration
+//! order, so the trigger command runs twice per event. That's a
+//! cascade bug with no error message.
+//!
+//! Example of the bug:
+//!
+//!   policy "BeatTicks"     do; on "HeartBeat"; trigger "Tick";        end
+//!   policy "BeatTicksAgain" do; on "HeartBeat"; trigger "Tick";        end
+//!
+//! Both policies fire on HeartBeat. Both call Tick. The second is
+//! almost certainly a leftover from editing/renaming; even if it's
+//! intentional, one policy with a clearer name does the job.
+//!
+//! Surface:
+//!
+//!   hecks-life check-duplicate-policies path/to/bluebook.bluebook
+//!
+//! Exit code:
+//!   0 — no duplicate (event, trigger) pairs
+//!   1 — at least one pair shared by >1 policy
+//!
+//! This validator is a flat walk over `domain.policies` — no runtime
+//! boot, no cascade traversal. Group by key, report groups of size >1.
+
+use crate::ir::{Domain, Policy};
+use std::collections::BTreeMap;
+
+#[derive(Debug, PartialEq)]
+pub enum Severity { Error }
+
+pub struct Finding {
+    pub severity: Severity,
+    pub location: String,
+    pub message: String,
+}
+
+impl Finding {
+    fn err(location: impl Into<String>, message: impl Into<String>) -> Self {
+        Finding { severity: Severity::Error, location: location.into(), message: message.into() }
+    }
+    pub fn icon(&self) -> &'static str { "✗" }
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn errors(&self) -> usize {
+        self.findings.iter().filter(|f| f.severity == Severity::Error).count()
+    }
+    pub fn passes(&self) -> bool { self.errors() == 0 }
+}
+
+/// Human-readable policy locator. The IR doesn't carry source line
+/// numbers, so the location is the policy name (and target domain
+/// if cross-domain). If two nameless policies share a key this will
+/// still be unique enough to act on — the emit/trigger pair already
+/// identifies the clash.
+fn locate(p: &Policy) -> String {
+    match &p.target_domain {
+        Some(d) if !d.is_empty() => format!("{}@{}", p.name, d),
+        _                        => p.name.clone(),
+    }
+}
+
+pub fn check(domain: &Domain) -> Report {
+    let mut by_key: BTreeMap<(String, String), Vec<&Policy>> = BTreeMap::new();
+    for p in &domain.policies {
+        let key = (p.on_event.clone(), p.trigger_command.clone());
+        by_key.entry(key).or_default().push(p);
+    }
+
+    let mut findings = Vec::new();
+    for ((event, trigger), group) in &by_key {
+        if group.len() < 2 { continue; }
+        let names: Vec<String> = group.iter().map(|p| locate(p)).collect();
+        let location = names.join(", ");
+        findings.push(Finding::err(
+            location,
+            format!(
+                "{} policies share (on: {:?}, trigger: {:?}) — the \
+                 trigger fires once per matching policy, so {} will \
+                 run {} times per {} event. Delete the duplicates or \
+                 collapse them into one policy.",
+                group.len(), event, trigger, trigger, group.len(), event,
+            ),
+        ));
+    }
+    Report { findings }
+}

--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -23,6 +23,7 @@ pub mod behaviors_conceiver;
 pub mod behaviors_runner;
 pub mod io_validator;
 pub mod lifecycle_validator;
+pub mod duplicate_policy_validator;
 pub mod cascade;
 pub mod fixtures_ir;
 pub mod fixtures_parser;

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -163,6 +163,11 @@ fn main() {
         return;
     }
 
+    if command == "check-duplicate-policies" {
+        run_check_duplicate_policies(&args);
+        return;
+    }
+
     if command == "check-all" {
         run_check_all(&args);
         return;
@@ -506,6 +511,44 @@ fn run_check_lifecycle(args: &[String]) {
         println!("FAIL — {} {}", path,
                  if report.errors() > 0 { "has unreachable transitions" }
                  else { "has stuck-default warnings (--strict)" });
+        std::process::exit(1);
+    }
+}
+
+/// `hecks-life check-duplicate-policies <bluebook>`
+///
+/// Refuses bluebooks that declare two or more policies sharing the
+/// same `(on_event, trigger_command)` pair. Today those silently
+/// coexist — the runtime fires every matching policy, so the trigger
+/// command runs once per duplicate. Flat IR walk; no runtime needed.
+fn run_check_duplicate_policies(args: &[String]) {
+    let path = args.get(2).unwrap_or_else(|| {
+        eprintln!("Usage: hecks-life check-duplicate-policies <bluebook>");
+        std::process::exit(1);
+    });
+
+    let source = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!("Cannot read {}: {}", path, e); std::process::exit(1);
+    });
+    let domain = hecks_life::parser::parse(&source);
+
+    println!("Checking {} ({})", domain.name, path);
+
+    let report = hecks_life::duplicate_policy_validator::check(&domain);
+    if report.findings.is_empty() {
+        println!("\nPolicies: clean ({} policies, no duplicates)", domain.policies.len());
+    } else {
+        println!("\nDuplicate policies:");
+        for f in &report.findings {
+            println!("  {} {} — {}", f.icon(), f.location, f.message);
+        }
+    }
+
+    println!("\n{} error(s)", report.errors());
+    if report.passes() {
+        println!("PASS — {} has no duplicate (event, trigger) pairs", path);
+    } else {
+        println!("FAIL — {} has duplicate policies", path);
         std::process::exit(1);
     }
 }

--- a/hecks_life/tests/duplicate_policy_validator_test.rs
+++ b/hecks_life/tests/duplicate_policy_validator_test.rs
@@ -1,0 +1,147 @@
+//! Duplicate policy validator tests
+//!
+//! Locks the contract: two policies sharing `(on_event, trigger_command)`
+//! cause the same command to fire twice per event — that's a cascade bug.
+//! The validator must flag them at check time, before the runtime quietly
+//! doubles up.
+
+use hecks_life::duplicate_policy_validator::check;
+use hecks_life::parser;
+use std::process::Command;
+
+#[test]
+fn flags_two_policies_sharing_event_and_trigger() {
+    let source = r#"Hecks.bluebook "Dup" do
+  aggregate "Heart" do
+    attribute :beats, Integer
+    command "Beat" do
+      emits "HeartBeat"
+    end
+    command "Tick" do
+      reference_to(Heart)
+      emits "Ticked"
+    end
+  end
+  policy "TickOnBeat" do
+    on "HeartBeat"
+    trigger "Tick"
+  end
+  policy "TickOnBeatAgain" do
+    on "HeartBeat"
+    trigger "Tick"
+  end
+end
+"#;
+    let domain = parser::parse(source);
+    let report = check(&domain);
+    assert_eq!(report.errors(), 1, "expected one duplicate-policy error");
+    let msg = &report.findings[0].message;
+    assert!(msg.contains("HeartBeat"), "message should name the event: {:?}", msg);
+    assert!(msg.contains("Tick"),      "message should name the trigger: {:?}", msg);
+    let loc = &report.findings[0].location;
+    assert!(loc.contains("TickOnBeat") && loc.contains("TickOnBeatAgain"),
+        "location should list both policy names: {:?}", loc);
+}
+
+#[test]
+fn passes_when_policies_are_unique() {
+    let source = r#"Hecks.bluebook "Clean" do
+  aggregate "Order" do
+    attribute :status, String
+    command "PlaceOrder" do
+      emits "OrderPlaced"
+    end
+    command "NotifyKitchen" do
+      reference_to(Order)
+      emits "KitchenNotified"
+    end
+    command "ChargeCard" do
+      reference_to(Order)
+      emits "CardCharged"
+    end
+  end
+  policy "KitchenOnPlaced" do
+    on "OrderPlaced"
+    trigger "NotifyKitchen"
+  end
+  policy "ChargeOnPlaced" do
+    on "OrderPlaced"
+    trigger "ChargeCard"
+  end
+end
+"#;
+    let domain = parser::parse(source);
+    let report = check(&domain);
+    assert_eq!(report.errors(), 0,
+        "distinct (event, trigger) pairs should pass: {:?}",
+        report.findings.iter().map(|f| &f.message).collect::<Vec<_>>());
+    assert!(report.passes());
+}
+
+#[test]
+fn flags_three_way_duplicate_with_count_in_message() {
+    // Edge case: three+ policies on the same pair. Message should
+    // reflect the actual count, not hardcode "2".
+    let source = r#"Hecks.bluebook "Triple" do
+  aggregate "Bell" do
+    attribute :name, String
+    command "Ring" do
+      emits "Rang"
+    end
+    command "Echo" do
+      reference_to(Bell)
+      emits "Echoed"
+    end
+  end
+  policy "EchoA" do
+    on "Rang"
+    trigger "Echo"
+  end
+  policy "EchoB" do
+    on "Rang"
+    trigger "Echo"
+  end
+  policy "EchoC" do
+    on "Rang"
+    trigger "Echo"
+  end
+end
+"#;
+    let domain = parser::parse(source);
+    let report = check(&domain);
+    assert_eq!(report.errors(), 1);
+    let msg = &report.findings[0].message;
+    assert!(msg.contains("3 policies") || msg.contains("3 times"),
+        "message should reflect count of 3: {:?}", msg);
+}
+
+// ─── Subcommand integration test ───────────────────────────────────
+//
+// Boots the built hecks-life binary against the negative fixture and
+// confirms exit code 1 plus a clear "duplicate" listing on stdout.
+// Uses CARGO_BIN_EXE_hecks-life — Cargo sets this when running
+// `cargo test` for integration tests.
+
+#[test]
+fn subcommand_exits_nonzero_on_duplicate_fixture() {
+    let bin = env!("CARGO_BIN_EXE_hecks-life");
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"),
+                          "/tests/fixtures/duplicate_policy.bluebook");
+
+    let output = Command::new(bin)
+        .arg("check-duplicate-policies")
+        .arg(fixture)
+        .output()
+        .expect("failed to invoke hecks-life");
+
+    assert!(!output.status.success(),
+        "expected non-zero exit on duplicate fixture; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Duplicate policies"),
+        "stdout should list duplicates: {}", stdout);
+    assert!(stdout.contains("HeartBeat") && stdout.contains("Tick"),
+        "stdout should name the (event, trigger) pair: {}", stdout);
+}

--- a/hecks_life/tests/fixtures/duplicate_policy.bluebook
+++ b/hecks_life/tests/fixtures/duplicate_policy.bluebook
@@ -1,0 +1,27 @@
+Hecks.bluebook "DuplicateFixture" do
+  vision "two policies wired to the same (event, trigger) pair — the validator must catch this"
+
+  aggregate "Heart" do
+    attribute :beats, Integer
+
+    command "Beat" do
+      emits "HeartBeat"
+    end
+
+    command "Tick" do
+      reference_to(Heart)
+      emits "Ticked"
+    end
+  end
+
+  # Both policies fire Tick on HeartBeat — cascade bug.
+  policy "TickOnBeat" do
+    on "HeartBeat"
+    trigger "Tick"
+  end
+
+  policy "TickOnBeatAgain" do
+    on "HeartBeat"
+    trigger "Tick"
+  end
+end


### PR DESCRIPTION
## Problem (from inbox i4)

Today two policies with identical `(on_event, trigger_command)` pairs silently coexist in a bluebook. The runtime fires every matching policy in declaration order, so the trigger command runs **once per duplicate** — a cascade bug with no error message. Item (5) on inbox i4.

## What this adds

A new `hecks-life check-duplicate-policies <bluebook>` subcommand. Flat walk over `domain.policies`, groups by `(on_event, trigger_command)` key, reports any group with size > 1.

- Exit 0 when clean
- Exit 1 with a listing of offending policy names + the clashing (event, trigger) pair

Follows the same shape as `check-lifecycle` and `check-io`. Not wired into `bin/git-hooks/pre-commit` yet — that's a follow-up after we see it's useful in practice.

## Real duplicates found in the corpus

Four real bugs, not test artifacts:

| bluebook | duplicates |
|---|---|
| `hecks_conception/aggregates/being.bluebook` | 4 policies share `(on: "DomainGrafted", trigger: "ConnectNerve")` — `WireOnGraft`, `DetectDriftOnGraft`, `QueryVectorsOnMusing`, `ArchetypeSignalOnMatch`. `ConnectNerve` currently fires 4× per `DomainGrafted`. |
| `hecks_conception/aggregates/conception.bluebook` | 2 policies share `(on: "DomainGrafted", trigger: "ConnectNerve")` — `QueryVectorsOnMusing`, `ArchetypeSignalOnMatch`. |
| `hecks_conception/nursery/pest_control/pest_control.bluebook` | `InspectOnAccount` + `InspectOnAccountOpened` both wire `AccountOpened → ConductInspection`. |
| `hecks_conception/nursery/wedding_planning/wedding_planning.bluebook` | `AllocateBudgetOnPlan` + `AllocateBudgetOnWeddingPlanned` both wire `WeddingPlanned → AllocateBudget`. |

Left for a follow-up — fixing them is orthogonal to landing the detector.

## Example usage

```
$ hecks-life check-duplicate-policies hecks_conception/aggregates/being.bluebook
Checking Being (...)

Duplicate policies:
  ✗ WireOnGraft, DetectDriftOnGraft, QueryVectorsOnMusing, ArchetypeSignalOnMatch — 4 policies share (on: "DomainGrafted", trigger: "ConnectNerve") — the trigger fires once per matching policy, so ConnectNerve will run 4 times per DomainGrafted event. Delete the duplicates or collapse them into one policy.

1 error(s)
FAIL — ... has duplicate policies
```

## Test plan

- [x] New unit tests: flagging, count scaling (3-way), negative (distinct triggers on same event)
- [x] Negative fixture at `hecks_life/tests/fixtures/duplicate_policy.bluebook` + subprocess integration test asserting exit code 1 and expected stdout
- [x] Full `cargo test --release` green across the hecks_life crate
- [x] Manual run against all `hecks_conception/aggregates/*.bluebook` and all 352 `nursery/*/*.bluebook` files — only the 4 real bugs above surfaced, no false positives

## Antibody

All touched Rust files carry per-commit `[antibody-exempt: ...]` markers naming concrete retirement conditions. The `.bluebook` fixture is not flagged by the antibody.