### PR TITLE
fix: compost_seasonal_beings Reverse cascade parity (Ruby 8/9 → 9/9)

### DIFF
--- a/lib/hecks/behaviors/value.rb
+++ b/lib/hecks/behaviors/value.rb
@@ -90,11 +90,18 @@ module Hecks
 
       # Loose equality: Bool(true)==Str("true"), Int(42)==Str("42"),
       # numeric coercion handles Int<->Str("0")<->Null comparisons.
+      # A Null on either side compares via numeric ONLY — it must NOT
+      # fall through to the display-form tiebreaker, where Null's ""
+      # would match Str("") and make `before_snapshot != ""` silently
+      # pass on uninitialized state. Mirrors hecks_life's
+      # `values_equal`, where `Display(Null) = "null"` keeps the same
+      # fallback false and the cascade (policy→command→given) advances.
       def self.equal?(a, b)
         return true if a.kind == b.kind && a.raw == b.raw
         an = a.numeric
         bn = b.numeric
         return an == bn if an && bn
+        return false if a.kind == :null || b.kind == :null
         a.to_display == b.to_display
       end
 


### PR DESCRIPTION
## The regression

`hecks_conception/actions/compost_seasonal_beings.behaviors` has 9 tests. Under the Rust runner all 9 passed. Under the Ruby runner only 8/9 passed — this was the only non-parser-gap failure surfaced by the behaviors inventory.

Failing test: **Reverse cascades through policy chain**.

Failure output:
```
✗ Reverse cascades through policy chain
    expected emits: ["ActionReversed", "BeingRestored"], got ["ActionReversed"]
```

## Root cause

The cascade stopped at the `RestoreOnReverse` policy because `Restore`'s `given { before_snapshot != "" }` silently evaluated `true` in Rust and `false` in Ruby.

In Rust's `values_equal(Null, Str(""))`:
- variants differ; numeric coercion: `Null → Some(0.0)`, `Str("") → None` — no match
- display fallback: `Display(Null) = "null"` vs `""` — not equal
- therefore `!=` is true and the policy fires `Restore`, which emits `BeingRestored`

In Ruby's `Value.equal?(Null, Str(""))`:
- same numeric short-circuit (`0.0` vs `nil`) — skipped
- display fallback: `Null.to_display = ""` vs `""` — **equal**
- therefore `!=` is false → GivenFailed → cascade halts silently

## Fix applied

`lib/hecks/behaviors/value.rb` — when either side is `:null`, skip the display-form fallback so `Null` is only equal to `Null` (or to a numeric whose coerced value is 0). Mirrors Rust's `values_equal` exactly.

Example usage:

```ruby
Hecks::Behaviors::Value.equal?(Value.null, Value.from(""))   # => false (was true)
Hecks::Behaviors::Value.equal?(Value.null, Value.from(0))    # => true (unchanged — numeric path)
Hecks::Behaviors::Value.equal?(Value.null, Value.null)       # => true (unchanged — kind match)
```

## Before / after

Before fix:
- `compost_seasonal_beings.behaviors`: Ruby 8/9 (fail), Rust 9/9
- Full behaviors parity suite: 128/455 agreed, 327 divergent

After fix:
- `compost_seasonal_beings.behaviors`: Ruby 9/9, Rust 9/9 (parity)
- Full behaviors parity suite: 129/455 agreed, 326 divergent (exactly the target test flipped — no other file moved)

## Test plan

- [x] `ruby -Ilib spec/parity/behaviors_parity_test.rb hecks_conception/actions/compost_seasonal_beings.behaviors` → `1/1 parity`
- [x] `bin/hecks-behaviors hecks_conception/actions/compost_seasonal_beings.behaviors` → `9 passed, 0 failed, 0 errored`
- [x] Full parity suite diffed before/after: exactly one file flipped (the target), zero regressions