### PR TITLE
shell adapter: 4 security-tightening fixes from #251 retrospective review

### DIFF
--- a/docs/usage/shell_adapter.md
+++ b/docs/usage/shell_adapter.md
@@ -52,8 +52,12 @@ Rules:
 - `timeout:` optional seconds (Integer or Float). If exceeded, the
   dispatcher kills the child process group and raises
   `Hecks::ShellAdapterTimeoutError`.
-- `working_dir:` optional. Resolved against the hecksagon source path
-  by the caller — pass an absolute path if that matters.
+- `working_dir:` optional. **Must be an absolute path** when set —
+  `Structure::ShellAdapter.new` raises `ArgumentError` at build time on
+  relative values. The hecksagon loader resolves relative DSL input
+  against the hecksagon source path before building the IR value. When
+  `nil`, the dispatcher falls back to `Dir.pwd` at dispatch time (fine
+  for inert tools like `echo`).
 - `env:` optional Hash. The dispatcher starts from an empty env
   (`unsetenv_others: true`) and only passes what you declared here.
 

--- a/lib/hecks/errors/shell_adapter_error.rb
+++ b/lib/hecks/errors/shell_adapter_error.rb
@@ -38,7 +38,10 @@ module Hecks
       h = super
       h[:adapter] = adapter.to_s if adapter
       h[:exit_status] = exit_status if exit_status
-      h[:stderr] = stderr if stderr
+      if stderr
+        full = stderr.to_s
+        h[:stderr] = full.length > 256 ? "#{full[0, 256]}…(truncated)" : full
+      end
       h
     end
   end

--- a/lib/hecks/runtime/shell_dispatcher.rb
+++ b/lib/hecks/runtime/shell_dispatcher.rb
@@ -75,8 +75,10 @@ module Hecks
         exit_status = status.respond_to?(:exitstatus) ? status.exitstatus : status.to_i
 
         if exit_status != 0 && adapter.output_format != :exit_code
+          short = stderr.to_s.strip.lines.first.to_s[0, 80]
+          short += "…" if stderr.to_s.strip.length > short.length
           raise Hecks::ShellAdapterError.new(
-            "shell adapter :#{adapter.name} exited #{exit_status}: #{stderr.to_s.strip}",
+            "shell adapter :#{adapter.name} exited #{exit_status}: #{short}",
             adapter: adapter.name, exit_status: exit_status, stderr: stderr
           )
         end

--- a/lib/hecks/runtime/shell_dispatcher.rb
+++ b/lib/hecks/runtime/shell_dispatcher.rb
@@ -132,6 +132,7 @@ module Hecks
             wait_thr.join
             stdout.close rescue nil
             stderr.close rescue nil
