### PR TITLE
docs: orphan inventory for .fixtures and .behaviors (aggregate-reference check)

### DIFF
--- a/ORPHAN_INVENTORY.md
+++ b/ORPHAN_INVENTORY.md
@@ -1,0 +1,84 @@
+# Orphan Inventory — .fixtures and .behaviors
+
+Aggregate-reference check: for each `.fixtures` and `.behaviors` file,
+confirm every `aggregate` / `on:` reference resolves to an aggregate
+declared in a `.bluebook` for the matching `Hecks.<kind> "Domain"`.
+
+Generated: 2026-04-21
+
+## Corpus
+
+- `.bluebook` files scanned: 480
+- Distinct domain names declared: 468
+- `.fixtures` files scanned: 356
+- `.behaviors` files scanned: 455
+
+## .fixtures
+
+### Counts
+
+| Category | Files |
+|---|---|
+| All aggregate refs found in bluebook | 354 |
+| Some orphans (partial match) | 1 |
+| All refs orphan | 1 |
+| Domain name not declared in any bluebook | 0 |
+| No aggregate refs present | 0 |
+| **Total** | 356 |
+
+### .fixtures — some orphans
+
+**`hecks_conception/aggregates/fixtures/sleep.fixtures`** — domain `"Sleep"`
+  - L2: `Fatigue` — ORPHAN
+  - L10: `WakeMood` — OK
+  - L16: `Consciousness` — OK
+  - L21: `Monitor` — OK
+
+### .fixtures — all orphans
+
+**`hecks_conception/capabilities/antibody/fixtures/antibody.fixtures`** — domain `"Antibody"`
+  - L9: `FlaggedExtension` — ORPHAN
+  - L31: `ShebangMapping` — ORPHAN
+  - L47: `ExemptionPattern` — ORPHAN
+  - L58: `TestCase` — ORPHAN
+
+## .behaviors
+
+### Counts
+
+| Category | Files |
+|---|---|
+| All aggregate refs found in bluebook | 454 |
+| Some orphans (partial match) | 0 |
+| All refs orphan | 0 |
+| Domain name not declared in any bluebook | 0 |
+| No aggregate refs present | 1 |
+| **Total** | 455 |
+
+### .behaviors — no aggregate refs present
+
+**`hecks_conception/aggregates/bluebook.behaviors`** — domain `"Bluebook"`
+  A scaffold with section-comment headers for every Bluebook aggregate
+  (Domain, Aggregate, Attribute, ValueObject, Reference, Command, Query,
+  Given, Mutation, Lifecycle, Transition, Policy, Fixture) but no
+  `tests … on: …` blocks yet. Not an orphan — an unwritten draft.
+
+## Notes on Findings
+
+### `Fatigue` in `aggregates/fixtures/sleep.fixtures`
+
+The `Fatigue` aggregate was removed from `aggregates/sleep.bluebook` on
+2026-04-20 (see the header comment in that file). The fixtures file was
+not updated — `aggregate "Fatigue"` at L2 with six fixtures is now
+referencing an aggregate that no longer exists. Safe to delete.
+
+### Antibody fixtures as config tables
+
+All four aggregates in `capabilities/antibody/fixtures/antibody.fixtures`
+(`FlaggedExtension`, `ShebangMapping`, `ExemptionPattern`, `TestCase`)
+are orphans in the strict sense — they are not declared as aggregates
+in `antibody.bluebook`. The file is being used as a config/seed table
+(CODE_EXTS, shebang map, exemption regex, test scenarios) rather than
+as seed data for bluebook-declared aggregates. Either the bluebook
+should grow formal aggregates for these, or these config rows belong
+somewhere else (a `.heki` store, or a dedicated config format).


### PR DESCRIPTION
## Summary

Walks every `.bluebook`, `.fixtures`, and `.behaviors` file in `hecks_conception/` and flags any aggregate referenced from a fixtures/behaviors file that is not declared in a `.bluebook` for the same `Hecks.<kind> \"Domain\"` name.

- **480** `.bluebook` / **356** `.fixtures` / **455** `.behaviors` files scanned; 468 distinct domain names.
- `.fixtures`: **354 clean**, **1 partial orphan**, **1 all-orphans**.
- `.behaviors`: **454 clean**, **0 orphans**, **1 empty scaffold**.

### Two real orphans

- `aggregates/fixtures/sleep.fixtures` L2 `Fatigue` — the aggregate was removed from `sleep.bluebook` on 2026-04-20 (header comment documents the migration to `MietteBody::Heartbeat`), but the fixtures row was never deleted.
- `capabilities/antibody/fixtures/antibody.fixtures` — all four aggregates (`FlaggedExtension`, `ShebangMapping`, `ExemptionPattern`, `TestCase`) are config tables with no matching aggregate in `antibody.bluebook`. Either the bluebook grows these aggregates, or the tables move to a different home.

### Empty scaffold (not an orphan)

- `aggregates/bluebook.behaviors` — section-comment headers for every Bluebook aggregate but no `tests` yet. Unwritten draft.

## Test plan

- [ ] Read `ORPHAN_INVENTORY.md` at repo root
- [ ] Confirm `Fatigue` in `sleep.fixtures` can be deleted (the aggregate is gone from `sleep.bluebook`)
- [ ] Decide on `antibody.fixtures` — promote to aggregates or move to a config store