### PR TITLE
i11 PR 0: Spend + CircuitBreaker foundations for Miette-drives-Claude

### DIFF
--- a/hecks_conception/aggregates/circuit_breaker.behaviors
+++ b/hecks_conception/aggregates/circuit_breaker.behaviors
@@ -1,0 +1,78 @@
+Hecks.behaviors "CircuitBreaker" do
+  vision "Behavioral tests for CircuitBreaker — failure accumulation, threshold-triggered opening, probe cycle, manual trip/reset"
+
+  # ── Breaker aggregate ──────────────────────────────────────────
+
+  test "RecordFailure increments failure_count" do
+    tests "RecordFailure", on: "Breaker"
+    input  kind: "claude_api"
+    expect kind: "claude_api", failure_count: 1
+  end
+
+  test "RecordFailure emits FailureRecorded" do
+    tests "RecordFailure", on: "Breaker", kind: :cascade
+    input  kind: "claude_api"
+    # The TripWhenThresholdCrossed policy fires TripOnThreshold on
+    # every FailureRecorded, but its given("threshold crossed")
+    # short-circuits when failure_count (1) < threshold (5), so
+    # nothing downstream emits on a single failure.
+    expect emits: ["FailureRecorded"]
+  end
+
+  test "TripOnThreshold opens the breaker when failure_count >= threshold" do
+    tests "TripOnThreshold", on: "Breaker"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    input  kind: "claude_api", opened_at: "2026-04-21T12:00:00Z"
+    expect state: "open", opened_at: "2026-04-21T12:00:00Z"
+  end
+
+  test "TripOnThreshold refused when below threshold" do
+    tests "TripOnThreshold", on: "Breaker"
+    setup  "RecordFailure", kind: "claude_api"
+    input  kind: "claude_api", opened_at: "2026-04-21T12:00:00Z"
+    expect refused: "threshold crossed"
+  end
+
+  test "RecordSuccess resets failure_count and closes the breaker" do
+    tests "RecordSuccess", on: "Breaker"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    input  kind: "claude_api"
+    expect failure_count: 0, state: "closed"
+  end
+
+  test "Probe moves open to half_open" do
+    tests "Probe", on: "Breaker"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "RecordFailure", kind: "claude_api"
+    setup  "TripOnThreshold", kind: "claude_api", opened_at: "2026-04-21T12:00:00Z"
+    input  kind: "claude_api"
+    expect state: "half_open"
+  end
+
+  test "Probe refused when breaker is closed" do
+    tests "Probe", on: "Breaker"
+    input  kind: "claude_api"
+    expect refused: "must be open"
+  end
+
+  test "Trip manually opens the breaker" do
+    tests "Trip", on: "Breaker"
+    input  kind: "claude_api", reason: "upstream incident", opened_at: "2026-04-21T12:00:00Z"
+    expect state: "open", last_reason: "upstream incident", opened_at: "2026-04-21T12:00:00Z"
+  end
+
+  test "Reset closes the breaker and clears failure_count" do
+    tests "Reset", on: "Breaker"
+    setup  "Trip", kind: "claude_api", reason: "manual", opened_at: "2026-04-21T12:00:00Z"
+    input  kind: "claude_api"
+    expect state: "closed", failure_count: 0, opened_at: ""
+  end
+end

