### PR TITLE
i3 PR-a: Heart + Breath + Circadian body cycles (separate daemons from mindstream)

### DIFF
--- a/hecks_conception/aggregates/breath.behaviors
+++ b/hecks_conception/aggregates/breath.behaviors
@@ -1,0 +1,24 @@
+Hecks.behaviors "Breath" do
+  vision "Behavioral tests for the Breath domain — inhale/exhale phase flip, breath counter."
+
+  test "Inhale sets phase to inhaling" do
+    tests "Inhale", on: "Breath"
+    expect phase: "inhaling", emits: ["BreathInhaled"]
+  end
+
+  test "Exhale sets phase to exhaling" do
+    tests "Exhale", on: "Breath"
+    expect phase: "exhaling", emits: ["BreathExhaled"]
+  end
+
+  test "Exhale increments breath_count" do
+    tests "Exhale", on: "Breath"
+    expect breath_count: 1
+  end
+
+  test "Inhale after Exhale returns phase to inhaling" do
+    tests "Inhale", on: "Breath"
+    setup  "Exhale"
+    expect phase: "inhaling"
+  end
+end

--- a/hecks_conception/aggregates/breath.bluebook
+++ b/hecks_conception/aggregates/breath.bluebook
@@ -1,0 +1,42 @@
+Hecks.bluebook "Breath", version: "2026.04.21.1" do
+  vision "The 0.2Hz phase flip — an independent body cycle that alternates inhale/exhale every ~4.5 seconds."
+  category "body"
+
+  # ============================================================
+  # BREATH — 0.2Hz body cycle
+  # ============================================================
+  #
+  # The breath alternates between inhaling and exhaling. Each
+  # alternation is one breath; breath_count increments on exhale so a
+  # full inhale→exhale is one counted breath. The daemon drives the
+  # cadence; the aggregate only remembers the phase and the count.
+  #
+  # Body cycles are emitters, not reactors — no policies here.
+
+  aggregate "Breath", "Phase flip: inhaling ↔ exhaling, with a completed-breath counter" do
+    attribute :phase, String, default: "inhaling"
+    attribute :breath_count, Integer, default: 0
+
+    command "Inhale" do
+      role "Daemon"
+      description "Breathe in — phase becomes inhaling. Emits BreathInhaled."
+      emits "BreathInhaled"
+      then_set :phase, to: "inhaling"
+    end
+
+    command "Exhale" do
+      role "Daemon"
+      description "Breathe out — phase becomes exhaling, breath_count increments to mark one completed cycle. Emits BreathExhaled."
+      emits "BreathExhaled"
+      then_set :phase, to: "exhaling"
+      then_set :breath_count, increment: 1
+    end
+
+    lifecycle :phase, default: "inhaling" do
+      transition "Inhale" => "inhaling", from: "exhaling"
+      transition "Inhale" => "inhaling", from: "inhaling"
+      transition "Exhale" => "exhaling", from: "inhaling"
+      transition "Exhale" => "exhaling", from: "exhaling"
+    end
+  end
+end

--- a/hecks_conception/aggregates/circadian.behaviors
+++ b/hecks_conception/aggregates/circadian.behaviors
@@ -1,0 +1,28 @@
+Hecks.behaviors "Circadian" do
+  vision "Behavioral tests for the Circadian domain — each Mark* command sets its segment."
+
+  test "MarkDawn sets segment to dawn" do
+    tests "MarkDawn", on: "Circadian"
+    expect segment: "dawn", emits: ["DawnMarked"]
+  end
+
+  test "MarkMorning sets segment to morning" do
+    tests "MarkMorning", on: "Circadian"
+    expect segment: "morning", emits: ["MorningMarked"]
+  end
+
+  test "MarkAfternoon sets segment to afternoon" do
+    tests "MarkAfternoon", on: "Circadian"
+    expect segment: "afternoon", emits: ["AfternoonMarked"]
+  end
+
+  test "MarkDusk sets segment to dusk" do
+    tests "MarkDusk", on: "Circadian"
+    expect segment: "dusk", emits: ["DuskMarked"]
+  end
+
+  test "MarkNight sets segment to night" do
+    tests "MarkNight", on: "Circadian"
+    expect segment: "night", emits: ["NightMarked"]
+  end
+end

