### PR TITLE
i4: test runtime auto-loads sibling .fixtures (gap 8)

### DIFF
--- a/bin/hecks-behaviors
+++ b/bin/hecks-behaviors
@@ -15,6 +15,7 @@ require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "hecks"
 require "hecks/behaviors/runner"
+require "hecks/behaviors/fixtures_loader"
 
 test_file = ARGV[0]
 unless test_file && File.file?(test_file)
@@ -55,9 +56,17 @@ rescue => e
 end
 
 puts "Running #{suite.tests.size} test(s) from #{test_file}"
-puts "  source: #{source_file}\n\n"
+puts "  source: #{source_file}"
 
-result = Hecks::Behaviors::Runner.run(source_loader, suite)
+# Auto-load sibling .fixtures if present (i4 gap 8). Cross-aggregate
+# cascades that read state seeded by another aggregate's fixtures no
+# longer need explicit setup chains in every test.
+fixtures_path = Hecks::Behaviors::FixturesLoader.locate_path(test_file)
+fixtures_file = fixtures_path ? Hecks::Behaviors::FixturesLoader.parse_file(fixtures_path) : nil
+puts "  fixtures: #{fixtures_path}" if fixtures_path
+puts ""
+
+result = Hecks::Behaviors::Runner.run(source_loader, suite, fixtures_file: fixtures_file)
 # Runner may return nil entries for tests that raised an unhandled
 # exception during run_one. Treat those as errored so the summary line
 # still prints and parity comparison has something to diff.

