### PR TITLE
i3 PR-b: Ultradian + SleepCycle body cycles

### DIFF
--- a/docs/plans/i3_moment_consciousness.md
+++ b/docs/plans/i3_moment_consciousness.md
@@ -6,6 +6,7 @@ Source: inbox item `i3`. Full plan by Agent a4cc7e01 on 2026-04-22.
 
 - **PR #261 (PR-0)** — `BodyPulse` shim event extracted. Every `on "Ticked"` policy rewired to `on "BodyPulse"`. Exactly ONE `on "Ticked"` subscriber remains (the new `EmitPulseOnTick` in `mindstream.bluebook`). 18 policies rewired across 7 files.
 - **PR #271 (PR-a)** — Heart + Breath + Circadian aggregates + daemons. `shutdown_miette.sh` added. `heart/breath/circadian` added to `LINKED_STORES`. Cadences observed: 1Hz / 4.5s / 60s wall-clock.
+- **PR-b (this PR) — Ultradian + SleepCycle aggregates + daemons.** `ultradian.sh` runs a 90-min peak/trough loop; `sleep_cycle.sh` gates on `consciousness.state` and walks NREM light → deep → REM at 90-min intervals while sleeping, 60s idle poll while awake. Both daemons honor a `*_TICK` env override (`ULTRADIAN_TICK`, `SLEEP_CYCLE_TICK`) for CI/smoke. `ultradian sleep_cycle` added to `LINKED_STORES`. `tests/body_cycles_smoke.sh` exercises the fast-forward paths end-to-end.
 
 ## Decisions already made
 