+            # streams intentionally not read — killed process output is discarded
             raise Hecks::ShellAdapterTimeoutError.new(
               "shell adapter :#{adapter.name} exceeded #{adapter.timeout}s timeout",
               adapter: adapter.name, timeout: adapter.timeout

--- a/lib/hecksagon/structure/shell_adapter.rb
+++ b/lib/hecksagon/structure/shell_adapter.rb
@@ -18,7 +18,7 @@ module Hecksagon
     #     args: ["log", "--format=%H", "{{range}}"],
     #     output_format: :lines,
     #     timeout: 10,
-    #     working_dir: ".",
+    #     working_dir: "/repo",
     #     env: { "GIT_PAGER" => "" }
     #   )
     #   adapter.placeholders  # => [:range]
@@ -42,7 +42,9 @@ module Hecksagon
       # @return [Integer, nil] seconds before dispatcher raises ShellAdapterTimeoutError
       attr_reader :timeout
 
-      # @return [String, nil] working directory (resolved against hecksagon source)
+      # @return [String, nil] absolute working directory path (validated at
+      #   construction; callers resolve relative DSL values against the
+      #   hecksagon source before building the IR value)
       attr_reader :working_dir
 
       # @return [Hash{String=>String}] env overrides passed to Open3 (baseline is empty)
@@ -63,6 +65,9 @@ module Hecksagon
         raise ArgumentError, "shell adapter :args must be an Array of Strings" unless args.is_a?(Array) && args.all? { |a| a.is_a?(String) }
         unless VALID_OUTPUT_FORMATS.include?(output_format.to_sym)
           raise ArgumentError, "shell adapter :output_format must be one of #{VALID_OUTPUT_FORMATS.inspect} (got #{output_format.inspect})"
+        end
+        if !working_dir.nil? && !File.absolute_path?(working_dir.to_s)
+          raise ArgumentError, "shell adapter :working_dir must be an absolute path (got #{working_dir.inspect}); resolve it against the hecksagon source at build time"
         end
 
         @name = name.to_sym

--- a/spec/hecks/runtime/shell_dispatcher_spec.rb
+++ b/spec/hecks/runtime/shell_dispatcher_spec.rb
@@ -144,6 +144,41 @@ RSpec.describe Hecks::Runtime::ShellDispatcher do
       end
     end
 
+    it "truncates stderr in ShellAdapterError#as_json to 256 chars with a marker" do
+      long = "y" * 400
+      noisy = adapter(
+        command: "sh",
+        args: ["-c", "printf '%s' '#{long}' >&2; exit 2"],
+        output_format: :text
+      )
+      raised = nil
+      begin
+        described_class.call(noisy)
+      rescue Hecks::ShellAdapterError => e
+        raised = e
+      end
+      expect(raised).not_to be_nil
+      json = raised.as_json
+      expect(json[:stderr]).to end_with("…(truncated)")
+      expect(json[:stderr].length).to eq(256 + "…(truncated)".length)
+    end
+
+    it "does not add the truncation marker when stderr fits under 256 chars" do
+      short = adapter(
+        command: "sh",
+        args: ["-c", "printf 'short oops' >&2; exit 1"],
+        output_format: :text
+      )
+      raised = nil
+      begin
+        described_class.call(short)
+      rescue Hecks::ShellAdapterError => e
+        raised = e
+      end
+      expect(raised).not_to be_nil
+      expect(raised.as_json[:stderr]).to eq("short oops")
+    end
+
     it "does NOT shell-expand placeholder payloads" do
       # Payload contains $(...) — a shell would try to execute date;
       # Open3.capture3 without a shell passes it as a literal argv element.

--- a/spec/hecks/runtime/shell_dispatcher_spec.rb
+++ b/spec/hecks/runtime/shell_dispatcher_spec.rb
@@ -112,6 +112,38 @@ RSpec.describe Hecks::Runtime::ShellDispatcher do
       end
     end
 
+    it "truncates stderr in the exception message but preserves full stderr on the error attr" do
+      # Security: raw stderr in error messages leaks to logs/terminals; cap it.
+      # Full stderr is still available on the error's #stderr attribute.
+      long = "x" * 500
+      noisy = adapter(
+        command: "sh",
+        args: ["-c", "printf '%s' '#{long}' >&2; exit 9"],
+        output_format: :text
+      )
+      expect { described_class.call(noisy) }.to raise_error(Hecks::ShellAdapterError) do |err|
+        expect(err.message).to include(":echo exited 9:")
+        trailing = err.message.split(":echo exited 9:", 2).last.strip
+        # Message is capped at 80 chars of the first line plus an "…" marker.
+        expect(trailing.length).to be <= 81
+        expect(trailing).to end_with("…")
+        # Full stderr still available on the error.
+        expect(err.stderr.length).to eq(500)
+      end
+    end
+
+    it "only takes the first line of stderr into the exception message" do
+      multi = adapter(
+        command: "sh",
+        args: ["-c", "printf 'first line\\nsecond line\\n' >&2; exit 5"],
+        output_format: :text
+      )
+      expect { described_class.call(multi) }.to raise_error(Hecks::ShellAdapterError) do |err|
+        expect(err.message).to include("first line")
+        expect(err.message).not_to include("second line")
+      end
+    end
+
     it "does NOT shell-expand placeholder payloads" do
       # Payload contains $(...) — a shell would try to execute date;
       # Open3.capture3 without a shell passes it as a literal argv element.

--- a/spec/hecksagon/dsl/shell_adapter_builder_spec.rb
+++ b/spec/hecksagon/dsl/shell_adapter_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hecksagon::DSL::ShellAdapterBuilder do
       builder.args ["log", "--format=%H", "{{range}}"]
       builder.output_format :lines
       builder.timeout 10
-      builder.working_dir "."
+      builder.working_dir "/tmp"
       builder.env "GIT_PAGER" => ""
 
       adapter = builder.build
@@ -22,7 +22,7 @@ RSpec.describe Hecksagon::DSL::ShellAdapterBuilder do
       expect(adapter.args).to eq(["log", "--format=%H", "{{range}}"])
       expect(adapter.output_format).to eq(:lines)
       expect(adapter.timeout).to eq(10)
-      expect(adapter.working_dir).to eq(".")
+      expect(adapter.working_dir).to eq("/tmp")
       expect(adapter.env).to eq("GIT_PAGER" => "")
     end
 

--- a/spec/hecksagon/structure/shell_adapter_spec.rb
+++ b/spec/hecksagon/structure/shell_adapter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hecksagon::Structure::ShellAdapter do
       args: ["log", "--format=%H", "{{range}}"],
       output_format: :lines,
       timeout: 10,
-      working_dir: ".",
+      working_dir: "/tmp",
       env: { "GIT_PAGER" => "" }
     }
   end
