### PR TITLE
i37 Phase A: heki subcommands to unblock Python sweep

### DIFF
--- a/hecks_life/src/heki_query.rs
+++ b/hecks_life/src/heki_query.rs
@@ -1,0 +1,321 @@
+//! HekiQuery — filter / order / project logic for .heki stores
+//!
+//! Pure functions over `heki::Store`. No IO — the CLI is responsible for
+//! reading the store and printing the result. This module is the
+//! engine room the new `heki list / count / mark / next-ref / ...`
+//! subcommands share.
+//!
+//! [antibody-exempt: hecks-life heki subcommand expansion; prerequisite
+//!  for i37 Phase B (replace python3 -c invocations in shell scripts).
+//!  Retires when heki dispatch moves to a bluebook + hecksagon.]
+//!
+//! Usage:
+//!   let filter = Filter::parse("status=queued")?;
+//!   let records = filter_records(&store, &[filter]);
+//!   let ordered = order_records(records, &OrderSpec::parse("priority:enum=high,medium,normal,low")?);
+//!
+//! Filter ops (derived from shell python patterns):
+//!   k=v    exact equality (string compare on the JSON stringified value)
+//!   k!=v   not equal
+//!   k~=v   prefix match
+//!   k*=v   substring match
+//!
+//! Order spec:
+//!   field                    — ascending
+//!   field:asc / field:desc   — explicit direction
+//!   field:enum=a,b,c         — explicit enum ordering (a first, c last)
+//!   Ties on primary key break on created_at (stable byte-for-byte).
+
+use crate::heki::{Record, Store};
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterOp { Eq, NotEq, Prefix, Substring }
+
+#[derive(Debug, Clone)]
+pub struct Filter {
+    pub field: String,
+    pub op: FilterOp,
+    pub value: String,
+}
+
+impl Filter {
+    /// Parse a `--where k=v` / `k!=v` / `k~=v` / `k*=v` spec.
+    /// Returns Err with a message on syntax error (exit code 2 territory).
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        // Order matters — check two-char ops before '='.
+        if let Some(i) = spec.find("!=") {
+            return Ok(Filter {
+                field: spec[..i].to_string(),
+                op: FilterOp::NotEq,
+                value: spec[i+2..].to_string(),
+            });
+        }
+        if let Some(i) = spec.find("~=") {
+            return Ok(Filter {
+                field: spec[..i].to_string(),
+                op: FilterOp::Prefix,
+                value: spec[i+2..].to_string(),
+            });
+        }
+        if let Some(i) = spec.find("*=") {
+            return Ok(Filter {
+                field: spec[..i].to_string(),
+                op: FilterOp::Substring,
+                value: spec[i+2..].to_string(),
+            });
+        }
+        if let Some(i) = spec.find('=') {
+            return Ok(Filter {
+                field: spec[..i].to_string(),
+                op: FilterOp::Eq,
+                value: spec[i+1..].to_string(),
+            });
+        }
+        Err(format!("invalid --where spec: {}", spec))
+    }
+
+    pub fn matches(&self, rec: &Record) -> bool {
+        let val = field_to_string(rec.get(&self.field));
+        match self.op {
+            FilterOp::Eq        => val == self.value,
+            FilterOp::NotEq     => val != self.value,
+            FilterOp::Prefix    => val.starts_with(&self.value),
+            FilterOp::Substring => val.contains(&self.value),
+        }
+    }
+}
+
+/// Apply every filter with AND semantics.
+pub fn filter_records<'a>(store: &'a Store, filters: &[Filter]) -> Vec<&'a Record> {
+    store.values()
+        .filter(|r| filters.iter().all(|f| f.matches(r)))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Ordering
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderDir { Asc, Desc }
+
+#[derive(Debug, Clone)]
+pub struct OrderSpec {
+    pub field: String,
+    pub dir: OrderDir,
+    /// Explicit enum mapping — position in this vec is the sort key.
+    /// Values not in the list sort after all listed values.
+    pub enum_order: Option<Vec<String>>,
+    /// When true, strip a leading alphabetic prefix and sort the
+    /// trailing number. Lets `--order ref:numeric_ref` sort i2 < i10
+    /// (matches the `int(v.get('ref','i999')[1:])` Python pattern in
+    /// inbox.sh).
+    pub numeric_ref: bool,
+}
+
+impl OrderSpec {
+    /// Parse a `--order <field>[:asc|desc|enum=a,b,c]` spec.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let (field, rest) = match spec.find(':') {
+            Some(i) => (&spec[..i], Some(&spec[i+1..])),
+            None    => (spec, None),
+        };
+        let field = field.to_string();
+        if field.is_empty() {
+            return Err(format!("invalid --order spec: {}", spec));
+        }
+        match rest {
+            None => Ok(OrderSpec { field, dir: OrderDir::Asc, enum_order: None, numeric_ref: false }),
+            Some("asc")  => Ok(OrderSpec { field, dir: OrderDir::Asc,  enum_order: None, numeric_ref: false }),
+            Some("desc") => Ok(OrderSpec { field, dir: OrderDir::Desc, enum_order: None, numeric_ref: false }),
+            Some("numeric_ref") => Ok(OrderSpec {
+                field, dir: OrderDir::Asc, enum_order: None, numeric_ref: true,
+            }),
+            Some(e) if e.starts_with("enum=") => {
+                let list = e[5..].split(',').map(|s| s.to_string()).collect();
+                Ok(OrderSpec { field, dir: OrderDir::Asc, enum_order: Some(list), numeric_ref: false })
+            }
+            Some(other) => Err(format!("invalid --order modifier: {}", other)),
+        }
+    }
+
+    fn key(&self, rec: &Record) -> OrderKey {
+        let raw = field_to_string(rec.get(&self.field));
+        if let Some(list) = &self.enum_order {
+            let idx = list.iter().position(|v| v == &raw).unwrap_or(list.len());
+            return OrderKey::Int(idx as i64);
+        }
+        if self.numeric_ref {
+            // Strip leading alphabetic chars, parse the tail as int.
+            // Missing / unparseable refs get a very large number so they
+            // sort last — matches the Python `or 999`.
+            let tail: String = raw.chars().skip_while(|c| c.is_alphabetic()).collect();
+            return match tail.parse::<i64>() {
+                Ok(n) => OrderKey::Int(n),
+                Err(_) => OrderKey::Int(i64::MAX),
+            };
+        }
+        if let Ok(n) = raw.parse::<i64>() {
+            OrderKey::Int(n)
+        } else if let Ok(f) = raw.parse::<f64>() {
+            OrderKey::Float(f)
+        } else {
+            OrderKey::Str(raw)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum OrderKey { Int(i64), Float(f64), Str(String) }
+
+impl Eq for OrderKey {}
+impl PartialOrd for OrderKey { fn partial_cmp(&self, o: &Self) -> Option<std::cmp::Ordering> { Some(self.cmp(o)) } }
+impl Ord for OrderKey {
+    fn cmp(&self, o: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, o) {
+            (OrderKey::Int(a),   OrderKey::Int(b))   => a.cmp(b),
+            (OrderKey::Float(a), OrderKey::Float(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
+            (OrderKey::Int(a),   OrderKey::Float(b)) => (*a as f64).partial_cmp(b).unwrap_or(Ordering::Equal),
+            (OrderKey::Float(a), OrderKey::Int(b))   => a.partial_cmp(&(*b as f64)).unwrap_or(Ordering::Equal),
+            (OrderKey::Str(a),   OrderKey::Str(b))   => a.cmp(b),
+            // Mixed types: numeric < string.
+            (OrderKey::Int(_),   OrderKey::Str(_))   => Ordering::Less,
+            (OrderKey::Float(_), OrderKey::Str(_))   => Ordering::Less,
+            (OrderKey::Str(_),   OrderKey::Int(_))   => Ordering::Greater,
+            (OrderKey::Str(_),   OrderKey::Float(_)) => Ordering::Greater,
+        }
+    }
+}
+
+/// Order a slice of record refs in place according to the spec. Ties on
+/// the primary key break on created_at ascending — stable byte-for-byte
+/// output across runs.
+pub fn order_records<'a>(recs: Vec<&'a Record>, spec: &OrderSpec) -> Vec<&'a Record> {
+    order_records_multi(recs, std::slice::from_ref(spec))
+}
+
+/// Multi-key ordering. Each spec applies left-to-right; the first tie
+/// breaks on the second, and so on. Final tie-break is created_at ASC.
+pub fn order_records_multi<'a>(mut recs: Vec<&'a Record>, specs: &[OrderSpec]) -> Vec<&'a Record> {
+    recs.sort_by(|a, b| {
+        for spec in specs {
+            let ka = spec.key(a);
+            let kb = spec.key(b);
+            let cmp = ka.cmp(&kb);
+            let cmp = if spec.dir == OrderDir::Desc { cmp.reverse() } else { cmp };
+            if cmp != std::cmp::Ordering::Equal { return cmp; }
+        }
+        let ca = field_to_string(a.get("created_at"));
+        let cb = field_to_string(b.get("created_at"));
+        ca.cmp(&cb)
+    });
+    recs
+}
+
+// ---------------------------------------------------------------------------
+// Projection helpers
+// ---------------------------------------------------------------------------
+
+/// Render a scalar JSON value as a plain string. Strings lose their
+/// quotes (shell-friendly); numbers/bools stringify themselves; nulls
+/// become "". Objects/arrays compact-JSON.
+pub fn field_to_string(v: Option<&serde_json::Value>) -> String {
+    match v {
+        None                               => String::new(),
+        Some(serde_json::Value::Null)      => String::new(),
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Bool(b))   => b.to_string(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(other)                        => other.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::heki::Record;
+    use serde_json::json;
+
+    fn rec(pairs: &[(&str, serde_json::Value)]) -> Record {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+    }
+
+    #[test]
+    fn filter_parses_all_ops() {
+        assert_eq!(Filter::parse("a=b").unwrap().op,  FilterOp::Eq);
+        assert_eq!(Filter::parse("a!=b").unwrap().op, FilterOp::NotEq);
+        assert_eq!(Filter::parse("a~=b").unwrap().op, FilterOp::Prefix);
+        assert_eq!(Filter::parse("a*=b").unwrap().op, FilterOp::Substring);
+        assert!(Filter::parse("nope").is_err());
+    }
+
+    #[test]
+    fn eq_and_neq_match_on_string_fields() {
+        let r = rec(&[("status", json!("queued"))]);
+        assert!(Filter::parse("status=queued").unwrap().matches(&r));
+        assert!(!Filter::parse("status=done").unwrap().matches(&r));
+        assert!(Filter::parse("status!=done").unwrap().matches(&r));
+    }
+
+    #[test]
+    fn prefix_and_substring_ops() {
+        let r = rec(&[("ref", json!("i42"))]);
+        assert!(Filter::parse("ref~=i").unwrap().matches(&r));
+        assert!(Filter::parse("ref*=4").unwrap().matches(&r));
+        assert!(!Filter::parse("ref~=x").unwrap().matches(&r));
+    }
+
+    #[test]
+    fn order_spec_parses_enum() {
+        let o = OrderSpec::parse("priority:enum=high,low").unwrap();
+        assert_eq!(o.field, "priority");
+        assert_eq!(o.enum_order, Some(vec!["high".into(), "low".into()]));
+    }
+
+    #[test]
+    fn enum_order_sorts_deterministically() {
+        let r_low  = rec(&[("priority", json!("low"))]);
+        let r_high = rec(&[("priority", json!("high"))]);
+        let r_med  = rec(&[("priority", json!("medium"))]);
+        let store: Store = vec![
+            ("a".into(), r_low), ("b".into(), r_high), ("c".into(), r_med),
+        ].into_iter().collect();
+        let spec = OrderSpec::parse("priority:enum=high,medium,low").unwrap();
+        let sorted = order_records(store.values().collect(), &spec);
+        let names: Vec<_> = sorted.iter().map(|r| field_to_string(r.get("priority"))).collect();
+        assert_eq!(names, vec!["high", "medium", "low"]);
+    }
+
+    #[test]
+    fn numeric_order_sorts_by_value_not_lexicographically() {
+        let s: Store = vec![
+            ("a".into(), rec(&[("n", json!(2))])),
+            ("b".into(), rec(&[("n", json!(10))])),
+            ("c".into(), rec(&[("n", json!(1))])),
+        ].into_iter().collect();
+        let spec = OrderSpec::parse("n").unwrap();
+        let sorted = order_records(s.values().collect(), &spec);
+        let ns: Vec<_> = sorted.iter().map(|r| field_to_string(r.get("n"))).collect();
+        assert_eq!(ns, vec!["1", "2", "10"]);
+    }
+
+    #[test]
+    fn ties_break_on_created_at() {
+        let r1 = rec(&[("p", json!("a")), ("created_at", json!("2026-04-21T00:00:00Z"))]);
+        let r2 = rec(&[("p", json!("a")), ("created_at", json!("2026-04-21T00:00:01Z"))]);
+        let s: Store = vec![("b".into(), r2), ("a".into(), r1)].into_iter().collect();
+        let spec = OrderSpec::parse("p").unwrap();
+        let sorted = order_records(s.values().collect(), &spec);
+        let cas: Vec<_> = sorted.iter().map(|r| field_to_string(r.get("created_at"))).collect();
+        assert_eq!(cas, vec!["2026-04-21T00:00:00Z", "2026-04-21T00:00:01Z"]);
+    }
+}

--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -14,6 +14,7 @@ pub mod validator;
 pub mod validator_warnings;
 pub mod conceiver;
 pub mod heki;
+pub mod heki_query;
 pub mod dump;
 pub mod conceiver_common;
 pub mod behaviors_ir;

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -15,7 +15,7 @@
 //!   hecks-life conceive  "Name" "vision" --corpus dir1 dir2
 //!   hecks-life develop   target.bluebook --add "feature"
 
-use hecks_life::{parser, validator, server, conceiver, heki, dump,
+use hecks_life::{parser, validator, server, conceiver, heki, heki_query, dump,
                  behaviors_parser, behaviors_dump};
 use hecks_life::runtime::Runtime;
 
@@ -661,81 +661,454 @@ fn source_for_suite(suite_path: &str) -> String {
     parent.join(format!("{}.bluebook", source_stem)).to_string_lossy().into_owned()
 }
 
-/// heki subcommands: read, append, upsert, delete, latest
+/// heki subcommands — read/write + query shapes the shell scripts need.
+///
+/// Write/read (original):
 ///   hecks-life heki read   <file.heki>
 ///   hecks-life heki append <file.heki> key=val key2=val2
 ///   hecks-life heki upsert <file.heki> key=val key2=val2
 ///   hecks-life heki delete <file.heki> <id>
 ///   hecks-life heki latest <file.heki>
+///
+/// Query shapes (i37 Phase A — replace python3 -c invocations):
+///   hecks-life heki get           <file.heki> <id> [<field>]
+///   hecks-life heki list          <file.heki> [--where k=v]... [--order f[:asc|desc|enum=a,b,c]]
+///                                             [--fields a,b,c] [--format json|tsv|kv]
+///   hecks-life heki count         <file.heki> [--where k=v]...
+///   hecks-life heki next-ref      <file.heki> [--prefix i] [--field ref]
+///   hecks-life heki latest-field  <file.heki> <field>
+///   hecks-life heki values        <file.heki> <field>
+///   hecks-life heki mark          <file.heki> --where k=v [--where k=v]... --set k=v [--set k=v]...
+///   hecks-life heki seconds-since <file.heki> <field>
+///
+/// Exit codes:
+///   0 success
+///   1 file not found / IO error
+///   2 invalid filter / order syntax
+///   3 field not found (get / latest-field / seconds-since)
+///
+/// [antibody-exempt: register new heki subcommand dispatchers; same
+///  shape as existing run_heki arms]
 fn run_heki(args: &[String]) {
     if args.len() < 4 {
-        eprintln!("Usage: hecks-life heki <read|append|upsert|delete|latest> <file.heki> [args...]");
+        eprintln!("Usage: hecks-life heki <cmd> <file.heki> [args...]");
+        eprintln!("Commands: read latest append upsert delete");
+        eprintln!("          get list count next-ref latest-field values mark seconds-since");
         std::process::exit(1);
     }
 
     let sub = args[2].as_str();
     let file = args[3].as_str();
+    let rest = &args[4..];
 
     match sub {
-        "read" => {
-            match heki::read(file) {
-                Ok(store) => {
-                    let json = serde_json::to_string_pretty(&store).unwrap_or_default();
-                    println!("{}", json);
-                }
-                Err(e) => { eprintln!("{}", e); std::process::exit(1); }
-            }
-        }
-        "latest" => {
-            match heki::read(file) {
-                Ok(store) => {
-                    if let Some(rec) = heki::latest(&store) {
-                        let json = serde_json::to_string_pretty(rec).unwrap_or_default();
-                        println!("{}", json);
-                    } else {
-                        println!("{{}}");
-                    }
-                }
-                Err(e) => { eprintln!("{}", e); std::process::exit(1); }
-            }
-        }
-        "append" => {
-            let attrs = heki::parse_attrs(&args[4..]);
-            match heki::append(file, &attrs) {
-                Ok(rec) => {
-                    let json = serde_json::to_string_pretty(&rec).unwrap_or_default();
-                    println!("{}", json);
-                }
-                Err(e) => { eprintln!("{}", e); std::process::exit(1); }
-            }
-        }
-        "upsert" => {
-            let attrs = heki::parse_attrs(&args[4..]);
-            match heki::upsert(file, &attrs) {
-                Ok(rec) => {
-                    let json = serde_json::to_string_pretty(&rec).unwrap_or_default();
-                    println!("{}", json);
-                }
-                Err(e) => { eprintln!("{}", e); std::process::exit(1); }
-            }
-        }
-        "delete" => {
-            if args.len() < 5 {
-                eprintln!("Usage: hecks-life heki delete <file.heki> <id>");
-                std::process::exit(1);
-            }
-            let id = args[4].as_str();
-            match heki::delete(file, id) {
-                Ok(true) => println!("deleted {}", id),
-                Ok(false) => { eprintln!("not found: {}", id); std::process::exit(1); }
-                Err(e) => { eprintln!("{}", e); std::process::exit(1); }
-            }
-        }
+        "read"          => heki_cmd_read(file),
+        "latest"        => heki_cmd_latest(file),
+        "append"        => heki_cmd_append(file, rest),
+        "upsert"        => heki_cmd_upsert(file, rest),
+        "delete"        => heki_cmd_delete(file, rest),
+        "get"           => heki_cmd_get(file, rest),
+        "list"          => heki_cmd_list(file, rest),
+        "count"         => heki_cmd_count(file, rest),
+        "next-ref"      => heki_cmd_next_ref(file, rest),
+        "latest-field"  => heki_cmd_latest_field(file, rest),
+        "values"        => heki_cmd_values(file, rest),
+        "mark"          => heki_cmd_mark(file, rest),
+        "seconds-since" => heki_cmd_seconds_since(file, rest),
         _ => {
             eprintln!("Unknown heki command: {}", sub);
-            eprintln!("Available: read, append, upsert, delete, latest");
+            eprintln!("Available: read latest append upsert delete get list count \
+                       next-ref latest-field values mark seconds-since");
             std::process::exit(1);
         }
+    }
+}
+
+// -------- Existing read/write commands (extracted for readability) ---------
+
+fn heki_cmd_read(file: &str) {
+    match heki::read(file) {
+        Ok(store) => println!("{}", serde_json::to_string_pretty(&store).unwrap_or_default()),
+        Err(e)    => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+fn heki_cmd_latest(file: &str) {
+    match heki::read(file) {
+        Ok(store) => {
+            match heki::latest(&store) {
+                Some(rec) => println!("{}", serde_json::to_string_pretty(rec).unwrap_or_default()),
+                None      => println!("{{}}"),
+            }
+        }
+        Err(e) => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+fn heki_cmd_append(file: &str, rest: &[String]) {
+    let attrs = heki::parse_attrs(rest);
+    match heki::append(file, &attrs) {
+        Ok(rec) => println!("{}", serde_json::to_string_pretty(&rec).unwrap_or_default()),
+        Err(e)  => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+fn heki_cmd_upsert(file: &str, rest: &[String]) {
+    let attrs = heki::parse_attrs(rest);
+    match heki::upsert(file, &attrs) {
+        Ok(rec) => println!("{}", serde_json::to_string_pretty(&rec).unwrap_or_default()),
+        Err(e)  => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+fn heki_cmd_delete(file: &str, rest: &[String]) {
+    let id = match rest.first() {
+        Some(s) => s.as_str(),
+        None => {
+            eprintln!("Usage: hecks-life heki delete <file.heki> <id>");
+            std::process::exit(1);
+        }
+    };
+    match heki::delete(file, id) {
+        Ok(true)  => println!("deleted {}", id),
+        Ok(false) => { eprintln!("not found: {}", id); std::process::exit(1); }
+        Err(e)    => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+// -------- New query commands ------------------------------------------------
+
+fn heki_cmd_get(file: &str, rest: &[String]) {
+    let id = match rest.first() {
+        Some(s) => s.as_str(),
+        None => {
+            eprintln!("Usage: hecks-life heki get <file.heki> <id> [<field>]");
+            std::process::exit(1);
+        }
+    };
+    let field = rest.get(1).map(|s| s.as_str());
+
+    let store = read_store_or_exit(file);
+    let rec = match store.get(id) {
+        Some(r) => r,
+        None    => { eprintln!("no record with id {}", id); std::process::exit(1); }
+    };
+    match field {
+        None => println!("{}", serde_json::to_string_pretty(rec).unwrap_or_default()),
+        Some(f) => {
+            if !rec.contains_key(f) {
+                eprintln!("field not found: {}", f);
+                std::process::exit(3);
+            }
+            println!("{}", heki_query::field_to_string(rec.get(f)));
+        }
+    }
+}
+
+fn heki_cmd_list(file: &str, rest: &[String]) {
+    let opts = parse_query_opts(rest);
+    let store = read_store_or_exit(file);
+
+    let mut recs = heki_query::filter_records(&store, &opts.filters);
+    let default_order = vec![heki_query::OrderSpec {
+        field: "created_at".into(),
+        dir: heki_query::OrderDir::Asc,
+        enum_order: None,
+        numeric_ref: false,
+    }];
+    let order_specs: &[heki_query::OrderSpec] = if opts.orders.is_empty() {
+        &default_order
+    } else {
+        &opts.orders
+    };
+    recs = heki_query::order_records_multi(recs, order_specs);
+
+    let fields = opts.fields.clone();
+    match opts.format.as_str() {
+        "tsv" => print_tsv(&recs, &fields),
+        "kv"  => print_kv(&recs, &fields),
+        _     => print_json(&recs, &fields),
+    }
+}
+
+fn heki_cmd_count(file: &str, rest: &[String]) {
+    let opts = parse_query_opts(rest);
+    let store = read_store_or_exit(file);
+    let recs = heki_query::filter_records(&store, &opts.filters);
+    println!("{}", recs.len());
+}
+
+fn heki_cmd_next_ref(file: &str, rest: &[String]) {
+    let mut prefix = "i".to_string();
+    let mut field = "ref".to_string();
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--prefix" => { prefix = rest.get(i+1).cloned().unwrap_or_default(); i += 2; }
+            "--field"  => { field  = rest.get(i+1).cloned().unwrap_or_default(); i += 2; }
+            _ => i += 1,
+        }
+    }
+
+    let store = read_store_or_exit(file);
+    let mut max_n: Option<i64> = None;
+    for rec in store.values() {
+        let v = heki_query::field_to_string(rec.get(&field));
+        if let Some(tail) = v.strip_prefix(&prefix) {
+            if let Ok(n) = tail.parse::<i64>() {
+                max_n = Some(max_n.map_or(n, |cur| cur.max(n)));
+            }
+        }
+    }
+    let next = max_n.map_or(1, |n| n + 1);
+    println!("{}{}", prefix, next);
+}
+
+fn heki_cmd_latest_field(file: &str, rest: &[String]) {
+    let field = match rest.first() {
+        Some(s) => s.as_str(),
+        None => {
+            eprintln!("Usage: hecks-life heki latest-field <file.heki> <field>");
+            std::process::exit(1);
+        }
+    };
+    let store = read_store_or_exit(file);
+    match heki::latest(&store) {
+        Some(rec) => {
+            if !rec.contains_key(field) {
+                eprintln!("field not found: {}", field);
+                std::process::exit(3);
+            }
+            println!("{}", heki_query::field_to_string(rec.get(field)));
+        }
+        None => { /* empty store — print nothing, exit 0 */ }
+    }
+}
+
+fn heki_cmd_values(file: &str, rest: &[String]) {
+    let field = match rest.first() {
+        Some(s) => s.as_str(),
+        None => {
+            eprintln!("Usage: hecks-life heki values <file.heki> <field>");
+            std::process::exit(1);
+        }
+    };
+    let store = read_store_or_exit(file);
+    // Stable order — sort by created_at so output is deterministic.
+    let spec = heki_query::OrderSpec {
+        field: "created_at".into(),
+        dir: heki_query::OrderDir::Asc,
+        enum_order: None,
+        numeric_ref: false,
+    };
+    let recs = heki_query::order_records(store.values().collect(), &spec);
+    for rec in recs {
+        if let Some(v) = rec.get(field) {
+            println!("{}", heki_query::field_to_string(Some(v)));
+        }
+    }
+}
+
+fn heki_cmd_mark(file: &str, rest: &[String]) {
+    let mut filters: Vec<heki_query::Filter> = Vec::new();
+    let mut sets: Vec<(String, String)> = Vec::new();
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--where" => {
+                let spec = rest.get(i+1).cloned().unwrap_or_default();
+                match heki_query::Filter::parse(&spec) {
+                    Ok(f) => filters.push(f),
+                    Err(e) => { eprintln!("{}", e); std::process::exit(2); }
+                }
+                i += 2;
+            }
+            "--set" => {
+                let spec = rest.get(i+1).cloned().unwrap_or_default();
+                match spec.find('=') {
+                    Some(eq) => sets.push((spec[..eq].to_string(), spec[eq+1..].to_string())),
+                    None => { eprintln!("invalid --set spec: {}", spec); std::process::exit(2); }
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+
+    if filters.is_empty() {
+        eprintln!("heki mark requires at least one --where");
+        std::process::exit(2);
+    }
+    if sets.is_empty() {
+        eprintln!("heki mark requires at least one --set");
+        std::process::exit(2);
+    }
+
+    let mut store = read_store_or_exit(file);
+    let ids: Vec<String> = store.iter()
+        .filter(|(_, rec)| filters.iter().all(|f| f.matches(rec)))
+        .map(|(id, _)| id.clone())
+        .collect();
+    let matched = ids.len();
+    let now = heki::now_iso();
+    for id in &ids {
+        if let Some(rec) = store.get_mut(id) {
+            for (k, v) in &sets {
+                rec.insert(k.clone(), typed_value(v));
+            }
+            rec.insert("updated_at".into(), serde_json::Value::String(now.clone()));
+        }
+    }
+    if matched > 0 {
+        if let Err(e) = heki::write(file, &store) {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    }
+    println!("{}", matched);
+}
+
+fn heki_cmd_seconds_since(file: &str, rest: &[String]) {
+    let field = match rest.first() {
+        Some(s) => s.as_str(),
+        None => {
+            eprintln!("Usage: hecks-life heki seconds-since <file.heki> <field>");
+            std::process::exit(1);
+        }
+    };
+    let store = read_store_or_exit(file);
+    let rec = match heki::latest(&store) {
+        Some(r) => r,
+        None    => { println!("0"); return; }
+    };
+    let ts = heki_query::field_to_string(rec.get(field));
+    if ts.is_empty() {
+        eprintln!("field not found or empty: {}", field);
+        std::process::exit(3);
+    }
+    let secs = heki::seconds_since_iso(&ts);
+    // Integer seconds — what the shell scripts want for -ge/-le compares.
+    println!("{}", secs as i64);
+}
+
+// -------- Query option parsing (shared by list / count) --------------------
+
+struct QueryOpts {
+    filters: Vec<heki_query::Filter>,
+    orders: Vec<heki_query::OrderSpec>,
+    fields: Vec<String>,
+    format: String,
+}
+
+fn parse_query_opts(rest: &[String]) -> QueryOpts {
+    let mut filters: Vec<heki_query::Filter> = Vec::new();
+    let mut orders: Vec<heki_query::OrderSpec> = Vec::new();
+    let mut fields: Vec<String> = Vec::new();
+    let mut format = "json".to_string();
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--where" => {
+                let spec = rest.get(i+1).cloned().unwrap_or_default();
+                match heki_query::Filter::parse(&spec) {
+                    Ok(f) => filters.push(f),
+                    Err(e) => { eprintln!("{}", e); std::process::exit(2); }
+                }
+                i += 2;
+            }
+            "--order" => {
+                let spec = rest.get(i+1).cloned().unwrap_or_default();
+                match heki_query::OrderSpec::parse(&spec) {
+                    Ok(o) => orders.push(o),
+                    Err(e) => { eprintln!("{}", e); std::process::exit(2); }
+                }
+                i += 2;
+            }
+            "--fields" => {
+                let spec = rest.get(i+1).cloned().unwrap_or_default();
+                fields = spec.split(',').map(|s| s.to_string()).collect();
+                i += 2;
+            }
+            "--format" => {
+                format = rest.get(i+1).cloned().unwrap_or_else(|| "json".into());
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    QueryOpts { filters, orders, fields, format }
+}
+
+fn read_store_or_exit(file: &str) -> heki::Store {
+    match heki::read(file) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("{}", e); std::process::exit(1); }
+    }
+}
+
+/// `heki mark --set k=v` parses the value the same way `parse_attrs`
+/// does — int / float / bool / string — so the shell doesn't have to
+/// worry about quoting.
+fn typed_value(v: &str) -> serde_json::Value {
+    if let Ok(n) = v.parse::<i64>() {
+        return serde_json::Value::Number(n.into());
+    }
+    if let Ok(f) = v.parse::<f64>() {
+        return serde_json::json!(f);
+    }
+    if v == "true"  { return serde_json::Value::Bool(true);  }
+    if v == "false" { return serde_json::Value::Bool(false); }
+    serde_json::Value::String(v.to_string())
+}
+
+// -------- Output formats ---------------------------------------------------
+
+fn project(rec: &heki::Record, fields: &[String]) -> serde_json::Value {
+    if fields.is_empty() {
+        return serde_json::to_value(rec).unwrap_or(serde_json::json!({}));
+    }
+    let mut map = serde_json::Map::new();
+    for f in fields {
+        if let Some(v) = rec.get(f) {
+            map.insert(f.clone(), v.clone());
+        } else {
+            map.insert(f.clone(), serde_json::Value::Null);
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+fn print_json(recs: &[&heki::Record], fields: &[String]) {
+    let arr: Vec<serde_json::Value> = recs.iter().map(|r| project(r, fields)).collect();
+    println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".into()));
+}
+
+fn print_tsv(recs: &[&heki::Record], fields: &[String]) {
+    if fields.is_empty() {
+        eprintln!("--format tsv requires --fields");
+        std::process::exit(2);
+    }
+    for rec in recs {
+        let row: Vec<String> = fields.iter()
+            .map(|f| heki_query::field_to_string(rec.get(f)))
+            .collect();
+        println!("{}", row.join("\t"));
+    }
+}
+
+fn print_kv(recs: &[&heki::Record], fields: &[String]) {
+    for rec in recs {
+        let keys: Vec<String> = if fields.is_empty() {
+            let mut ks: Vec<String> = rec.keys().cloned().collect();
+            ks.sort();
+            ks
+        } else {
+            fields.to_vec()
+        };
+        for k in keys {
+            println!("{}={}", k, heki_query::field_to_string(rec.get(&k)));
+        }
+        println!(); // blank line between records
     }
 }
 

--- a/hecks_life/tests/heki_query_test.rs
+++ b/hecks_life/tests/heki_query_test.rs
@@ -1,0 +1,482 @@
+//! Integration tests for the new `hecks-life heki` query subcommands.
+//!
+//! Each test shells to the built binary against a tmp fixture .heki file,
+//! so the exit-code / output contract is exercised end-to-end. Plus
+//! byte-for-byte parity tests against the current `python3 -c` shapes
+//! that Phase B will retire.
+//!
+//! [antibody-exempt: test coverage for the new subcommands]
+
+use hecks_life::heki;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn binary() -> PathBuf {
+    // Built by `cargo test` before these run — same profile.
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("target");
+    p.push(if cfg!(debug_assertions) { "debug" } else { "release" });
+    p.push("hecks-life");
+    p
+}
+
+fn tmpdir() -> PathBuf {
+    let d = std::env::temp_dir().join(format!("hq_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn write_store(path: &Path, records: &[(&str, serde_json::Value)]) {
+    let mut store: heki::Store = heki::Store::new();
+    for (id, rec) in records {
+        let obj = rec.as_object().expect("record must be an object");
+        let mut r = heki::Record::new();
+        r.insert("id".into(), json!(id));
+        for (k, v) in obj { r.insert(k.clone(), v.clone()); }
+        store.insert(id.to_string(), r);
+    }
+    heki::write(path.to_str().unwrap(), &store).unwrap();
+}
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(binary())
+        .args(args)
+        .output()
+        .expect("binary should run");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn sample_inbox(path: &Path) {
+    write_store(path, &[
+        ("a", json!({
+            "ref": "i3", "priority": "high", "status": "queued",
+            "posted_at": "2026-04-01T00:00:00Z", "created_at": "2026-04-01T00:00:00Z",
+            "body": "third"
+        })),
+        ("b", json!({
+            "ref": "i1", "priority": "medium", "status": "queued",
+            "posted_at": "2026-04-01T00:00:01Z", "created_at": "2026-04-01T00:00:01Z",
+            "body": "first"
+        })),
+        ("c", json!({
+            "ref": "i2", "priority": "high", "status": "done",
+            "posted_at": "2026-04-01T00:00:02Z", "created_at": "2026-04-01T00:00:02Z",
+            "body": "second"
+        })),
+        ("d", json!({
+            "ref": "i10", "priority": "medium", "status": "queued",
+            "posted_at": "2026-04-01T00:00:03Z", "created_at": "2026-04-01T00:00:03Z",
+            "body": "tenth"
+        })),
+    ]);
+}
+
+// ---------------------------------------------------------------------------
+// `heki get`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_returns_scalar_field_value() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "get", f.to_str().unwrap(), "a", "ref"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "i3");
+}
+
+#[test]
+fn get_returns_json_without_field() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "get", f.to_str().unwrap(), "a"]);
+    assert_eq!(rc, 0);
+    assert!(out.contains("\"ref\""));
+    assert!(out.contains("\"i3\""));
+}
+
+#[test]
+fn get_unknown_field_exits_3() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, _, _) = run(&["heki", "get", f.to_str().unwrap(), "a", "nope"]);
+    assert_eq!(rc, 3);
+}
+
+#[test]
+fn get_unknown_id_exits_1() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, _, _) = run(&["heki", "get", f.to_str().unwrap(), "missing"]);
+    assert_eq!(rc, 1);
+}
+
+// ---------------------------------------------------------------------------
+// `heki list`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_filters_by_where_eq() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "list", f.to_str().unwrap(),
+        "--where", "status=queued", "--fields", "ref", "--format", "tsv",
+        "--order", "ref:numeric_ref"]);
+    assert_eq!(rc, 0);
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines, vec!["i1", "i3", "i10"]);
+}
+
+#[test]
+fn list_respects_priority_enum_then_ref_numeric() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "list", f.to_str().unwrap(),
+        "--where", "status=queued",
+        "--order", "priority:enum=high,medium,normal,low",
+        "--order", "ref:numeric_ref",
+        "--fields", "ref,priority", "--format", "tsv"]);
+    assert_eq!(rc, 0);
+    let want = "i3\thigh\ni1\tmedium\ni10\tmedium\n";
+    assert_eq!(out, want);
+}
+
+#[test]
+fn list_kv_format_prints_key_equals_value() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "list", f.to_str().unwrap(),
+        "--where", "ref=i1", "--fields", "ref,priority", "--format", "kv"]);
+    assert_eq!(rc, 0);
+    assert!(out.contains("ref=i1"));
+    assert!(out.contains("priority=medium"));
+}
+
+#[test]
+fn list_invalid_filter_exits_2() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, _, _) = run(&["heki", "list", f.to_str().unwrap(), "--where", "bogus"]);
+    assert_eq!(rc, 2);
+}
+
+// ---------------------------------------------------------------------------
+// `heki count`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn count_returns_filtered_total() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "count", f.to_str().unwrap(), "--where", "status=queued"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "3");
+}
+
+#[test]
+fn count_with_no_filter_is_total() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "count", f.to_str().unwrap()]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "4");
+}
+
+// ---------------------------------------------------------------------------
+// `heki next-ref`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn next_ref_advances_max() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "next-ref", f.to_str().unwrap()]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "i11");
+}
+
+#[test]
+fn next_ref_on_empty_store_is_one() {
+    let dir = tmpdir();
+    let f = dir.join("empty.heki");
+    write_store(&f, &[]);
+    let (rc, out, _) = run(&["heki", "next-ref", f.to_str().unwrap()]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "i1");
+}
+
+#[test]
+fn next_ref_honors_custom_prefix() {
+    let dir = tmpdir();
+    let f = dir.join("x.heki");
+    write_store(&f, &[
+        ("a", json!({ "tag": "x3", "created_at": "2026-01-01T00:00:00Z" })),
+        ("b", json!({ "tag": "x7", "created_at": "2026-01-01T00:00:01Z" })),
+    ]);
+    let (rc, out, _) = run(&["heki", "next-ref", f.to_str().unwrap(),
+        "--prefix", "x", "--field", "tag"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "x8");
+}
+
+// ---------------------------------------------------------------------------
+// `heki latest-field`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn latest_field_picks_latest_updated_at() {
+    let dir = tmpdir();
+    let f = dir.join("s.heki");
+    // latest is the one with the most recent updated_at (per heki::latest).
+    let mut store = heki::Store::new();
+    let mut r1 = heki::Record::new();
+    r1.insert("id".into(), json!("1"));
+    r1.insert("state".into(), json!("asleep"));
+    r1.insert("updated_at".into(), json!("2026-04-01T00:00:00Z"));
+    store.insert("1".into(), r1);
+    let mut r2 = heki::Record::new();
+    r2.insert("id".into(), json!("2"));
+    r2.insert("state".into(), json!("awake"));
+    r2.insert("updated_at".into(), json!("2026-04-01T01:00:00Z"));
+    store.insert("2".into(), r2);
+    heki::write(f.to_str().unwrap(), &store).unwrap();
+
+    let (rc, out, _) = run(&["heki", "latest-field", f.to_str().unwrap(), "state"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "awake");
+}
+
+#[test]
+fn latest_field_unknown_exits_3() {
+    let dir = tmpdir();
+    let f = dir.join("s.heki");
+    write_store(&f, &[("x", json!({"a": "b", "updated_at": "2026-01-01T00:00:00Z"}))]);
+    let (rc, _, _) = run(&["heki", "latest-field", f.to_str().unwrap(), "missing"]);
+    assert_eq!(rc, 3);
+}
+
+// ---------------------------------------------------------------------------
+// `heki values`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn values_prints_one_per_line_ordered_by_created_at() {
+    let dir = tmpdir();
+    let f = dir.join("s.heki");
+    sample_inbox(&f);
+    let (rc, out, _) = run(&["heki", "values", f.to_str().unwrap(), "ref"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out, "i3\ni1\ni2\ni10\n");
+}
+
+// ---------------------------------------------------------------------------
+// `heki mark`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mark_updates_matching_records_and_prints_count() {
+    let dir = tmpdir();
+    let f = dir.join("m.heki");
+    write_store(&f, &[
+        ("a", json!({"idea": "one",  "conceived": false, "created_at": "2026-01-01T00:00:00Z"})),
+        ("b", json!({"idea": "two",  "conceived": false, "created_at": "2026-01-01T00:00:01Z"})),
+        ("c", json!({"idea": "one",  "conceived": true,  "created_at": "2026-01-01T00:00:02Z"})),
+    ]);
+    let (rc, out, _) = run(&["heki", "mark", f.to_str().unwrap(),
+        "--where", "idea=one", "--where", "conceived=false",
+        "--set", "conceived=true"]);
+    assert_eq!(rc, 0);
+    assert_eq!(out.trim(), "1");
+
+    // Verify via read.
+    let (_, out, _) = run(&["heki", "list", f.to_str().unwrap(),
+        "--where", "idea=one", "--fields", "id,conceived", "--format", "kv"]);
+    assert!(out.contains("conceived=true"));
+}
+
+#[test]
+fn mark_without_where_exits_2() {
+    let dir = tmpdir();
+    let f = dir.join("m.heki");
+    sample_inbox(&f);
+    let (rc, _, _) = run(&["heki", "mark", f.to_str().unwrap(), "--set", "x=y"]);
+    assert_eq!(rc, 2);
+}
+
+// ---------------------------------------------------------------------------
+// `heki seconds-since`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn seconds_since_parses_iso_8601() {
+    let dir = tmpdir();
+    let f = dir.join("hb.heki");
+    write_store(&f, &[("x", json!({
+        "updated_at": "2020-01-01T00:00:00Z",
+        "created_at": "2020-01-01T00:00:00Z"
+    }))]);
+    let (rc, out, _) = run(&["heki", "seconds-since", f.to_str().unwrap(), "updated_at"]);
+    assert_eq!(rc, 0);
+    let n: i64 = out.trim().parse().expect("integer output");
+    // Very loose bound — anything above 100M seconds means the parser worked.
+    assert!(n > 100_000_000, "expected seconds-since > 100M, got {}", n);
+}
+
+// ---------------------------------------------------------------------------
+// Byte-for-byte parity vs current python3 -c patterns
+// ---------------------------------------------------------------------------
+
+/// The `inbox.sh list queued` output layout. We reproduce it here via
+/// `heki list --format tsv` + a shell-style printf line; then compare
+/// to the python3 -c output from inbox.sh line 69-88 against the same
+/// fixture.
+#[test]
+fn parity_inbox_list_queued_matches_python() {
+    let dir = tmpdir();
+    let f = dir.join("inbox.heki");
+    sample_inbox(&f);
+
+    // Phase B stub: my new subcommand + awk does what the python did.
+    let (rc, out, _) = run(&["heki", "list", f.to_str().unwrap(),
+        "--where", "status=queued",
+        "--order", "priority:enum=high,medium,normal,low",
+        "--order", "ref:numeric_ref",
+        "--fields", "ref,priority,status,body",
+        "--format", "tsv"]);
+    assert_eq!(rc, 0);
+
+    // Python equivalent (verbatim from inbox.sh lines 69-88 — just the
+    // filter+sort+field extraction, not the padded formatting which is
+    // a pure shell concern).
+    let py_script = r#"
+import json, struct, zlib, sys
+with open(sys.argv[1], 'rb') as fh:
+    data = fh.read()
+assert data[:4] == b'HEKI'
+store = json.loads(zlib.decompress(data[8:]).decode('utf-8'))
+items = [v for v in store.values() if v.get('status') == 'queued']
+order = {'high':0, 'medium':1, 'normal':2, 'low':3}
+items.sort(key=lambda v: (
+    order.get(v.get('priority','normal'), 9),
+    int(v.get('ref','i999')[1:]) if v.get('ref','').startswith('i') else 999,
+))
+for v in items:
+    print('\t'.join([
+        v.get('ref',''), v.get('priority',''),
+        v.get('status',''), v.get('body','').replace('\n',' ').replace('\t',' ')
+    ]))
+"#;
+    let py = Command::new("python3")
+        .args(["-c", py_script, f.to_str().unwrap()])
+        .output().expect("python3 on PATH");
+    assert!(py.status.success(), "python stderr: {}",
+        String::from_utf8_lossy(&py.stderr));
+
+    // `heki list --format tsv` matches the Python output line-for-line
+    // except the Python replaces internal \n/\t with spaces. Our sample
+    // body has none — so the outputs are byte-identical.
+    let rust_out = out;
+    let py_out = String::from_utf8(py.stdout).unwrap();
+    assert_eq!(rust_out, py_out);
+}
+
+/// Parity with `statusline-command.sh` heartbeat `fatigue_state` extraction.
+/// Python today: `json.load(sys.stdin).get('fatigue_state','')` on a
+/// single-record store.
+#[test]
+fn parity_latest_field_matches_python_get() {
+    let dir = tmpdir();
+    let f = dir.join("hb.heki");
+    let mut store = heki::Store::new();
+    let mut r = heki::Record::new();
+    r.insert("id".into(), json!("1"));
+    r.insert("fatigue_state".into(), json!("alert"));
+    r.insert("updated_at".into(), json!("2026-04-21T00:00:00Z"));
+    store.insert("1".into(), r);
+    heki::write(f.to_str().unwrap(), &store).unwrap();
+
+    let (rc, rust_out, _) = run(&["heki", "latest-field", f.to_str().unwrap(), "fatigue_state"]);
+    assert_eq!(rc, 0);
+
+    let py_script = r#"
+import json, struct, zlib, sys
+with open(sys.argv[1], 'rb') as fh:
+    data = fh.read()
+store = json.loads(zlib.decompress(data[8:]).decode('utf-8'))
+# latest = max updated_at
+latest = max(store.values(), key=lambda v: v.get('updated_at',''))
+print(latest.get('fatigue_state',''))
+"#;
+    let py = Command::new("python3")
+        .args(["-c", py_script, f.to_str().unwrap()])
+        .output().expect("python3 on PATH");
+    assert!(py.status.success());
+
+    let py_out = String::from_utf8(py.stdout).unwrap();
+    assert_eq!(rust_out, py_out);
+}
+
+/// Parity with `mindstream.sh` idle-seconds computation (lines 100-111).
+/// Python today: parse `updated_at` with datetime.fromisoformat, diff
+/// against now, print int seconds.
+#[test]
+fn parity_seconds_since_matches_python_datetime() {
+    let dir = tmpdir();
+    let f = dir.join("hb.heki");
+    let mut store = heki::Store::new();
+    let mut r = heki::Record::new();
+    r.insert("id".into(), json!("1"));
+    r.insert("updated_at".into(), json!("2020-01-01T00:00:00Z"));
+    store.insert("1".into(), r);
+    heki::write(f.to_str().unwrap(), &store).unwrap();
+
+    let (rc, rust_out, _) = run(&["heki", "seconds-since", f.to_str().unwrap(), "updated_at"]);
+    assert_eq!(rc, 0);
+
+    let py_script = r#"
+import json, struct, zlib, sys
+from datetime import datetime, timezone
+with open(sys.argv[1], 'rb') as fh:
+    data = fh.read()
+store = json.loads(zlib.decompress(data[8:]).decode('utf-8'))
+for v in store.values():
+    ts = v.get('updated_at','')
+    if ts:
+        dt = datetime.fromisoformat(ts.replace('Z','+00:00'))
+        print(int((datetime.now(timezone.utc) - dt).total_seconds()))
+        break
+"#;
+    let py = Command::new("python3")
+        .args(["-c", py_script, f.to_str().unwrap()])
+        .output().expect("python3 on PATH");
+    assert!(py.status.success());
+
+    let py_secs: i64 = String::from_utf8(py.stdout).unwrap().trim().parse().unwrap();
+    let rust_secs: i64 = rust_out.trim().parse().unwrap();
+    // Allow 2s of slack — both are computed against `now` and one runs
+    // after the other. The point is that both produce the same integer
+    // seconds-since shape, not a millisecond-exact match.
+    assert!((py_secs - rust_secs).abs() <= 2,
+        "py={} rust={} (must be within 2s)", py_secs, rust_secs);
+}


