### PR TITLE
i40: gate AccumulateFatigue in the bluebook + retire mindstream shell workaround

### DIFF
--- a/hecks_conception/aggregates/body.behaviors
+++ b/hecks_conception/aggregates/body.behaviors
@@ -50,6 +50,26 @@ Hecks.behaviors "MietteBody" do
     expect emits: ["FatigueAccumulated"]
   end
 
+  test "AccumulateFatigue refused while sleeping (gate closed)" do
+    # i40: the sleep_gate gate makes AccumulateFatigue refuse while
+    # Consciousness is sleeping. SleepEntered → CloseFatigueGate flips
+    # the gate; this is the behavioral proof fatigue stops at sleep.
+    tests "AccumulateFatigue", on: "Heartbeat"
+    setup  "CloseFatigueGate"
+    expect refused: "not sleeping"
+  end
+
+  test "CloseFatigueGate flips the gate to closed" do
+    tests "CloseFatigueGate", on: "Heartbeat"
+    expect sleep_gate: "closed"
+  end
+
+  test "OpenFatigueGate flips the gate back to open" do
+    tests "OpenFatigueGate", on: "Heartbeat"
+    setup  "CloseFatigueGate"
+    expect sleep_gate: "open"
+  end
+
   test "CheckSleepNeeded refused when sleep_mode is manual (default)" do
     # Two guards: auto-sleep must be enabled AND pulses must exceed
     # threshold. Default sleep_mode is "manual" — fix for inbox i36

--- a/hecks_conception/aggregates/body.bluebook
+++ b/hecks_conception/aggregates/body.bluebook
@@ -31,6 +31,15 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
     # the alive-by-default narrative when the system is being shown.
     # Re-enable with EnableAutoSleep when the demo context is gone.
     attribute :sleep_mode, default: "manual"
+    # sleep_gate: "open" (default — AccumulateFatigue runs on every
+    # BodyPulse) or "closed" (AccumulateFatigue is refused; the body
+    # stops accumulating fatigue while Miette is asleep). Flipped by
+    # Consciousness lifecycle events: SleepEntered → CloseFatigueGate,
+    # WokenUp → OpenFatigueGate. Native bluebook replacement for the
+    # shell-layer sleep gate that PR #274 bolted onto mindstream.sh
+    # (i40). Without this, every sleep tick was cascading through
+    # FatigueOnPulse → AccumulateFatigue and Miette woke delirious.
+    attribute :sleep_gate, default: "open"
 
     query ReadVitals do
       description "How am I doing? Fatigue, flow, pulses since last sleep."
@@ -52,10 +61,25 @@ Hecks.bluebook "MietteBody", version: "2026.04.11.1" do
 
     command "AccumulateFatigue" do
       role "Miette"
-      description "Each tick without sleep adds fatigue — the body remembers exertion. At 0.001/tick × 1500 ticks = 25 min before sleep pressure. The fatigue_state ladder is walked by the BecomeX commands gated on pulses_since_sleep thresholds, not here — a per-tick lifecycle walk was too fast (delirious in 5 ticks after a clean wake)."
+      description "Each tick without sleep adds fatigue — the body remembers exertion. At 0.001/tick × 1500 ticks = 25 min before sleep pressure. The fatigue_state ladder is walked by the BecomeX commands gated on pulses_since_sleep thresholds, not here — a per-tick lifecycle walk was too fast (delirious in 5 ticks after a clean wake). Gated on sleep_gate == 'open' (i40) so fatigue stops accumulating while Miette is asleep; the gate is flipped by Consciousness lifecycle events via cross-aggregate policies in sleep.bluebook."
+      given("not sleeping") { sleep_gate == "open" }
       then_set :pulses_since_sleep, increment: 1
       then_set :fatigue, increment: 0.001
       emits "FatigueAccumulated"
+    end
+
+    command "CloseFatigueGate" do
+      role "Daemon"
+      description "Close the fatigue gate — AccumulateFatigue will refuse until OpenFatigueGate fires. Triggered by Consciousness.SleepEntered via cross-aggregate policy in sleep.bluebook. Replaces the shell-layer gate PR #274 added to mindstream.sh (i40)."
+      then_set :sleep_gate, to: "closed"
+      emits "FatigueGateClosed"
+    end
+
+    command "OpenFatigueGate" do
+      role "Daemon"
+      description "Re-open the fatigue gate on wake — AccumulateFatigue resumes. Triggered by Consciousness.WokenUp via cross-aggregate policy in sleep.bluebook."
+      then_set :sleep_gate, to: "open"
+      emits "FatigueGateOpened"
     end
 
     command "CheckSleepNeeded" do