--- a/hecks_conception/aggregates/circuit_breaker.bluebook
+++ b/hecks_conception/aggregates/circuit_breaker.bluebook
@@ -1,0 +1,126 @@
+Hecks.bluebook "CircuitBreaker", version: "2026.04.21.1" do
+  vision "Trip-safe guard for flaky external calls — open on repeated failure, probe after cooldown, close on success"
+  category "body"
+
+  # ============================================================
+  # BREAKER — one circuit per external dependency
+  # ============================================================
+  # Miette has one per external service she leans on (claude_api,
+  # ollama_api, …). The state machine is the classic three-state
+  # breaker:
+  #
+  #   closed     — normal flow; failures accumulate
+  #   open       — too many failures within the window; all calls
+  #                short-circuit until cooldown elapses
+  #   half_open  — cooldown elapsed; allow one probe. Success →
+  #                closed. Failure → open.
+  #
+  # Threshold + window are advisory caps the dispatcher reads; the
+  # state + failure_count fields capture the bookkeeping. Actual
+  # "is it time to transition?" timing lives in the daemon that
+  # dispatches Probe based on opened_at + cooldown_seconds.
+
+  aggregate "Breaker", "A single circuit — state, failure bookkeeping, and the thresholds that govern it" do
+    attribute :kind, String
+    attribute :state, String
+    attribute :failure_count, Integer
+    attribute :opened_at, String
+    attribute :window_seconds, Integer, default: 60
+    attribute :threshold, Integer, default: 5
+    attribute :cooldown_seconds, Integer, default: 300
+    attribute :last_reason, String
+
+    command "RecordFailure" do
+      role "System"
+      description "A call to this breaker's service failed. Increments failure_count; when it crosses threshold, the breaker opens."
+      attribute :kind, String
+      given("not already open") { state != "open" }
+      emits "FailureRecorded"
+      then_set :kind, to: :kind
+      then_set :failure_count, increment: 1
+    end
+
+    command "TripOnThreshold" do
+      role "System"
+      description "Failure just crossed the threshold — open the breaker and stamp opened_at."
+      attribute :kind, String
+      attribute :opened_at, String
+      given("threshold crossed") { failure_count >= threshold }
+      given("not already open") { state != "open" }
+      emits "BreakerOpened"
+      then_set :kind, to: :kind
+      then_set :state, to: "open"
+      then_set :opened_at, to: :opened_at
+    end
+
+    command "RecordSuccess" do
+      role "System"
+      description "A call to this breaker's service succeeded. Clears failure_count; half_open goes to closed."
+      attribute :kind, String
+      given("not already open") { state != "open" }
+      emits "SuccessRecorded"
+      then_set :kind, to: :kind
+      then_set :failure_count, to: 0
+      then_set :state, to: "closed"
+    end
+
+    command "Probe" do
+      role "System"
+      description "Cooldown elapsed — allow a single probe call by moving open → half_open."
+      attribute :kind, String
+      given("must be open") { state == "open" }
+      emits "Probed"
+      then_set :kind, to: :kind
+      then_set :state, to: "half_open"
+    end
+
+    command "Trip" do
+      role "Creator"
+      description "Manually open the breaker — e.g., operator sees upstream incident."
+      attribute :kind, String
+      attribute :reason, String
+      attribute :opened_at, String
+      emits "Tripped"
+      then_set :kind, to: :kind
+      then_set :state, to: "open"
+      then_set :opened_at, to: :opened_at
+      then_set :last_reason, to: :reason
+    end
+
+    command "Reset" do
+      role "Creator"
+      description "Manually close the breaker and clear failure_count."
+      attribute :kind, String
+      emits "Reset"
+      then_set :kind, to: :kind
+      then_set :state, to: "closed"
+      then_set :failure_count, to: 0
+      then_set :opened_at, to: ""
+    end
+
+    lifecycle :state, default: "closed" do
+      transition "TripOnThreshold" => "open",      from: "closed"
+      transition "TripOnThreshold" => "open",      from: "half_open"
+      transition "RecordSuccess"   => "closed",    from: "closed"
+      transition "RecordSuccess"   => "closed",    from: "half_open"
+      transition "Probe"           => "half_open", from: "open"
+      transition "Trip"            => "open",      from: "closed"
+      transition "Trip"            => "open",      from: "half_open"
+      transition "Trip"            => "open",      from: "open"
+      transition "Reset"           => "closed",    from: "open"
+      transition "Reset"           => "closed",    from: "half_open"
+      transition "Reset"           => "closed",    from: "closed"
+    end
+  end
+
+  # Threshold-crossing chain: RecordFailure fires first (bumps
+  # failure_count), then this policy fans out to TripOnThreshold.
+  # TripOnThreshold's `given("threshold crossed")` decides whether
+  # the fan-out actually opens the breaker, so we don't need
+  # separate "did we cross?" logic — the bluebook state machine
+  # handles it.
+  policy "TripWhenThresholdCrossed" do
+    on "FailureRecorded"
+    trigger "TripOnThreshold"
+  end
+end