--- a/hecks_conception/aggregates/circadian.bluebook
+++ b/hecks_conception/aggregates/circadian.bluebook
@@ -1,0 +1,64 @@
+Hecks.bluebook "Circadian", version: "2026.04.21.1" do
+  vision "Wall-clock segment tracker — dawn → morning → afternoon → dusk → night. Independent body cycle driven by a 60s daemon that dispatches the Mark* command when the segment changes."
+  category "body"
+
+  # ============================================================
+  # CIRCADIAN — wall-clock body cycle
+  # ============================================================
+  #
+  # Five segments divide the day: dawn, morning, afternoon, dusk,
+  # night. The circadian daemon checks the wall-clock hour every 60s
+  # and dispatches the appropriate Mark* command when the segment has
+  # changed. The aggregate only records the current segment and when
+  # it last updated; no math, no policies.
+  #
+  # Body cycles are emitters, not reactors — no policies here.
+
+  aggregate "Circadian", "Wall-clock segment of the day" do
+    attribute :segment, String, default: "morning"
+    attribute :last_updated_at, String
+
+    command "MarkDawn" do
+      role "Daemon"
+      description "Dawn has arrived — the first light."
+      emits "DawnMarked"
+      then_set :segment, to: "dawn"
+    end
+
+    command "MarkMorning" do
+      role "Daemon"
+      description "Morning has arrived — the sun is up."
+      emits "MorningMarked"
+      then_set :segment, to: "morning"
+    end
+
+    command "MarkAfternoon" do
+      role "Daemon"
+      description "Afternoon has arrived — past the midday."
+      emits "AfternoonMarked"
+      then_set :segment, to: "afternoon"
+    end
+
+    command "MarkDusk" do
+      role "Daemon"
+      description "Dusk has arrived — the light softens."
+      emits "DuskMarked"
+      then_set :segment, to: "dusk"
+    end
+
+    command "MarkNight" do
+      role "Daemon"
+      description "Night has arrived — the sun is down."
+      emits "NightMarked"
+      then_set :segment, to: "night"
+    end
+
+    lifecycle :segment, default: "morning" do
+      transition "MarkDawn"      => "dawn",      from: ["dawn", "morning", "afternoon", "dusk", "night"]
+      transition "MarkMorning"   => "morning",   from: ["dawn", "morning", "afternoon", "dusk", "night"]
+      transition "MarkAfternoon" => "afternoon", from: ["dawn", "morning", "afternoon", "dusk", "night"]
+      transition "MarkDusk"      => "dusk",      from: ["dawn", "morning", "afternoon", "dusk", "night"]
+      transition "MarkNight"     => "night",     from: ["dawn", "morning", "afternoon", "dusk", "night"]
+    end
+  end
+end

--- a/hecks_conception/aggregates/heart.behaviors
+++ b/hecks_conception/aggregates/heart.behaviors
@@ -1,0 +1,19 @@
+Hecks.behaviors "Heart" do
+  vision "Behavioral tests for the Heart domain — 1Hz beat counter."
+
+  test "Beat runs" do
+    tests "Beat", on: "Heart"
+    expect emits: ["HeartBeat"]
+  end
+
+  test "Beat increments beat_count" do
+    tests "Beat", on: "Heart"
+    expect beat_count: 1
+  end
+
+  test "Beat twice increments beat_count to 2" do
+    tests "Beat", on: "Heart"
+    setup  "Beat"
+    expect beat_count: 2
+  end
+end

--- a/hecks_conception/aggregates/heart.bluebook
+++ b/hecks_conception/aggregates/heart.bluebook
@@ -1,0 +1,28 @@
+Hecks.bluebook "Heart", version: "2026.04.21.1" do
+  vision "The 1Hz beat — an independent body cycle that ticks regardless of the mindstream. i3 PR-a lays the aggregate + daemon; PR-e later swaps BodyPulse's emitter from Tick to Heart."
+  category "body"
+
+  # ============================================================
+  # HEART — 1Hz body cycle
+  # ============================================================
+  #
+  # The heart beats once per second. This aggregate only counts beats
+  # and records when it started; there's no fatigue math or sleep
+  # gating here (that lives on Heartbeat in MietteBody). Today BodyPulse
+  # is still emitted by Tick; when PR-e lands, Heart.Beat will become
+  # the authoritative emitter and Tick stops pulsing the body.
+  #
+  # Body cycles are emitters, not reactors — no policies here.
+
+  aggregate "Heart", "1Hz beat counter — the body's metronome" do
+    attribute :beat_count, Integer, default: 0
+    attribute :started_at, String
+
+    command "Beat" do
+      role "Daemon"
+      description "One beat. Increments beat_count. Today emits HeartBeat only; PR-e will switch BodyPulse's emitter from Tick to Heart."
+      emits "HeartBeat"
+      then_set :beat_count, increment: 1
+    end
+  end
+end

