### PR TITLE
docs: repo-wide .heki orphan sweep

### DIFF
--- a/HEKI_ORPHAN_SWEEP.md
+++ b/HEKI_ORPHAN_SWEEP.md
@@ -1,0 +1,41 @@
+# Repo-Wide `.heki` Orphan Sweep
+
+Follow-up to PR #239 (which renamed 25 orphan `.heki` files in `hecks_conception/nursery/`
+that actually contained Bluebook DSL source) to verify no remaining orphans exist anywhere
+else in the repo.
+
+## Scan parameters
+
+- **Pattern:** `find <repo-root> -name '*.heki'`
+- **Excluded:** `.claude/worktrees/**` (transient agent worktrees) and
+  `hecks_conception/information/**` (runtime-persisted `.heki` stores — JSON-ish snapshots,
+  not DSL source)
+- **Orphan criterion:** first non-blank lines contain a Bluebook DSL declaration such as
+  `Hecks.bluebook "..."`, `Hecks.hecksagon "..."`, `Hecks.world "..."`, etc.
+
+## Results
+
+| Bucket                                | Count |
+|---------------------------------------|------:|
+| Total `.heki` files scanned           |     0 |
+| Genuine orphans (Bluebook source)     |     0 |
+| Clean files                           |     0 |
+
+**Every `.heki` file in the repo lives under one of the excluded paths.**
+
+- Main checkout: all `.heki` files are in `hecks_conception/information/` (runtime state).
+- Worktrees: all `.heki` files are in `.claude/worktrees/<agent>/hecks_conception/information/`
+  (also runtime state, inherited per-worktree).
+- Nursery (`hecks_conception/nursery/`): contains **zero** `.heki` files — the 25 orphans
+  fixed by PR #239 were the only ones, and they have all been correctly renamed to
+  `.bluebook` / `.behaviors` / `.fixtures`.
+
+## Surprises outside `hecks_conception/nursery/`
+
+**None.** No stray Bluebook-source `.heki` files were found anywhere else in the tree.
+PR #239 appears to have caught the complete set.
+
+## Conclusion
+
+The repo is clean. No further renames needed. The `.heki` extension is now consistently
+reserved for runtime-persisted aggregate state under `hecks_conception/information/`.


### PR DESCRIPTION
## Summary

Follow-up to PR #239 (which renamed 25 orphan `.heki` files in `hecks_conception/nursery/` that actually contained Bluebook DSL source).

Swept the entire tree for any remaining `.heki` files containing Bluebook DSL. Excluded `.claude/worktrees/**` and `hecks_conception/information/**` (runtime-persisted stores, not source).

**Result: clean.** Every `.heki` file in the repo lives under one of the excluded paths. Nursery contains zero `.heki` files — PR #239 caught the complete set. No surprises outside the nursery.

Adds `HEKI_ORPHAN_SWEEP.md` at repo root documenting the scan.

## Test plan

- [x] `find` sweep of full repo confirms no `.heki` files outside `hecks_conception/information/` (and worktree mirrors thereof)
- [x] `hecks_conception/nursery/` contains zero `.heki` files