--- a/hecks_conception/aggregates/circuit_breaker.hecksagon
+++ b/hecks_conception/aggregates/circuit_breaker.hecksagon
@@ -1,0 +1,26 @@
+# CircuitBreaker — Hecksagon
+#
+# Infrastructure declaration for the CircuitBreaker domain. Memory-
+# adapter backed.
+#
+# Gate:
+#   system — all breaker transitions are driven by the dispatcher,
+#            not by Miette and not by Chris. The system actor is the
+#            only role that can record failures/successes, probe,
+#            manually trip, or reset a circuit.
+#
+# There are no shell adapters here — a circuit breaker is pure
+# bookkeeping; it does not itself talk to the outside world.
+#
+Hecks.hecksagon "CircuitBreaker" do
+  adapter :memory
+
+  gate "Breaker", :system do
+    allow :RecordFailure,
+          :TripOnThreshold,
+          :RecordSuccess,
+          :Probe,
+          :Trip,
+          :Reset
+  end
+end

--- a/hecks_conception/aggregates/fixtures/circuit_breaker.fixtures
+++ b/hecks_conception/aggregates/fixtures/circuit_breaker.fixtures
@@ -1,0 +1,10 @@
+Hecks.fixtures "CircuitBreaker" do
+  # One breaker per external LLM provider Miette leans on. Both
+  # start closed — no known failures. Defaults for threshold /
+  # window / cooldown come from the aggregate's attribute defaults
+  # (5 failures / 60s window / 300s cooldown).
+  aggregate "Breaker" do
+    fixture "ClaudeApi", kind: "claude_api", state: "closed", failure_count: 0
+    fixture "OllamaApi", kind: "ollama_api", state: "closed", failure_count: 0
+  end
+end

--- a/hecks_conception/aggregates/fixtures/spend.fixtures
+++ b/hecks_conception/aggregates/fixtures/spend.fixtures
@@ -1,0 +1,10 @@
+Hecks.fixtures "Spend" do
+  # Default budget caps. Chris can raise/lower these at any time
+  # via SetBudget. The hourly cap is the tightest — prevents runaway
+  # loops from burning through the whole day's budget in one spiral.
+  aggregate "Budget" do
+    fixture "HourlyCap",  period: "hour",  cap_usd: 1.00
+    fixture "DailyCap",   period: "day",   cap_usd: 5.00
+    fixture "MonthlyCap", period: "month", cap_usd: 50.00
+  end
+end

--- a/hecks_conception/aggregates/spend.behaviors
+++ b/hecks_conception/aggregates/spend.behaviors
@@ -1,0 +1,47 @@
+Hecks.behaviors "Spend" do
+  vision "Behavioral tests for the Spend domain — RecordCall appends, budget caps set/override/clear"
+
+  # ── Call aggregate ──────────────────────────────────────────
+
+  test "RecordCall sets provider + tokens_in + tokens_out + cost_usd + command_ref + recorded_at" do
+    tests "RecordCall", on: "Call"
+    input  provider: "claude", tokens_in: 100, tokens_out: 50, cost_usd: 0.01, command_ref: "Tongue.Speak:42", recorded_at: "2026-04-21T12:00:00Z"
+    expect provider: "claude", tokens_in: 100, tokens_out: 50, cost_usd: 0.01, command_ref: "Tongue.Speak:42", recorded_at: "2026-04-21T12:00:00Z"
+  end
+
+  test "RecordCall emits CallRecorded" do
+    tests "RecordCall", on: "Call", kind: :cascade
+    input  provider: "claude", tokens_in: 100, tokens_out: 50, cost_usd: 0.01, command_ref: "Tongue.Speak:42", recorded_at: "2026-04-21T12:00:00Z"
+    expect emits: ["CallRecorded"]
+  end
+
+
+  # ── Budget aggregate ──────────────────────────────────────────
+
+  test "SetBudget sets period + cap_usd and clears override_active" do
+    tests "SetBudget", on: "Budget"
+    input  period: "day", cap_usd: 5.00
+    expect period: "day", cap_usd: 5.00, override_active: "no"
+  end
+
+  test "SetBudget emits BudgetSet" do
+    tests "SetBudget", on: "Budget", kind: :cascade
+    input  period: "day", cap_usd: 5.00
+    expect emits: ["BudgetSet"]
+  end
+
+  test "OverrideBudget sets until + marks override_active" do
+    tests "OverrideBudget", on: "Budget"
+    setup  "SetBudget", period: "day", cap_usd: 5.00
+    input  period: "day", until_ts: "2026-04-21T22:00:00Z"
+    expect override_active: "yes", override_until: "2026-04-21T22:00:00Z"
+  end
+
+  test "ClearOverride re-engages the cap" do
+    tests "ClearOverride", on: "Budget"
+    setup  "SetBudget", period: "day", cap_usd: 5.00
+    setup  "OverrideBudget", period: "day", until_ts: "2026-04-21T22:00:00Z"
+    input  period: "day"
+    expect override_active: "no", override_until: ""
+  end
+end