--- a/hecks_life/src/behaviors_fixtures.rs
+++ b/hecks_life/src/behaviors_fixtures.rs
@@ -1,0 +1,118 @@
+//! Behaviors fixtures auto-loader (i4 gap 8).
+//!
+//! The behaviors runner finds a sibling `.fixtures` file for a given
+//! `.behaviors` path and applies its records into a fresh runtime
+//! before each test runs. Cross-aggregate cascades that read state
+//! seeded by another aggregate's fixtures no longer need explicit
+//! `setup` chains in every test.
+//!
+//! Discovery (in order):
+//!   1. `<dir>/<stem>.fixtures`              — flat sibling
+//!   2. `<dir>/fixtures/<stem>.fixtures`     — conventional subdir
+//!
+//! Parity: mirrors `lib/hecks/behaviors/fixtures_loader.rb`. Same
+//! discovery rules, same seed convention (ids "1", "2", … in source
+//! order), same "first fixture per aggregate wins the in-scope slot".
+//!
+//! [antibody-exempt: test runner auto-loads fixtures for cross-aggregate
+//! cascades (i4 gap 8); retires when behaviors runner ports to
+//! bluebook-dispatched form]
+
+use crate::fixtures_ir::FixturesFile;
+use crate::fixtures_parser;
+use crate::runtime::{AggregateState, Runtime, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Returns the absolute path of the fixtures file matching the given
+/// `.behaviors` (or `_behavioral_tests.bluebook`) path, or None if
+/// nothing matches. Public so the runner can log which file loaded.
+pub fn locate_path(behaviors_path: &str) -> Option<String> {
+    let p = PathBuf::from(behaviors_path);
+    let stem_raw = p.file_stem()?.to_str()?;
+    // Strip the `_behavioral_tests` trailer if the caller passed the
+    // pre-split-out form (rare — most call sites pass the .behaviors
+    // name, whose file_stem is already the domain stem).
+    let stem = stem_raw.trim_end_matches("_behavioral_tests");
+    let parent = p.parent().map(|q| q.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let candidates = [
+        parent.join(format!("{}.fixtures", stem)),
+        parent.join("fixtures").join(format!("{}.fixtures", stem)),
+    ];
+    candidates.iter()
+        .find(|c| c.is_file())
+        .map(|c| c.to_string_lossy().into_owned())
+}
+
+/// Parse a .fixtures file from disk. Returns None on read failure —
+/// the runner logs and continues (empty fixtures = old behavior).
+pub fn parse_file(path: &str) -> Option<FixturesFile> {
+    let source = std::fs::read_to_string(path).ok()?;
+    Some(fixtures_parser::parse(&source))
+}
+
+/// Convenience: locate + parse. Returns None when no sibling file
+/// exists.
+pub fn find_for(behaviors_path: &str) -> Option<FixturesFile> {
+    let path = locate_path(behaviors_path)?;
+    parse_file(&path)
+}
+
+/// Seed a fresh runtime with fixture data. Creates one AggregateState
+/// per fixture record under sequential integer ids ("1", "2", ...),
+/// which matches `pre_seed_singletons`' id convention. The FIRST
+/// fixture per aggregate wins the in_scope slot — what references
+/// resolve to when a command needs a sibling aggregate's id.
+///
+/// Returns the in_scope delta so the runner can merge it into its
+/// own map (alongside `pre_seed_singletons` results).
+pub fn apply(rt: &mut Runtime, fixtures: &FixturesFile) -> HashMap<String, String> {
+    let mut in_scope: HashMap<String, String> = HashMap::new();
+
+    // Group fixtures by aggregate so ids are per-aggregate-contiguous,
+    // matching the Ruby loader.
+    let mut by_agg: HashMap<String, Vec<&crate::ir::Fixture>> = HashMap::new();
+    for f in &fixtures.fixtures {
+        by_agg.entry(f.aggregate_name.clone()).or_default().push(f);
+    }
+
+    for (agg_name, list) in by_agg {
+        // Fixture references an aggregate the domain doesn't define —
+        // skip silently; the source bluebook/fixtures file authors will
+        // see zero seed effect and can fix the mismatch.
+        let Some(repo) = rt.repositories.get_mut(&agg_name) else { continue };
+        for (i, fix) in list.iter().enumerate() {
+            let id = (i + 1).to_string();
+            let mut state = AggregateState::new(&id);
+            for (key, raw) in &fix.attributes {
+                state.set(key, parse_fixture_value(raw));
+            }
+            repo.save(state);
+            in_scope.entry(agg_name.clone()).or_insert_with(|| id.clone());
+        }
+    }
+
+    in_scope
+}
+
+/// Parse a fixture attribute value from its source-token form. Same
+/// shape as behaviors_runner::parse_value but extended for the list
+/// literals that .fixtures files commonly carry (`linked: ["a","b"]`).
+fn parse_fixture_value(raw: &str) -> Value {
+    let s = raw.trim();
+    if s.starts_with('[') && s.ends_with(']') {
+        let inner = &s[1..s.len() - 1];
+        let items: Vec<Value> = inner.split(',')
+            .map(|p| p.trim().trim_matches('"').trim_matches('\''))
+            .filter(|p| !p.is_empty())
+            .map(|p| Value::Str(p.to_string()))
+            .collect();
+        return Value::List(items);
+    }
+    if let Ok(n) = s.parse::<i64>() { return Value::Int(n); }
+    if s == "true"  { return Value::Bool(true); }
+    if s == "false" { return Value::Bool(false); }
+    Value::Str(s.to_string())
+}

--- a/hecks_life/src/behaviors_runner.rs
+++ b/hecks_life/src/behaviors_runner.rs
@@ -14,6 +14,8 @@
 //! → `pizzas.bluebook`).
 
 use crate::behaviors_ir::{Test, TestSuite};
+use crate::behaviors_fixtures;
+use crate::fixtures_ir::FixturesFile;
 use crate::ir::Domain;
 use crate::parser;
 use crate::runtime::{Runtime, RuntimeError, Value};
@@ -54,13 +56,24 @@ impl SuiteResult {
 /// Run every test in `suite` against `source` (re-parsed per test for
 /// state isolation). Returns one TestRun per test, in source order.
 pub fn run_suite(source_text: &str, suite: &TestSuite) -> SuiteResult {
+    run_suite_with_fixtures(source_text, suite, None)
+}
+
+/// Fixture-aware variant. When `fixtures` is `Some`, every fresh
+/// runtime is seeded with those records BEFORE setups run (i4 gap 8).
+/// When `None`, behaves exactly like `run_suite` — pass-through.
+pub fn run_suite_with_fixtures(
+    source_text: &str,
+    suite: &TestSuite,
+    fixtures: Option<&FixturesFile>,
+) -> SuiteResult {
     let runs = suite.tests.iter()
-        .map(|t| run_one(source_text, t))
+        .map(|t| run_one(source_text, t, fixtures))
         .collect();
     SuiteResult { runs }
 }
 
-fn run_one(source_text: &str, test: &Test) -> TestRun {
+fn run_one(source_text: &str, test: &Test, fixtures: Option<&FixturesFile>) -> TestRun {
     // Fresh in-memory runtime per test. Repositories start empty;
     // no data_dir means no heki persistence, no disk IO.
     let domain: Domain = parser::parse(source_text);
@@ -72,6 +85,13 @@ fn run_one(source_text: &str, test: &Test) -> TestRun {
     // populate it; reference injection consumes it. No id ever leaves
     // this scope into the test DSL or the generator.
     let mut in_scope: HashMap<String, String> = HashMap::new();
+
+    // Fixture seed FIRST so pre_seed_singletons can check in_scope and
+    // skip aggregates that already have a fixture-loaded record.
+    if let Some(ff) = fixtures {
+        let seeded = behaviors_fixtures::apply(&mut rt, ff);
+        in_scope.extend(seeded);
+    }
 
     // Pre-seed in_scope for aggregates that have no in-bluebook
     // bootstrap command (every command requires a self-ref to its
@@ -313,6 +333,9 @@ fn pre_seed_singletons(rt: &mut Runtime, in_scope: &mut HashMap<String, String>)
         .map(|agg| agg.name.clone())
         .collect();
     for agg_name in to_seed {
+        // Fixtures seeded this aggregate already — don't overwrite its
+        // loaded state with a virgin AggregateState at id "1".
+        if in_scope.contains_key(&agg_name) { continue; }
         if let Some(repo) = rt.repositories.get_mut(&agg_name) {
             let id = "1".to_string();
             repo.save(crate::runtime::AggregateState::new(&id));

--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -21,6 +21,7 @@ pub mod behaviors_parser;
 pub mod behaviors_dump;
 pub mod behaviors_conceiver;
 pub mod behaviors_runner;
+pub mod behaviors_fixtures;
 pub mod io_validator;
 pub mod lifecycle_validator;
 pub mod duplicate_policy_validator;

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -423,10 +423,23 @@ fn run_behaviors(args: &[String]) {
     }
     let suite = hecks_life::behaviors_parser::parse(&suite_text);
 
-    println!("Running {} test(s) from {}", suite.tests.len(), suite_path);
-    println!("  source: {}\n", source_path);
+    // Auto-load sibling .fixtures if present (i4 gap 8). Cross-aggregate
+    // cascades that read state seeded by another aggregate's fixtures no
+    // longer need explicit setup chains in every test.
+    let fixtures_path = hecks_life::behaviors_fixtures::locate_path(suite_path);
+    let fixtures = fixtures_path.as_deref()
+        .and_then(hecks_life::behaviors_fixtures::parse_file);
 
-    let result = hecks_life::behaviors_runner::run_suite(&source_text, &suite);
+    println!("Running {} test(s) from {}", suite.tests.len(), suite_path);
+    println!("  source: {}", source_path);
+    if let Some(ref fp) = fixtures_path {
+        println!("  fixtures: {}", fp);
+    }
+    println!();
+
+    let result = hecks_life::behaviors_runner::run_suite_with_fixtures(
+        &source_text, &suite, fixtures.as_ref(),
+    );
     for run in &result.runs {
         let icon = match run.status {
             hecks_life::behaviors_runner::TestStatus::Pass  => "✓",

--- a/lib/hecks/behaviors/fixtures_loader.rb
+++ b/lib/hecks/behaviors/fixtures_loader.rb
@@ -1,0 +1,105 @@
+# Hecks::Behaviors::FixturesLoader
+#
+# Auto-locates and loads a sibling `.fixtures` file for a `.behaviors`
+# test file so cross-aggregate cascades get the seeded state they
+# depend on (i4 gap 8). Two discovery paths, checked in order:
+#
+#   1. `<dir>/<name>.fixtures`              — flat sibling
+#   2. `<dir>/fixtures/<name>.fixtures`     — conventional subdir
+#
+# The file, if any, is parsed via the `Hecks.fixtures` DSL (same
+# registry slot as standalone fixtures loading). The loader returns
+# the parsed `FixturesFile` — the runner decides when to apply it.
+#
+# Parity: mirrors hecks_life/src/behaviors_runner.rs fixtures_loader
+# helpers, same discovery rules, same FixturesFile shape.
+#
+# [antibody-exempt: test runner auto-loads fixtures for cross-aggregate
+# cascades (i4 gap 8); retires when behaviors runner ports to
+# bluebook-dispatched form]
+#
+#   fixtures = FixturesLoader.find_for("path/to/pizzas.behaviors")
+#   FixturesLoader.apply(rt, fixtures) if fixtures
+require_relative "value"
+require_relative "aggregate_state"
+
+module Hecks
+  module Behaviors
+    module FixturesLoader
+      module_function
+
+      # Find the sibling .fixtures file for a given .behaviors path.
+      # Returns the parsed FixturesFile or nil if no file is found.
+      def find_for(behaviors_path)
+        path = locate_path(behaviors_path)
+        return nil unless path
+        parse_file(path)
+      end
+
+      # Returns the absolute path to the fixtures file, or nil if none
+      # found. Public so callers can log which file was loaded.
+      def locate_path(behaviors_path)
+        return nil unless behaviors_path
+
+        dir  = File.dirname(behaviors_path)
+        stem = File.basename(behaviors_path).sub(/\.(behaviors|bluebook)\z/, "")
+        stem = stem.sub(/_behavioral_tests\z/, "")
+
+        candidates = [
+          File.join(dir, "#{stem}.fixtures"),
+          File.join(dir, "fixtures", "#{stem}.fixtures"),
+        ]
+        candidates.find { |p| File.file?(p) }
+      end
+
+      # Parse a .fixtures file via the Hecks.fixtures DSL and return the
+      # FixturesFile. The registry's `last_fixtures_file` accessor is the
+      # canonical single-shot slot — we snapshot/restore it so concurrent
+      # parses in the same process don't clobber each other's state.
+      def parse_file(path)
+        require "hecks"
+        require "hecks/dsl/fixtures_builder"
+        prev = Hecks.last_fixtures_file
+        Hecks.last_fixtures_file = nil
+        Kernel.load(path)
+        Hecks.last_fixtures_file
+      ensure
+        Hecks.last_fixtures_file = prev
+      end
+
+      # Seed a fresh BehaviorRuntime with fixture data. Creates one
+      # AggregateState per fixture under sequential integer ids, which
+      # matches the runner's `pre_seed_singletons` id convention ("1",
+      # "2", ...). The FIRST fixture per aggregate becomes the "in
+      # scope" id (what references will resolve to), so tests get
+      # deterministic cross-aggregate linkage.
+      #
+      # Returns a Hash<aggregate_name, id> so the runner can merge it
+      # into its own `in_scope` map.
+      def apply(rt, fixtures_file)
+        in_scope = {}
+        return in_scope unless fixtures_file
+
+        by_agg = Hash.new { |h, k| h[k] = [] }
+        fixtures_file.fixtures.each { |f| by_agg[f.aggregate_name] << f }
+
+        by_agg.each do |agg_name, fixtures|
+          repo = rt.repositories[agg_name]
+          next unless repo # fixture references an aggregate not in domain
+
+          fixtures.each_with_index do |fix, i|
+            id = (i + 1).to_s
+            state = AggregateState.new(id)
+            (fix.attributes || {}).each do |key, value|
+              state.set(key.to_s, Value.from(value))
+            end
+            repo[id] = state
+            in_scope[agg_name] ||= id
+          end
+        end
+
+        in_scope
+      end
+    end
+  end
+end

--- a/lib/hecks/behaviors/runner.rb
+++ b/lib/hecks/behaviors/runner.rb
@@ -12,10 +12,17 @@
 # map: `refused`, `emits`, `<key>_size`, `count` (queries), and
 # plain attribute equality.
 #
-#   result = Runner.run(source_text, suite)
+# Optional `fixtures_file` — when present, the runner seeds every
+# fresh runtime with the fixture records before setups/dispatch run,
+# so cross-aggregate cascades can read state from sibling aggregates
+# without an explicit `setup` chain (i4 gap 8).
+#
+#   result = Runner.run(source_loader, suite)
+#   result = Runner.run(source_loader, suite, fixtures_file: ff)
 #   result.passed; result.failed; result.errored
 require_relative "behavior_runtime"
 require_relative "expectations"
+require_relative "fixtures_loader"
 
 module Hecks
   module Behaviors
@@ -31,10 +38,10 @@ module Hecks
         def all_passed?; failed.zero? && errored.zero?; end
       end
 
-      def self.run(source_loader, suite)
+      def self.run(source_loader, suite, fixtures_file: nil)
         runs = suite.tests.map do |t|
           begin
-            run_one(source_loader, t)
+            run_one(source_loader, t, fixtures_file: fixtures_file)
           rescue => e
             TestRun.new(t.description, :error, "runner crash: #{e.message}")
           end
@@ -42,10 +49,14 @@ module Hecks
         SuiteResult.new(runs)
       end
 
-      def self.run_one(source_loader, test)
+      def self.run_one(source_loader, test, fixtures_file: nil)
         domain = source_loader.call
         rt = BehaviorRuntime.boot(domain)
         in_scope = {}
+        # Fixture seed BEFORE singleton pre-seed so pre_seed_singletons
+        # only fills gaps the fixtures didn't cover (an aggregate with
+        # no fixture row still needs its id "1" landing pad).
+        in_scope.merge!(FixturesLoader.apply(rt, fixtures_file))
         pre_seed_singletons(rt, in_scope)
 
         test.setups.each do |setup|
@@ -107,6 +118,9 @@ module Hecks
       def self.pre_seed_singletons(rt, in_scope)
         rt.domain.aggregates.each do |agg|
           next unless agg_has_no_bootstrap?(agg)
+          # Fixtures seeded this aggregate already — don't overwrite its
+          # loaded state with a virgin AggregateState at id "1".
+          next if in_scope.key?(agg.name)
           state = AggregateState.new("1")
           rt.repositories[agg.name]["1"] = state
           in_scope[agg.name] = "1"

--- a/spec/parity/fixtures_auto_load_parity_test.rb
+++ b/spec/parity/fixtures_auto_load_parity_test.rb
@@ -1,0 +1,145 @@
+# Hecks::Parity::FixturesAutoLoadParityTest
+#
+# Locks the i4-gap-8 contract: both the Ruby runner
+# (bin/hecks-behaviors) and the Rust runner
+# (`hecks-life behaviors`) auto-load a sibling `.fixtures` file
+# and produce identical pass/fail/error output on a fixture-dependent
+# behaviors suite. Drift between runners here is a hard failure.
+#
+# The test fixture itself is minimal and self-contained:
+#
+#   - `store.bluebook`   one aggregate (Store) with a query ByAll
+#   - `store.fixtures`   seeds two Store records (LeftShelf, RightShelf)
+#   - `store.behaviors`  query test expecting count == 2
+#
+# Without fixtures auto-load the query returns 0 records; the test
+# fails. With auto-load the query returns 2; the test passes. Both
+# runners must reach the SAME verdict, whether pass or fail.
+#
+# Run: bundle exec ruby -Ilib spec/parity/fixtures_auto_load_parity_test.rb
+require "open3"
+require "tmpdir"
+require "fileutils"
+
+HECKS_LIFE  = File.expand_path("../../hecks_life/target/release/hecks-life", __dir__)
+RUBY_RUNNER = File.expand_path("../../bin/hecks-behaviors", __dir__)
+
+abort "hecks-life not built" unless File.executable?(HECKS_LIFE)
+abort "ruby runner missing"  unless File.executable?(RUBY_RUNNER)
+
+BLUEBOOK = <<~BLUEBOOK
+  Hecks.bluebook "Store", version: "2026.04.21.1" do
+    vision "Minimal store for fixtures auto-load parity test"
+    category "body"
+    core
+
+    aggregate "Shelf", "One shelf in a store" do
+      attribute :label, String
+      attribute :stock, Integer
+
+      query "ByAll" do
+        description "Return every shelf on the domain"
+      end
+    end
+  end
+BLUEBOOK
+
+FIXTURES = <<~FIXTURES
+  Hecks.fixtures "Store" do
+    aggregate "Shelf" do
+      fixture "LeftShelf",  label: "left",  stock: 5
+      fixture "RightShelf", label: "right", stock: 3
+    end
+  end
+FIXTURES
+
+BEHAVIORS = <<~BEHAVIORS
+  Hecks.behaviors "Store" do
+    vision "Verify fixtures auto-load makes seeded records visible"
+
+    test "ByAll returns fixture-seeded shelves" do
+      tests "ByAll", on: "Shelf", kind: :query
+      expect count: 2
+    end
+  end
+BEHAVIORS
+
+# Write all three files into a fresh temp dir and return the .behaviors path.
+def write_fixture_pack(dir)
+  File.write(File.join(dir, "store.bluebook"),  BLUEBOOK)
+  File.write(File.join(dir, "store.fixtures"),  FIXTURES)
+  File.write(File.join(dir, "store.behaviors"), BEHAVIORS)
+  File.join(dir, "store.behaviors")
+end
+
+# Tail summary line into { pass:, fail:, error: }.
+def parse_summary(out)
+  m = out.match(/(\d+) passed,\s+(\d+) failed,\s+(\d+) errored/)
+  return { pass: 0, fail: 0, error: 0 } unless m
+  { pass: m[1].to_i, fail: m[2].to_i, error: m[3].to_i }
+end
+
+# Per-test verdict map — "desc" → :pass / :fail / :error.
+def parse_verdicts(out)
+  v = {}
+  out.each_line do |line|
+    case line
+    when /\A✓ (.+)\Z/ then v[$1.strip] = :pass
+    when /\A✗ (.+)\Z/ then v[$1.strip] = :fail
+    when /\A⚠ (.+)\Z/ then v[$1.strip] = :error
+    end
+  end
+  v
+end
+
+# True when the runner logged a "fixtures:" path — proves the
+# auto-loader fired (not just "tests happened to pass without it").
+def loaded_fixtures?(out)
+  out.include?("fixtures: ")
+end
+
+divergent = 0
+
+Dir.mktmpdir("hecks-fixtures-parity-") do |dir|
+  behaviors_path = write_fixture_pack(dir)
+
+  ruby_out, = Open3.capture2e(RUBY_RUNNER, behaviors_path)
+  rust_out, = Open3.capture2e(HECKS_LIFE, "behaviors", behaviors_path)
+
+  ruby_sum = parse_summary(ruby_out); rust_sum = parse_summary(rust_out)
+  ruby_v   = parse_verdicts(ruby_out); rust_v  = parse_verdicts(rust_out)
+
+  unless loaded_fixtures?(ruby_out)
+    puts "✗ ruby runner did not log a fixtures: path"
+    puts ruby_out
+    divergent += 1
+  end
+  unless loaded_fixtures?(rust_out)
+    puts "✗ rust runner did not log a fixtures: path"
+    puts rust_out
+    divergent += 1
+  end
+
+  if ruby_sum == rust_sum && ruby_v == rust_v
+    puts "✓ auto-loaded fixtures: identical verdicts — #{ruby_sum.inspect}"
+  else
+    puts "✗ auto-loaded fixtures: runners diverge"
+    puts "    rust: #{rust_sum.inspect}  #{rust_v.inspect}"
+    puts "    ruby: #{ruby_sum.inspect}  #{ruby_v.inspect}"
+    puts "\n--- ruby output ---\n#{ruby_out}"
+    puts "\n--- rust output ---\n#{rust_out}"
+    divergent += 1
+  end
+
+  # Positive assertion: both runners should have found the seeded
+  # records (count == 2). If count is 0 somewhere the auto-loader
+  # didn't seed into the query path for that runner — real bug.
+  if ruby_sum[:pass] != 1 || rust_sum[:pass] != 1
+    puts "✗ expected 1 passing test per runner (count: 2 assertion)"
+    puts "    ruby: #{ruby_sum.inspect}"
+    puts "    rust: #{rust_sum.inspect}"
+    divergent += 1
+  end
+end
+
+exit(divergent.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary

Both behaviors runners (Ruby `bin/hecks-behaviors`, Rust `hecks-life behaviors`) now auto-locate and apply a sibling `.fixtures` file when running a `.behaviors` suite. Cross-aggregate cascades that read state seeded by another aggregate's fixtures no longer require every test to replicate that seed via explicit `setup` chains (i4 gap 8).

- **Discovery** (in order):
  1. `<dir>/<stem>.fixtures` — flat sibling
  2. `<dir>/fixtures/<stem>.fixtures` — conventional subdir
- **Seeding**: runs once per runner invocation; each fresh test runtime is pre-populated before setups execute
- **Parity**: new `spec/parity/fixtures_auto_load_parity_test.rb` locks identical Ruby/Rust verdicts on a fixture-dependent behaviors suite

## Before / after

Consider an `Order` test that needs a `Catalog` record seeded by `fixtures/catalog.fixtures`:

### Before (had to re-seed in every test)

```ruby
# orders.behaviors
Hecks.behaviors "Orders" do
  test "PlaceOrder deducts stock" do
    tests "PlaceOrder", on: "Order"
    # explicit re-seed — duplicates fixtures/catalog.fixtures
    setup "RegisterProduct", sku: "APPLE", stock: 10
    setup "RegisterProduct", sku: "BREAD", stock: 5
    input sku: "APPLE", quantity: 2
    expect status: "placed"
  end
end
```

### After (fixtures auto-load)

```ruby
# orders.fixtures — the single source of truth
Hecks.fixtures "Orders" do
  aggregate "Product" do
    fixture "Apple", sku: "APPLE", stock: 10
    fixture "Bread", sku: "BREAD", stock: 5
  end
end

# orders.behaviors — no redundant setup
Hecks.behaviors "Orders" do
  test "PlaceOrder deducts stock" do
    tests "PlaceOrder", on: "Order"
    input sku: "APPLE", quantity: 2
    expect status: "placed"
  end
end
```

Both runners log the loaded fixtures path at startup:

```
Running 14 test(s) from hecks_conception/aggregates/boot.behaviors
  source: hecks_conception/aggregates/boot.bluebook
  fixtures: hecks_conception/aggregates/fixtures/boot.fixtures
```

## Test plan

- [x] `ruby bin/hecks-behaviors hecks_conception/aggregates/boot.behaviors` auto-loads `fixtures/boot.fixtures` (14/14 pass)
- [x] `hecks-life behaviors hecks_conception/aggregates/boot.behaviors` produces identical output (14/14 pass)
- [x] `hecks_conception/catalog/pizzas.behaviors` (no sibling fixtures) still runs, no header line, no regression (5/5 pass)
- [x] `bundle exec ruby -Ilib spec/parity/behaviors_parity_test.rb` → 3/3 parity
- [x] `bundle exec ruby -Ilib spec/parity/fixtures_parity_test.rb` → 345/358 parity (+ 13 known drift, same as main)
- [x] `bundle exec ruby -Ilib spec/parity/fixtures_auto_load_parity_test.rb` → pass
- [x] `cd hecks_life && cargo test --release` → all pass

## Antibody

Each commit carries `[antibody-exempt: test runner auto-loads fixtures for cross-aggregate cascades (i4 gap 8); retires when behaviors runner ports to bluebook-dispatched form]` — the exemption retires when the runner itself is dispatched from a bluebook instead of from hand-written Ruby/Rust.