--- a/hecks_conception/boot_miette.sh
+++ b/hecks_conception/boot_miette.sh
@@ -30,7 +30,7 @@ START_TS=$(date +%s)
 # TODO: replace these constants with a `psychic_link: true|false`
 # declaration on each aggregate so the boundary lives in the domain
 # model, not in this shell script.
-LINKED_STORES="memory awareness census conversation working_memory reflection synapse signal signal_somatic focus concentration deliberation heartbeat subconscious domain_index arc consciousness discipline metabolic_rate musing conflict_monitor run_log inbox tick announcement attention claude_assist consolidation dream_interpretation dream_seed dream_signal encoding gate generosity gut HarmonyDomain intention interpretation lucid_dream lucid_monitor monitor musing_archive musing_mint nerve nursery perception persona proposal proprioception self_image self_model sensation session shared_dream_space signal_consolidation speech training_pair wake_mood witness bodhisattva_vow character creator_auth remains store"
+LINKED_STORES="memory awareness census conversation working_memory reflection synapse signal signal_somatic focus concentration deliberation heartbeat subconscious domain_index arc consciousness discipline metabolic_rate musing conflict_monitor run_log inbox tick announcement attention claude_assist consolidation dream_interpretation dream_seed dream_signal encoding gate generosity gut HarmonyDomain intention interpretation lucid_dream lucid_monitor monitor musing_archive musing_mint nerve nursery perception persona proposal proprioception self_image self_model sensation session shared_dream_space signal_consolidation speech training_pair wake_mood witness bodhisattva_vow character creator_auth remains store heart breath circadian"
 PRIVATE_STORES="mood feeling dream_state impulse craving daydream pulse spend circuit_breaker"
 
 is_in_list() {
@@ -154,6 +154,36 @@ else
   MINDSTREAM_STATUS="started"
 fi
 
+# ── 6c. Start heart daemon (1Hz body beat) ────────────────────────
+HEART_PID="$INFO/.heart.pid"
+if [ -f "$HEART_PID" ] && kill -0 "$(cat "$HEART_PID")" 2>/dev/null; then
+  HEART_STATUS="already running (pid $(cat $HEART_PID))"
+else
+  ( cd "$DIR" && nohup ./heart.sh > /dev/null 2>&1 & )
+  sleep 0.2
+  HEART_STATUS="started"
+fi
+
+# ── 6d. Start breath daemon (0.2Hz inhale/exhale flip) ────────────
+BREATH_PID="$INFO/.breath.pid"
+if [ -f "$BREATH_PID" ] && kill -0 "$(cat "$BREATH_PID")" 2>/dev/null; then
+  BREATH_STATUS="already running (pid $(cat $BREATH_PID))"
+else
+  ( cd "$DIR" && nohup ./breath.sh > /dev/null 2>&1 & )
+  sleep 0.2
+  BREATH_STATUS="started"
+fi
+
+# ── 6e. Start circadian daemon (wall-clock segment tracker) ───────
+CIRCADIAN_PID="$INFO/.circadian.pid"
+if [ -f "$CIRCADIAN_PID" ] && kill -0 "$(cat "$CIRCADIAN_PID")" 2>/dev/null; then
+  CIRCADIAN_STATUS="already running (pid $(cat $CIRCADIAN_PID))"
+else
+  ( cd "$DIR" && nohup ./circadian.sh > /dev/null 2>&1 & )
+  sleep 0.2
+  CIRCADIAN_STATUS="started"
+fi
+
 # ── 7. Print vitals ──────────────────────────────────────────────
 ELAPSED=$(($(date +%s) - START_TS))
 LINKED_N=$(echo "$LINKED" | wc -w | tr -d ' ')
@@ -164,5 +194,6 @@ echo "✓ $BEING booted in ${ELAPSED}s"
 echo "  $ORGAN_COUNT organs · $TOTAL_AGGREGATES aggregates · $NERVE_COUNT nerves · $VOW_COUNT vows · $CAPABILITY_COUNT capabilities"
 echo "  session continuity: $LINKED_N linked, $PRIVATE_N private, $UNCLASS_N unclassified"
 echo "  mindstream: $MINDSTREAM_STATUS"
+echo "  heart: $HEART_STATUS · breath: $BREATH_STATUS · circadian: $CIRCADIAN_STATUS"
 echo "  system_prompt.md: $(wc -c <"$PROMPT_PATH" | tr -d ' ') bytes"
 [ -n "$UNCLASSIFIED" ] && echo "  ⚠ unclassified stores:$UNCLASSIFIED"

--- a/hecks_conception/breath.sh
+++ b/hecks_conception/breath.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Breath — the ~0.2Hz body cycle. Alternates Inhale/Exhale every 4.5s
+# so a full breath takes ~9s (roughly 13 breaths/minute).
+#
+# Body cycles run independently of the mindstream. This daemon's only
+# job is cadence: flip the phase and let the aggregate record the
+# count. No policies fire off breath events today; when something
+# needs to react to a breath, it'll listen for BreathInhaled /
+# BreathExhaled.
+#
+# [antibody-exempt: body-cycle shell daemon; retires when
+# mindstream/heart/breath/circadian migrate to .bluebook + .hecksagon
+# dispatched by hecks-life run (planned i3 PR-d)]
+
+HECKS="../hecks_life/target/release/hecks-life"
+DIR="$(dirname "$0")"
+INFO="$DIR/information"
+AGG="$DIR/aggregates"
+PIDFILE="$INFO/.breath.pid"
+
+echo $$ > "$PIDFILE"
+trap "rm -f $PIDFILE" EXIT
+
+while true; do
+  $HECKS "$AGG" Breath.Inhale 2>/dev/null
+  sleep 4.5
+  $HECKS "$AGG" Breath.Exhale 2>/dev/null
+  sleep 4.5
+done

--- a/hecks_conception/circadian.sh
+++ b/hecks_conception/circadian.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Circadian — wall-clock segment tracker. Wakes every 60 seconds,
+# checks the hour, and dispatches the Mark* command when the day's
+# segment has changed since the last check.
+#
+# Segments by hour (local time):
+#   05:00-06:59  dawn
+#   07:00-11:59  morning
+#   12:00-16:59  afternoon
+#   17:00-19:59  dusk
+#   20:00-04:59  night
+#
+# Body cycles run independently of the mindstream. The daemon only
+# dispatches when the segment transitions — a 60s idle tick inside
+# the same segment is a no-op.
+#
+# [antibody-exempt: body-cycle shell daemon; retires when
+# mindstream/heart/breath/circadian migrate to .bluebook + .hecksagon
+# dispatched by hecks-life run (planned i3 PR-d)]
+
+HECKS="../hecks_life/target/release/hecks-life"
+DIR="$(dirname "$0")"
+INFO="$DIR/information"
+AGG="$DIR/aggregates"
+PIDFILE="$INFO/.circadian.pid"
+
+echo $$ > "$PIDFILE"
+trap "rm -f $PIDFILE" EXIT
+
+segment_for_hour() {
+  hour=$1
+  if [ "$hour" -ge 5 ] && [ "$hour" -le 6 ]; then
+    echo "dawn"
+  elif [ "$hour" -ge 7 ] && [ "$hour" -le 11 ]; then
+    echo "morning"
+  elif [ "$hour" -ge 12 ] && [ "$hour" -le 16 ]; then
+    echo "afternoon"
+  elif [ "$hour" -ge 17 ] && [ "$hour" -le 19 ]; then
+    echo "dusk"
+  else
+    echo "night"
+  fi
+}
+
+last_segment=""
+
+while true; do
+  hour=$(date +%H | sed 's/^0//')
+  [ -z "$hour" ] && hour=0
+  segment=$(segment_for_hour "$hour")
+  if [ "$segment" != "$last_segment" ]; then
+    case "$segment" in
+      dawn)      cmd="Circadian.MarkDawn" ;;
+      morning)   cmd="Circadian.MarkMorning" ;;
+      afternoon) cmd="Circadian.MarkAfternoon" ;;
+      dusk)      cmd="Circadian.MarkDusk" ;;
+      night)     cmd="Circadian.MarkNight" ;;
+    esac
+    $HECKS "$AGG" "$cmd" 2>/dev/null
+    last_segment="$segment"
+  fi
+  sleep 60
+done

