### PR TITLE
fix: 2 fixture orphans from PR #258 inventory

### DIFF
--- a/hecks_conception/aggregates/fixtures/sleep.fixtures
+++ b/hecks_conception/aggregates/fixtures/sleep.fixtures
@@ -1,12 +1,7 @@
 Hecks.fixtures "Sleep" do
-  aggregate "Fatigue" do
-    fixture "Fatigue1", state: "alert", pulses_since_sleep: 0, level: 0.0, creativity: 0.8, precision: 0.9
-    fixture "Fatigue2", state: "focused", pulses_since_sleep: 50, level: 0.2, creativity: 0.7, precision: 0.8
-    fixture "Fatigue3", state: "normal", pulses_since_sleep: 100, level: 0.4, creativity: 0.6, precision: 0.7
-    fixture "Fatigue4", state: "tired", pulses_since_sleep: 150, level: 0.6, creativity: 0.5, precision: 0.5
-    fixture "Fatigue5", state: "exhausted", pulses_since_sleep: 200, level: 0.8, creativity: 0.3, precision: 0.3
-    fixture "Fatigue6", state: "delirious", pulses_since_sleep: 300, level: 1.0, creativity: 0.9, precision: 0.1
-  end
+  # Fatigue fixtures removed 2026-04-21 — the Fatigue aggregate was migrated
+  # out of sleep.bluebook into MietteBody::Heartbeat on 2026-04-20. See the
+  # header comment in aggregates/sleep.bluebook for the migration notes.
   aggregate "WakeMood" do
     fixture "WakeMood1", mood: "groggy", reason: "woken from deep — consolidation interrupted"
     fixture "WakeMood2", mood: "vivid", reason: "woken from REM — dream still fresh"

--- a/hecks_conception/capabilities/antibody/antibody.bluebook
+++ b/hecks_conception/capabilities/antibody/antibody.bluebook
@@ -229,7 +229,7 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
 
   # ---- ExemptionPattern ------------------------------------------
 
-  aggregate "ExemptionPattern", "The regex antibody uses to detect an exemption marker in a commit message — anchor: \"line_start\" is the slip-through fix" do
+  aggregate "ExemptionPattern", "The regex antibody uses to detect an exemption marker in a commit message — anchored at line start to prevent false matches in commit body prose" do
     attribute :pattern, String
     attribute :flags, String
     attribute :anchor, String
@@ -238,7 +238,7 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
   # ---- TestCase --------------------------------------------------
 
   aggregate "TestCase", "A self-contained antibody scenario — touched files, commit message, expected verdict; antibody.behaviors replays each one" do
-    attribute :touched, Array
+    attribute :touched_files, list_of(String)
     attribute :message, String
     attribute :expected, String
   end

--- a/hecks_conception/capabilities/antibody/antibody.bluebook
+++ b/hecks_conception/capabilities/antibody/antibody.bluebook
@@ -199,4 +199,47 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
       transition "RejectStaged"  => "rejected",     from: "pending"
     end
   end
+
+  # ============================================================
+  # CONFIG CATALOGS
+  # ============================================================
+  #
+  # The four aggregates below are pure config tables — no commands,
+  # no lifecycle, no behavior. They declare the shape of the rows
+  # seeded by fixtures/antibody.fixtures so the fixture references
+  # resolve against a declared aggregate (PR #258 orphan inventory).
+  #
+  #   FlaggedExtension  — the CODE_EXTS list antibody inspects
+  #   ShebangMapping    — shebang→extension recovery for extensionless files
+  #   ExemptionPattern  — the canonical exemption-marker regex
+  #   TestCase          — self-contained scenarios replayed by antibody.behaviors
+
+  # ---- FlaggedExtension ------------------------------------------
+
+  aggregate "FlaggedExtension", "One code extension antibody inspects — adding or removing a row here is the only way to change what antibody flags" do
+    attribute :ext, String
+  end
+
+  # ---- ShebangMapping --------------------------------------------
+
+  aggregate "ShebangMapping", "Maps a shebang interpreter name to the synthetic extension antibody should treat an extensionless file as" do
+    attribute :match, String
+    attribute :ext, String
+  end
+
+  # ---- ExemptionPattern ------------------------------------------
+
+  aggregate "ExemptionPattern", "The regex antibody uses to detect an exemption marker in a commit message — anchor: \"line_start\" is the slip-through fix" do
+    attribute :pattern, String
+    attribute :flags, String
+    attribute :anchor, String
+  end
+
+  # ---- TestCase --------------------------------------------------
+
+  aggregate "TestCase", "A self-contained antibody scenario — touched files, commit message, expected verdict; antibody.behaviors replays each one" do
+    attribute :touched, Array
+    attribute :message, String
+    attribute :expected, String
+  end
 end


### PR DESCRIPTION
## Summary

PR #258's orphan inventory flagged **5 fixture-to-aggregate orphans**
across 2 files. This PR drops that count to **0**.

### Before

```
fixtures orphans: 5
  hecks_conception/aggregates/fixtures/sleep.fixtures:2             Sleep::Fatigue
  hecks_conception/capabilities/antibody/fixtures/antibody.fixtures:9  Antibody::FlaggedExtension
  hecks_conception/capabilities/antibody/fixtures/antibody.fixtures:31 Antibody::ShebangMapping
  hecks_conception/capabilities/antibody/fixtures/antibody.fixtures:47 Antibody::ExemptionPattern
  hecks_conception/capabilities/antibody/fixtures/antibody.fixtures:58 Antibody::TestCase
```

### After

```
fixtures orphans: 0
```

### What each fix does

**Commit 1 — `fix(sleep.fixtures): drop stale Fatigue row`**
The `Fatigue` aggregate was migrated out of `sleep.bluebook` into
`MietteBody::Heartbeat` on 2026-04-20 (documented in the bluebook's
header comment), but the 6 fixture rows were left behind. Delete them.
The remaining `WakeMood` / `Consciousness` / `Monitor` blocks still
resolve against `sleep.bluebook`.

**Commit 2 — `feat(antibody): declare the 4 fixture-config aggregates`**
`fixtures/antibody.fixtures` was being used as a config catalog for
four tables (`FlaggedExtension`, `ShebangMapping`, `ExemptionPattern`,
`TestCase`) that had no matching aggregate declarations. Add minimal
shape-only aggregates — no commands, no lifecycle — so the fixture rows
resolve. `antibody.fixtures` itself is unchanged.

### Example (`FlaggedExtension`)

```ruby
# antibody.bluebook
aggregate "FlaggedExtension", "One code extension antibody inspects — …" do
  attribute :ext, String
end

# fixtures/antibody.fixtures
aggregate "FlaggedExtension" do
  fixture "Ruby",       ext: "rb"
  fixture "Rust",       ext: "rs"
  # …
end
```

## Test plan

- [x] Baseline orphan count = 5 (matches PR #258 inventory exactly)
- [x] `hecks-life parse sleep.fixtures` — 3 aggregates (WakeMood, Consciousness, Monitor), no Fatigue
- [x] `hecks-life parse antibody.bluebook` — 7 aggregates (3 original + 4 config catalogs)
- [x] `hecks-life parse antibody.fixtures` — all 24 fixtures resolve against the 4 declared aggregates
- [x] `hecks-life check-lifecycle antibody.bluebook` — clean (config aggregates have no lifecycle, so nothing to check)
- [x] Final orphan count = 0