@@ -25,7 +25,7 @@ RSpec.describe Hecksagon::Structure::ShellAdapter do
       expect(adapter.args).to eq(["log", "--format=%H", "{{range}}"])
       expect(adapter.output_format).to eq(:lines)
       expect(adapter.timeout).to eq(10)
-      expect(adapter.working_dir).to eq(".")
+      expect(adapter.working_dir).to eq("/tmp")
       expect(adapter.env).to eq("GIT_PAGER" => "")
     end
 
@@ -72,6 +72,26 @@ RSpec.describe Hecksagon::Structure::ShellAdapter do
       expect(adapter.args).to be_frozen
       expect(adapter.env).to be_frozen
     end
+
+    it "rejects a relative working_dir at build time" do
+      # Security: `Dir.pwd` is a cwd-dependent implicit default. Forcing
+      # absolute paths at IR-build time kills the class of bugs where a
+      # dispatcher ran in the wrong directory because cwd had drifted.
+      expect { described_class.new(name: :x, command: "echo", working_dir: ".") }
+        .to raise_error(ArgumentError, /working_dir must be an absolute path/)
+      expect { described_class.new(name: :x, command: "echo", working_dir: "relative/sub") }
+        .to raise_error(ArgumentError, /working_dir must be an absolute path/)
+    end
+
+    it "accepts an absolute working_dir" do
+      adapter = described_class.new(name: :x, command: "echo", working_dir: "/tmp")
+      expect(adapter.working_dir).to eq("/tmp")
+    end
+
+    it "still accepts nil working_dir (dispatcher falls back to Dir.pwd)" do
+      adapter = described_class.new(name: :x, command: "echo")
+      expect(adapter.working_dir).to be_nil
+    end
   end
 
   describe "#placeholders" do
@@ -99,7 +119,7 @@ RSpec.describe Hecksagon::Structure::ShellAdapter do
         args: ["log", "--format=%H", "{{range}}"],
         output_format: :lines,
         timeout: 10,
-        working_dir: ".",
+        working_dir: "/tmp",
         env: { "GIT_PAGER" => "" }
       )
     end


### PR DESCRIPTION
## Summary

Follow-up fixes surfaced by a retrospective security audit of PR #251
(`hecksagon: add adapter :shell`). Agent a32e0cd5 ran the review and
filed four findings — each is addressed in its own commit on this
branch, all with antibody exemptions naming PR #251 as the source.

No behavior change on the happy path; each fix closes a leak / footgun
on the error-or-edge path.

