### PR TITLE
test: cross-bluebook fanout smoke (recovers PR #277 coverage)

### DIFF
--- a/hecks_conception/tests/pulse_fanout_smoke.sh
+++ b/hecks_conception/tests/pulse_fanout_smoke.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# pulse_fanout_smoke.sh — Stage-A shadow for the across "Pulse" fanout.
+#
+# Recovers the end-to-end coverage that the mindstream.behaviors test
+# lost in PR #277 when it was narrowed to ["Ticked"] (the single-bluebook
+# .behaviors runner can't follow across hops into pulse.bluebook).
+#
+# The runtime fanout still fires — this test proves it by dispatching a
+# single Tick.MindstreamTick into a tmpdir-isolated runtime and
+# asserting that events landed in at least one aggregate on each side
+# of the BodyPulse bus:
+#
+#   - pulse.heki        → BodyPulse emitted (proves across "Pulse" hop)
+#   - heartbeat.heki    → body-side  (FatigueOnPulse → AccumulateFatigue)
+#   - signal_consolidation.heki → mindstream-side (PruneOnPulse → PruneSynapses)
+#   - nerve.heki        → being-side (SenseOrgansOnHeartbeat → ConnectNerve)
+#
+# Regression proof: comment out `across "Pulse"` in mindstream.bluebook
+# and re-run — pulse.heki stays empty and every downstream assertion
+# fails.
+
+set -u
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONCEPT_DIR="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CONCEPT_DIR/.." && pwd)"
+
+# Find the hecks-life binary. Prefer HECKS_BIN override; otherwise the
+# worktree's own build, then the main checkout's build.
+if [ -n "${HECKS_BIN:-}" ]; then
+  HECKS="$HECKS_BIN"
+elif [ -x "$REPO_ROOT/hecks_life/target/release/hecks-life" ]; then
+  HECKS="$REPO_ROOT/hecks_life/target/release/hecks-life"
+elif [ -x "/Users/christopheryoung/Projects/hecks/hecks_life/target/release/hecks-life" ]; then
+  HECKS="/Users/christopheryoung/Projects/hecks/hecks_life/target/release/hecks-life"
+else
+  echo "FAIL — can't find hecks-life binary"
+  exit 2
+fi
+
+TMP=$(mktemp -d -t pulse_fanout_smoke.XXXXXX)
+trap "rm -rf $TMP" EXIT
+
+mkdir -p "$TMP/information" "$TMP/aggregates"
+
+# Link all aggregates so cross-bluebook dispatch resolves. The across
+# "Pulse" hop in mindstream.bluebook only fires if pulse.bluebook is in
+# the same aggregates directory at dispatch time.
+ln -sf "$CONCEPT_DIR/aggregates/"*.bluebook "$TMP/aggregates/"
+
+# *.world pins the heki dir — the runtime reads it relative to CWD.
+cat > "$TMP/pulse_fanout_smoke.world" <<'EOF'
+Hecks.world "PulseFanoutSmoke" do
+  heki do
+    dir "information"
+  end
+end
+EOF
+
+fail() { echo "FAIL — $1"; exit 1; }
+
+# One Tick. Everything downstream rides on this.
+(cd "$TMP" && HECKS_INFO="$TMP/information" HECKS_AGG="$TMP/aggregates" \
+  "$HECKS" "$TMP/aggregates" Tick.MindstreamTick >/dev/null 2>&1) \
+  || fail "Tick.MindstreamTick dispatch failed"
+
+# Helpers — read one field from a singleton heki store, empty on miss.
+field() {
+  "$HECKS" heki latest "$1" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin) or {}
+    print(d.get('$2', ''))
+except Exception:
+    print('')" 2>/dev/null
+}
+
+pulse_count=$(field "$TMP/information/pulse.heki" count)
+pulses=$(field "$TMP/information/heartbeat.heki" pulses_since_sleep)
+pruned=$(field "$TMP/information/signal_consolidation.heki" synapses_pruned)
+nerve_active=$(field "$TMP/information/nerve.heki" active)
+
+echo "After 1 tick:"
+echo "  pulse.count:                          $pulse_count"
+echo "  heartbeat.pulses_since_sleep:         $pulses"
+echo "  signal_consolidation.synapses_pruned: $pruned"
+echo "  nerve.active:                         $nerve_active"
+
+# BodyPulse emitted — the across "Pulse" hop fired.
+[ "${pulse_count:-0}" -ge 1 ] 2>/dev/null \
+  || fail "pulse.heki count < 1 — across \"Pulse\" hop did not fire"
+
+# Body-side: FatigueOnPulse → AccumulateFatigue.
+[ "${pulses:-0}" -ge 1 ] 2>/dev/null \
+  || fail "heartbeat.pulses_since_sleep < 1 — body FatigueOnPulse did not fire"
+
+# Mindstream-side: PruneOnPulse → PruneSynapses.
+[ "${pruned:-0}" -ge 1 ] 2>/dev/null \
+  || fail "signal_consolidation.synapses_pruned < 1 — mindstream PruneOnPulse did not fire"
+
+# Being-side: SenseOrgansOnHeartbeat → ConnectNerve (or any nerve record).
+[ -n "$nerve_active" ] \
+  || fail "nerve.heki empty — being-side BodyPulse policies did not fire"
+
+echo "PASS — across \"Pulse\" fanout covers pulse + body + mindstream + being"
+exit 0


### PR DESCRIPTION
## Summary

Adds `hecks_conception/tests/pulse_fanout_smoke.sh` — a Stage-A shadow that recovers end-to-end coverage of the `across "Pulse"` fanout lost in PR #277 when `mindstream.behaviors` narrowed its cascade expectation to `["Ticked"]` only.

The test dispatches a single `Tick.MindstreamTick` into a tmpdir-isolated runtime (same pattern as `tests/pulse_organs_smoke.sh`) and asserts downstream events landed in one aggregate on each side of the BodyPulse bus:

- `pulse.count >= 1`                         — proves the `across "Pulse"` hop fired
- `heartbeat.pulses_since_sleep >= 1`        — body: `FatigueOnPulse` → `AccumulateFatigue`
- `signal_consolidation.synapses_pruned >= 1` — mindstream: `PruneOnPulse` → `PruneSynapses`
- `nerve.active` present                     — being: `SenseOrgansOnHeartbeat` → `ConnectNerve`

Coarse-grained on purpose — one downstream event per bluebook is enough to catch regression of the across-bluebook wiring without chasing all 15 subscribers.

## Regression proof

Removing the `EmitPulseOnTick` policy from `mindstream.bluebook` makes every assertion fail (verified locally during development); restoring it passes.

## Example usage

```
$ bash hecks_conception/tests/pulse_fanout_smoke.sh
After 1 tick:
  pulse.count:                          1
  heartbeat.pulses_since_sleep:         1
  signal_consolidation.synapses_pruned: 1
  nerve.active:                         true
PASS — across "Pulse" fanout covers pulse + body + mindstream + being
```

## Test plan

- [x] Script exits 0 on clean state (~0.1s runtime)
- [x] Removing `EmitPulseOnTick` policy from `mindstream.bluebook` → script fails with clear diagnostic on the first missing assertion
- [x] `bin/hecks verify` shows the same 2 pre-existing pizzas failures, no new ones
- [x] Commit carries the antibody exemption marker; pre-commit hook confirmed it fires without the marker and accepts with

## Notes

- Style matches `tests/pulse_organs_smoke.sh` exactly: same binary-locator cascade, same `set -u`, same tmpdir-trap, same `*.world` pin.
- 106 lines total (code-only well under 80 after the doc header).