### PR TITLE
fix: 7 Ruby↔Rust value-equality cascade-dropping bugs (PR #264 follow-through)

### DIFF
--- a/lib/hecks/behaviors/value.rb
+++ b/lib/hecks/behaviors/value.rb
@@ -119,6 +119,11 @@ module Hecks
       # with `Str("[1, 2]")`. Structural equality via the new
       # `Value#==` already ran above; when it fails we should NOT let
       # display form cast a tie. Audit cases 27, 28, 30, 31, 39.
+      # Maps mirror lists: Rust's `Display for Value::Map` is
+      # `"{N fields}"` (count-only) — audit cases 33, 34, 35, 36.
+      # Structural map equality on the Ruby side gets insertion-order
+      # independence for free (Hash#==), which is the direction
+      # case 34 flips toward Rust.
       def self.equal?(a, b)
         return true if a.kind == b.kind && a.raw == b.raw
         an = a.numeric
@@ -126,6 +131,7 @@ module Hecks
         return an == bn if an && bn
         return false if a.kind == :null || b.kind == :null
         return false if a.kind == :list || b.kind == :list
+        return false if a.kind == :map  || b.kind == :map
         a.to_display == b.to_display
       end
 

--- a/lib/hecks/behaviors/value.rb
+++ b/lib/hecks/behaviors/value.rb
@@ -88,6 +88,23 @@ module Hecks
       def list_size; list? ? @raw.size : 0; end
       def str_size;  @kind == :str ? @raw.length : 0; end
 
+      # Structural equality on the Value ADT. Two Values are `==` when
+      # their kind matches and their raw payload matches; for :list and
+      # :map this recurses (Array#== and Hash#== call Value#== on inner
+      # elements). Without this, `raw == raw` on nested lists/maps fell
+      # through to object identity and leaked into `Value.equal?` — the
+      # latent bug flagged as class 5 in PR #264's audit.
+      def ==(other)
+        return false unless other.is_a?(Value)
+        return false unless @kind == other.kind
+        @raw == other.raw
+      end
+      alias eql? ==
+
+      def hash
+        [@kind, @raw].hash
+      end
+
       # Loose equality: Bool(true)==Str("true"), Int(42)==Str("42"),
       # numeric coercion handles Int<->Str("0")<->Null comparisons.
       # A Null on either side compares via numeric ONLY — it must NOT

--- a/lib/hecks/behaviors/value.rb
+++ b/lib/hecks/behaviors/value.rb
@@ -74,12 +74,20 @@ module Hecks
         end
       end
 
+      # Ruby's `Float(s, exception: false)` accepts leading/trailing
+      # whitespace (`" 1 "` → 1.0), where Rust's `s.parse::<f64>()`
+      # rejects any whitespace. Audit case 16 — a `" 1 "` from a CSV
+      # cell would coerce-equal `Int(1)` in Ruby but not in Rust and
+      # silently drop one cascade. Pre-validate the string shape to
+      # mirror Rust's stricter parser before handing to `Float()`.
+      NUMERIC_STR = /\A-?(?:\d+\.\d+|\d+\.|\.\d+|\d+)(?:[eE][-+]?\d+)?\z/.freeze
+
       def numeric
         case @kind
         when :int  then @raw.to_f
         when :bool then @raw ? 1.0 : 0.0
         when :null then 0.0
-        when :str  then Float(@raw, exception: false)
+        when :str  then NUMERIC_STR.match?(@raw) ? Float(@raw, exception: false) : nil
         else nil
         end
       end

--- a/lib/hecks/behaviors/value.rb
+++ b/lib/hecks/behaviors/value.rb
@@ -113,12 +113,19 @@ module Hecks
       # pass on uninitialized state. Mirrors hecks_life's
       # `values_equal`, where `Display(Null) = "null"` keeps the same
       # fallback false and the cascade (policy→command→given) advances.
+      # A :list on either side likewise short-circuits: Rust's
+      # `Display for Value::List` is `"[N items]"` (count-only) which
+      # collides for same-size lists, and Ruby's `"[1, 2]"` collides
+      # with `Str("[1, 2]")`. Structural equality via the new
+      # `Value#==` already ran above; when it fails we should NOT let
+      # display form cast a tie. Audit cases 27, 28, 30, 31, 39.
       def self.equal?(a, b)
         return true if a.kind == b.kind && a.raw == b.raw
         an = a.numeric
         bn = b.numeric
         return an == bn if an && bn
         return false if a.kind == :null || b.kind == :null
+        return false if a.kind == :list || b.kind == :list
         a.to_display == b.to_display
       end
 

--- a/spec/hecks/behaviors/value_equality_spec.rb
+++ b/spec/hecks/behaviors/value_equality_spec.rb
@@ -1,0 +1,157 @@
+# spec/hecks/behaviors/value_equality_spec.rb
+#
+# Regression tests for the seven cascade-dropping Ruby↔Rust value
+# equality divergences catalogued in PR #264's audit
+# (`VALUE_EQUALITY_AUDIT.md`).
+#
+# Each test case is keyed by the audit case number so a future
+# reader can cross-reference the report. The expected value is the
+# post-fix Ruby answer — in most cases "false" because the fix
+# short-circuits display-form fallback for Null/List/Map kinds and
+# tightens numeric string coercion to reject whitespace. One case
+# (34, map insertion order) flips from false to true because the
+# newly-structural `Value#==` means `Hash#==` is order-insensitive.
+#
+# [antibody-exempt: regression tests for the above; retires with the Ruby runner]
+#
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+require "hecks/behaviors/value"
+
+RSpec.describe Hecks::Behaviors::Value do
+  V = described_class
+
+  # Shortcuts for the five kinds, keyed to Rust's `Value` enum.
+  def i(n);  V.new(:int,  n);             end
+  def s(t);  V.new(:str,  t);             end
+  def b(x);  V.new(:bool, x);             end
+  def nul;   V.new(:null, nil);           end
+  def lst(*xs); V.new(:list, xs);         end
+  def mp(h);  V.new(:map,  h);            end
+
+  describe "structural equality (#==, #eql?, #hash)" do
+    # Without a custom `==`, `raw == raw` on nested lists/maps fell
+    # through to object identity — the latent bug flagged as class 5
+    # in the audit. These tests pin the structural contract.
+    it "equates two Int values with the same raw" do
+      expect(i(1) == i(1)).to eq(true)
+      expect(i(1).eql?(i(1))).to eq(true)
+      expect(i(1).hash).to eq(i(1).hash)
+    end
+
+    it "distinguishes Values by kind" do
+      expect(i(1) == s("1")).to eq(false)
+    end
+
+    it "equates nested lists element-wise" do
+      expect(lst(i(1), i(2)) == lst(i(1), i(2))).to eq(true)
+      expect(lst(i(1), i(2)) == lst(i(2), i(1))).to eq(false)
+    end
+
+    it "equates maps order-insensitively (Hash#== semantics)" do
+      expect(mp({ a: i(1), b: i(2) }) == mp({ b: i(2), a: i(1) })).to eq(true)
+    end
+
+    it "is not equal to non-Value objects" do
+      expect(i(1) == 1).to eq(false)
+      expect(i(1) == "1").to eq(false)
+    end
+  end
+
+  describe ".equal? (loose equality with coercion)" do
+    # Baseline sanity — the scalar cases from the audit that already
+    # agree (and must stay agreeing).
+    it "agrees on Int(0) == Str(\"0\")" do
+      expect(V.equal?(i(0), s("0"))).to eq(true)
+    end
+
+    it "agrees on Bool(true) == Str(\"true\")" do
+      expect(V.equal?(b(true), s("true"))).to eq(true)
+    end
+
+    it "agrees on Null == Int(0) (via numeric coercion, 0.0 == 0.0)" do
+      expect(V.equal?(nul, i(0))).to eq(true)
+    end
+
+    # ----- the 7 cascade-dropping fixes -----
+
+    # Case 8 — Null == Str("null") — PR #262 short-circuits display
+    # fallback on :null, keeping the Ruby answer at false (the Rust
+    # runner diverges at true; audit flags for a separate Rust fix).
+    it "case 8: Null is not equal to Str(\"null\") via display" do
+      expect(V.equal?(nul, s("null"))).to eq(false)
+      expect(V.equal?(s("null"), nul)).to eq(false)
+    end
+
+    # Case 16 — numeric coercion must reject leading/trailing whitespace
+    # to mirror Rust's `s.parse::<f64>()`.
+    it "case 16: Str(\" 1 \") is not equal to Int(1) (whitespace rejected)" do
+      expect(V.equal?(s(" 1 "), i(1))).to eq(false)
+      expect(V.equal?(i(1), s(" 1 "))).to eq(false)
+    end
+
+    it "case 16 corollary: non-numeric strings still fail coercion" do
+      expect(V.equal?(s("abc"), i(0))).to eq(false)
+    end
+
+    it "case 16 corollary: scientific notation still coerces" do
+      expect(V.equal?(s("1e3"), i(1000))).to eq(true)
+    end
+
+    # Case 27 — list order matters (structural, positional).
+    it "case 27: [1,2] is not equal to [2,1] (order preserved)" do
+      expect(V.equal?(lst(i(1), i(2)), lst(i(2), i(1)))).to eq(false)
+    end
+
+    # Case 28 — same-length different-content lists are unequal.
+    it "case 28: [1,2] is not equal to [3,4] (no display collision)" do
+      expect(V.equal?(lst(i(1), i(2)), lst(i(3), i(4)))).to eq(false)
+    end
+
+    # Case 30 — an empty list is not equal to the literal string "[]".
+    # Structural-only for :list kills the display-form fallback.
+    it "case 30: [] is not equal to Str(\"[]\")" do
+      expect(V.equal?(lst, s("[]"))).to eq(false)
+      expect(V.equal?(s("[]"), lst)).to eq(false)
+    end
+
+    # Case 31 — display-form leakage in the other direction.
+    it "case 31: [] is not equal to Str(\"[0 items]\")" do
+      expect(V.equal?(lst, s("[0 items]"))).to eq(false)
+    end
+
+    # Case 33 — same-size different-keys maps are unequal.
+    it "case 33: {a:1} is not equal to {b:1}" do
+      expect(V.equal?(mp({ a: i(1) }), mp({ b: i(1) }))).to eq(false)
+    end
+
+    # Case 34 — map insertion order is irrelevant once Value has a
+    # structural `==` (Ruby's Hash#== is order-independent). This is
+    # the one case where the fix flips the answer from false to true.
+    it "case 34: {a:1,b:2} equals {b:2,a:1} (insertion-order independent)" do
+      expect(V.equal?(
+        mp({ a: i(1), b: i(2) }),
+        mp({ b: i(2), a: i(1) })
+      )).to eq(true)
+    end
+
+    # Case 36 — an empty map is not equal to the literal string "{}".
+    it "case 36: {} is not equal to Str(\"{}\")" do
+      expect(V.equal?(mp({}), s("{}"))).to eq(false)
+    end
+
+    # Case 39 — same-length lists with different string content are
+    # unequal; structural positional equality (no display collision).
+    it "case 39: [\"a\",\"b\"] is not equal to [\"c\",\"d\"]" do
+      expect(V.equal?(
+        lst(s("a"), s("b")),
+        lst(s("c"), s("d"))
+      )).to eq(false)
+    end
+
+    # Regression guards: PR #262's fix stays alive.
+    it "pr #262: Null != Str(\"\")" do
+      expect(V.equal?(nul, s(""))).to eq(false)
+      expect(V.equal?(s(""), nul)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-through on PR #264's audit (`VALUE_EQUALITY_AUDIT.md`). Five of the seven
cascade-dropping divergences between Ruby's `Hecks::Behaviors::Value.equal?`
and Rust's `values_equal` are fixed on the Ruby side; two (case 8's mirror
and the Null short-circuit) were already papered over by PR #262 and are
now pinned by regression tests so they can't drift.

Each fix is its own commit so an individual bug class can be reverted if a
downstream behaviors test turns out to depend on the old (wrong) shape.

### Fixed audit cases

| Case | Pair | Before | After | Rust |
|------|------|--------|-------|------|
| 16 | `Str(" 1 ") == Int(1)` | `true` | **`false`** | `false` |
| 27 | `[1,2] == [2,1]` | `false` (by luck) | **`false`** (structural) | `true` (Rust bug) |
| 28 | `[1,2] == [3,4]` | `false` (by luck) | **`false`** (structural) | `true` (Rust bug) |
| 30 | `[] == Str("[]")` | `true` | **`false`** | `false` |
| 31 | `[] == Str("[0 items]")` | `false` | **`false`** (structural) | `true` (Rust bug) |
| 33 | `{a:1} == {b:1}` | `false` (by luck) | **`false`** (structural) | `true` (Rust bug) |
| 34 | `{a:1,b:2} == {b:2,a:1}` | `false` | **`true`** | `true` |
| 35 | `{} == Str("{0 fields}")` | `false` | **`false`** | `true` (Rust bug) |
| 36 | `{} == Str("{}")` | `true` | **`false`** | `false` |
| 39 | `["a","b"] == ["c","d"]` | `false` (by luck) | **`false`** (structural) | `true` (Rust bug) |
|  8 | `Null == Str("null")` | `false` (PR #262) | `false` | `true` (Rust bug) |

### Fix classes

1. **Structural `==`, `eql?`, `hash` on `Value`** — the meta-fix. Nested list
   and map equality now recurses through `Value#==` instead of falling through
   to `Object#equal?` (identity). Precondition for (2) and (3).
2. **Structural List equality** — short-circuit the display-form fallback
   when either side is `:list`. Rust's `"[N items]"` display collides for
   any same-size lists.
3. **Structural Map equality** — same for `:map`. Rust's `"{N fields}"`
   collides. Case 34 flips to `true` (correct) because Hash#== is
   insertion-order independent once inner Values compare structurally.
4. **Strict numeric coercion** — `Value#numeric` for `:str` now pre-validates
   with `NUMERIC_STR` (no whitespace, no trailing garbage, scientific
   notation allowed) to mirror Rust's `f64::parse`.
5. **Null short-circuit mirror** — already handled by PR #262; pinned by
   spec so case 8 can't silently drift.

Rust-side follow-ups (cases 27/28/31/33/35/39 where Rust still says `true`)
are out of scope for this PR — tracked in the audit report's follow-up
inbox items as "Rust: drop display-form fallback for List/Map".

### Parity count

Running `ruby -Ilib spec/parity/behaviors_parity_test.rb "hecks_conception/**/*.behaviors"`:

- **Before:** 131/457 bluebooks agree between Ruby and Rust runners
- **After:** 226/460 agree (+95 bluebooks, +3 newly-added files in-between)

The 95-file jump is roughly 3× the catalogued list because one cascade can
hit multiple bluebooks once it stops dropping events.

### Deferred

Five cosmetic divergences from the audit (`[] == Str("[]")` in the
"other" direction etc.) remain — they're flagged in the audit as low-risk
synthetic cases. See `VALUE_EQUALITY_AUDIT.md` on `origin/main` for the
full inventory.

## Test plan

- [x] `bundle exec rspec spec/hecks/behaviors/value_equality_spec.rb` — 21 examples, 0 failures (<5ms)
- [x] `bin/hecks-behaviors hecks_conception/actions/compost_seasonal_beings.behaviors` — 9/9 (PR #262's cascade not regressed)
- [x] `ruby -Ilib spec/parity/behaviors_parity_test.rb "hecks_conception/**/*.behaviors"` — 131/457 → 226/460
- [x] `ruby -Ilib examples/pizzas/pizzas.rb` — runs clean

## Example usage

```ruby
V = Hecks::Behaviors::Value

# Before this PR:
V.equal?(V.new(:str, " 1 "), V.new(:int, 1))              # => true  (drifted from Rust)
V.equal?(V.new(:list, []), V.new(:str, "[]"))             # => true  (drifted from Rust)
V.equal?(V.new(:map, {}),  V.new(:str, "{}"))             # => true  (drifted from Rust)
V.equal?(V.new(:map, {a: 1, b: 2}),
         V.new(:map, {b: 2, a: 1}))                        # => false (drifted from Rust)

# After:
V.equal?(V.new(:str, " 1 "), V.new(:int, 1))              # => false ✓
V.equal?(V.new(:list, []), V.new(:str, "[]"))             # => false ✓
V.equal?(V.new(:map, {}),  V.new(:str, "{}"))             # => false ✓
V.equal?(V.new(:map, {a: 1, b: 2}),
         V.new(:map, {b: 2, a: 1}))                        # => true  ✓
```

Antibody exempted — `lib/hecks/behaviors/value.rb` is Ruby runtime,
retires when the Ruby runner ports to the Rust dispatch path.