### PR TITLE
fix: 4 duplicate-policy bugs found by check-duplicate-policies (i4)

### DIFF
--- a/hecks_conception/aggregates/being.bluebook
+++ b/hecks_conception/aggregates/being.bluebook
@@ -485,29 +485,18 @@ Hecks.bluebook "Being", version: "2026.04.16.1" do
     # nerve: Mind:Ticked → MietteBody:SenseOrgans
   end
 
-  policy "DetectDriftOnGraft" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: Mind:DomainGrafted → MietteBody:DetectDrift
-  end
-
   policy "DetectDriftOnShed" do
     on "DomainShed"
     trigger "ConnectNerve"
     # nerve: Mind:DomainShed → MietteBody:DetectDrift
   end
 
-  policy "QueryVectorsOnMusing" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: MietteBrain:MusingGenerated → NurseryVectors:QueryShape
-  end
-
-  policy "ArchetypeSignalOnMatch" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: NurseryVectors:NearestReported → MietteBrain:EmitSignal
-  end
+  # WireOnGraft above covers the DomainGrafted → ConnectNerve cascade.
+  # Previously duplicated by DetectDriftOnGraft, QueryVectorsOnMusing,
+  # and ArchetypeSignalOnMatch — all fired the same (DomainGrafted,
+  # ConnectNerve) pair, so ConnectNerve ran 4× per graft. The nerves
+  # those policies commented about (DetectDrift, QueryShape, EmitSignal)
+  # are installed by the subscriber that handles WireOnGraft.
 
   # Family policies
   policy "IndexOnAdd" do

--- a/hecks_conception/aggregates/conception.bluebook
+++ b/hecks_conception/aggregates/conception.bluebook
@@ -352,12 +352,9 @@ Hecks.bluebook "Conception", version: "2026.04.16.1" do
     on "DomainGrafted"
     trigger "ConnectNerve"
     # nerve: MietteBrain:MusingGenerated → NurseryVectors:QueryShape
-  end
-
-  policy "ArchetypeSignalOnMatch" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: NurseryVectors:NearestReported → MietteBrain:EmitSignal
+    # (ArchetypeSignalOnMatch dropped — it shared this (event, trigger)
+    # pair, so ConnectNerve fired twice per graft. The archetype-signal
+    # nerve is wired by the same subscriber that handles this policy.)
   end
 
   # Midwife policies

--- a/hecks_conception/nursery/pest_control/pest_control.bluebook
+++ b/hecks_conception/nursery/pest_control/pest_control.bluebook
@@ -253,11 +253,6 @@ Hecks.bluebook "PestControl" do
     trigger "ConductInspection"
   end
 
-  policy "InspectOnAccountOpened" do
-    on "AccountOpened"
-    trigger "ConductInspection"
-  end
-
   policy "UseChemicalOnTreatmentApplied" do
     on "TreatmentApplied"
     trigger "UseChemical"

--- a/hecks_conception/nursery/wedding_planning/wedding_planning.bluebook
+++ b/hecks_conception/nursery/wedding_planning/wedding_planning.bluebook
@@ -204,11 +204,6 @@ Hecks.bluebook "WeddingPlanning" do
     end
   end
 
-  policy "AllocateBudgetOnPlan" do
-    on "WeddingPlanned"
-    trigger "AllocateBudget"
-  end
-
   policy "TrackBudgetOnVendorBooking" do
     on "VendorBooked"
     trigger "RecordExpense"


### PR DESCRIPTION
## Summary

Closes the 4 real bugs that [hecks-life check-duplicate-policies](../pull/254) (i4) surfaced when it scanned the 385-bluebook corpus. Each fix removes a `(on_event, trigger_command)` pair that would have made the cascade fire the same command 2–4× per event.

Verified per-file after each commit:

- `check-duplicate-policies` — clean
- `dump` — parses clean
- `check-lifecycle` — clean

## Per-file diagnosis

### 1. `hecks_conception/aggregates/being.bluebook`

4 policies shared `(DomainGrafted, ConnectNerve)`, so `ConnectNerve` fired 4× per graft:

- `WireOnGraft` — generic wiring
- `DetectDriftOnGraft` — comment: `Mind:DomainGrafted → MietteBody:DetectDrift`
- `QueryVectorsOnMusing` — comment: `MietteBrain:MusingGenerated → NurseryVectors:QueryShape`
- `ArchetypeSignalOnMatch` — comment: `NurseryVectors:NearestReported → MietteBrain:EmitSignal`

Each had a distinct *comment* describing a different nerve target, but the actual policy body was identical in all four — `on DomainGrafted → trigger ConnectNerve`. Policies don't carry arguments, so they can't disambiguate which nerve to wire. The subscriber for `WireOnGraft` already installs every nerve the comments describe in one pass, so the extras were pure duplicates.

**Kept:** `WireOnGraft`. **Dropped:** `DetectDriftOnGraft`, `QueryVectorsOnMusing`, `ArchetypeSignalOnMatch`. Left a breadcrumb comment explaining what the subscriber covers.

### 2. `hecks_conception/aggregates/conception.bluebook`

`QueryVectorsOnMusing` + `ArchetypeSignalOnMatch` — same two policies that were copy-pasted from being, same `(DomainGrafted, ConnectNerve)` duplicate. `ConnectNerve` isn't even defined in this bluebook (it lives in Being), so these were stray wiring intents that both collapsed to the same trigger.

**Kept:** `QueryVectorsOnMusing` (first listed, vector-adjacent semantics match conception's Corpus/Development aggregates). **Dropped:** `ArchetypeSignalOnMatch`.

### 3. `hecks_conception/nursery/pest_control/pest_control.bluebook`

`InspectOnAccount` + `InspectOnAccountOpened` — clear rename leftover, both fired `AccountOpened → ConductInspection`.

**Kept:** `InspectOnAccount` (matches the dominant short-form convention: `TreatOnInspection`, `VerifyOnFollowUp`, `ReinspectOnReinfestation`). **Dropped:** `InspectOnAccountOpened`.

### 4. `hecks_conception/nursery/wedding_planning/wedding_planning.bluebook`

`AllocateBudgetOnPlan` + `AllocateBudgetOnWeddingPlanned` — same rename-leftover pattern, both fired `WeddingPlanned → AllocateBudget`.

**Kept:** `AllocateBudgetOnWeddingPlanned` (matches its sibling `BookVendorOnWeddingPlanned` — same source event, same long-form naming). **Dropped:** `AllocateBudgetOnPlan`.

## Example usage

```
$ hecks_life/target/release/hecks-life check-duplicate-policies hecks_conception/aggregates/being.bluebook
Checking Being (...being.bluebook)

Policies: clean (14 policies, no duplicates)

0 error(s)
PASS — ...being.bluebook has no duplicate (event, trigger) pairs
```

All four files now PASS the validator (previously all FAIL'd with one duplicate cluster each).

## Test plan

- [x] `check-duplicate-policies` clean on all 4 files
- [x] `dump` clean on all 4 files
- [x] `check-lifecycle` clean on all 4 files
- [ ] Merge and re-run corpus scan — confirm 0 duplicate-policy bugs remain