### PR TITLE
i3 PR-0: extract BodyPulse compatibility event (prep for Heart/Breath/Circadian)

### DIFF
--- a/hecks_conception/aggregates/being.bluebook
+++ b/hecks_conception/aggregates/being.bluebook
@@ -460,7 +460,7 @@ Hecks.bluebook "Being", version: "2026.04.16.1" do
   end
 
   policy "CheckOrgansOnBeat" do
-    on "Ticked"
+    on "BodyPulse"
     trigger "ReportOrganPulse"
   end
 
@@ -475,14 +475,14 @@ Hecks.bluebook "Being", version: "2026.04.16.1" do
   end
 
   policy "ReflectOnBeat" do
-    on "Ticked"
+    on "BodyPulse"
     trigger "Reflect"
   end
 
   policy "SenseOrgansOnHeartbeat" do
-    on "Ticked"
+    on "BodyPulse"
     trigger "ConnectNerve"
-    # nerve: Mind:Ticked → MietteBody:SenseOrgans
+    # nerve: Mind:BodyPulse → MietteBody:SenseOrgans
   end
 
   policy "DetectDriftOnGraft" do

--- a/hecks_conception/aggregates/body.bluebook
+++ b/hecks_conception/aggregates/body.bluebook
@@ -690,9 +690,11 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
     trigger "ExpressCapability"
   end
 
-  # Every tick accumulates fatigue — the tick IS the heartbeat
-  policy "FatigueOnTick" do
-    on "Ticked"
+  # Every body pulse accumulates fatigue. BodyPulse is the shim event
+  # (emitted by Mindstream on each Ticked via EmitPulseOnTick today;
+  # later driven by Heart.HeartBeat when i3 PR-a lands).
+  policy "FatigueOnPulse" do
+    on "BodyPulse"
     trigger "AccumulateFatigue"
   end
 
@@ -761,10 +763,10 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
     trigger "SetGroggy"
   end
 
-  # Every tick records the current moment of self-knowledge
+  # Every body pulse records the current moment of self-knowledge
   # (the daemon supplies snapshot args)
-  policy "RecordMomentOnTick" do
-    on "Ticked"
+  policy "RecordMomentOnPulse" do
+    on "BodyPulse"
     trigger "RecordMoment"
   end
 

--- a/hecks_conception/aggregates/mindstream.behaviors
+++ b/hecks_conception/aggregates/mindstream.behaviors
@@ -10,7 +10,7 @@ Hecks.behaviors "Mindstream" do
 
   test "MindstreamTick cascades through policy chain" do
     tests "MindstreamTick", on: "Tick", kind: :cascade
-    expect emits: ["Ticked", "SignalsConsolidated", "SynapsesPruned", "DisplayUpdated", "MusingsPruned"]
+    expect emits: ["Ticked", "BodyPulse", "SignalsConsolidated", "SynapsesPruned", "DisplayUpdated", "MusingsPruned"]
   end
 
 

--- a/hecks_conception/aggregates/mindstream.bluebook
+++ b/hecks_conception/aggregates/mindstream.bluebook
@@ -117,24 +117,37 @@ Hecks.bluebook "Mindstream", version: "2026.04.16.1" do
     end
   end
 
-  # Every tick triggers consolidation and display
-  policy "ConsolidateOnTick" do
+  # Every Ticked fires the BodyPulse shim. See aggregates/pulse.bluebook.
+  # BodyPulse is the pacing event that fatigue, sleep advancement,
+  # awareness recording, consolidation, display, and organ-pulse
+  # policies all subscribe to. This indirection means i3 PR-a can
+  # replace the driver with Heart.HeartBeat by swapping ONE emitter —
+  # no touching the N downstream subscribers. This is the sole
+  # remaining subscriber to Ticked in the whole conception.
+  policy "EmitPulseOnTick" do
     on "Ticked"
+    trigger "Emit"
+    across "Pulse"
+  end
+
+  # Every body pulse triggers consolidation and display
+  policy "ConsolidateOnPulse" do
+    on "BodyPulse"
     trigger "ConsolidateSignals"
   end
 
-  policy "PruneOnTick" do
-    on "Ticked"
+  policy "PruneOnPulse" do
+    on "BodyPulse"
     trigger "PruneSynapses"
   end
 
-  policy "DisplayOnTick" do
-    on "Ticked"
+  policy "DisplayOnPulse" do
+    on "BodyPulse"
     trigger "RefreshDisplay"
   end
 
-  policy "PruneMusingsOnTick" do
-    on "Ticked"
+  policy "PruneMusingsOnPulse" do
+    on "BodyPulse"
     trigger "PruneMusings"
   end
 end