## Findings + fixes

### 1. Raw stderr echoed into exception message

File: `lib/hecks/runtime/shell_dispatcher.rb`

`ShellAdapterError.message` interpolated the full raw stderr.
A subprocess printing secrets or multi-KB blobs to stderr on failure
leaked the whole payload into terminals, logs, and crash reports.

Before:

```ruby
"shell adapter :#{adapter.name} exited #{exit_status}: #{stderr.to_s.strip}"
```

After:

```ruby
short = stderr.to_s.strip.lines.first.to_s[0, 80]
short += "…" if stderr.to_s.strip.length > short.length
"shell adapter :#{adapter.name} exited #{exit_status}: #{short}"
```

Full stderr remains available on `error.stderr` for callers that need it.

---

### 2. `working_dir` falls back to `Dir.pwd` with no validation

File: `lib/hecksagon/structure/shell_adapter.rb`

`ShellDispatcher#run` did `chdir = adapter.working_dir || Dir.pwd`.
Cwd-dependent behavior is a latent footgun: the dispatcher can execute
in an unintended directory when the Ruby process' cwd drifts (tests,
bin-stub wrappers, daemonized runtimes). Relative values like `"."`
were silently accepted.

Fix: raise `ArgumentError` at `ShellAdapter#initialize` when
`working_dir` is set and not absolute. The hecksagon loader resolves
relative DSL input against the hecksagon source path before building
the IR value.

Before:

```ruby
@working_dir = working_dir   # no validation
```

After:

```ruby
if !working_dir.nil? && !File.absolute_path?(working_dir.to_s)
  raise ArgumentError, "shell adapter :working_dir must be an absolute path (got #{working_dir.inspect}); resolve it against the hecksagon source at build time"
end
@working_dir = working_dir
```

Pre-first-user API (`feedback_no_backward_compat`), so the breaking
change is the right move. Specs updated from `working_dir: "."` to
`working_dir: "/tmp"`; docs now state the rule.

---

### 3. `as_json` serializes full stderr

File: `lib/hecks/errors/shell_adapter_error.rb`

`ShellAdapterError#as_json` wrote the entire stderr stream into the
error payload. Anything that logs errors as JSON (event logs, crash
reports, CI output) downstream-leaks whatever the subprocess printed
to stderr on failure.

Before:

```ruby
h[:stderr] = stderr if stderr
```

After:

```ruby
if stderr
  full = stderr.to_s
  h[:stderr] = full.length > 256 ? "#{full[0, 256]}…(truncated)" : full
end
```

Consumers that need everything can still read `error.stderr`.

---

### 4. Timeout path's closed-stream invariant is implicit

File: `lib/hecks/runtime/shell_dispatcher.rb`

After `Process.kill("-KILL", pid)` + `wait_thr.join`, the code closes
`stdout` / `stderr` and raises. A future maintainer adding a post-raise
`stdout.read` would hit `IOError: closed stream` — and not all
callers catch that cleanly. Make the invariant explicit with a comment.

Before: no comment.

After:

```ruby
stdout.close rescue nil
stderr.close rescue nil
# streams intentionally not read — killed process output is discarded
raise Hecks::ShellAdapterTimeoutError.new(...)
```

## Test plan

- [x] `bundle exec rspec` — 73 examples, 0 failures, 0.48s (under the 1s budget)
- [x] `bundle exec rspec spec/hecks/runtime/shell_dispatcher_spec.rb` — 17 examples (4 new: long-stderr truncation, first-line-only, `as_json` truncation, no-marker-under-256)
- [x] `bundle exec rspec spec/hecksagon/structure/shell_adapter_spec.rb` — added rejection + acceptance tests for the new absolute-path rule
- [x] `ruby -Ilib examples/pizzas/pizzas.rb` — smoke passes
- [x] `ruby -Ilib examples/shell_adapter/shell_demo.rb` — smoke passes
- [x] `bin/antibody-check --each-commit --base origin/main` — all 4 commits exempted with concrete reasons