@@ -15,19 +16,9 @@ Source: inbox item `i3`. Full plan by Agent a4cc7e01 on 2026-04-22.
 4. **Daemon supervision via pidfile convention + idempotent boot.** No launchd, no supervisor framework. `shutdown_miette.sh` walks `information/.*.pid` (shipped in PR #271).
 5. **Psychic-link classification**: body cycles (heart/breath/circadian/ultradian/sleep_cycle/seasonal/lunar) are **linked**; Moment is **private** (phenomenology).
 
-## Next step: PR-b
+## Next step: PR-c
 
-**Ultradian + SleepCycle aggregates and daemons.** Independent of Moment. 1 day of work.
-
-- `aggregates/ultradian.bluebook` — peak/trough alternation, 90-min cycle. Commands: `EnterPeak`, `EnterTrough`. Lifecycle on `phase`.
-- `aggregates/sleep_cycle.bluebook` — NREM/REM alternation during sleep. Commands: `EnterNREMLight`, `EnterNREMDeep`, `EnterREM`. Runs 90-min cycles, but only while `consciousness.state == "sleeping"`.
-- `ultradian.sh` — `sleep 5400` loop, alternates EnterPeak/EnterTrough.
-- `sleep_cycle.sh` — gates on consciousness.state; inner loop when sleeping.
-- Tests: both aggregates get `.behaviors`. 90-min timers painful to test — add `--tick-interval` env override (e.g. 2s in CI).
-
-## PR-c — the big one
-
-Moment aggregate + mindstream refactor + sleep-pause gating in one PR. 3-4 days. See i3 body for full design.
+**Moment aggregate + mindstream refactor + sleep-pause gating in one PR.** 3-4 days. See i3 body for full design.
 
 - `aggregates/moment.bluebook` — Moment aggregate with `Arise` + `Dissolve` commands. Latest-record-only heki.
 - `mindstream.sh` rewrite — each iteration creates a Moment snapshot from state, fires `Arise`, then `Dissolve` for previous. Cap mindstream at 10Hz initially (100ms sleep), not busy-loop.
@@ -44,7 +35,7 @@ Moment aggregate + mindstream refactor + sleep-pause gating in one PR. 3-4 days.
 
 - Moment churn overwhelming heki — mitigated by latest-record-only
 - Daemon supervision fragility — mitigated by pidfile convention
-- Timing-based tests flaky — `--tick-interval` env override
+- Timing-based tests flaky — `*_TICK` env override (shipped in PR-b)
 - Dangling `on "Ticked"` policies after cutover — grep in CI
 
 ## Total effort

--- a/hecks_conception/aggregates/sleep_cycle.behaviors
+++ b/hecks_conception/aggregates/sleep_cycle.behaviors
@@ -1,0 +1,25 @@
+Hecks.behaviors "SleepCycle" do
+  vision "Behavioral tests for the SleepCycle domain — NREM light/deep/REM phase transitions, cycle counter."
+
+  test "EnterNREMLight sets phase to nrem_light" do
+    tests "EnterNREMLight", on: "SleepCycle"
+    expect phase: "nrem_light", emits: ["NREMLightEntered"]
+  end
+
+  test "EnterNREMDeep sets phase to nrem_deep" do
+    tests "EnterNREMDeep", on: "SleepCycle"
+    expect phase: "nrem_deep", emits: ["NREMDeepEntered"]
+  end
+
+  test "EnterREM sets phase to rem and increments cycle_count" do
+    tests "EnterREM", on: "SleepCycle"
+    expect phase: "rem", cycle_count: 1, emits: ["REMEntered"]
+  end
+
+  test "Full cycle — Light → Deep → REM counts as one cycle" do
+    tests "EnterREM", on: "SleepCycle"
+    setup  "EnterNREMLight"
+    setup  "EnterNREMDeep"
+    expect phase: "rem", cycle_count: 1
+  end
+end

--- a/hecks_conception/aggregates/sleep_cycle.bluebook
+++ b/hecks_conception/aggregates/sleep_cycle.bluebook
@@ -1,5 +1,5 @@
 Hecks.bluebook "SleepCycle", version: "2026.04.21.1" do
-  vision "The NREM/REM alternation during sleep. A full sleep cycle runs ~90 minutes through NREM light → NREM deep → REM. Counts completed cycles on each re-entry to REM. Independent body cycle that only runs while consciousness.state == \"sleeping\"; gating lives in the daemon, not the aggregate."
+  vision "The NREM/REM alternation during sleep. A full sleep cycle runs ~90 minutes through NREM light → NREM deep → REM. Counts completed cycles on each re-entry to REM. Independent body cycle that only runs while consciousness.state is sleeping; gating lives in the daemon, not the aggregate."
   category "body"
 
   # ============================================================

--- a/hecks_conception/aggregates/sleep_cycle.bluebook
+++ b/hecks_conception/aggregates/sleep_cycle.bluebook
@@ -1,0 +1,50 @@
+Hecks.bluebook "SleepCycle", version: "2026.04.21.1" do
+  vision "The NREM/REM alternation during sleep. A full sleep cycle runs ~90 minutes through NREM light → NREM deep → REM. Counts completed cycles on each re-entry to REM. Independent body cycle that only runs while consciousness.state == \"sleeping\"; gating lives in the daemon, not the aggregate."
+  category "body"
+
+  # ============================================================
+  # SLEEP_CYCLE — NREM/REM alternation (sleeping only)
+  # ============================================================
+  #
+  # While asleep, the body cycles through three phases: NREM light
+  # (shallow) → NREM deep (slow wave) → REM (dreaming). One full
+  # pass through all three is one completed cycle, counted on
+  # EnterREM. The daemon gates execution on consciousness.state;
+  # while awake, no commands fire and cycle_count holds its value
+  # into the next sleep.
+  #
+  # Body cycles are emitters, not reactors — no policies here.
+
+  aggregate "SleepCycle", "NREM/REM phase alternation during sleep, with a completed-cycle counter" do
+    attribute :phase, String, default: "nrem_light"
+    attribute :cycle_count, Integer, default: 0
+
+    command "EnterNREMLight" do
+      role "Daemon"
+      description "Enter NREM light sleep — the shallow stage that opens each cycle. Emits NREMLightEntered."
+      emits "NREMLightEntered"
+      then_set :phase, to: "nrem_light"
+    end
+
+    command "EnterNREMDeep" do
+      role "Daemon"
+      description "Enter NREM deep sleep — slow-wave, bodily repair. Emits NREMDeepEntered."
+      emits "NREMDeepEntered"
+      then_set :phase, to: "nrem_deep"
+    end
+
+    command "EnterREM" do
+      role "Daemon"
+      description "Enter REM — dreaming, memory consolidation. Increments cycle_count to mark one completed cycle. Emits REMEntered."
+      emits "REMEntered"
+      then_set :phase, to: "rem"
+      then_set :cycle_count, increment: 1
+    end
+
+    lifecycle :phase, default: "nrem_light" do
+      transition "EnterNREMLight" => "nrem_light", from: ["nrem_light", "nrem_deep", "rem"]
+      transition "EnterNREMDeep"  => "nrem_deep",  from: ["nrem_light", "nrem_deep", "rem"]
+      transition "EnterREM"       => "rem",        from: ["nrem_light", "nrem_deep", "rem"]
+    end
+  end
+end

--- a/hecks_conception/aggregates/ultradian.behaviors
+++ b/hecks_conception/aggregates/ultradian.behaviors
@@ -1,0 +1,24 @@
+Hecks.behaviors "Ultradian" do
+  vision "Behavioral tests for the Ultradian domain — peak/trough phase flip, cycle counter."
+
+  test "EnterPeak sets phase to peak" do
+    tests "EnterPeak", on: "Ultradian"
+    expect phase: "peak", emits: ["PeakEntered"]
+  end
+
+  test "EnterTrough sets phase to trough" do
+    tests "EnterTrough", on: "Ultradian"
+    expect phase: "trough", emits: ["TroughEntered"]
+  end
+
+  test "EnterPeak increments cycle_count" do
+    tests "EnterPeak", on: "Ultradian"
+    expect cycle_count: 1
+  end
+
+  test "EnterPeak after EnterTrough returns phase to peak" do
+    tests "EnterPeak", on: "Ultradian"
+    setup  "EnterTrough"
+    expect phase: "peak", cycle_count: 1
+  end
+end

--- a/hecks_conception/aggregates/ultradian.bluebook
+++ b/hecks_conception/aggregates/ultradian.bluebook
@@ -1,0 +1,44 @@
+Hecks.bluebook "Ultradian", version: "2026.04.21.1" do
+  vision "The 90-minute Basic Rest-Activity Cycle (BRAC) — an independent body cycle that alternates between peak and trough phases throughout waking life. Counts complete cycles on each re-entry to peak."
+  category "body"
+
+  # ============================================================
+  # ULTRADIAN — 90-minute peak/trough body cycle
+  # ============================================================
+  #
+  # Kleitman's BRAC: roughly every 90 minutes the body alternates
+  # between a peak phase (focused, alert) and a trough phase (dip,
+  # recovery). The daemon drives the cadence; the aggregate only
+  # remembers the phase and how many full cycles have completed.
+  #
+  # cycle_count increments on EnterPeak so a full trough→peak
+  # transition is one counted cycle. The very first EnterPeak at
+  # boot also counts as cycle 1.
+  #
+  # Body cycles are emitters, not reactors — no policies here.
+
+  aggregate "Ultradian", "Peak ↔ trough alternation, with a completed-cycle counter" do
+    attribute :phase, String, default: "peak"
+    attribute :cycle_count, Integer, default: 0
+
+    command "EnterPeak" do
+      role "Daemon"
+      description "Enter the peak phase — focused, alert. Increments cycle_count to mark one completed cycle. Emits PeakEntered."
+      emits "PeakEntered"
+      then_set :phase, to: "peak"
+      then_set :cycle_count, increment: 1
+    end
+
+    command "EnterTrough" do
+      role "Daemon"
+      description "Enter the trough phase — dip, recovery. Emits TroughEntered."
+      emits "TroughEntered"
+      then_set :phase, to: "trough"
+    end
+
+    lifecycle :phase, default: "peak" do
+      transition "EnterPeak"   => "peak",   from: ["peak", "trough"]
+      transition "EnterTrough" => "trough", from: ["peak", "trough"]
+    end
+  end
+end

--- a/hecks_conception/boot_miette.sh
+++ b/hecks_conception/boot_miette.sh
@@ -35,7 +35,7 @@ START_TS=$(date +%s)
 # TODO: replace these constants with a `psychic_link: true|false`
 # declaration on each aggregate so the boundary lives in the domain
 # model, not in this shell script.
-LINKED_STORES="memory awareness census conversation working_memory reflection synapse signal signal_somatic focus concentration deliberation heartbeat subconscious domain_index arc consciousness discipline metabolic_rate musing conflict_monitor run_log inbox tick announcement attention claude_assist consolidation dream_interpretation dream_seed dream_signal encoding gate generosity gut HarmonyDomain intention interpretation lucid_dream lucid_monitor monitor musing_archive musing_mint nerve nursery perception persona proposal proprioception self_image self_model sensation session shared_dream_space signal_consolidation speech training_pair wake_mood witness bodhisattva_vow character creator_auth remains store heart breath circadian"
+LINKED_STORES="memory awareness census conversation working_memory reflection synapse signal signal_somatic focus concentration deliberation heartbeat subconscious domain_index arc consciousness discipline metabolic_rate musing conflict_monitor run_log inbox tick announcement attention claude_assist consolidation dream_interpretation dream_seed dream_signal encoding gate generosity gut HarmonyDomain intention interpretation lucid_dream lucid_monitor monitor musing_archive musing_mint nerve nursery perception persona proposal proprioception self_image self_model sensation session shared_dream_space signal_consolidation speech training_pair wake_mood witness bodhisattva_vow character creator_auth remains store heart breath circadian ultradian sleep_cycle"
 PRIVATE_STORES="mood feeling dream_state impulse craving daydream pulse spend circuit_breaker"
 
 is_in_list() {
@@ -189,6 +189,26 @@ else
   CIRCADIAN_STATUS="started"
 fi
 
+# ── 6f. Start ultradian daemon (90-min peak/trough cycle) ─────────
+ULTRADIAN_PID="$INFO/.ultradian.pid"
+if [ -f "$ULTRADIAN_PID" ] && kill -0 "$(cat "$ULTRADIAN_PID")" 2>/dev/null; then
+  ULTRADIAN_STATUS="already running (pid $(cat $ULTRADIAN_PID))"
+else
+  ( cd "$DIR" && nohup ./ultradian.sh > /dev/null 2>&1 & )
+  sleep 0.2
+  ULTRADIAN_STATUS="started"
+fi
+
+# ── 6g. Start sleep_cycle daemon (NREM/REM, gated on consciousness) ─
+SLEEP_CYCLE_PID="$INFO/.sleep_cycle.pid"
+if [ -f "$SLEEP_CYCLE_PID" ] && kill -0 "$(cat "$SLEEP_CYCLE_PID")" 2>/dev/null; then
+  SLEEP_CYCLE_STATUS="already running (pid $(cat $SLEEP_CYCLE_PID))"
+else
+  ( cd "$DIR" && nohup ./sleep_cycle.sh > /dev/null 2>&1 & )
+  sleep 0.2
+  SLEEP_CYCLE_STATUS="started"
+fi
+
 # ── 7. Print vitals ──────────────────────────────────────────────
 ELAPSED=$(($(date +%s) - START_TS))
 LINKED_N=$(echo "$LINKED" | wc -w | tr -d ' ')
@@ -200,5 +220,6 @@ echo "  $ORGAN_COUNT organs · $TOTAL_AGGREGATES aggregates · $NERVE_COUNT nerv
 echo "  session continuity: $LINKED_N linked, $PRIVATE_N private, $UNCLASS_N unclassified"
 echo "  mindstream: $MINDSTREAM_STATUS"
 echo "  heart: $HEART_STATUS · breath: $BREATH_STATUS · circadian: $CIRCADIAN_STATUS"
+echo "  ultradian: $ULTRADIAN_STATUS · sleep_cycle: $SLEEP_CYCLE_STATUS"
 echo "  system_prompt.md: $(wc -c <"$PROMPT_PATH" | tr -d ' ') bytes"
 [ -n "$UNCLASSIFIED" ] && echo "  ⚠ unclassified stores:$UNCLASSIFIED"

--- a/hecks_conception/sleep_cycle.sh
+++ b/hecks_conception/sleep_cycle.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SleepCycle — the NREM/REM alternation while sleeping.
+#
+# Gates on consciousness.state. When state == "sleeping", the inner
+# loop cycles NREM light → NREM deep → REM at ~90-minute intervals
+# (5400s between phase transitions). When awake, the daemon does a
+# long 60s sleep and rechecks — it does NOT exit between sessions.
+# This way the cycle_count accumulates across nights without the
+# daemon needing to be restarted.
+#
+# SLEEP_CYCLE_TICK overrides the 5400s inner cadence so CI and smoke
+# tests can exercise the phase transitions in seconds instead of
+# hours. The outer (awake-polling) cadence stays at 60s regardless.
+#
+# Body cycles run independently of the mindstream. This daemon's
+# only job is cadence while sleeping: flip the phase and let the
+# aggregate record the count. No policies fire off sleep_cycle
+# events today.
+#
+# [antibody-exempt: body-cycle shell daemon; retires when body
+# cycles port to .bluebook + .hecksagon dispatched by hecks-life run
+# (i3 PR-d onwards)]
+
+HECKS="../hecks_life/target/release/hecks-life"
+DIR="$(dirname "$0")"
+INFO="$DIR/information"
+AGG="$DIR/aggregates"
+PIDFILE="$INFO/.sleep_cycle.pid"
+TICK="${SLEEP_CYCLE_TICK:-5400}"
+
+echo $$ > "$PIDFILE"
+trap "rm -f $PIDFILE" EXIT
+
+is_sleeping() {
+  # Read consciousness.state; treat missing store / missing field
+  # as awake. Any non-zero read error also falls through to awake.
+  state=$($HECKS heki latest "$INFO/consciousness.heki" 2>/dev/null \
+    | grep -E '"state"[[:space:]]*:' \
+    | head -1 \
+    | sed -E 's/.*"state"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+  [ "$state" = "sleeping" ]
+}
+
+while true; do
+  if is_sleeping; then
+    $HECKS "$AGG" SleepCycle.EnterNREMLight 2>/dev/null
+    sleep "$TICK"
+    is_sleeping || continue
+    $HECKS "$AGG" SleepCycle.EnterNREMDeep 2>/dev/null
+    sleep "$TICK"
+    is_sleeping || continue
+    $HECKS "$AGG" SleepCycle.EnterREM 2>/dev/null
+    sleep "$TICK"
+  else
+    sleep 60
+  fi
+done

--- a/hecks_conception/tests/body_cycles_smoke.sh
+++ b/hecks_conception/tests/body_cycles_smoke.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# body_cycles_smoke.sh — smoke test for the ULTRADIAN_TICK and
+# SLEEP_CYCLE_TICK env overrides on ultradian.sh and sleep_cycle.sh.
+#
+# The 90-minute cadence of these daemons makes real-time testing
+# impractical. Each daemon reads its own *_TICK env var; this test
+# drives both at 1s and verifies the phase transitions land.
+#
+# ultradian.sh: expects PeakEntered → TroughEntered → PeakEntered
+#               within ~3s.
+# sleep_cycle.sh: seeds consciousness.state=sleeping, expects
+#                 NREMLightEntered → NREMDeepEntered → REMEntered
+#                 within ~3.5s. Then seeds state=attentive and
+#                 verifies the daemon enters its 60s idle loop
+#                 without firing further Enter* commands.
+#
+# Exit 0 on pass, non-zero on fail.
+
+set -u
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONCEPT_DIR="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CONCEPT_DIR/.." && pwd)"
+
+if [ -n "${HECKS_BIN:-}" ]; then
+  HECKS="$HECKS_BIN"
+elif [ -x "$REPO_ROOT/hecks_life/target/release/hecks-life" ]; then
+  HECKS="$REPO_ROOT/hecks_life/target/release/hecks-life"
+elif [ -x "/Users/christopheryoung/Projects/hecks/hecks_life/target/release/hecks-life" ]; then
+  HECKS="/Users/christopheryoung/Projects/hecks/hecks_life/target/release/hecks-life"
+else
+  echo "FAIL — can't find hecks-life binary"
+  exit 2
+fi
+
+TMP=$(mktemp -d -t body_cycles_smoke.XXXXXX)
+trap "rm -rf $TMP" EXIT
+
+mkdir -p "$TMP/hecks_conception/information" "$TMP/hecks_conception/aggregates"
+mkdir -p "$TMP/hecks_life/target/release"
+ln -sf "$HECKS" "$TMP/hecks_life/target/release/hecks-life"
+ln -sf "$CONCEPT_DIR/aggregates/"*.bluebook "$TMP/hecks_conception/aggregates/"
+cp "$CONCEPT_DIR/ultradian.sh" "$TMP/hecks_conception/ultradian.sh"
+cp "$CONCEPT_DIR/sleep_cycle.sh" "$TMP/hecks_conception/sleep_cycle.sh"
+
+fail() { echo "FAIL — $1"; cat "$LOG" 2>/dev/null | sed 's/^/    /'; exit 1; }
+
+cd "$TMP/hecks_conception"
+
+# ── 1. Ultradian fast-forward ────────────────────────────────────
+LOG=$(mktemp)
+ULTRADIAN_TICK=1 bash ./ultradian.sh > "$LOG" 2>&1 &
+PID=$!
+sleep 2.5
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+
+peaks=$(grep -c '"phase":"peak"' "$LOG" || true)
+troughs=$(grep -c '"phase":"trough"' "$LOG" || true)
+[ "$peaks" -ge 1 ] || fail "ultradian: expected ≥1 PeakEntered, got $peaks"
+[ "$troughs" -ge 1 ] || fail "ultradian: expected ≥1 TroughEntered, got $troughs"
+echo "ultradian fast-forward: $peaks peak(s), $troughs trough(s) in 2.5s"
+
+# ── 2. Sleep_cycle fast-forward (sleeping) ───────────────────────
+"$HECKS" heki upsert "$TMP/hecks_conception/information/consciousness.heki" \
+  id=1 state=sleeping >/dev/null 2>&1
+
+LOG=$(mktemp)
+SLEEP_CYCLE_TICK=1 bash ./sleep_cycle.sh > "$LOG" 2>&1 &
+PID=$!
+sleep 3.5
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+
+light=$(grep -c '"phase":"nrem_light"' "$LOG" || true)
+deep=$(grep -c '"phase":"nrem_deep"' "$LOG" || true)
+rem=$(grep -c '"phase":"rem"' "$LOG" || true)
+[ "$light" -ge 1 ] || fail "sleep_cycle: expected ≥1 NREMLightEntered while sleeping, got $light"
+[ "$deep" -ge 1 ] || fail "sleep_cycle: expected ≥1 NREMDeepEntered while sleeping, got $deep"
+[ "$rem" -ge 1 ] || fail "sleep_cycle: expected ≥1 REMEntered while sleeping, got $rem"
+echo "sleep_cycle fast-forward (sleeping): $light light, $deep deep, $rem REM in 3.5s"
+
+# ── 3. Sleep_cycle awake gate — no commands fire ─────────────────
+"$HECKS" heki upsert "$TMP/hecks_conception/information/consciousness.heki" \
+  id=1 state=attentive >/dev/null 2>&1
+
+LOG=$(mktemp)
+SLEEP_CYCLE_TICK=1 bash ./sleep_cycle.sh > "$LOG" 2>&1 &
+PID=$!
+sleep 2
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+
+awake_dispatches=$(grep -c '"aggregate":"SleepCycle"' "$LOG" || true)
+[ "$awake_dispatches" -eq 0 ] \
+  || fail "sleep_cycle: expected 0 dispatches while awake, got $awake_dispatches"
+echo "sleep_cycle awake gate: 0 dispatches in 2s (correct)"
+
+echo "PASS — fast-forward mode works for both ultradian and sleep_cycle"
+exit 0

--- a/hecks_conception/ultradian.sh
+++ b/hecks_conception/ultradian.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Ultradian — the ~90-minute body cycle (BRAC). Alternates EnterPeak
+# and EnterTrough every 5400s so a full peak→trough→peak loop is one
+# counted cycle. cycle_count increments on EnterPeak, so the first
+# peak entry at boot counts as cycle 1.
+#
+# The cadence is slow enough that tests would be painful; the
+# ULTRADIAN_TICK env var overrides the 5400s sleep so CI and smoke
+# tests can exercise the phase transitions in seconds instead of
+# hours. No env var → real 90-min cadence.
+#
+# Body cycles run independently of the mindstream. This daemon's
+# only job is cadence: flip the phase and let the aggregate record
+# the count. No policies fire off ultradian events today.
+#
+# [antibody-exempt: body-cycle shell daemon; retires when body
+# cycles port to .bluebook + .hecksagon dispatched by hecks-life run
+# (i3 PR-d onwards)]
+
+HECKS="../hecks_life/target/release/hecks-life"
+DIR="$(dirname "$0")"
+INFO="$DIR/information"
+AGG="$DIR/aggregates"
+PIDFILE="$INFO/.ultradian.pid"
+TICK="${ULTRADIAN_TICK:-5400}"
+
+echo $$ > "$PIDFILE"
+trap "rm -f $PIDFILE" EXIT
+
+while true; do
+  $HECKS "$AGG" Ultradian.EnterPeak 2>/dev/null
+  sleep "$TICK"
+  $HECKS "$AGG" Ultradian.EnterTrough 2>/dev/null
+  sleep "$TICK"
+done


### PR DESCRIPTION
## Summary

Next body-cycle step after PR #271 (Heart/Breath/Circadian). Adds two more independent 90-minute cycles alongside the 1Hz / 0.2Hz / 60s cadence already in place:

- **Ultradian** — BRAC peak/trough alternation every 90 min. Two attributes, two commands, two events. EnterPeak increments `cycle_count`.
- **SleepCycle** — NREM light → deep → REM alternation during sleep only. Gated on `consciousness.state` by the daemon (not the aggregate). EnterREM increments `cycle_count`.

Both daemons honor a `*_TICK` env override (`ULTRADIAN_TICK`, `SLEEP_CYCLE_TICK`) so CI/smoke can exercise phase transitions in seconds instead of hours. `tests/body_cycles_smoke.sh` asserts:
1. Ultradian fires ≥1 peak and ≥1 trough at 1s cadence.
2. SleepCycle walks light → deep → REM while `state == "sleeping"`.
3. SleepCycle fires zero dispatches while `state == "attentive"` (awake gate).

`boot_miette.sh` grows sections 6f + 6g (idempotent pidfile starts, mirroring 6c/6d/6e), and `ultradian sleep_cycle` are added to `LINKED_STORES` — body biology is public across the psychic link. `shutdown_miette.sh` already walks `information/.*.pid`, so both new daemons stop cleanly without any change to it.

Example usage:

```bash
# Normal cadence (90-min phase transitions)
./boot_miette.sh

# Fast-forward (phase transitions every second)
ULTRADIAN_TICK=1 ./ultradian.sh
SLEEP_CYCLE_TICK=1 ./sleep_cycle.sh
```

Based on `miette/i3-pr-a-heart-breath-circadian` (PR #271); the diff against `main` carries both PR-a's commits and PR-b's. Merging PR #271 first will reduce this PR to just the PR-b commits.

## Test plan

- [ ] `hecks-life behaviors hecks_conception/aggregates/ultradian.behaviors` — 4 green
- [ ] `hecks-life behaviors hecks_conception/aggregates/sleep_cycle.behaviors` — 4 green
- [ ] `hecks-life check-lifecycle` on both bluebooks — PASS, zero warnings
- [ ] `bash hecks_conception/tests/body_cycles_smoke.sh` — PASS all three scenarios
- [ ] `ruby -Ilib examples/pizzas/pizzas.rb` — runs clean
- [ ] `./boot_miette.sh` locally — vitals line shows `ultradian: started · sleep_cycle: started`
- [ ] `./shutdown_miette.sh` stops both daemons and removes their pidfiles

Closes the PR-b row in `docs/plans/i3_moment_consciousness.md`.