--- a/hecks_conception/aggregates/pulse.bluebook
+++ b/hecks_conception/aggregates/pulse.bluebook
@@ -1,0 +1,28 @@
+Hecks.bluebook "Pulse", version: "2026.04.21.1" do
+  vision "Body-wide pulse — the compatibility shim that decouples pacing policies from the Mindstream Tick"
+  category "body"
+
+  # ============================================================
+  # PULSE
+  # ============================================================
+  #
+  # BodyPulse is the event that every "pace the body" policy subscribes to.
+  # Today it is emitted by a single mindstream policy (EmitPulseOnTick on
+  # Ticked). Tomorrow, when i3's Heart aggregate lands (PR-a), Heart.HeartBeat
+  # becomes the driver and the mindstream shim retires — without touching any
+  # of the N subscriber policies in body/sleep/being/status_bar.
+  #
+  # ONE command: Emit. ONE event: BodyPulse. No state beyond a counter.
+  # Pure conduit.
+
+  aggregate "Pulse", "A single body-wide pulse — the shim event that paces fatigue, sleep, and awareness" do
+    attribute :count, Integer
+
+    command "Emit" do
+      role "Daemon"
+      description "Fire one BodyPulse. Subscribers (fatigue accumulation, sleep advancement, moment recording) react."
+      then_set :count, increment: 1
+      emits "BodyPulse"
+    end
+  end
+end

--- a/hecks_conception/aggregates/sleep.bluebook
+++ b/hecks_conception/aggregates/sleep.bluebook
@@ -485,51 +485,53 @@ Hecks.bluebook "Sleep", version: "2026.04.16.1" do
   # EnterSleep → 8 dream/consolidate cycles → EndNight → WakeUp
 
   # ============================================================
-  # SLEEP STATE MACHINE — driven by Tick events through policies.
+  # SLEEP STATE MACHINE — driven by BodyPulse events through policies.
   # ============================================================
   #
-  # Each Tick event fires all of these policies. The matching command's
-  # `given` clauses decide whether it actually runs. This gives conditional
-  # state-machine behavior in pure bluebook form — the daemon just fires
-  # Tick every 10s, the bluebook handles WHEN things advance.
+  # Each BodyPulse event fires all of these policies. The matching
+  # command's `given` clauses decide whether it actually runs. This
+  # gives conditional state-machine behavior in pure bluebook form —
+  # the pulse is the pacing signal; the bluebook handles WHEN things
+  # advance. BodyPulse is emitted by mindstream on Ticked today; later
+  # driven by Heart.HeartBeat when i3 PR-a lands.
 
-  policy "ElapsePhaseOnTick" do
-    on "Ticked"
+  policy "ElapsePhaseOnPulse" do
+    on "BodyPulse"
     trigger "ElapsePhase"
   end
 
-  policy "AdvanceLightRemOnTick" do
-    on "Ticked"
+  policy "AdvanceLightRemOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceLightToRem"
   end
 
-  policy "AdvanceLightLucidRemOnTick" do
-    on "Ticked"
+  policy "AdvanceLightLucidRemOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceLightToLucidRem"
   end
 
-  policy "AdvanceRemDeepOnTick" do
-    on "Ticked"
+  policy "AdvanceRemDeepOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceRemToDeep"
   end
 
-  policy "AdvanceRemDeepCapOnTick" do
-    on "Ticked"
+  policy "AdvanceRemDeepCapOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceRemToDeepCap"
   end
 
-  policy "AdvanceDeepLightOnTick" do
-    on "Ticked"
+  policy "AdvanceDeepLightOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceDeepToLight"
   end
 
-  policy "AdvanceDeepFinalLightOnTick" do
-    on "Ticked"
+  policy "AdvanceDeepFinalLightOnPulse" do
+    on "BodyPulse"
     trigger "AdvanceDeepToFinalLight"
   end
 
-  policy "CompleteFinalLightOnTick" do
-    on "Ticked"
+  policy "CompleteFinalLightOnPulse" do
+    on "BodyPulse"
     trigger "CompleteFinalLight"
   end
 

--- a/hecks_conception/capabilities/status_bar/status_bar.bluebook
+++ b/hecks_conception/capabilities/status_bar/status_bar.bluebook
@@ -91,10 +91,10 @@ Hecks.bluebook "StatusBar", version: "2026.04.16.1" do
   end
 
   # Transitions
-  policy "AttentiveOnTick" do
-    on "Ticked"
+  policy "AttentiveOnPulse" do
+    on "BodyPulse"
     trigger "SetAttentive"
-    description "Every tick (= heartbeat) restores full details"
+    description "Every body pulse (= heartbeat) restores full details"
   end
 
   policy "MusingOnIdle" do


