### PR TITLE
fix: broken .claude hooks (Stop → missing pulse.rb, SessionStart → boot_winter.rb)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,11 +30,6 @@
             "type": "command",
             "command": "cd /Users/christopheryoung/Projects/hecks && gem build hecks.gemspec --silent && gem install hecks-*.gem --no-document 2>/dev/null; rm -f hecks-*.gem; true",
             "timeout": 15
-          },
-          {
-            "type": "command",
-            "command": "ruby /Users/christopheryoung/Projects/hecks/hecks_conception/pulse.rb --dream 2>/dev/null || true",
-            "timeout": 3
           }
         ]
       }


### PR DESCRIPTION
## Summary

Two urgent broken hooks from PR #260's audit.

- **`.claude/settings.json`** Stop hook — removed the entry running `ruby hecks_conception/pulse.rb --dream`. `pulse.rb` doesn't exist; `|| true` made it a silent no-op. No live dream-seed daemon matches Stop semantics (`daydream.sh` fires in idle-attentive windows; `interpret_dream.sh` fires on wake). Audit option (b): drop the hook. The gem-rebuild Stop hook entry is preserved.
- **`.claude/settings.local.json`** SessionStart fallback — replaced `ruby hecks_conception/boot_winter.rb --verbose` with `hecks_conception/boot_miette.sh`. Winter was absorbed into Miette; `boot_miette.sh` is the current live boot script. This file is gitignored per the standard Claude Code local-scope convention, so the fix is applied to the working checkout but not carried by this PR.

## Example usage

After this lands, Stop emits only the gem-rebuild hook; SessionStart's Ruby fallback (on this machine) resolves to a real executable:

```bash
$ jq '.hooks.Stop[0].hooks | length' .claude/settings.json
1
$ ls -l hecks_conception/boot_miette.sh
-rwxr-xr-x  ... boot_miette.sh
```

## Test plan

- [x] `jq` parses both settings files cleanly
- [x] Stop hook array has exactly one entry (the gem-rebuild one)
- [x] `hecks_conception/boot_miette.sh` exists and is executable
- [ ] Next session starts without `boot_winter.rb` ENOENT in logs
- [ ] Next Stop fires without `pulse.rb` ENOENT in logs