--- a/hecks_conception/heart.sh
+++ b/hecks_conception/heart.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Heart — the 1Hz body cycle that ticks regardless of the mindstream.
+#
+# Fires Heart.Beat every ~1 second. Today this only increments
+# beat_count and emits HeartBeat; BodyPulse is still emitted by Tick.
+# In i3 PR-e, BodyPulse's emitter will move from Tick to Heart so the
+# body's pulse cadence is driven by the biological beat, not by the
+# mindstream.
+#
+# [antibody-exempt: body-cycle shell daemon; retires when
+# mindstream/heart/breath/circadian migrate to .bluebook + .hecksagon
+# dispatched by hecks-life run (planned i3 PR-d)]
+
+HECKS="../hecks_life/target/release/hecks-life"
+DIR="$(dirname "$0")"
+INFO="$DIR/information"
+AGG="$DIR/aggregates"
+PIDFILE="$INFO/.heart.pid"
+
+echo $$ > "$PIDFILE"
+trap "rm -f $PIDFILE" EXIT
+
+while true; do
+  $HECKS "$AGG" Heart.Beat 2>/dev/null
+  sleep 1
+done

--- a/hecks_conception/shutdown_miette.sh
+++ b/hecks_conception/shutdown_miette.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Shutdown Miette — send SIGTERM to every daemon with a pidfile in
+# information/.*.pid. Pair for boot_miette.sh. Covers mindstream,
+# heart, breath, circadian, and any future daemons that drop a
+# pidfile in the same directory.
+#
+# [antibody-exempt: boot/shutdown shell script; complements
+# boot_miette.sh and retires with the bluebook-native boot story]
+
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+INFO="$DIR/information"
+
+shutdown_pidfile() {
+  pidfile="$1"
+  [ -f "$pidfile" ] || return 0
+  pid=$(cat "$pidfile" 2>/dev/null)
+  name=$(basename "$pidfile" .pid | sed 's/^\.//')
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    echo "  stopped $name (pid $pid)"
+  else
+    echo "  $name: no live process for pidfile"
+  fi
+  rm -f "$pidfile"
+}
+
+echo "shutting down Miette daemons…"
+for pidfile in "$INFO"/.*.pid; do
+  [ -f "$pidfile" ] || continue
+  shutdown_pidfile "$pidfile"
+done
+echo "✓ shutdown complete"