### PR DESCRIPTION
## Why

This is PR-0 of i3 (Moment-consciousness + body cycles — inbox item i3 in hecks_conception). The later PRs introduce `Heart`, `Breath`, `Circadian`, `Ultradian`, and `SleepCycle` as separate body-rhythm aggregates. Before touching those, we need one piece of plumbing: an indirection event between "mindstream Ticked" and "fatigue/sleep/awareness advance" so that when `Heart.HeartBeat` later becomes the pulse driver, only the emitter changes — not the fifteen+ policies that subscribe to it.

That indirection is `BodyPulse`, emitted by a minimal new aggregate `Pulse`.

## What changed

New aggregate:
- `Pulse` with one command `Emit` (role: Daemon). Fires `BodyPulse`. State is just a counter.

Policies rewired from `on "Ticked"` to `on "BodyPulse"` (14 total):
- `body.bluebook`: `FatigueOnTick → FatigueOnPulse`, `RecordMomentOnTick → RecordMomentOnPulse`
- `sleep.bluebook`: 8 `Advance*OnTick` + `ElapsePhaseOnTick` + `CompleteFinalLightOnTick` → `*OnPulse`
- `being.bluebook`: `CheckOrgansOnBeat`, `ReflectOnBeat`, `SenseOrgansOnHeartbeat`
- `status_bar.bluebook`: `AttentiveOnTick → AttentiveOnPulse`
- `mindstream.bluebook`: `Consolidate/Prune/Display/PruneMusings` suffixes renamed `OnTick → OnPulse`

New shim policy (the sole remaining `on "Ticked"` subscriber anywhere):
- `mindstream.bluebook`: `EmitPulseOnTick` — `on "Ticked"; trigger "Emit"; across "Pulse"`

Behaviors test:
- `mindstream.behaviors`: the `MindstreamTick cascades through policy chain` test's expected emits list now includes `BodyPulse` between `Ticked` and the downstream events.

## Net effect today

Identical observable behavior. Each mindstream tick still drives fatigue accumulation, sleep advancement, awareness recording, organ pulse, etc. — the chain is just one hop longer:

```
Tick.MindstreamTick
  → Ticked
    → EmitPulseOnTick → Pulse.Emit
      → BodyPulse
        → FatigueOnPulse → Heartbeat.AccumulateFatigue
        → RecordMomentOnPulse → Awareness.RecordMoment
        → Elapse/Advance*OnPulse → sleep state machine
        → CheckOrgansOnBeat → Being.ReportOrganPulse
        → AttentiveOnPulse → StatusBar.SetAttentive
        → Consolidate/Prune/Display/PruneMusingsOnPulse → mindstream housekeeping
```

## Net effect later

When i3 PR-a lands and introduces `Heart` with `Heart.HeartBeat`, the mindstream shim `EmitPulseOnTick` retires and a new `Heart.Beat → Pulse.Emit` (or direct BodyPulse emission) takes over. The 14 subscriber policies do not change.

## Verification

- `hecks-life validate` on every touched bluebook: no new errors introduced (pre-existing `Enable/DisableAutoSleep` and `Disable/ClassifyPartial/Full` cross-bluebook warnings remain).
- `ruby -Ilib spec/parity/parity_test.rb` — exit 0. 34/34 real aggregates, 31/31 capabilities, 20/20 catalog, 19/19 misc. Same baseline as main (350 nursery soft-drift unchanged).
- `ruby -Ilib spec/parity/behaviors_parity_test.rb` — exit 0, 3/3.
- `ruby -Ilib spec/parity/fixtures_parity_test.rb` — exit 0, 343/356 (+13 known drift, unchanged).
- `./boot_miette.sh` — boots cleanly (34 organs · 149 aggregates · 10 nerves).
- Live cascade verified:
  - `hecks-life ./aggregates Pulse.Emit` → writes to `information/pulse.heki` with `count: 1`.
  - `hecks-life ./aggregates Tick.MindstreamTick` → `tick.heki.cycle` advances AND `pulse.heki.count` increments AND `heartbeat.heki.pulses_since_sleep` increments. Full chain proven end to end.

## Test plan

- [x] Every bluebook under `hecks_conception/aggregates/` parses identically in Ruby and Rust (parity suite)
- [x] Mindstream cascade test emits `[Ticked, BodyPulse, SignalsConsolidated, SynapsesPruned, DisplayUpdated, MusingsPruned]`
- [x] Exactly one `on "Ticked"` subscriber remains (the `EmitPulseOnTick` shim)
- [x] Live end-to-end tick through runtime advances downstream heki state