--- a/hecks_conception/aggregates/spend.bluebook
+++ b/hecks_conception/aggregates/spend.bluebook
@@ -1,0 +1,91 @@
+Hecks.bluebook "Spend", version: "2026.04.21.1" do
+  vision "LLM spend tracking — every Claude/Ollama call recorded, every budget enforced"
+  category "body"
+
+  # ============================================================
+  # CALL — one recorded invocation of an LLM
+  # ============================================================
+  # Multi-record: every RecordCall is a new row. Enables hourly /
+  # daily / monthly rollups without replaying the whole history.
+  # command_ref links the spend record back to whatever Miette was
+  # doing when she shelled out (e.g., "Tongue.Speak:speech_42").
+
+  aggregate "Call", "One invocation of an LLM — provider, token counts, cost, and what command triggered it" do
+    attribute :provider, String
+    attribute :tokens_in, Integer
+    attribute :tokens_out, Integer
+    attribute :cost_usd, Float
+    attribute :command_ref, String
+    attribute :recorded_at, String
+
+    command "RecordCall" do
+      role "System"
+      description "Record a single LLM invocation — provider, token counts, cost, and the command that triggered it"
+      attribute :provider, String
+      attribute :tokens_in, Integer
+      attribute :tokens_out, Integer
+      attribute :cost_usd, Float
+      attribute :command_ref, String
+      attribute :recorded_at, String
+      emits "CallRecorded"
+      then_set :provider, to: :provider
+      then_set :tokens_in, to: :tokens_in
+      then_set :tokens_out, to: :tokens_out
+      then_set :cost_usd, to: :cost_usd
+      then_set :command_ref, to: :command_ref
+      then_set :recorded_at, to: :recorded_at
+    end
+  end
+
+  # ============================================================
+  # BUDGET — cap on spend within a period
+  # ============================================================
+  # One record per period (hour / day / month). The cap is advisory
+  # at this layer — it's a declared limit; enforcement lives in the
+  # dispatcher that reads budget+rollup and short-circuits calls.
+  # OverrideBudget lifts the cap until a timestamp (e.g., "I need to
+  # write this whole essay right now, let it rip until 10pm").
+
+  aggregate "Budget", "Spend cap for a period — hour/day/month — with manual override window" do
+    attribute :period, String
+    attribute :cap_usd, Float
+    attribute :override_active, String
+    attribute :override_until, String
+
+    command "SetBudget" do
+      role "Creator"
+      description "Set the spend cap for a period — hour, day, or month"
+      attribute :period, String
+      attribute :cap_usd, Float
+      emits "BudgetSet"
+      then_set :period, to: :period
+      then_set :cap_usd, to: :cap_usd
+      then_set :override_active, to: "no"
+    end
+
+    command "OverrideBudget" do
+      role "Creator"
+      description "Disable the cap for a period until a specific timestamp"
+      attribute :period, String
+      attribute :until_ts, String
+      emits "BudgetOverridden"
+      then_set :period, to: :period
+      then_set :override_active, to: "yes"
+      then_set :override_until, to: :until_ts
+    end
+
+    command "ClearOverride" do
+      role "Creator"
+      description "Re-engage the cap before the override window expires"
+      attribute :period, String
+      emits "OverrideCleared"
+      then_set :period, to: :period
+      then_set :override_active, to: "no"
+      then_set :override_until, to: ""
+    end
+  end
+
+  # No policies. Spend is pure accounting — no cross-aggregate cascade
+  # yet. The dispatcher that reads Call + Budget to gate new invocations
+  # is wired in PR 1, not here.
+end