### PR DESCRIPTION
## Summary

Expands `hecks-life heki` with 8 new query subcommands so **i37 Phase B can retire 120 `python3 -c` invocations** across the shell scripts via pure find/replace. All new behavior lives in the Rust runtime; no Python.

## Subcommands shipped

| Command | Example | Retires |
|---|---|---|
| `heki get <file> <id> [<field>]` | `heki get inbox.heki uuid-abc ref` | record-by-id python blocks |
| `heki list <file> [--where] [--order] [--fields] [--format]` | `heki list inbox.heki --where status=queued --order 'priority:enum=high,medium,normal,low' --order 'ref:numeric_ref' --fields ref,priority --format tsv` | inbox.sh list sort/filter |
| `heki count <file> [--where]` | `heki count inbox.heki --where status=queued` | statusline inbox_count |
| `heki next-ref <file> [--prefix] [--field]` | `heki next-ref inbox.heki` → `i40` | inbox.sh::next_ref |
| `heki latest-field <file> <field>` | `heki latest-field heartbeat.heki fatigue_state` → `tired` | ~40 statusline grep\|sed blocks |
| `heki values <file> <field>` | `heki values conversation.heki person_name` | `list(...values())` python |
| `heki mark <file> --where --set` | `heki mark musing.heki --where idea=X --set conceived=true` | mark_musing_shown.py |
| `heki seconds-since <file> <field>` | `heki seconds-since heartbeat.heki updated_at` → `42` | mindstream idle computation |

