### PR TITLE
docs: Ruby/Rust value-equality parity audit

### DIFF
--- a/VALUE_EQUALITY_AUDIT.md
+++ b/VALUE_EQUALITY_AUDIT.md
@@ -1,0 +1,279 @@
+# Ruby/Rust Value-Equality Parity Audit
+
+**Audit branch:** `miette/value-equality-parity-audit`
+**Baseline:** `origin/main` @ 8ef8afb4
+**Context:** follow-up to PR #262 (`compost_seasonal_beings` cascade regression).
+**Scope:** inventory only — every divergence below needs its own PR.
+
+PR #262 fixed one specific false-positive in Ruby's `Hecks::Behaviors::Value.equal?`
+(Null == Str("") via a display-form tiebreaker). The hypothesis driving this
+audit is that the same _class_ of bug — divergent coercion or divergent
+display-form fallback — exists in other shapes. It does. **Twelve pairs**
+disagree between Ruby's `Value.equal?` and Rust's `values_equal`; four are
+plausibly cascade-dropping in real bluebooks.
+
+---
+
+## Method
+
+1. Read both sides end-to-end:
+   - Ruby: `lib/hecks/behaviors/value.rb` (the `Value.equal?` class method).
+   - Rust: `hecks_life/src/runtime/interpreter.rs` (`values_equal` +
+     `numeric_value`), plus `hecks_life/src/runtime/mod.rs`
+     (`enum Value` + `impl Display for Value`).
+2. Diffed the two algorithms pass by pass:
+   structural equality → numeric coercion → display-form fallback.
+3. Built a harness (`value_equality_audit_harness.rb`) that runs thirty-nine
+   synthetic pairs through:
+   - the _actual_ Ruby `Hecks::Behaviors::Value.equal?`, and
+   - a line-faithful Ruby port of Rust's `values_equal`
+     (cross-checked against live `rustc` runs for `f64::parse`
+     and `HashMap == HashMap` semantics).
+4. Tabulated every disagreement.
+
+Both reference algorithms are short:
+
+**Ruby `Value.equal?(a, b)`**
+```
+return true if a.kind == b.kind && a.raw == b.raw    # structural
+an = a.numeric; bn = b.numeric                       # coercion
+return an == bn if an && bn
+a.to_display == b.to_display                         # display fallback
+```
+
+**Rust `values_equal(left, right)`**
+```
+if left == right { return true }                     # structural (derived PartialEq)
+if let (Some(a), Some(b)) = (numeric_value(left), numeric_value(right)) {
+    return a == b;                                   # coercion
+}
+format!("{}", left) == format!("{}", right)          # display fallback
+```
+
+The shape is identical. The bugs live in _what each step means_:
+
+| Step | Ruby | Rust |
+|---|---|---|
+| Structural | `a.raw == b.raw` — inner `Value` objects have **no custom `==`**, so nested equality falls through to `Object#equal?` (identity). | `#[derive(PartialEq)]` on the `Value` enum — nested `Value`s compare structurally; `HashMap` ignores key order; `Vec` is positional. |
+| Numeric `Str → f64` | `Float(s, exception: false)` — lenient; accepts whitespace, leading `.`, etc. | `s.parse::<f64>().ok()` — strict; rejects any whitespace, empty string. |
+| Display `List` | `"[1, 2]"` — recurses into each element. | `"[N items]"` — **count only**. |
+| Display `Map` | `"{a: 1, b: 2}"` — recurses; preserves insertion order. | `"{N fields}"` — **count only**. |
+| Display `Null` | `""` (fix in PR #262 skips fallback when either side is Null, but the empty-string form is still exposed elsewhere). | `"null"` |
+
+Those five cells generate every divergence below.
+
+---
+
+## Test cases
+
+| # | Case | Ruby | Rust | Agrees |
+|---|------|------|------|--------|
+| 1 | `Null == Str("")` (PR #262 regression) | `true` | `false` | **NO** |
+| 2 | `Null == Int(0)` | `true` | `true` | yes |
+| 3 | `Null == Str("0")` | `true` | `true` | yes |
+| 4 | `Null == Bool(false)` | `true` | `true` | yes |
+| 5 | `Null == Null` | `true` | `true` | yes |
+| 6 | `Null == []` | `false` | `false` | yes |
+| 7 | `Null == {}` | `false` | `false` | yes |
+| 8 | `Null == Str("null")` | `false` | `true` | **NO** |
+| 9 | `Int(0) == Str("0")` | `true` | `true` | yes |
+| 10 | `Int(1) == Str("1.0")` | `true` | `true` | yes |
+| 11 | `Int(1) == Str("1.5")` | `false` | `false` | yes |
+| 12 | `Int(0) == Bool(false)` | `true` | `true` | yes |
+| 13 | `Int(1) == Bool(true)` | `true` | `true` | yes |
+| 14 | `Str("1") == Bool(true)` | `true` | `true` | yes |
+| 15 | `Str("true") == Bool(true)` | `true` | `true` | yes |
+| 16 | `Str(" 1 ") == Int(1)` (whitespace) | `true` | `false` | **NO** |
+| 17 | `Str("1e3") == Int(1000)` | `true` | `true` | yes |
+| 18 | `Bool(false) == Int(0)` | `true` | `true` | yes |
+| 19 | `Bool(false) == Null` | `true` | `true` | yes |
+| 20 | `Bool(false) == Str("false")` | `true` | `true` | yes |
+| 21 | `Bool(true) == Str("true")` | `true` | `true` | yes |
+| 22 | `Bool(true) == Str("TRUE")` | `false` | `false` | yes |
+| 23 | `Str("foo") == Str("FOO")` | `false` | `false` | yes |
+| 24 | `Str("") == Str("")` | `true` | `true` | yes |
+| 25 | `Str("abc") == Str("abc")` | `true` | `true` | yes |
+| 26 | `[1,2] == [1,2]` | `true` | `true` | yes |
+| 27 | `[1,2] == [2,1]` (order) | `false` | `true` | **NO** |
+| 28 | `[1,2] == [3,4]` (same length, different content) | `false` | `true` | **NO** |
+| 29 | `[] == []` | `true` | `true` | yes |
+| 30 | `[] == Str("[]")` | `true` | `false` | **NO** |
+| 31 | `[] == Str("[0 items]")` | `false` | `true` | **NO** |
+| 32 | `{a:1} == {a:1}` | `true` | `true` | yes |
+| 33 | `{a:1} == {b:1}` (same size, different keys) | `false` | `true` | **NO** |
+| 34 | `{a:1,b:2} == {b:2,a:1}` (insertion order) | `false` | `true` | **NO** |
+| 35 | `{} == Str("{0 fields}")` | `false` | `true` | **NO** |
+| 36 | `{} == Str("{}")` | `true` | `false` | **NO** |
+| 37 | `Float 1.0 (Ruby-side Str) == Int(1)` | `true` | `true` | yes |
+| 38 | `Int(2) == Str("[2 items]")` | `false` | `false` | yes |
+| 39 | `[a,b] == [c,d]` (same length, different content) | `false` | `true` | **NO** |
+
+**Totals:** 39 cases, 27 agreements, **12 disagreements**.
+
+---
+
+## Disagreements — root cause, fix sketch, severity
+
+Severity grades:
+- **cascade-dropping** — plausible to appear in a real bluebook `given` and
+  silently halt a cascade (same class as PR #262).
+- **cosmetic** — likely only surfaces in synthetic inputs; still a parity bug.
+- **design-gap** — both sides disagree _and_ both sides are arguably wrong;
+  needs a spec decision before picking a side to fix.
+
+### 1. `Null == Str("")` — PR #262 regression baseline
+Ruby `true`, Rust `false`. **Already fixed** on the PR #262 branch; included
+here as the control. Severity: cascade-dropping (historical).
+
+### 2. `Null == Str("null")` (case 8)
+- **Ruby:** `Null.to_display == ""`, `Str("null").to_display == "null"`,
+  fallback says no.
+- **Rust:** `Null.display == "null"`, `Str("null").display == "null"`,
+  fallback says yes.
+- **Fix sketch:** change Rust `Display(Null)` from `"null"` to `""`, OR
+  drop the display-form fallback when either side is `Null` (same shape
+  as PR #262). Symmetric with PR #262 — only flipped.
+- **Severity: cascade-dropping.** A `given { status != "null" }` where
+  `status` is the literal string `"null"` (rare but possible in e.g. a
+  parsed CSV) would fire in Ruby, be blocked in Rust.
+
+### 3. `Str(" 1 ") == Int(1)` (case 16)
+- **Ruby:** `Float(" 1 ", exception: false) == 1.0`, Ruby's `Float()` trims.
+- **Rust:** `" 1 ".parse::<f64>()` returns `Err`; numeric coercion bails;
+  display `" 1 "` vs `"1"` differ.
+- **Fix sketch:** make Ruby `Value#numeric` strip-reject: return `nil`
+  for any `Str` that isn't already trimmed. Mirrors Rust's `f64::parse`.
+- **Severity: cascade-dropping.** Any attribute piped through a stringy
+  source (CSV cell, JSON body, user input without normalization) can end
+  up as `" 1 "` and silently switch on one runner only.
+
+### 4. `[1,2] == [2,1]` (list order) (case 27)
+- **Ruby:** `raw == raw` is `Array#==` on `Hecks::Behaviors::Value` objects,
+  but `Value` has no custom `==` so elements compare by identity → `false`.
+  Display `"[1, 2]"` vs `"[2, 1]"` → `false`. Correct result _by luck_.
+- **Rust:** derived `Vec<Value>` `==` is positional → `false` for reversed.
+  But then `Display` for both is `"[2 items]"` → fallback says **equal**.
+- **Fix sketch:** Rust should early-return on structural inequality for
+  List/Map rather than falling through to a display-count fallback. (Or:
+  make Rust's Display recursive like Ruby's.)
+- **Severity: cascade-dropping.** Any `given { members != members_before }`
+  across a list reorder fires in Ruby, is blocked in Rust.
+
+### 5. `[1,2] == [3,4]` (same-length different-content) (case 28)
+Same root cause as case 27. Rust falls back to `"[2 items]" == "[2 items]"`
+and says **equal**. Severity: **cascade-dropping**. More dangerous than
+reorder — this is "different-but-same-size" which is common (two lists
+of ingredients, two event queues, etc.).
+
+### 6. `[] == Str("[]")` (case 30)
+- **Ruby:** `"[]".to_display == "[]"` fallback matches.
+- **Rust:** `Str("[]").display == "[]"`, `[].display == "[0 items]"`, differ.
+- **Fix sketch:** this one the display-form disagreement between runners
+  does the work. Aligning Rust Display to Ruby's (`"[]"` for empty list)
+  or vice versa will flip it. Given PR #262's direction (skip display when
+  either side is "specialish"), prefer: don't compare list/map by
+  display form at all — structural only.
+- **Severity: cosmetic.** `given { items == "[]" }` is implausible real-world;
+  authors write `items.empty?`.
+
+### 7. `[] == Str("[0 items]")` (case 31)
+- Inverse of case 30. Ruby false, Rust true (Rust's display form collides
+  with the literal). Severity: **cosmetic** but demonstrates the
+  `[N items]` display form is leaking into equality.
+
+### 8. `{a:1} == {b:1}` (same-size different-keys) (case 33)
+Same shape as case 28 but for Map. Ruby `false`, Rust `true` via
+`"{1 fields}" == "{1 fields}"`. **Cascade-dropping.** Two records with
+the same number of fields but different field names are considered
+equal in Rust.
+
+### 9. `{a:1,b:2} == {b:2,a:1}` (insertion order) (case 34)
+- **Rust:** derived `HashMap == HashMap` is order-independent → `true`
+  structurally.
+- **Ruby:** inner `Value` identity makes `raw == raw` `false`; `to_display`
+  is insertion-ordered `"{a: 1, b: 2}"` vs `"{b: 2, a: 1}"` — differs.
+- **Fix sketch:** define `Hecks::Behaviors::Value#==` / `#eql?` /
+  `#hash` properly (structural, kind + raw) so nested lists/maps
+  compare by value. Once that's in place, Ruby Hash `==` will handle
+  order-insensitivity for free and these cases align with Rust.
+- **Severity: cascade-dropping.** Any `given { attrs == prior_attrs }`
+  where attrs come from a HashMap-backed state store can flip purely
+  on insertion-order differences.
+
+### 10. `{} == Str("{0 fields}")` (case 35)
+Inverse of case 8 for maps. Ruby `false`, Rust `true` (literal string
+equals Rust's display form for empty map). Severity: **cosmetic**.
+
+### 11. `{} == Str("{}")` (case 36)
+- **Ruby:** display `"{}"` vs `"{}"` → `true`.
+- **Rust:** display `"{0 fields}"` vs `"{}"` → `false`.
+Severity: **cosmetic** — but confirms the Display inconsistency runs
+in both directions.
+
+### 12. `[a,b] == [c,d]` (string-content differ, same length) (case 39)
+Same root as case 28. Strings instead of ints; Rust still says
+`"[2 items]" == "[2 items]"` → **equal**. Severity: **cascade-dropping**.
+
+---
+
+## Summary of bug classes
+
+| Class | Cases | Severity | Root cause |
+|---|---|---|---|
+| Rust Display-count collision for List | 27, 28, 30, 31, 39 | cascade-dropping + cosmetic | `impl Display for Value::List` emits `"[N items]"` — not a diagnostic-only form, it's load-bearing in equality. |
+| Rust Display-count collision for Map | 33, 35, 36 | cascade-dropping + cosmetic | `impl Display for Value::Map` emits `"{N fields}"` — same issue. |
+| Ruby `Null` display is empty string | 1 (fixed), 8 | cascade-dropping | `Null.to_display == ""` leaks into comparisons. PR #262 patched half; case 8 remains the mirror. |
+| Ruby `Float()` accepts whitespace | 16 | cascade-dropping | Ruby `Float(s, exception: false)` trims; Rust `f64::parse` doesn't. |
+| Ruby `Value` lacks structural `==` | 27, 28, 33, 34, 39 (secondary) | latent | Without `Value#==`, nested equality depends on object identity; masked today only because `to_display` _happens_ to recurse. Any refactor of display form would re-expose this. |
+
+**Count:** 12 disagreements / 39 cases.
+**Severity distribution:** 7 cascade-dropping, 5 cosmetic, 0 design-gap.
+
+---
+
+## Recommended follow-up inbox items (do **not** file yet)
+
+Each of these should become its own Linear issue + PR. They are ordered by
+severity, not by effort.
+
+1. **Rust: drop display-form fallback for `List`/`Map`** — structural
+   inequality should be final, don't let `"[N items]"` act as a
+   comparison primitive. Fixes cases 27, 28, 30, 31, 39.
+2. **Rust: drop display-form fallback for `Map`** (same as #1 but
+   separately scoped if one lands first) — fixes cases 33, 35, 36.
+3. **Ruby: mirror PR #262 fix for `Str("null")`** — when either side is
+   `Null`, skip the display fallback (currently fallback uses `""` vs
+   `"null"` which hides the bug; case 8 shows it still leaks).
+   Alternative: change `Null.to_display` to return `"null"` and revisit
+   PR #262's direction. Needs a spec decision.
+4. **Ruby: strict numeric coercion for `Str`** —
+   `Value#numeric` for `:str` should reject whitespace (and empty
+   string, already does). Mirror Rust's `f64::parse` semantics. Fixes
+   case 16.
+5. **Ruby: define structural `==` / `eql?` / `hash` on
+   `Hecks::Behaviors::Value`** — so nested list/map comparisons use
+   value identity, not object identity. Precondition for many other
+   fixes (e.g. once Rust stops falling back to display for lists, Ruby
+   will need real structural equality for list-content cases to stay
+   green). Latent-bug class (currently masked by `to_display`).
+6. **Consider a shared test harness** — the
+   `tmp_audit/harness.rb` pattern (run the same pairs through both
+   runners) is cheap; promote it to `hecks_life/tests/` or
+   `spec/parity/` and gate CI on it. Would have caught PR #262 before it
+   shipped.
+
+---
+
+## Appendix — harness source
+
+See `value_equality_audit_harness.rb`. To re-run:
+
+```
+ruby value_equality_audit_harness.rb
+```
+
+The harness loads the real `Hecks::Behaviors::Value` from `lib/` and runs
+it alongside a line-faithful port of `values_equal` / `numeric_value` /
+`Display for Value` from `hecks_life/src/runtime/`. The Rust port was
+spot-checked against `rustc` for `f64::parse` whitespace rejection and
+`HashMap == HashMap` order-independence — both behave as ported.

--- a/value_equality_audit_harness.rb
+++ b/value_equality_audit_harness.rb
@@ -1,0 +1,207 @@
+#!/usr/bin/env ruby
+# Value-equality parity harness
+#
+# Runs the SAME test pairs through two reference implementations:
+#   - Ruby: the actual Hecks::Behaviors::Value in lib/hecks/behaviors/value.rb
+#   - Rust: a line-faithful port of hecks_life/src/runtime/interpreter.rs
+#           values_equal + numeric_value + Display for Value
+#
+# Emits a markdown table of (left, right, ruby, rust, agree?) rows.
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "hecks/behaviors/value"
+
+RubyValue = Hecks::Behaviors::Value
+
+# --------------------------------------------------------------------
+# Rust port — mirrors hecks_life/src/runtime/interpreter.rs exactly
+# --------------------------------------------------------------------
+
+module RustPort
+  # Value variants: :int, :str, :bool, :list, :map, :null
+  class V
+    attr_reader :kind, :raw
+    def initialize(kind, raw); @kind = kind; @raw = raw; end
+
+    # Rust derives PartialEq on Value — structural equality.
+    # HashMap<String, Value> equality ignores order; Vec<Value> is positional.
+    def ==(other)
+      return false unless other.is_a?(V)
+      return false unless kind == other.kind
+      case kind
+      when :list
+        return false unless raw.length == other.raw.length
+        raw.each_with_index.all? { |x, i| x == other.raw[i] }
+      when :map
+        return false unless raw.size == other.raw.size
+        raw.all? { |k, v| other.raw.key?(k) && other.raw[k] == v }
+      else
+        raw == other.raw
+      end
+    end
+  end
+
+  def self.display(v)
+    case v.kind
+    when :str  then v.raw.to_s
+    when :int  then v.raw.to_s
+    when :bool then v.raw ? "true" : "false"
+    when :list then "[#{v.raw.length} items]"
+    when :map  then "{#{v.raw.size} fields}"
+    when :null then "null"
+    end
+  end
+
+  # Exact port of numeric_value():
+  #   Int(n) → n as f64; Bool true→1.0 false→0.0;
+  #   Str(s) → s.parse::<f64>().ok(); Null → 0.0; List/Map → None
+  def self.numeric(v)
+    case v.kind
+    when :int  then v.raw.to_f
+    when :bool then v.raw ? 1.0 : 0.0
+    when :str
+      # Rust f64 parsing: accepts "1", "1.0", "1e3", ".5", "-1",
+      # rejects "", "abc", "1 ", " 1" (leading/trailing spaces).
+      s = v.raw
+      return nil if s.nil? || s.empty?
+      return nil if s != s.strip
+      Float(s, exception: false)
+    when :null then 0.0
+    else nil
+    end
+  end
+
+  def self.equal?(a, b)
+    return true if a == b
+    na = numeric(a); nb = numeric(b)
+    return na == nb if na && nb
+    display(a) == display(b)
+  end
+end
+
+# --------------------------------------------------------------------
+# Helpers to build values
+# --------------------------------------------------------------------
+
+def rb_int(n);    RubyValue.new(:int, n); end
+def rb_str(s);    RubyValue.new(:str, s); end
+def rb_bool(b);   RubyValue.new(:bool, b); end
+def rb_null;      RubyValue.null; end
+def rb_list(*xs); RubyValue.list(xs); end
+def rb_map(h);    RubyValue.from(h); end
+
+def rs_int(n);    RustPort::V.new(:int, n); end
+def rs_str(s);    RustPort::V.new(:str, s); end
+def rs_bool(b);   RustPort::V.new(:bool, b); end
+def rs_null;      RustPort::V.new(:null, nil); end
+def rs_list(*xs); RustPort::V.new(:list, xs); end
+def rs_map(h);    RustPort::V.new(:map, h); end
+
+# --------------------------------------------------------------------
+# Test pairs — each entry is [label, ruby_pair, rust_pair]
+# --------------------------------------------------------------------
+
+CASES = [
+  # --- PR #262 regression baseline (should now agree) ---
+  ["Null == Str(\"\") [PR #262 regression]", [rb_null, rb_str("")], [rs_null, rs_str("")]],
+
+  # --- to_display fallback misfires ---
+  ["Null == Int(0)",                    [rb_null, rb_int(0)],        [rs_null, rs_int(0)]],
+  ["Null == Str(\"0\")",                [rb_null, rb_str("0")],      [rs_null, rs_str("0")]],
+  ["Null == Bool(false)",               [rb_null, rb_bool(false)],   [rs_null, rs_bool(false)]],
+  ["Null == Null",                      [rb_null, rb_null],          [rs_null, rs_null]],
+  ["Null == empty List",                [rb_null, rb_list],          [rs_null, rs_list]],
+  ["Null == empty Map",                 [rb_null, rb_map({})],       [rs_null, rs_map({})]],
+  ["Null == Str(\"null\")",             [rb_null, rb_str("null")],   [rs_null, rs_str("null")]],
+
+  # --- numeric coercion edges ---
+  ["Int(0) == Str(\"0\")",              [rb_int(0), rb_str("0")],       [rs_int(0), rs_str("0")]],
+  ["Int(1) == Str(\"1.0\")",            [rb_int(1), rb_str("1.0")],     [rs_int(1), rs_str("1.0")]],
+  ["Int(1) == Str(\"1.5\")",            [rb_int(1), rb_str("1.5")],     [rs_int(1), rs_str("1.5")]],
+  ["Int(0) == Bool(false)",             [rb_int(0), rb_bool(false)],    [rs_int(0), rs_bool(false)]],
+  ["Int(1) == Bool(true)",              [rb_int(1), rb_bool(true)],     [rs_int(1), rs_bool(true)]],
+  ["Str(\"1\") == Bool(true)",          [rb_str("1"), rb_bool(true)],   [rs_str("1"), rs_bool(true)]],
+  ["Str(\"true\") == Bool(true)",       [rb_str("true"), rb_bool(true)],[rs_str("true"), rs_bool(true)]],
+  ["Str(\" 1 \") == Int(1) (whitespace)", [rb_str(" 1 "), rb_int(1)],   [rs_str(" 1 "), rs_int(1)]],
+  ["Str(\"1e3\") == Int(1000)",         [rb_str("1e3"), rb_int(1000)],  [rs_str("1e3"), rs_int(1000)]],
+
+  # --- boolean / truthy ---
+  ["Bool(false) == Int(0)",             [rb_bool(false), rb_int(0)],    [rs_bool(false), rs_int(0)]],
+  ["Bool(false) == Null",               [rb_bool(false), rb_null],      [rs_bool(false), rs_null]],
+  ["Bool(false) == Str(\"false\")",     [rb_bool(false), rb_str("false")], [rs_bool(false), rs_str("false")]],
+  ["Bool(true) == Str(\"true\")",       [rb_bool(true), rb_str("true")],[rs_bool(true), rs_str("true")]],
+  ["Bool(true) == Str(\"TRUE\")",       [rb_bool(true), rb_str("TRUE")],[rs_bool(true), rs_str("TRUE")]],
+
+  # --- string case sensitivity ---
+  ["Str(\"foo\") == Str(\"FOO\")",      [rb_str("foo"), rb_str("FOO")], [rs_str("foo"), rs_str("FOO")]],
+  ["Str(\"\") == Str(\"\")",            [rb_str(""), rb_str("")],       [rs_str(""), rs_str("")]],
+  ["Str(\"abc\") == Str(\"abc\")",      [rb_str("abc"), rb_str("abc")], [rs_str("abc"), rs_str("abc")]],
+
+  # --- list comparison ---
+  ["[1,2] == [1,2]",                    [rb_list(rb_int(1), rb_int(2)), rb_list(rb_int(1), rb_int(2))],
+                                        [rs_list(rs_int(1), rs_int(2)), rs_list(rs_int(1), rs_int(2))]],
+  ["[1,2] == [2,1] (order)",            [rb_list(rb_int(1), rb_int(2)), rb_list(rb_int(2), rb_int(1))],
+                                        [rs_list(rs_int(1), rs_int(2)), rs_list(rs_int(2), rs_int(1))]],
+  ["[1,2] == [3,4] (same length, diff)", [rb_list(rb_int(1), rb_int(2)), rb_list(rb_int(3), rb_int(4))],
+                                        [rs_list(rs_int(1), rs_int(2)), rs_list(rs_int(3), rs_int(4))]],
+  ["[] == []",                          [rb_list, rb_list],             [rs_list, rs_list]],
+  ["[] == Str(\"[]\")",                 [rb_list, rb_str("[]")],        [rs_list, rs_str("[]")]],
+  ["[] == Str(\"[0 items]\")",          [rb_list, rb_str("[0 items]")], [rs_list, rs_str("[0 items]")]],
+
+  # --- map comparison ---
+  ["{a:1} == {a:1}",                    [rb_map({"a" => 1}), rb_map({"a" => 1})],
+                                        [rs_map({"a" => rs_int(1)}), rs_map({"a" => rs_int(1)})]],
+  ["{a:1} == {b:1} (same size)",        [rb_map({"a" => 1}), rb_map({"b" => 1})],
+                                        [rs_map({"a" => rs_int(1)}), rs_map({"b" => rs_int(1)})]],
+  ["{a:1,b:2} == {b:2,a:1} (order)",    [rb_map({"a" => 1, "b" => 2}), rb_map({"b" => 2, "a" => 1})],
+                                        [rs_map({"a" => rs_int(1), "b" => rs_int(2)}),
+                                         rs_map({"b" => rs_int(2), "a" => rs_int(1)})]],
+  ["{} == Str(\"{0 fields}\")",         [rb_map({}), rb_str("{0 fields}")],
+                                        [rs_map({}), rs_str("{0 fields}")]],
+  ["{} == Str(\"{}\")",                 [rb_map({}), rb_str("{}")],
+                                        [rs_map({}), rs_str("{}")]],
+
+  # --- float / whole-number formatting ---
+  # NB: Ruby Value.from(Float) stores as :str with #to_s. Rust has no
+  # Float variant. So Ruby 1.0 → Str("1.0"); 1 → Int(1).
+  ["Float 1.0 (Ruby Str) == Int(1)",    [RubyValue.from(1.0), rb_int(1)], [rs_str("1.0"), rs_int(1)]],
+
+  # --- special values in strings that collide with display forms ---
+  ["Int(2) == Str(\"[2 items]\")",      [rb_int(2), rb_str("[2 items]")], [rs_int(2), rs_str("[2 items]")]],
+  ["[a,b] == [c,d] (content differs, length same)",
+     [rb_list(rb_str("a"), rb_str("b")), rb_list(rb_str("c"), rb_str("d"))],
+     [rs_list(rs_str("a"), rs_str("b")), rs_list(rs_str("c"), rs_str("d"))]],
+]
+
+# --------------------------------------------------------------------
+# Run
+# --------------------------------------------------------------------
+
+rows = CASES.map do |label, rb_pair, rs_pair|
+  a_rb, b_rb = rb_pair
+  a_rs, b_rs = rs_pair
+  ruby_result = RubyValue.equal?(a_rb, b_rb)
+  rust_result = RustPort.equal?(a_rs, b_rs)
+  agree = (ruby_result == rust_result)
+  { label: label, ruby: ruby_result, rust: rust_result, agree: agree }
+end
+
+disagreements = rows.reject { |r| r[:agree] }
+
+puts "## Test cases\n\n"
+puts "| # | Case | Ruby | Rust | Agrees |"
+puts "|---|------|------|------|--------|"
+rows.each_with_index do |r, i|
+  marker = r[:agree] ? "yes" : "**NO**"
+  puts "| #{i + 1} | #{r[:label]} | `#{r[:ruby]}` | `#{r[:rust]}` | #{marker} |"
+end
+
+puts "\n## Summary\n"
+puts "Total cases:    #{rows.length}"
+puts "Agreements:     #{rows.length - disagreements.length}"
+puts "Disagreements:  #{disagreements.length}"
+puts
+puts "## Disagreements only\n"
+disagreements.each do |r|
+  puts "- #{r[:label]} — Ruby=#{r[:ruby]}, Rust=#{r[:rust]}"
+end


### PR DESCRIPTION
## Summary

Inventory-only audit of Ruby's `Hecks::Behaviors::Value.equal?` vs Rust's `values_equal` — follow-up to PR #262 (`compost_seasonal_beings` cascade regression). Harness runs 39 synthetic pairs through both implementations and reports divergences.

- **12 disagreements** out of 39 cases
- **7 cascade-dropping** (same class as PR #262), **5 cosmetic**
- Root causes cluster into 5 bug classes — listed at the bottom of the report
- No fixes applied; each class should get its own PR later

## Example — cascade-dropping bugs the harness surfaces

Beyond the PR #262 baseline (Null == Str("")), the audit finds:

- `Null == Str("null")` — Ruby `false`, Rust `true` (mirror of PR #262)
- `Str(" 1 ") == Int(1)` — Ruby `true`, Rust `false` (Ruby's `Float()` trims)
- `[1,2] == [3,4]` — Ruby `false`, Rust `true` (Rust's `Display for List` is `"[N items]"`, collides on length)
- `{a:1} == {b:1}` — Ruby `false`, Rust `true` (same shape for `Map`)
- `{a:1,b:2} == {b:2,a:1}` — Ruby `false`, Rust `true` (Rust HashMap `==` is order-independent; Ruby `Value` has no structural `==` so nested eq falls through to identity)

Each of these could silently halt a cascade on one runner only.

## Test plan

- [x] Harness runs against actual `Hecks::Behaviors::Value` (`ruby value_equality_audit_harness.rb`)
- [x] Rust port spot-checked against `rustc` for `f64::parse(" 1 ")` (rejects) and `HashMap == HashMap` (order-independent)
- [ ] Reviewer sanity-checks that every disagreement row in the table reproduces by running the harness locally
- [ ] Reviewer confirms severity assignments (cascade-dropping vs cosmetic) match their judgment
- [ ] Follow-up PRs opened for each of the five bug classes listed under "Recommended follow-up inbox items"

## Deliverables

- `VALUE_EQUALITY_AUDIT.md` — full report
- `value_equality_audit_harness.rb` — reproducible harness (antibody-exempt: evidence, not domain code)