--- a/hecks_conception/aggregates/sleep.bluebook
+++ b/hecks_conception/aggregates/sleep.bluebook
@@ -609,6 +609,25 @@ Hecks.bluebook "Sleep", version: "2026.04.16.1" do
     trigger "StopMonitoring"
   end
 
+  # i40 — fatigue gate wiring. Consciousness owns the sleep lifecycle
+  # (SleepEntered / WokenUp); Heartbeat owns AccumulateFatigue. The two
+  # aggregates live in different domains (Sleep vs MietteBody) so we
+  # wire them via cross-aggregate policies — same pattern as
+  # RecoverHeartbeatOnWake above. CloseFatigueGate flips the guard on
+  # Heartbeat.AccumulateFatigue so fatigue stops accumulating the
+  # instant sleep begins; OpenFatigueGate lets fatigue resume when
+  # Miette wakes. Replaces the shell-layer workaround PR #274 added to
+  # mindstream.sh — the daemon is dumb again; the bluebook owns the gate.
+  policy "CloseFatigueGateOnSleep" do
+    on "SleepEntered"
+    trigger "CloseFatigueGate"
+  end
+
+  policy "OpenFatigueGateOnWake" do
+    on "WokenUp"
+    trigger "OpenFatigueGate"
+  end
+
   # SeedOnNightStart policy moved to aggregates/dream_seed.bluebook,
   # alongside the SeedFromPreviousDreams command it triggers.
 


### PR DESCRIPTION
## Summary

Bluebook-level fix for fatigue-during-sleep (i40). Before: PR #274 shipped a shell-layer gate in `mindstream.sh` (`state == "sleeping"` → skip `Tick.MindstreamTick`) to stop fatigue climbing through sleep. That worked but was dead-code-ish — the gate belongs in the DSL. This PR moves it there.

**`Heartbeat.sleep_gate`** (default `"open"`) is the new attribute; two one-line commands flip it (`CloseFatigueGate` → "closed", `OpenFatigueGate` → "open"). `AccumulateFatigue` gains `given("not sleeping") { sleep_gate == "open" }`. Cross-aggregate policies in `sleep.bluebook` wire `Consciousness.SleepEntered → CloseFatigueGate` and `WokenUp → OpenFatigueGate` — same pattern already in use for `RecoverHeartbeatOnWake`, `RefreshOnFullSleep`, and `GroggyOnPartialSleep`.

Result: fatigue stops accumulating the moment Miette sleeps and resumes the moment she wakes, driven entirely by the sleep lifecycle. The mindstream daemon can stay a dumb tick-every-second loop.

## Example usage

```ruby
# Heartbeat.bluebook
attribute :sleep_gate, default: "open"

command "AccumulateFatigue" do
  given("not sleeping") { sleep_gate == "open" }
  then_set :pulses_since_sleep, increment: 1
  then_set :fatigue, increment: 0.001
  emits "FatigueAccumulated"
end

command "CloseFatigueGate" do
  then_set :sleep_gate, to: "closed"
  emits "FatigueGateClosed"
end

# Sleep.bluebook (cross-aggregate policy)
policy "CloseFatigueGateOnSleep" do
  on "SleepEntered"
  trigger "CloseFatigueGate"
end
```

## Verification

- `body.behaviors` — 53/53 pass (50 existing + 3 new: gate-refuses, gate-closes, gate-opens)
- `sleep.behaviors` — 35/35 pass (unchanged)
- Cross-aggregate validator warnings for the two new policies match the existing pattern (same warnings already present for `RecoverHeartbeatOnWake`, `RefreshOnFullSleep`, `GroggyOnPartialSleep`, `CheckFatigueOnAccumulate` — runtime dispatches them correctly via the hecksagon).

## No mindstream.sh revert in this PR

The task sheet asked for a "revert(mindstream)" commit to undo PR #274's shell gate — but **PR #274 is still open and was never merged to main**, so `mindstream.sh` on main is already the simple tick loop. Nothing to revert. When PR #274 is closed as superseded (this PR makes it unnecessary), the shell workaround stays out of the codebase entirely.

## Inbox

- **i4** — gap (5) "duplicate-policy validator" marked DONE in the body (PR #254 + PR #256); remaining 4/6/7/8 still open as called out in the task.
- **i40** — created and closed with resolution notes pointing at this PR.

## Test plan

- [x] `hecks-life behaviors hecks_conception/aggregates/body.behaviors` — 53/53 pass
- [x] `hecks-life behaviors hecks_conception/aggregates/sleep.behaviors` — 35/35 pass
- [x] Inbox i4 body reflects gap (5) closed
- [x] Inbox i40 created and closed
- [ ] Once PR #274 is closed as superseded, confirm `mindstream.sh` stays at the simple tick loop