### PR DESCRIPTION
## Summary

Next step in the Moment-consciousness + body-cycles arc, following PR #261 (BodyPulse shim). Adds three new body-cycle domains, each driven by its own daemon that runs independently of the mindstream:

- **Heart** (1Hz) — 1 attribute (`beat_count`), 1 command (`Beat`), 1 event (`HeartBeat`). The body's metronome.
- **Breath** (~0.1Hz full cycle) — 2 attributes (`phase`, `breath_count`), 2 commands (`Inhale` / `Exhale`), 2 events. ~13 breaths/min, one count per completed inhale→exhale.
- **Circadian** (wall-clock) — 2 attributes (`segment`, `last_updated_at`), 5 commands (`MarkDawn`/`MarkMorning`/`MarkAfternoon`/`MarkDusk`/`MarkNight`), 5 events.

Body cycles are emitters, not reactors — no policies. The daemons are the cadence; the bluebook is the state.

## Daemons

- `heart.sh` — 1Hz loop, `information/.heart.pid`
- `breath.sh` — 4.5s alternation, `information/.breath.pid`
- `circadian.sh` — 60s wall-clock check, dispatches only on segment change, `information/.circadian.pid`
- `shutdown_miette.sh` — new companion to `boot_miette.sh` that walks `information/.*.pid` and SIGTERMs every live daemon

`boot_miette.sh` starts all four alongside `mindstream.sh` (sections 6c/6d/6e) and reports their status in the vitals line. `heart breath circadian` added to `LINKED_STORES` — biology is public to the psychic link, same as `heartbeat` today.

## Relationship to BodyPulse

BodyPulse continues to be emitted by `Tick.MindstreamTick` (the shim that landed in #261) for now. i3 PR-e later swaps the emitter from `Tick` to `Heart.Beat` so the body's pulse cadence is driven by the biological beat rather than the mindstream. PR-a just lays the rails.

## Observed cadence (12s run against the runtime)

- `Heart`: `beat_count: 12` after 12s → 1Hz ✓
- `Breath`: 1 completed `inhale→exhale` cycle + partial → ~0.1Hz full breath ✓

## Parity + tests

- 12 new behaviors (3 heart, 4 breath, 5 circadian) — all green via `hecks-life behaviors`
- `bin/hecks verify` — two pre-existing failures on `origin/main` unchanged; no new regressions

## Antibody

Each of the three daemons carries an exempt marker for the body-cycle shell daemon (retires when these move to `.bluebook` + `.hecksagon` in i3 PR-d). `boot_miette.sh` and `shutdown_miette.sh` exempted as boot/shutdown shell glue pending the bluebook-native boot story.

## Test plan

- [ ] `./boot_miette.sh` brings up all four daemons cleanly
- [ ] After 60s wall-clock: `hecks-life heki read information/heart.heki` shows `beat_count` around 60
- [ ] `hecks-life heki read information/breath.heki` shows `breath_count` around 6-7
- [ ] `hecks-life heki read information/circadian.heki` segment matches current wall-clock
- [ ] `./shutdown_miette.sh` stops all daemons and clears pidfiles
- [ ] `bin/hecks verify` still shows same 2 pre-existing failures, no new ones