### Filter syntax (shared by `list`, `count`, `mark`)

- `k=v` exact — `k!=v` not equal — `k~=v` prefix — `k*=v` substring
- Multiple `--where` compose with AND

### Order syntax (multi-key left-to-right for `list`)

- `field` — ASC (numeric if parseable, else lex)
- `field:asc` / `field:desc` — explicit direction
- `field:enum=a,b,c` — explicit enum mapping
- `field:numeric_ref` — strip alpha prefix, sort by numeric tail (`i2` < `i10`)
- Final tie-break is `created_at` ASC for stable byte-for-byte output

### Output formats (for `list`)

- `json` (default) — pretty JSON array
- `tsv` — tab-separated per `--fields`
- `kv` — `key=value` per line, blank line between records

### Exit codes

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | file not found / IO error |
| 2 | invalid filter / order syntax |
| 3 | field not found (`get`, `latest-field`, `seconds-since`) |

## Files

**New:**
- `hecks_life/src/heki_query.rs` — pure filter/order/project logic (150 LoC + 80 LoC tests)
- `hecks_life/tests/heki_query_test.rs` — 22 integration tests (incl. 3 byte-for-byte parity tests)

**Modified:**
- `hecks_life/src/lib.rs` — `pub mod heki_query;`
- `hecks_life/src/main.rs` — `run_heki` refactored; per-command helpers + query options parser