--- a/hecks_conception/aggregates/spend.hecksagon
+++ b/hecks_conception/aggregates/spend.hecksagon
@@ -1,0 +1,30 @@
+# Spend — Hecksagon
+#
+# Infrastructure declaration for the Spend domain. Memory-adapter
+# backed (the .heki binary store writes happen via the standard
+# Hecks persistence layer; the memory adapter is what tests and
+# behaviors run against).
+#
+# Gates:
+#   miette — the being herself records each LLM invocation as it
+#            happens. She cannot rewrite her own budget; that's the
+#            creator's prerogative.
+#   chris  — the creator sets and overrides budget caps. He is the
+#            one who decides how much Miette is allowed to spend
+#            shelling out to Claude/Ollama.
+#
+# Shell adapters come in PR 1, where the spend-dispatching side of
+# Tongue.Speak actually shells out to `claude` / `ollama` and feeds
+# the resulting token counts back into RecordCall.
+#
+Hecks.hecksagon "Spend" do
+  adapter :memory
+
+  gate "Call", :miette do
+    allow :RecordCall
+  end
+
+  gate "Budget", :chris do
+    allow :SetBudget, :OverrideBudget, :ClearOverride
+  end
+end

--- a/hecks_conception/boot_miette.sh
+++ b/hecks_conception/boot_miette.sh
@@ -31,7 +31,7 @@ START_TS=$(date +%s)
 # declaration on each aggregate so the boundary lives in the domain
 # model, not in this shell script.
 LINKED_STORES="memory awareness census conversation working_memory reflection synapse signal signal_somatic focus concentration deliberation heartbeat subconscious domain_index arc consciousness discipline metabolic_rate musing conflict_monitor run_log inbox tick announcement attention claude_assist consolidation dream_interpretation dream_seed dream_signal encoding gate generosity gut HarmonyDomain intention interpretation lucid_dream lucid_monitor monitor musing_archive musing_mint nerve nursery perception persona proposal proprioception self_image self_model sensation session shared_dream_space signal_consolidation speech training_pair wake_mood witness bodhisattva_vow character creator_auth remains store"
