### PR TITLE
test: fix 4 stale behaviors tests expecting duplicate cascade (PR #256 collateral)

### DIFF
--- a/hecks_conception/aggregates/being.behaviors
+++ b/hecks_conception/aggregates/being.behaviors
@@ -21,7 +21,7 @@ Hecks.behaviors "Being" do
     setup  "ConceiveBeing", name: "sample", vision: "sample"
     setup  "ConnectNerve", name: "sample", from_domain: "sample", from_event: "sample", to_domain: "sample", to_command: "sample"
     input  domain_name: "sample", domain_version: "sample", source_path: "sample", grafted_at: "sample"
-    expect emits: ["DomainGrafted", "NerveConnected", "NerveConnected", "NerveConnected", "NerveConnected"]
+    expect emits: ["DomainGrafted", "NerveConnected"]
   end
 
   test "ShedDomain sets domain_name" do
@@ -82,7 +82,7 @@ Hecks.behaviors "Being" do
     setup  "ConceiveBeing", name: "sample", vision: "sample"
     setup  "ConnectNerve", name: "sample", from_domain: "sample", from_event: "sample", to_domain: "sample", to_command: "sample"
     input  domain_name: "sample", new_version: "sample"
-    expect emits: ["OrganUpgraded", "DomainGrafted", "NerveConnected", "NerveConnected", "NerveConnected", "NerveConnected"]
+    expect emits: ["OrganUpgraded", "DomainGrafted", "NerveConnected"]
   end
 
 

--- a/hecks_conception/aggregates/mindstream.behaviors
+++ b/hecks_conception/aggregates/mindstream.behaviors
@@ -10,7 +10,14 @@ Hecks.behaviors "Mindstream" do
 
   test "MindstreamTick cascades through policy chain" do
     tests "MindstreamTick", on: "Tick", kind: :cascade
-    expect emits: ["Ticked", "BodyPulse", "SignalsConsolidated", "SynapsesPruned", "DisplayUpdated", "MusingsPruned"]
+    # After PR #261 (BodyPulse rewiring): EmitPulseOnTick triggers
+    # `Pulse.Emit` via `across "Pulse"` — Pulse lives in its own
+    # bluebook. The single-bluebook behaviors runner can't cross
+    # that boundary, so the cascade terminates at `Ticked`. The
+    # downstream fanout (BodyPulse → Consolidate/Prune/Display/
+    # PruneMusings) is now asserted in the respective subscriber
+    # bluebooks' cascade tests.
+    expect emits: ["Ticked"]
   end
 
 

--- a/hecks_conception/nursery/pest_control/pest_control.behaviors
+++ b/hecks_conception/nursery/pest_control/pest_control.behaviors
@@ -16,7 +16,7 @@ Hecks.behaviors "PestControl" do
     setup  "ScheduleFollowUp", visit_date: "sample", purpose: "sample"
     setup  "StockChemical", product_name: "sample", epa_registration: "sample", active_ingredient: "sample", quantity_on_hand: 1.0, unit: "sample", expiration_date: "sample"
     input  customer_name: "sample", phone: "sample", email: "sample", service_address: "sample", property_type: "sample"
-    expect emits: ["AccountOpened", "InspectionConducted", "TreatmentApplied", "ReentryTimeRecorded", "FollowUpScheduled", "ChemicalUsed", "InspectionConducted", "TreatmentApplied", "ReentryTimeRecorded", "FollowUpScheduled", "ChemicalUsed"]
+    expect emits: ["AccountOpened", "InspectionConducted", "TreatmentApplied", "ReentryTimeRecorded", "FollowUpScheduled", "ChemicalUsed"]
   end
 
   test "SuspendAccount runs" do

--- a/hecks_conception/nursery/wedding_planning/wedding_planning.behaviors
+++ b/hecks_conception/nursery/wedding_planning/wedding_planning.behaviors
@@ -14,7 +14,7 @@ Hecks.behaviors "WeddingPlanning" do
     setup  "AllocateBudget", category: "sample", allocated_amount: 1.0
     setup  "BookVendor", vendor_name: "sample", service_type: "sample", contract_amount: 1.0, deposit_paid: 1.0
     input  couple_names: "sample", wedding_date: "sample", venue_name: "sample", total_budget: 1.0, expected_guests: 1
-    expect emits: ["WeddingPlanned", "BudgetAllocated", "BudgetAllocated", "VendorBooked", "ExpenseRecorded"]
+    expect emits: ["WeddingPlanned", "BudgetAllocated", "VendorBooked", "ExpenseRecorded"]
   end
 
   test "FinalizeDetails runs" do


### PR DESCRIPTION
## Summary

Four `.behaviors` files held stale `expect emits: [...]` assertions that pre-dated the recent cascade hygiene work. With them fixed, the Rust behaviors suite goes **453/457 → 457/457** green.

Three are direct PR #256 collateral — the duplicate-policy cascade fix deduplicated N-fold emit repetition. The fourth (mindstream) is PR #261 collateral — the BodyPulse rewiring moved the downstream fanout behind a cross-bluebook boundary the single-bluebook behaviors runner can't traverse.

## Per-file before/after

### `hecks_conception/aggregates/being.behaviors` (2 assertions)

**GraftDomain cascades through policy chain**
- was: `["DomainGrafted", "NerveConnected", "NerveConnected", "NerveConnected", "NerveConnected"]`
- now: `["DomainGrafted", "NerveConnected"]`

**UpgradeOrgan cascades through policy chain**
- was: `["OrganUpgraded", "DomainGrafted", "NerveConnected", "NerveConnected", "NerveConnected", "NerveConnected"]`
- now: `["OrganUpgraded", "DomainGrafted", "NerveConnected"]`

### `hecks_conception/nursery/wedding_planning/wedding_planning.behaviors` (1 assertion)

**PlanWedding cascades through policy chain**
- was: `["WeddingPlanned", "BudgetAllocated", "BudgetAllocated", "VendorBooked", "ExpenseRecorded"]`
- now: `["WeddingPlanned", "BudgetAllocated", "VendorBooked", "ExpenseRecorded"]`

### `hecks_conception/nursery/pest_control/pest_control.behaviors` (1 assertion)

**OpenAccount cascades through policy chain**
- was: the 5-event subchain (`InspectionConducted, TreatmentApplied, ReentryTimeRecorded, FollowUpScheduled, ChemicalUsed`) asserted **twice** after `AccountOpened`
- now: once

### `hecks_conception/aggregates/mindstream.behaviors` (different class)

**MindstreamTick cascades through policy chain**
- was: `["Ticked", "BodyPulse", "SignalsConsolidated", "SynapsesPruned", "DisplayUpdated", "MusingsPruned"]`
- now: `["Ticked"]`

The `EmitPulseOnTick` policy triggers `Pulse.Emit` via `across "Pulse"` after PR #261. `Pulse` lives in its own bluebook; when the behaviors runner boots the Mindstream bluebook alone, `Pulse.Emit` isn't registered, so the cascade terminates at `Ticked`. The downstream fanout is now exercised where the subscribers live.

## Behaviors pass count

Before: 453/457 suites green
After:  **457/457** suites green (8210 tests, 0 failed, 0 errored)

## Test plan
- [x] `hecks-life behaviors <each of the 4 files>` — all pass 100%
- [x] Full suite: `find hecks_conception -name '*.behaviors' -not -path '*/worktrees/*' -exec hecks-life behaviors {} \;` — 457/457 green, 8210 passed