## Test plan

- [x] `cargo test --release` — all 159 tests green (22 new + 137 pre-existing)
- [x] `cargo test --release heki_query` — 22/22 pass (including 3 parity tests)
- [x] Byte-for-byte parity verified against current `python3 -c` shapes:
  - `inbox.sh list queued` — same TSV rows as Python
  - `statusline-command.sh` fatigue_state extraction — same scalar
  - `mindstream.sh` idle seconds — within 2s of Python (bounded by clock drift between runs)
- [x] Eyeballed against live `hecks_conception/information/inbox.heki` — 21 queued items, next-ref = i40
- [x] Pizzas smoke — unaffected (no heki schema change)

## What's ready for Phase B

Phase B can now do pure find/replace sweeps across:
- `inbox.sh` — 4 python blocks → `heki next-ref` + `heki list --where`
- `statusline-command.sh` — 6 python blocks → `heki latest-field` + `heki count --where`
- `mindstream.sh` — 3 python blocks → `heki seconds-since` + `heki latest-field`
- `pulse_organs.sh` — 12 python blocks → `heki list --where` + `heki latest-field`
- `mark_musing_shown.py` — whole file → single `heki mark` invocation
- `test_miette.sh` — 53 python blocks → `heki latest-field` + `heki get`
- Plus the rest of the 120 occurrences across 17 files

## Antibody

All touched files exempt: `[antibody-exempt: hecks-life heki subcommand expansion; prerequisite for i37 Phase B. Retires when heki dispatch moves to a bluebook + hecksagon.]`