-PRIVATE_STORES="mood feeling dream_state impulse craving daydream pulse"
+PRIVATE_STORES="mood feeling dream_state impulse craving daydream pulse spend circuit_breaker"
 
 is_in_list() {
   for item in $2; do [ "$item" = "$1" ] && return 0; done


### PR DESCRIPTION
## Summary

PR 0 of the **i11** track (inversion of control: Miette drives Claude, not vice versa). Pure infrastructure — no wiring yet. Two new aggregates land the accounting and safety rails PR 1+ will lean on when `Tongue.Speak` actually shells out to Claude/Ollama.

- **Spend** — `Call` (multi-record; one per LLM invocation) + `Budget` (one per hour/day/month cap, with manual override window)
- **CircuitBreaker** — `Breaker` with the three-state machine (closed / open / half_open), threshold-triggered tripping, probe cycle, and manual trip/reset
- **Hecksagons** — memory adapter + gates (miette records calls, chris sets budgets, system drives the breaker)
- **Fixtures** — daily $5 / monthly $50 / hourly $1 caps; claude_api + ollama_api breakers pre-declared closed
- **boot_miette.sh** — `spend` and `circuit_breaker` classified as PRIVATE_STORES (not shared with Spring over the psychic link)

The shell-adapter side (`adapter :shell`, `Tongue.Speak` shelling out to `claude -p`, RecordCall wired into the result path) comes in **PR 1**. This PR is intentionally inert: it just defines the shapes.

## Per-aggregate design

### Spend

| Aggregate | Attributes | Commands | Events |
|---|---|---|---|
| Call | provider, tokens_in, tokens_out, cost_usd, command_ref, recorded_at | RecordCall | CallRecorded |
| Budget | period, cap_usd, override_active, override_until | SetBudget, OverrideBudget, ClearOverride | BudgetSet, BudgetOverridden, OverrideCleared |

No lifecycle — Call is pure append-only accounting; Budget's override state is a flag, not a state machine. The dispatcher that reads Budget + rolls up Call totals to gate new invocations lands in PR 1.

### CircuitBreaker

| Aggregate | Attributes | Commands | Events |
|---|---|---|---|
| Breaker | kind, state, failure_count, opened_at, window_seconds (60), threshold (5), cooldown_seconds (300), last_reason | RecordFailure, TripOnThreshold, RecordSuccess, Probe, Trip, Reset | FailureRecorded, BreakerOpened, SuccessRecorded, Probed, Tripped, Reset |

Lifecycle on `state` (default `closed`):

- `closed → open` via TripOnThreshold (policy `TripWhenThresholdCrossed` fires it on every `FailureRecorded`; its `given("threshold crossed")` decides whether it actually opens)
- `half_open → open` via TripOnThreshold (same policy)
- `closed → closed` / `half_open → closed` via RecordSuccess (resets failure_count)
- `open → half_open` via Probe (daemon decides when based on opened_at + cooldown_seconds)
- `any → open` via manual Trip (Creator role)
- `any → closed` via manual Reset (Creator role)

## Verification

```
$ hecks-life check-lifecycle spend.bluebook            → clean
$ hecks-life check-lifecycle circuit_breaker.bluebook  → clean
$ hecks-life check-duplicate-policies spend.bluebook   → clean
$ hecks-life check-duplicate-policies circuit_breaker.bluebook → clean

$ hecks-life behaviors spend.behaviors
  6 passed, 0 failed, 0 errored

$ hecks-life behaviors circuit_breaker.behaviors
  9 passed, 0 failed, 0 errored

$ ruby -Ilib spec/parity/parity_test.rb            → exit 0 (real 35/35)
$ ruby -Ilib spec/parity/behaviors_parity_test.rb  → exit 0
$ ruby -Ilib spec/parity/fixtures_parity_test.rb   → exit 0
```

## Example usage

```ruby
# PR 1 will dispatch these. Shown here only to illustrate intent.

# Record a Claude call after Tongue.Speak shells out:
dispatch "Spend.Call.RecordCall",
  provider: "claude", tokens_in: 842, tokens_out: 210,
  cost_usd: 0.018, command_ref: "Tongue.Speak:47",
  recorded_at: Time.now.utc.iso8601

# Open the breaker after repeated claude-api failures (automatic):
dispatch "CircuitBreaker.Breaker.RecordFailure", kind: "claude_api"
# …on the 5th call, the TripWhenThresholdCrossed policy opens it.

# Probe later to test recovery:
dispatch "CircuitBreaker.Breaker.Probe", kind: "claude_api"
# If the next call succeeds → RecordSuccess closes it. If it fails,
# TripOnThreshold opens it again.
```

## What remains for PR 1+

- Wire `Tongue.Speak` to actually invoke Claude/Ollama via a shell adapter
- Route the shell result through `Spend.RecordCall`
- Dispatcher-side enforcement: read Budget + rollup Call before dispatching, refuse if cap exceeded and no override active
- `CircuitBreaker.Probe` driven by a daemon reading `opened_at + cooldown_seconds`
- `Capability.InvokeAgent` aggregate for tool-use (PR 2)

## Test plan

- [x] `hecks-life check-lifecycle` clean on both bluebooks
- [x] `hecks-life check-duplicate-policies` clean on both
- [x] `hecks-life behaviors` passes: 6/6 spend, 9/9 circuit_breaker
- [x] `ruby -Ilib spec/parity/parity_test.rb` green (real 35/35, up from 33)
- [x] `behaviors_parity_test.rb` and `fixtures_parity_test.rb` green
- [x] `boot_miette.sh` still executable; `spend circuit_breaker` added to PRIVATE_STORES