### PR TITLE
feat: Ruby-side heki reader (prereq for i30 fuzzer)

### DIFF
--- a/lib/hecks/heki/reader.rb
+++ b/lib/hecks/heki/reader.rb
@@ -1,0 +1,46 @@
+# Hecks::Heki::Reader
+#
+# Purpose: Ruby-side reader for .heki files. Parses the binary envelope
+# used by the Rust hecks-life runtime (4-byte "HEKI" magic, big-endian
+# u32 record count, zlib-deflated JSON payload) and returns the
+# decoded hash of records. Prerequisite for the i30 differential
+# fuzzer, which round-trips .heki files between Ruby and Rust to
+# detect format drift.
+#
+# Usage:
+#   data = Hecks::Heki::Reader.read("hecks_conception/information/identity.heki")
+#   data.each { |id, record| puts id }
+#
+require "zlib"
+require "json"
+
+module Hecks
+  module Heki
+    MAGIC = "HEKI".b
+
+    class InvalidFormatError < StandardError; end
+
+    module Reader
+      module_function
+
+      def read(path)
+        bytes = File.binread(path)
+        raise InvalidFormatError, "bad magic" unless bytes.start_with?(MAGIC)
+        raise InvalidFormatError, "truncated header" if bytes.bytesize < 8
+        count = bytes[4, 4].unpack1("N")   # big-endian u32
+        payload = bytes[8..] || "".b
+        begin
+          inflated = Zlib::Inflate.inflate(payload)
+        rescue Zlib::DataError => e
+          raise InvalidFormatError, "zlib: #{e.message}"
+        end
+        data = JSON.parse(inflated)
+        raise InvalidFormatError, "not hash" unless data.is_a?(Hash)
+        raise InvalidFormatError, "count mismatch #{count} vs #{data.size}" if count != data.size
+        data
+      rescue Errno::ENOENT
+        raise InvalidFormatError, "file not found: #{path}"
+      end
+    end
+  end
+end

--- a/spec/hecks/heki/reader_spec.rb
+++ b/spec/hecks/heki/reader_spec.rb
@@ -1,0 +1,57 @@
+# spec/hecks/heki/reader_spec.rb
+#
+# Contract for Hecks::Heki::Reader. Reads an existing .heki produced
+# by the Rust runtime, and validates the three InvalidFormatError
+# surfaces (bad magic, truncated header, corrupted zlib).
+#
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)
+require "hecks/heki/reader"
+require "tempfile"
+
+RSpec.describe Hecks::Heki::Reader do
+  describe ".read" do
+    it "reads an existing .heki file and returns a hash of records with ids" do
+      path = File.expand_path("../../../hecks_conception/information/identity.heki", __dir__)
+      data = described_class.read(path)
+      expect(data).to be_a(Hash)
+      expect(data.size).to be >= 1
+      data.each_value do |record|
+        expect(record).to be_a(Hash)
+        expect(record).to have_key("id")
+      end
+    end
+
+    it "raises InvalidFormatError on wrong magic" do
+      Tempfile.create(["bad_magic", ".heki"]) do |f|
+        f.binmode
+        f.write("ZZZZ\x00\x00\x00\x00".b)
+        f.flush
+        expect { described_class.read(f.path) }.to raise_error(
+          Hecks::Heki::InvalidFormatError, /bad magic/
+        )
+      end
+    end
+
+    it "raises InvalidFormatError on truncated file (magic only, no count/payload)" do
+      Tempfile.create(["truncated", ".heki"]) do |f|
+        f.binmode
+        f.write("HEKI".b)
+        f.flush
+        expect { described_class.read(f.path) }.to raise_error(
+          Hecks::Heki::InvalidFormatError
+        )
+      end
+    end
+
+    it "raises InvalidFormatError on corrupted zlib payload" do
+      Tempfile.create(["bad_zlib", ".heki"]) do |f|
+        f.binmode
+        f.write("HEKI\x00\x00\x00\x01".b + "not zlib".b)
+        f.flush
+        expect { described_class.read(f.path) }.to raise_error(
+          Hecks::Heki::InvalidFormatError, /zlib/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Hecks::Heki::Reader.read(path)` — parses the Rust hecks-life binary envelope (`HEKI` magic + u32 big-endian record count + zlib-deflated JSON) and returns the decoded hash of records.
- Validates format at every boundary: raises `Hecks::Heki::InvalidFormatError` on missing file, bad magic, truncated header, corrupted zlib, non-hash payload, or count mismatch.
- Prerequisite for the i30 differential fuzzer (round-trips `.heki` files between Ruby and Rust to detect format drift).

## Example usage

```ruby
require "hecks/heki/reader"

data = Hecks::Heki::Reader.read("hecks_conception/information/identity.heki")
data.each { |id, record| puts "#{id}: #{record["name"]}" }
```

## Scope & size

- `lib/hecks/heki/reader.rb` — 46 lines (doc header + ~30 LoC)
- `spec/hecks/heki/reader_spec.rb` — 4 examples, runs in <5ms
- Antibody-exempted in commit message (Ruby prereq, retires when runtime ports to cross-runtime state via bluebook)

## Test plan

- [x] `bundle exec rspec spec/hecks/heki/reader_spec.rb` — 4/4 passing, <5ms
- [x] Reads a real `.heki` produced by `hecks-life` (`identity.heki`) and confirms every record has an `id` field
- [x] Raises on bad magic / truncated header / corrupted zlib