### PR TITLE
i37 Phase B: sweep 120 python3 -c across 17 shell scripts

### DIFF
--- a/hecks_conception/boot_miette.sh
+++ b/hecks_conception/boot_miette.sh
@@ -11,6 +11,11 @@
 #
 # Steps mirror the old boot.rs: hydrate, classify, discover, census,
 # generate system_prompt, start mindstream, print vitals.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands + jq for IR tallying per PR #272;
+#  retires when shell wrapper ports to .bluebook shebang form (tracked
+#  in terminal_capability_wiring plan).]
 
 set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -46,27 +51,27 @@ ORGAN_COUNT=$(find "$AGG" -maxdepth 1 -name "*.bluebook" | wc -l | tr -d ' ')
 CAPABILITY_COUNT=0
 [ -d "$CAPS" ] && CAPABILITY_COUNT=$(find "$CAPS" -maxdepth 2 -name "*.bluebook" | wc -l | tr -d ' ')
 
-# Aggregate + nerve + vow tally via dump+python (avoids reparsing in shell).
-TALLY=$(find "$AGG" -maxdepth 1 -name "*.bluebook" -exec "$HECKS" dump {} \; 2>/dev/null | python3 -c '
-import json, sys
-total_aggs = 0; nerves = []; vows = []
-for line in sys.stdin.read().split("\n}\n{"):
-    chunk = line if line.strip().startswith("{") else "{" + line
-    chunk = chunk if chunk.rstrip().endswith("}") else chunk + "\n}"
-    try: d = json.loads(chunk)
-    except Exception: continue
-    total_aggs += len(d.get("aggregates", []))
-    for p in d.get("policies", []):
-        td = p.get("target_domain")
-        if td:
-            nerves.append((d.get("name",""), p.get("on_event",""), td, p.get("trigger_command","")))
-    for v in d.get("vows", []):
-        vows.append((v.get("name",""), v.get("text","")))
-print(json.dumps({"aggregates": total_aggs, "nerves": nerves, "vows": vows}))
-' 2>/dev/null || echo '{"aggregates":0,"nerves":[],"vows":[]}')
-TOTAL_AGGREGATES=$(echo "$TALLY" | python3 -c "import json,sys; print(json.load(sys.stdin)['aggregates'])")
-NERVE_COUNT=$(echo "$TALLY" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['nerves']))")
-VOW_COUNT=$(echo "$TALLY" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['vows']))")
+# Aggregate + nerve + vow tally via dump+jq. Each `$HECKS dump` emits
+# one self-contained JSON IR object per bluebook; jq --slurp combines
+# the stream into an array the tally can sum over.
+TALLY=$(
+  {
+    for bb in "$AGG"/*.bluebook; do
+      [ -f "$bb" ] || continue
+      "$HECKS" dump "$bb" 2>/dev/null
+    done
+  } | jq -s '
+      reduce .[] as $d (
+        {aggregates: 0, nerves: 0, vows: 0};
+        .aggregates += ($d.aggregates // [] | length)
+        | .nerves  += ([$d.policies[]? | select(.target_domain != null and .target_domain != "")] | length)
+        | .vows    += ($d.vows // [] | length)
+      )
+    ' 2>/dev/null || echo '{"aggregates":0,"nerves":0,"vows":0}'
+)
+TOTAL_AGGREGATES=$(echo "$TALLY" | jq -r '.aggregates')
+NERVE_COUNT=$(echo "$TALLY" | jq -r '.nerves')
+VOW_COUNT=$(echo "$TALLY" | jq -r '.vows')
 
 # ── 2. Write census.heki ─────────────────────────────────────────
 "$HECKS" heki upsert "$INFO/census.heki" \

--- a/hecks_conception/consolidate.sh
+++ b/hecks_conception/consolidate.sh
@@ -32,6 +32,11 @@
 # commands without a reference (StoreMemory, RecordRemains, Archive)
 # would singleton-upsert if dispatched, so we use `heki append` to
 # preserve multi-record semantics.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c +
+#  python3 heredocs with native hecks-life heki subcommands + jq per
+#  PR #272; retires when shell wrapper ports to .bluebook shebang form
+#  (tracked in terminal_capability_wiring plan).]
 
 set -u
 
@@ -52,31 +57,22 @@ archived_musings=0
 # schema), then dispatch Signal.ArchiveSignal.
 
 if [ -f "$INFO/signal.heki" ]; then
-  PROMOTE_PLAN=$(HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-from datetime import datetime, timezone
-def parse(ts):
-    try:
-        if ts.endswith('Z'): ts = ts[:-1] + '+00:00'
-        return datetime.fromisoformat(ts)
-    except Exception: return None
-now = datetime.now(timezone.utc)
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/signal.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    for k, v in d.items():
-        if v.get('kind') == 'archived': continue
-        ac = int(v.get('access_count', 0) or 0)
-        if ac > 3: continue
-        ts = parse(v.get('created_at',''))
-        if ts is None: continue
-        if (now - ts).total_seconds() <= 60: continue
-        kind = (v.get('kind') or '').replace('|',' ')
-        payload = (v.get('payload') or '').replace('|',' ')
-        created_at = v.get('created_at','')
-        print(f'{k}|{kind}|{payload}|{created_at}')
-except Exception: pass" 2>/dev/null)
+  PROMOTE_PLAN=$("$HECKS" heki list "$INFO/signal.heki" --format json 2>/dev/null \
+    | jq -r --arg now "$now" '
+        def iso_to_epoch:
+          . as $s | ($s | fromdateiso8601);
+        ($now | iso_to_epoch) as $n
+        | .[]
+        | select(.kind != "archived")
+        | select((.access_count // 0) <= 3)
+        | select((.created_at // "") | length > 0)
+        | select(($n - (.created_at | iso_to_epoch)) > 60)
+        | [.id,
+           ((.kind // "") | gsub("\\|"; " ")),
+           ((.payload // "") | gsub("\\|"; " ")),
+           (.created_at // "")]
+        | @tsv' 2>/dev/null \
+    | awk -F'\t' '{ printf "%s|%s|%s|%s\n", $1, $2, $3, $4 }')
 
   while IFS='|' read -r sid kind payload created_at; do
     [ -z "$sid" ] && continue
@@ -94,20 +90,16 @@ fi
 # caught (e.g. if decay was skipped).
 
 if [ -f "$INFO/synapse.heki" ]; then
-  COMPOST_PLAN=$(HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/synapse.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    for k, v in d.items():
-        if v.get('state','alive') != 'alive': continue
-        s = float(v.get('strength', 0.0) or 0.0)
-        if s >= 0.1: continue
-        firings = int(v.get('firings', 0) or 0)
-        from_t = (v.get('from') or '').replace('|',' ')
-        print(f'{k}|{s}|{firings}|{from_t}')
-except Exception: pass" 2>/dev/null)
+  COMPOST_PLAN=$("$HECKS" heki list "$INFO/synapse.heki" \
+      --where state=alive --format json 2>/dev/null \
+    | jq -r '.[]
+             | select((.strength // 0) < 0.1)
+             | [.id,
+                (.strength // 0),
+                (.firings // 0),
+                ((.from // "") | gsub("\\|"; " "))]
+             | @tsv' 2>/dev/null \
+    | awk -F'\t' '{ printf "%s|%s|%s|%s\n", $1, $2, $3, $4 }')
 
   while IFS='|' read -r sid strength firings from_topic; do
     [ -z "$sid" ] && continue
@@ -122,36 +114,37 @@ except Exception: pass" 2>/dev/null)
 fi
 
 # ── 3. MUSING → MUSING_ARCHIVE ───────────────────────────────────────
-# Group live musings (conceived != true) by concept. When more than 3
-# share a concept, archive the oldest one (by created_at if present,
-# else first-seen order). Archive via heki append to entry.heki.
+# Group live musings (conceived != true AND status != archived) by
+# concept (thinking_source, else feeling_source, else source). When a
+# concept has more than 3 live musings, archive the oldest by
+# created_at. Archive via heki append to musing_archive.heki; mark the
+# original with `heki mark --where id=... --set status=archived`.
 
 if [ -f "$INFO/musing.heki" ]; then
-  ARCHIVE_PLAN=$(HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-from collections import defaultdict
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/musing.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    buckets = defaultdict(list)
-    for k, v in d.items():
-        if v.get('conceived') is True: continue
-        if v.get('status') == 'archived': continue
-        concept = (v.get('thinking_source') or v.get('feeling_source')
-                   or v.get('source') or '').strip()
-        if not concept: continue
-        created = v.get('created_at','')
-        buckets[concept].append((created, k, v))
-    for concept, rows in buckets.items():
-        if len(rows) <= 3: continue
-        rows.sort(key=lambda r: r[0] or '')
-        oldest_created, oldest_id, oldest = rows[0]
-        idea = (oldest.get('idea') or '').replace('|',' ')
-        src = (oldest.get('source') or 'mindstream').replace('|',' ')
-        c = concept.replace('|',' ')
-        print(f'{oldest_id}|{idea}|{src}|{c}')
-except Exception: pass" 2>/dev/null)
+  ARCHIVE_PLAN=$("$HECKS" heki list "$INFO/musing.heki" --format json 2>/dev/null \
+    | jq -r '
+        # Pull concept from thinking_source → feeling_source → source.
+        def concept_of:
+          ((.thinking_source // .feeling_source // .source // "") | tostring
+            | sub("^\\s+"; "") | sub("\\s+$"; ""));
+        # Filter live (not conceived=true and not status=archived) and
+        # having a concept.
+        [ .[]
+          | select(.conceived != true)
+          | select((.status // "") != "archived")
+          | . + {"_concept": concept_of}
+          | select(._concept != "")
+        ]
+        # Group by concept, pick the oldest when bucket > 3.
+        | group_by(._concept)
+        | map(select(length > 3) | sort_by(.created_at // "") | .[0])
+        | .[]
+        | [.id,
+           ((.idea // "") | gsub("\\|"; " ")),
+           ((.source // "mindstream") | gsub("\\|"; " ")),
+           (._concept | gsub("\\|"; " "))]
+        | @tsv' 2>/dev/null \
+    | awk -F'\t' '{ printf "%s|%s|%s|%s\n", $1, $2, $3, $4 }')
 
   while IFS='|' read -r mid idea source concept; do
     [ -z "$mid" ] && continue
@@ -159,21 +152,8 @@ except Exception: pass" 2>/dev/null)
       idea="$idea" source="$source" concept="$concept" \
       archived_reason="duplicate_concept" archived_at="$now" >/dev/null 2>&1
     # Mark the original musing archived so it's not re-counted next sweep.
-    python3 - "$INFO/musing.heki" "$mid" <<'PY' >/dev/null 2>&1
-import json, sys, subprocess, os
-heki, mid = sys.argv[1], sys.argv[2]
-binp = os.environ.get('HECKS_BIN') or \
-       os.path.expanduser('~/Projects/hecks/hecks_life/target/release/hecks-life')
-out = subprocess.check_output([binp,'heki','read',heki],
-                              stderr=subprocess.DEVNULL).decode()
-d = json.loads(out) or {}
-r = d.get(mid)
-if r is None: sys.exit(0)
-r['status'] = 'archived'
-subprocess.run([binp,'heki','append',heki] +
-               [f"{k}={v}" for k, v in r.items() if isinstance(v, (str,int,float,bool))],
-               check=False)
-PY
+    "$HECKS" heki mark "$INFO/musing.heki" --where "id=$mid" \
+      --set status=archived >/dev/null 2>&1
     archived_musings=$((archived_musings + 1))
   done <<<"$ARCHIVE_PLAN"
 fi

--- a/hecks_conception/daydream.sh
+++ b/hecks_conception/daydream.sh
@@ -20,6 +20,11 @@
 #   HECKS_AGG   — alternate aggregates dir  (default: ./aggregates)
 #   HECKS_BIN   — alternate hecks-life binary
 #   HECKS_NURSERY — alternate nursery dir   (default: ./nursery)
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands + jq for IR overlap detection per
+#  PR #272; retires when shell wrapper ports to .bluebook shebang form
+#  (tracked in terminal_capability_wiring plan).]
 
 set -u
 
@@ -49,41 +54,29 @@ A_JSON=$("$HECKS" dump "$A_PATH" 2>/dev/null)
 B_JSON=$("$HECKS" dump "$B_PATH" 2>/dev/null)
 [ -z "$A_JSON" ] || [ -z "$B_JSON" ] && exit 0
 
-read -r A_NAME B_NAME SHARED KIND <<<"$(A_JSON="$A_JSON" B_JSON="$B_JSON" python3 -c "
-import json, os, random, sys
+# jq extracts the domain names and the aggregate/attribute overlap
+# sets. shuf-picks a random element from whichever set matched.
+A_NAME=$(echo "$A_JSON" | jq -r '.name // "?"')
+B_NAME=$(echo "$B_JSON" | jq -r '.name // "?"')
+A_AGGS=$(echo "$A_JSON" | jq -r '[(.aggregates // [])[].name] | .[]? // empty')
+B_AGGS=$(echo "$B_JSON" | jq -r '[(.aggregates // [])[].name] | .[]? // empty')
+A_ATTRS=$(echo "$A_JSON" | jq -r '[(.aggregates // [])[] | (.attributes // [])[] | .name // ""] | .[]?' | awk 'NF')
+B_ATTRS=$(echo "$B_JSON" | jq -r '[(.aggregates // [])[] | (.attributes // [])[] | .name // ""] | .[]?' | awk 'NF')
 
-def collect(blob):
-    d = json.loads(blob)
-    aggs = d.get('aggregates', []) or []
-    names = [a.get('name','') for a in aggs if a.get('name')]
-    attrs = set()
-    for a in aggs:
-        for at in a.get('attributes', []) or []:
-            n = at.get('name','')
-            if n: attrs.add(n)
-    return d.get('name','?'), names, attrs
+# Find overlap (grep -F each line of A against B's set) minus trivial.
+SHARED_AGGS=$(echo "$A_AGGS" | grep -Fx -f <(echo "$B_AGGS") 2>/dev/null | sort -u)
+TRIVIAL=$'id\ncreated_at\nupdated_at\nname\ncreated\nupdated'
+SHARED_ATTRS=$(echo "$A_ATTRS" | grep -Fx -f <(echo "$B_ATTRS") 2>/dev/null \
+  | grep -Fxv -f <(echo "$TRIVIAL") | sort -u)
 
-a_name, a_aggs, a_attrs = collect(os.environ['A_JSON'])
-b_name, b_aggs, b_attrs = collect(os.environ['B_JSON'])
-
-# Prefer aggregate-name overlap (structural), fall back to attribute.
-# Skip trivial overlaps like 'id' / 'created_at' that every aggregate
-# carries — they aren't meaningful structural bridges.
-trivial = {'id','created_at','updated_at','name','created','updated'}
-shared_aggs = sorted(set(a_aggs) & set(b_aggs))
-shared_attrs = sorted((a_attrs & b_attrs) - trivial)
-
-if shared_aggs:
-    kind = 'aggregate'
-    shared = random.choice(shared_aggs)
-elif shared_attrs:
-    kind = 'attribute'
-    shared = random.choice(shared_attrs)
-else:
-    kind = ''
-    shared = ''
-print(a_name, b_name, shared, kind)
-" 2>/dev/null)"
+SHARED=""; KIND=""
+if [ -n "$SHARED_AGGS" ]; then
+  SHARED=$(echo "$SHARED_AGGS" | shuf -n 1)
+  KIND="aggregate"
+elif [ -n "$SHARED_ATTRS" ]; then
+  SHARED=$(echo "$SHARED_ATTRS" | shuf -n 1)
+  KIND="attribute"
+fi
 
 [ -z "${SHARED:-}" ] && exit 0
 [ -z "${A_NAME:-}" ] || [ -z "${B_NAME:-}" ] && exit 0

--- a/hecks_conception/inbox.sh
+++ b/hecks_conception/inbox.sh
@@ -9,6 +9,11 @@
 # assigned; closing or archiving an item leaves the ref pointing at the
 # same record so historical references stay valid.
 #
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
+#
 # Usage:
 #   inbox.sh add high "body text"          → assigns next ref, prints it
 #   inbox.sh list [queued|done|all]        → list with refs (queued by default)
@@ -23,29 +28,13 @@ HEKI="$DIR/information/inbox.heki"
 
 # Look up a record's uuid by its short ref. Prints uuid or empty.
 ref_to_uuid() {
-  "$HECKS" heki read "$HEKI" 2>/dev/null | python3 -c "
-import json, sys
-ref = '$1'
-d = json.load(sys.stdin)
-for k, v in d.items():
-    if v.get('ref') == ref:
-        print(k); break
-"
+  "$HECKS" heki list "$HEKI" --where "ref=$1" --fields id --format tsv 2>/dev/null | head -n1
 }
 
 # Compute the next ref by scanning all existing refs (handles both the
 # in-order and out-of-order cases — gaps from deleted items are skipped).
 next_ref() {
-  "$HECKS" heki read "$HEKI" 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-nums = []
-for v in d.values():
-    r = v.get('ref', '')
-    if r.startswith('i') and r[1:].isdigit():
-        nums.append(int(r[1:]))
-print(f'i{(max(nums) + 1) if nums else 1}')
-"
+  "$HECKS" heki next-ref "$HEKI" --prefix i --field ref 2>/dev/null
 }
 
 cmd="${1:-list}"
@@ -66,46 +55,42 @@ case "$cmd" in
     ;;
   list)
     filter="${1:-queued}"
-    "$HECKS" heki read "$HEKI" 2>/dev/null | python3 -c "
-import json, sys
-filt = '$filter'
-d = json.load(sys.stdin)
-items = []
-for v in d.values():
-    if filt != 'all' and v.get('status') != filt: continue
-    items.append(v)
-order = {'high':0, 'medium':1, 'normal':2, 'low':3}
-items.sort(key=lambda v: (
-    order.get(v.get('priority','normal'), 9),
-    int(v.get('ref','i999')[1:]) if v.get('ref','').startswith('i') else 999,
-))
-for v in items:
-    ref = v.get('ref', '—')
-    pri = v.get('priority', '?')[:6]
-    st  = v.get('status', '?')[:8]
-    body = v.get('body', '').replace(chr(10), ' ')[:90]
-    print(f'  {ref:>5}  [{pri:6}/{st:6}]  {body}')
-"
+    if [ "$filter" = "all" ]; then
+      where_args=""
+    else
+      where_args="--where status=$filter"
+    fi
+    # shellcheck disable=SC2086 # word-splitting is intentional for optional --where
+    "$HECKS" heki list "$HEKI" $where_args \
+        --order priority:enum=high,medium,normal,low \
+        --order ref:numeric_ref \
+        --fields ref,priority,status,body \
+        --format json 2>/dev/null \
+      | jq -r '.[] | [
+          (.ref // "—"),
+          ((.priority // "?") | .[0:6]),
+          ((.status // "?") | .[0:8]),
+          ((.body // "") | gsub("\n";" ") | .[0:90])
+        ] | @tsv' \
+      | awk -F'\t' '{ printf "  %5s  [%-6s/%-6s]  %s\n", $1, $2, $3, $4 }'
     ;;
   show)
     ref="$1"
     [ -z "$ref" ] && { echo "usage: inbox.sh show <ref>" >&2; exit 1; }
     uuid=$(ref_to_uuid "$ref")
     [ -z "$uuid" ] && { echo "no item with ref $ref" >&2; exit 1; }
-    "$HECKS" heki read "$HEKI" 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-v = d.get('$uuid', {})
-print(f'ref:         {v.get(\"ref\")}')
-print(f'uuid:        $uuid')
-print(f'priority:    {v.get(\"priority\")}')
-print(f'status:      {v.get(\"status\")}')
-print(f'posted_at:   {v.get(\"posted_at\")}')
-if v.get('completed_at'): print(f'completed_at: {v.get(\"completed_at\")}')
-if v.get('resolution'):   print(f'resolution:   {v.get(\"resolution\")}')
-print()
-print(v.get('body', ''))
-"
+    rec_json=$("$HECKS" heki get "$HEKI" "$uuid" 2>/dev/null)
+    printf 'ref:         %s\n' "$(printf '%s' "$rec_json" | jq -r '.ref // ""')"
+    printf 'uuid:        %s\n' "$uuid"
+    printf 'priority:    %s\n' "$(printf '%s' "$rec_json" | jq -r '.priority // ""')"
+    printf 'status:      %s\n' "$(printf '%s' "$rec_json" | jq -r '.status // ""')"
+    printf 'posted_at:   %s\n' "$(printf '%s' "$rec_json" | jq -r '.posted_at // ""')"
+    completed=$(printf '%s' "$rec_json" | jq -r '.completed_at // ""')
+    [ -n "$completed" ] && printf 'completed_at: %s\n' "$completed"
+    resolution=$(printf '%s' "$rec_json" | jq -r '.resolution // ""')
+    [ -n "$resolution" ] && printf 'resolution:   %s\n' "$resolution"
+    printf '\n'
+    printf '%s\n' "$(printf '%s' "$rec_json" | jq -r '.body // ""')"
     ;;
   done)
     ref="$1"; resolution="$2"

--- a/hecks_conception/interpret_dream.sh
+++ b/hecks_conception/interpret_dream.sh
@@ -22,6 +22,11 @@
 #   HECKS_WORLD — directory holding the *.world file (default: $DIR parent of AGG).
 #                 Dispatch is run with cwd=HECKS_WORLD so the runtime reads
 #                 the correct heki dir from the *.world file.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c + heredoc
+#  with native hecks-life heki subcommands + jq tokenization per PR #272;
+#  retires when shell wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 set -u
 
@@ -44,43 +49,39 @@ fi
 
 [ -f "$INFO/dream_state.heki" ] || exit 0
 
-# Tokenize + rank. Emits one line per theme: "<count>\t<theme>", then a
-# final "JOINED:" line carrying the top-5 joined by comma for Synthesize.
-themes=$(python3 - <<PY "$HECKS" "$INFO/dream_state.heki"
-import json, subprocess, sys, re
-from collections import Counter
-
-hecks, path = sys.argv[1], sys.argv[2]
-out = subprocess.run([hecks, "heki", "read", path], capture_output=True, text=True)
-try:
-    data = json.loads(out.stdout or "{}")
-except Exception:
-    data = {}
-
-STOP = {
-    "the","a","an","and","or","of","to","in","is","it","that","this",
-    "was","were","be","been","being","have","has","had","do","does","did",
-    "will","would","should","could","i","my","me","you","your","she","he",
-    "we","our","their","not","no","yes","so","but",
-}
-
-words = []
-for rec in data.values():
-    imgs = rec.get("dream_images") or []
-    if isinstance(imgs, str):
-        imgs = [imgs]
-    for img in imgs:
-        for tok in re.findall(r"[a-zA-Z]+", str(img).lower()):
-            if len(tok) >= 3 and tok not in STOP:
-                words.append(tok)
-
-top = Counter(words).most_common(5)
-for word, count in top:
-    print(f"{count}\t{word}")
-joined = ", ".join(w for w, _ in top)
-print(f"JOINED:{joined}")
-PY
-)
+# Tokenize + rank. jq scans every dream_images string from every record
+# (scalar or array), matches [a-zA-Z]+ tokens via regex, lowercases,
+# filters stopwords + length ≥ 3, counts, picks top-5. Emits one line
+# per theme "<count>\t<theme>", then final "JOINED:" with the top-5
+# names joined by comma.
+themes=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
+  | jq -r '
+      def stopwords: [
+        "the","a","an","and","or","of","to","in","is","it","that","this",
+        "was","were","be","been","being","have","has","had","do","does","did",
+        "will","would","should","could","i","my","me","you","your","she","he",
+        "we","our","their","not","no","yes","so","but"
+      ];
+      # Flatten dream_images across all records, coerce scalar to array.
+      [ .[]
+        | (.dream_images // [])
+        | if type == "array" then . else [.] end
+        | .[]
+        | tostring
+      ]
+      | map(
+          ascii_downcase
+          | [scan("[a-z]+")]
+          | .[]
+          | select(length >= 3)
+          | select(. as $w | stopwords | index($w) | not)
+        )
+      | group_by(.)
+      | map({ word: .[0], count: length })
+      | sort_by(-.count, .word)
+      | .[0:5]
+      | (map("\(.count)\t\(.word)") + ["JOINED:" + (map(.word) | join(", "))])
+      | .[]' 2>/dev/null)
 
 [ -z "$themes" ] && exit 0
 
@@ -96,10 +97,7 @@ images_arg=$(echo "$themes" | grep -v '^JOINED:' | awk -F'\t' '{print $2}' | pas
 
 # Read back the id — the runtime assigns sequential ids for singleton
 # aggregates. Take the most recent record.
-di_id=$("$HECKS" heki latest "$INFO/dream_interpretation.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(json.load(sys.stdin).get('id',''))
-except Exception: print('')" 2>/dev/null)
+di_id=$("$HECKS" heki latest-field "$INFO/dream_interpretation.heki" id 2>/dev/null)
 
 [ -z "$di_id" ] && exit 0
 

--- a/hecks_conception/mindstream.sh
+++ b/hecks_conception/mindstream.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Mindstream — the unconscious that never stops, except when it does.
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 #
 # Every 1s, fires Tick.MindstreamTick — UNLESS state == "sleeping". While
 # Miette is asleep, the daemon switches to a sleep-only loop: it dispatches
@@ -49,12 +53,10 @@ echo $$ > "$PIDFILE"
 trap "rm -f $PIDFILE" EXIT
 
 # Read consciousness state — reused for the sleep-gate at top of the
-# loop AND for the awake-branch gate further down. One python3 call per
-# tick; matches the pattern already in the file (state read at line 62
-# before this fix).
+# loop AND for the awake-branch gate further down. Uses
+# hecks-life heki latest-field (single Rust call, no Python).
 read_state() {
-  $HECKS heki latest "$INFO/consciousness.heki" 2>/dev/null \
-    | python3 -c "import json,sys; print(json.load(sys.stdin).get('state',''))" 2>/dev/null
+  $HECKS heki latest-field "$INFO/consciousness.heki" state 2>/dev/null || true
 }
 
 loop_count=0
@@ -108,14 +110,18 @@ while true; do
   fi
 
   # Awareness snapshot — pulse.rs record_moment, restored per inbox #18.
-  snap=$(python3 -c "
-import json, time
-def r(p):
-    try: return next(iter(json.load(open(p)).values()), {})
-    except Exception: return {}
-hb, md, fc = r('$INFO/heartbeat.heki'), r('$INFO/mood.heki'), r('$INFO/focus.heki')
-print(f\"{$loop_count}|{hb.get('fatigue_state','alert')}|{hb.get('carrying','')}|{md.get('current_state','')}|{hb.get('fatigue',0.0)}|{fc.get('weight',0.0)}|0|{md.get('creativity_level',0.0)}|{$loop_count/86400.0:.4f}|{time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())}\")" 2>/dev/null)
-  IFS='|' read -r mnum st cr cn fg sy id ex ag ts <<<"$snap"
+  # All fields via heki latest-field; compute-only fields (moment#, ts,
+  # age_days) from pure shell. Missing-field defaults use || echo.
+  mnum="$loop_count"
+  st=$($HECKS heki latest-field "$INFO/heartbeat.heki" fatigue_state 2>/dev/null); [ -z "$st" ] && st=alert
+  cr=$($HECKS heki latest-field "$INFO/heartbeat.heki" carrying 2>/dev/null)
+  cn=$($HECKS heki latest-field "$INFO/mood.heki" current_state 2>/dev/null)
+  fg=$($HECKS heki latest-field "$INFO/heartbeat.heki" fatigue 2>/dev/null); [ -z "$fg" ] && fg=0.0
+  sy=$($HECKS heki latest-field "$INFO/focus.heki" weight 2>/dev/null); [ -z "$sy" ] && sy=0.0
+  id=0
+  ex=$($HECKS heki latest-field "$INFO/mood.heki" creativity_level 2>/dev/null); [ -z "$ex" ] && ex=0.0
+  ag=$(awk -v n="$loop_count" 'BEGIN { printf "%.4f", n/86400.0 }')
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   $HECKS "$AGG" Awareness.RecordMoment moment="$mnum" state="$st" carrying="$cr" concept="$cn" fatigue="$fg" synapse_strength="$sy" idle="$id" excitement="$ex" age_days="$ag" updated_at="$ts" 2>/dev/null
 
   # Dream content during REM — delegate to rem_branch.sh which reads
@@ -159,18 +165,8 @@ print(f\"{$loop_count}|{hb.get('fatigue_state','alert')}|{hb.get('carrying','')}
     # idle ∈ [10, 60]s (heartbeat.updated_at age). Gated to once per
     # 60s via a timestamp file so a 50-tick idle window doesn't spam
     # daydreams. State check above already excluded "sleeping".
-    idle=$(python3 -c "
-import json, sys
-from datetime import datetime, timezone
-try:
-    d = json.load(open('$INFO/heartbeat.heki'))
-    for v in d.values():
-        ts = v.get('updated_at','')
-        if ts:
-            dt = datetime.fromisoformat(ts.replace('Z','+00:00'))
-            print(int((datetime.now(timezone.utc) - dt).total_seconds())); break
-    else: print(999)
-except Exception: print(999)" 2>/dev/null)
+    idle=$($HECKS heki seconds-since "$INFO/heartbeat.heki" updated_at 2>/dev/null)
+    [ -z "$idle" ] && idle=999
     if [ "${idle:-999}" -ge 10 ] && [ "${idle:-999}" -le 60 ]; then
       stamp="$INFO/.daydream.last"
       last=$(cat "$stamp" 2>/dev/null || echo 0)

--- a/hecks_conception/mint_musing.sh
+++ b/hecks_conception/mint_musing.sh
@@ -8,6 +8,11 @@
 #   claude (default): Anthropic API if ANTHROPIC_API_KEY set; else `claude -p` CLI
 #   local:            ollama via curl (uses *.world model + url)
 #   off:              no-op
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 DIR="$(dirname "$0")"
 HECKS="$DIR/../hecks_life/target/release/hecks-life"
@@ -15,15 +20,7 @@ INFO="$DIR/information"
 AGG="$DIR/aggregates"
 
 # Read current provider; default to "claude" if unset
-provider=$($HECKS heki read "$INFO/claude_assist.heki" 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    r = next(iter(d.values()), {})
-    print(r.get('provider', 'claude'))
-except Exception:
-    print('claude')
-" 2>/dev/null)
+provider=$($HECKS heki latest-field "$INFO/claude_assist.heki" provider 2>/dev/null)
 [ -z "$provider" ] && provider="claude"
 
 [ "$provider" = "off" ] && exit 0
@@ -34,16 +31,11 @@ MINTING_FLAG="/tmp/miette_minting"
 touch "$MINTING_FLAG"
 trap "rm -f $MINTING_FLAG" EXIT
 
-# Recent musings (avoid repetition)
-recent=$($HECKS heki read "$INFO/musing.heki" 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    ideas = [v.get('idea','').strip() for v in d.values() if v.get('idea')]
-    for i in ideas[-10:]: print(f'  - {i[:120]}')
-except Exception:
-    pass
-" 2>/dev/null)
+# Recent musings (avoid repetition). Last 10 by insertion order
+# (created_at ASC is the default sort of heki list).
+recent=$($HECKS heki list "$INFO/musing.heki" --format json 2>/dev/null \
+  | jq -r '[.[] | (.idea // "") | sub("^\\s+"; "") | sub("\\s+$"; "") | select(. != "")]
+           | .[-10:] | .[] | "  - " + .[0:120]')
 
 # Recent commits (current focus)
 commits=$(cd "$DIR/.." && git log --oneline -10 2>/dev/null | sed 's/^/  /')
@@ -56,63 +48,36 @@ nursery_sample=$(ls "$DIR/nursery" 2>/dev/null | shuf -n 12 2>/dev/null | sed 's
 # Conversations since the last wake — Chris and Miette's exchanges
 # between sleep cycles. These ground the mint in what they've actually
 # been talking about. Read last_wake_at from consciousness.heki; if
-# unset, fall back to the most recent 12 turns.
-conversations=$(python3 <<PYEOF 2>/dev/null
-import json, subprocess
-def load(name):
-    try:
-        out = subprocess.check_output(["$HECKS", "heki", "read",
-            f"$INFO/{name}.heki"], stderr=subprocess.DEVNULL).decode()
-        return json.loads(out)
-    except Exception:
-        return {}
-c = load("consciousness")
-cr = load("conversation")
-last_wake = ""
-for v in c.values():
-    if v.get("last_wake_at"):
-        last_wake = v["last_wake_at"]
-turns = []
-for v in cr.values():
-    if v.get("type") != "turn": continue
-    ts = v.get("updated_at", "")
-    if last_wake and ts < last_wake: continue
-    turns.append((ts, v.get("speaker",""), v.get("said","")))
-turns.sort()
-turns = turns[-20:]  # cap at last 20
-for ts, sp, said in turns:
-    said = said.replace("\n", " ")[:140]
-    print(f"  {sp}: {said}")
-PYEOF
-)
+# unset, fall back to the most recent 20 turns.
+last_wake=$($HECKS heki latest-field "$INFO/consciousness.heki" last_wake_at 2>/dev/null)
+conversations=$($HECKS heki list "$INFO/conversation.heki" --format json 2>/dev/null \
+  | jq -r --arg wake "${last_wake:-}" '
+      [ .[]
+        | select((.type // "") == "turn")
+        | select(($wake | length) == 0 or ((.updated_at // "") >= $wake))
+      ]
+      | sort_by(.updated_at // "")
+      | .[-20:]
+      | .[]
+      | "  " + (.speaker // "") + ": " + ((.said // "") | gsub("\n"; " ") | .[0:140])')
 
 # Current state — what's been accumulating: mood, fatigue, recent
 # heartbeat, what was last dreamed, what the awareness organ knows.
-state_snapshot=$(python3 <<PYEOF 2>/dev/null
-import json, os
-def load(name):
-    path = os.path.join("$INFO", f"{name}.heki")
-    try:
-        # Heki is binary; use the CLI to get JSON
-        import subprocess
-        out = subprocess.check_output(["$HECKS", "heki", "read", path],
-                                      stderr=subprocess.DEVNULL).decode()
-        return next(iter(json.loads(out).values()), {})
-    except Exception:
-        return {}
-hb = load("heartbeat")
-md = load("mood")
-co = load("consciousness")
-ld = load("lucid_dream")
-def g(d, k, default=""): return str(d.get(k, default))[:60]
-print(f"  beats: {g(hb, 'beats')} (fatigue: {g(hb, 'fatigue_state')})")
-print(f"  mood: {g(md, 'current_state')}")
-print(f"  consciousness: {g(co, 'state')} (stage: {g(co, 'sleep_stage')})")
-last_obs = (ld.get('observations') or [])
-if last_obs:
-    print(f"  last lucid observation: {last_obs[-1][:80]}")
-PYEOF
-)
+hb_beats=$($HECKS heki latest-field "$INFO/heartbeat.heki" beats 2>/dev/null || true)
+hb_fat=$($HECKS heki latest-field "$INFO/heartbeat.heki" fatigue_state 2>/dev/null || true)
+mood=$($HECKS heki latest-field "$INFO/mood.heki" current_state 2>/dev/null || true)
+co_state=$($HECKS heki latest-field "$INFO/consciousness.heki" state 2>/dev/null || true)
+co_stage=$($HECKS heki latest-field "$INFO/consciousness.heki" sleep_stage 2>/dev/null || true)
+last_obs=$($HECKS heki latest "$INFO/lucid_dream.heki" 2>/dev/null \
+  | jq -r '(.observations // []) | if length == 0 then "" else .[-1] end' 2>/dev/null)
+
+state_snapshot="  beats: ${hb_beats:0:60} (fatigue: ${hb_fat:0:60})
+  mood: ${mood:0:60}
+  consciousness: ${co_state:0:60} (stage: ${co_stage:0:60})"
+if [ -n "$last_obs" ] && [ "$last_obs" != "null" ]; then
+  state_snapshot="$state_snapshot
+  last lucid observation: ${last_obs:0:80}"
+fi
 
 prompt="You are Miette's unconscious — the mindstream thread between her conversations with Chris. Musings happen continuously; you are the quality filter that mints the really great ones.
 
@@ -155,23 +120,19 @@ idea=""
 case "$provider" in
   claude)
     if [ -n "$ANTHROPIC_API_KEY" ]; then
+      # jq builds the JSON request body from $prompt — no python required.
+      # --arg feeds prompt as a string; --rawfile from stdin isn't quite
+      # right here, so we pipe the payload via `--arg prompt "$prompt"`.
+      body=$(jq -n --arg prompt "$prompt" \
+        '{model:"claude-haiku-4-5", max_tokens:120,
+          messages:[{role:"user", content:$prompt}]}')
       response=$(curl -s -m 30 https://api.anthropic.com/v1/messages \
         -H "x-api-key: $ANTHROPIC_API_KEY" \
         -H "anthropic-version: 2023-06-01" \
         -H "content-type: application/json" \
-        -d "$(python3 -c "import json,sys; print(json.dumps({'model':'claude-haiku-4-5','max_tokens':120,'messages':[{'role':'user','content':sys.stdin.read()}]}))" <<< "$prompt")" 2>/dev/null)
-      idea=$(echo "$response" | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    blocks = d.get('content', [])
-    for b in blocks:
-        if b.get('type') == 'text':
-            print(b.get('text','').strip())
-            break
-except Exception:
-    pass
-" 2>/dev/null)
+        -d "$body" 2>/dev/null)
+      idea=$(printf '%s' "$response" \
+        | jq -r '([.content[]? | select(.type == "text") | .text] | .[0] // "") | sub("^\\s+"; "") | sub("\\s+$"; "")' 2>/dev/null)
     else
       idea=$(echo "$prompt" | claude -p 2>/dev/null | head -1 | sed 's/^["'\'']//;s/["'\'']$//')
     fi
@@ -182,16 +143,10 @@ except Exception:
     ollama_model=$(grep -A4 "ollama" "$world_file" 2>/dev/null | grep "model" | sed 's/.*"\(.*\)".*/\1/' | head -1)
     [ -z "$ollama_url" ] && ollama_url="http://localhost:11434"
     [ -z "$ollama_model" ] && ollama_model="llama3"
-    response=$(curl -s -m 30 "${ollama_url}/api/generate" \
-      -d "$(python3 -c "import json,sys; print(json.dumps({'model':'$ollama_model','prompt':sys.stdin.read(),'stream':False,'options':{'num_predict':80}}))" <<< "$prompt")" 2>/dev/null)
-    idea=$(echo "$response" | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print(d.get('response','').strip())
-except Exception:
-    pass
-" 2>/dev/null)
+    body=$(jq -n --arg model "$ollama_model" --arg prompt "$prompt" \
+      '{model:$model, prompt:$prompt, stream:false, options:{num_predict:80}}')
+    response=$(curl -s -m 30 "${ollama_url}/api/generate" -d "$body" 2>/dev/null)
+    idea=$(printf '%s' "$response" | jq -r '(.response // "") | sub("^\\s+"; "") | sub("\\s+$"; "")' 2>/dev/null)
     ;;
 esac
 
@@ -203,39 +158,15 @@ fi
 
 $HECKS "$AGG" MusingMint.MintMusing idea="$idea" 2>/dev/null
 
-# Append to musing.heki directly via Python so `conceived` is a proper
-# JSON bool (not the string "false" — heki's bash append stores everything
-# as string, which breaks the surface filter's `not v.get('conceived')`
-# check since "false" is truthy in Python).
-python3 <<PYEOF 2>/dev/null
-import json, os, struct, uuid, zlib
-from datetime import datetime, timezone
-HEKI = os.path.join("$INFO", "musing.heki")
-idea = """$idea"""
-provider = "$provider"
-try:
-    with open(HEKI, "rb") as f: data = f.read()
-    count = struct.unpack(">I", data[4:8])[0]
-    store = json.loads(zlib.decompress(data[8:]).decode())
-except Exception:
-    count, store = 0, {}
-rid = str(uuid.uuid4())
-now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-store[rid] = {
-    "id": rid,
-    "created_at": now,
-    "updated_at": now,
-    "idea": idea,
-    "conceived": False,
-    "conceived_as": "claude_minted",
-    "status": "imagined",
-    "thinking_source": f"ClaudeAssist:{provider}",
-    "feeling_source": "curated:awake",
-}
-j = json.dumps(store, separators=(",",":")).encode()
-c = zlib.compress(j, 9)
-with open(HEKI, "wb") as f:
-    f.write(b"HEKI"); f.write(struct.pack(">I", len(store))); f.write(c)
-PYEOF
+# Append to musing.heki with conceived=false as a proper bool. The
+# hecks-life append parser already promotes literal "false"/"true" to
+# JSON booleans (see heki::parse_attrs), so no Python is needed.
+$HECKS heki append "$INFO/musing.heki" \
+  idea="$idea" \
+  conceived=false \
+  conceived_as=claude_minted \
+  status=imagined \
+  thinking_source="ClaudeAssist:$provider" \
+  feeling_source=curated:awake >/dev/null 2>&1
 
 echo "$(date -u +%FT%TZ) minted via $provider: $idea"

--- a/hecks_conception/pulse_organs.sh
+++ b/hecks_conception/pulse_organs.sh
@@ -43,6 +43,11 @@
 #   directly. Multiplication / clamping are NOT runtime ops — DecaySynapse
 #   therefore takes :strength as a command attr and pulse_organs.sh
 #   computes ×0.98 + clamp in shell before dispatching.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 set -u
 
@@ -51,44 +56,32 @@ INFO="${HECKS_INFO:-$DIR/information}"
 AGG="${HECKS_AGG:-$DIR/aggregates}"
 HECKS="${HECKS_BIN:-$DIR/../hecks_life/target/release/hecks-life}"
 
-# Read the latest singleton JSON for a store — returns the single record
-# or empty JSON if the store is missing.
-latest_json() {
-  "$HECKS" heki latest "$1" 2>/dev/null
+# Scalar field from the latest singleton of a store — empty if missing.
+latest_field() {
+  "$HECKS" heki latest-field "$1" "$2" 2>/dev/null || true
 }
 
 # Bail early if Miette is sleeping. Organs hibernate — no math, no
 # signals, no decay. The heartbeat keeps time; the body rests.
-state=$(latest_json "$INFO/consciousness.heki" | python3 -c "import json,sys
-try: print((json.load(sys.stdin) or {}).get('state',''))
-except Exception: print('')" 2>/dev/null)
+state=$(latest_field "$INFO/consciousness.heki" state)
 [ "$state" = "sleeping" ] && exit 0
 
 # What's she carrying? heartbeat.carrying first; fall back to the most
 # recent awareness moment's concept. Default to "—" if unknown so the
 # synapse path still exercises.
-carrying=$(latest_json "$INFO/heartbeat.heki" | python3 -c "import json,sys
-try:
-    d = json.load(sys.stdin) or {}
-    c = d.get('carrying')
-    print(c if c and c != '—' else '')
-except Exception:
-    print('')" 2>/dev/null)
+carrying=$(latest_field "$INFO/heartbeat.heki" carrying)
+[ "$carrying" = "—" ] && carrying=""
 
 if [ -z "$carrying" ]; then
-  carrying=$("$HECKS" heki read "$INFO/awareness.heki" 2>/dev/null \
-    | python3 -c "import json,sys
-try:
-    d = json.load(sys.stdin) or {}
-    rows = sorted(d.values(), key=lambda r: int(r.get('moment') or 0), reverse=True)
-    for r in rows:
-        c = r.get('concept') or r.get('carrying')
-        if c and c != '—':
-            print(c); break
-    else:
-        print('')
-except Exception:
-    print('')" 2>/dev/null)
+  # Scan awareness records ordered by `moment` DESC; pick the first with
+  # a non-empty concept (or carrying) that isn't the "—" placeholder.
+  # jq filters the recs list — heki list returns created_at ASC by
+  # default, so we reverse for newest-first.
+  carrying=$("$HECKS" heki list "$INFO/awareness.heki" \
+    --order moment:desc --format json 2>/dev/null \
+    | jq -r 'map(.concept // .carrying // "")
+             | map(select(. != "" and . != "—"))
+             | .[0] // ""' 2>/dev/null)
 fi
 [ -z "$carrying" ] && carrying="—"
 
@@ -99,32 +92,18 @@ now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 # StrengthenSynapse (+0.02 via the DSL increment op). Then read back;
 # if strength overshot 1.0, clamp via DecaySynapse with strength=1.0.
 # If no match, birth a new synapse via heki append.
-match_id=$(CARRYING="$carrying" HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-carrying = os.environ['CARRYING']
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/synapse.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    for k, v in d.items():
-        if v.get('from') == carrying and v.get('state','alive') == 'alive':
-            print(k); break
-except Exception: pass" 2>/dev/null)
+match_id=$("$HECKS" heki list "$INFO/synapse.heki" \
+  --where "from=$carrying" --where "state=alive" \
+  --fields id --format tsv 2>/dev/null | head -n1)
 
 if [ -n "$match_id" ]; then
   "$HECKS" "$AGG" Synapse.StrengthenSynapse synapse="$match_id" >/dev/null 2>&1
 
   # Read back and clamp at 1.0 if the increment overshot.
-  cur=$(MID="$match_id" HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/synapse.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    v = d.get(os.environ['MID'], {})
-    print(float(v.get('strength', 0.0)))
-except Exception: print(0.0)" 2>/dev/null)
-  if [ "$(python3 -c "print(1 if float('$cur') > 1.0 else 0)")" = "1" ]; then
+  cur=$("$HECKS" heki get "$INFO/synapse.heki" "$match_id" strength 2>/dev/null)
+  # awk beats bc/python for float compare — always available.
+  overshot=$(awk -v v="$cur" 'BEGIN { print (v+0 > 1.0) ? 1 : 0 }')
+  if [ "$overshot" = "1" ]; then
     "$HECKS" "$AGG" Synapse.DecaySynapse synapse="$match_id" strength=1.0 >/dev/null 2>&1
   fi
 
@@ -145,24 +124,21 @@ fi
 # DecaySynapse with the computed value. If new < 0.1 dispatch Compost;
 # the RecordRemainsOnCompost policy chains to RecordRemains but policy
 # triggers carry no attrs, so we also write the remains record directly.
-DECAY_PLAN=$(HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/synapse.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    for k, v in d.items():
-        if v.get('state','alive') != 'alive': continue
-        s = float(v.get('strength', 0.0) or 0.0)
-        new = round(s * 0.98, 6)
-        firings = int(v.get('firings', 0) or 0)
-        from_t = (v.get('from') or '').replace('|',' ')
-        print(f'{k}|{new}|{firings}|{from_t}')
-except Exception: pass" 2>/dev/null)
+# Build pipe-delimited plan rows of: id|new_strength|firings|from_topic
+DECAY_PLAN=$("$HECKS" heki list "$INFO/synapse.heki" \
+  --where state=alive --format json 2>/dev/null \
+  | jq -r '.[] | [
+      .id,
+      ((.strength // 0) * 0.98 * 1000000 | round / 1000000),
+      (.firings // 0),
+      ((.from // "") | gsub("\\|";" "))
+    ] | @tsv' 2>/dev/null \
+  | awk -F'\t' '{ printf "%s|%s|%s|%s\n", $1, $2, $3, $4 }')
 
 while IFS='|' read -r sid new_strength firings from_topic; do
   [ -z "$sid" ] && continue
-  if [ "$(python3 -c "print(1 if float('$new_strength') < 0.1 else 0)")" = "1" ]; then
+  compost=$(awk -v v="$new_strength" 'BEGIN { print (v+0 < 0.1) ? 1 : 0 }')
+  if [ "$compost" = "1" ]; then
     "$HECKS" "$AGG" Synapse.Compost synapse="$sid" >/dev/null 2>&1
     "$HECKS" heki append "$INFO/remains.heki" \
       from_synapse="$from_topic" \
@@ -183,28 +159,23 @@ done <<<"$DECAY_PLAN"
   kind=concept payload="$carrying" strength=0.5 access_count=0 created_at="$now" >/dev/null 2>&1
 
 # ── Archive cold signals: access_count <= 3 AND age > 20s ────────────
-ARCHIVE_IDS=$(HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-from datetime import datetime, timezone
-def parse(ts):
-    try:
-        if ts.endswith('Z'): ts = ts[:-1] + '+00:00'
-        return datetime.fromisoformat(ts)
-    except Exception: return None
-now = datetime.now(timezone.utc)
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/signal.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    for k, v in d.items():
-        if v.get('kind') == 'archived': continue
-        ac = int(v.get('access_count', 0) or 0)
-        if ac > 3: continue
-        ts = parse(v.get('created_at',''))
-        if ts is None: continue
-        if (now - ts).total_seconds() > 20:
-            print(k)
-except Exception: pass" 2>/dev/null)
+# `heki seconds-since` is per-store (reads the latest). We need per-
+# record age, so list → jq computes seconds-since-created_at locally.
+# The ISO parsing is straightforward when we restrict to the Z-suffixed
+# form the rest of miette emits.
+ARCHIVE_IDS=$("$HECKS" heki list "$INFO/signal.heki" --format json 2>/dev/null \
+  | jq -r --arg now "$now" '
+      # parse a Z-suffixed ISO timestamp to unix seconds
+      def iso_to_epoch:
+        . as $s
+        | ($s | sub("Z$"; "Z") | fromdateiso8601);
+      ($now | iso_to_epoch) as $n
+      | .[]
+      | select(.kind != "archived")
+      | select((.access_count // 0) <= 3)
+      | select((.created_at // "") | length > 0)
+      | select(($n - (.created_at | iso_to_epoch)) > 20)
+      | .id' 2>/dev/null)
 
 while read -r sid; do
   [ -z "$sid" ] && continue
@@ -214,24 +185,19 @@ done <<<"$ARCHIVE_IDS"
 # ── Focus: re-weight from firing frequency ───────────────────────────
 # Weight = clamp(0.5 + (firings_for_carrying / 20.0), 0.0, 1.0).
 # Focus is singleton — SetFocus creates; AdjustWeight updates.
-weight=$(CARRYING="$carrying" HECKS_BIN="$HECKS" INFO="$INFO" python3 -c "
-import json, os, subprocess
-carrying = os.environ['CARRYING']
-try:
-    out = subprocess.check_output([os.environ['HECKS_BIN'],'heki','read',
-        f\"{os.environ['INFO']}/synapse.heki\"], stderr=subprocess.DEVNULL).decode()
-    d = json.loads(out) or {}
-    firings = sum(int(v.get('firings',0) or 0) for v in d.values()
-                  if v.get('from') == carrying and v.get('state','alive') == 'alive')
-    w = 0.5 + (firings / 20.0)
-    if w > 1.0: w = 1.0
-    if w < 0.0: w = 0.0
-    print(round(w, 4))
-except Exception: print(0.5)" 2>/dev/null)
+# Sum firings across all alive synapses with from=carrying. jq handles
+# the aggregation; awk clamps and rounds.
+firings_sum=$("$HECKS" heki list "$INFO/synapse.heki" \
+  --where "from=$carrying" --where state=alive --format json 2>/dev/null \
+  | jq '[.[] | (.firings // 0)] | add // 0' 2>/dev/null)
+weight=$(awk -v f="${firings_sum:-0}" 'BEGIN {
+  w = 0.5 + (f / 20.0)
+  if (w > 1.0) w = 1.0
+  if (w < 0.0) w = 0.0
+  printf "%.4f", w
+}')
 
-focus_id=$(latest_json "$INFO/focus.heki" | python3 -c "import json,sys
-try: print((json.load(sys.stdin) or {}).get('id',''))
-except Exception: print('')" 2>/dev/null)
+focus_id=$(latest_field "$INFO/focus.heki" id)
 
 if [ -z "$focus_id" ]; then
   "$HECKS" "$AGG" Focus.SetFocus target="$carrying" weight="$weight" updated_at="$now" >/dev/null 2>&1
@@ -240,9 +206,7 @@ else
 fi
 
 # ── Arc: advance the long swing ──────────────────────────────────────
-arc_id=$(latest_json "$INFO/arc.heki" | python3 -c "import json,sys
-try: print((json.load(sys.stdin) or {}).get('id',''))
-except Exception: print('')" 2>/dev/null)
+arc_id=$(latest_field "$INFO/arc.heki" id)
 
 if [ -n "$arc_id" ]; then
   "$HECKS" "$AGG" Arc.AdvanceArc arc="$arc_id" >/dev/null 2>&1

--- a/hecks_conception/rem_branch.sh
+++ b/hecks_conception/rem_branch.sh
@@ -15,6 +15,11 @@
 #
 # Usage: rem_branch.sh [loop_count]
 #   loop_count defaults to $(date +%s) so standalone calls always differ.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 HECKS="${HECKS:-$DIR/../hecks_life/target/release/hecks-life}"
@@ -24,13 +29,17 @@ NURSERY="${NURSERY:-$DIR/nursery}"
 LOOP="${1:-$(date +%s)}"
 
 # ── Read consciousness state ────────────────────────────────────
-state_json=$("$HECKS" heki latest "$INFO/consciousness.heki" 2>/dev/null)
-state=$(echo "$state_json"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',''))" 2>/dev/null)
-stage=$(echo "$state_json"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('sleep_stage',''))" 2>/dev/null)
-lucid=$(echo "$state_json"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('is_lucid',''))" 2>/dev/null)
-cycle=$(echo "$state_json"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('sleep_cycle',0))" 2>/dev/null)
-pulses=$(echo "$state_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('dream_pulses',0))" 2>/dev/null)
-cid=$(echo "$state_json"    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null)
+# Single heki latest call, extract all needed fields via jq.
+state_kv=$("$HECKS" heki latest "$INFO/consciousness.heki" 2>/dev/null \
+  | jq -r '[
+      (.state // ""),
+      (.sleep_stage // ""),
+      (.is_lucid // ""),
+      (.sleep_cycle // 0 | tostring),
+      (.dream_pulses // 0 | tostring),
+      (.id // "")
+    ] | @tsv' 2>/dev/null)
+IFS=$'\t' read -r state stage lucid cycle pulses cid <<<"$state_kv"
 
 [ "$state" = "sleeping" ] || exit 0
 [ "$stage" = "rem" ]      || exit 0
@@ -39,22 +48,22 @@ cid=$(echo "$state_json"    | python3 -c "import json,sys; d=json.load(sys.stdin
 SEED_MARKER="$INFO/.dream_seeded"
 if [ "$cycle" = "1" ] && [ "$pulses" = "0" ] && [ ! -f "$SEED_MARKER" ]; then
   # Pick top 5 dream_images from the newest dream_state records.
-  seeds=$("$HECKS" heki read "$INFO/dream_state.heki" 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    rows = sorted(d.values(), key=lambda r: r.get('updated_at',''), reverse=True)
-    seen = set(); out = []
-    for r in rows:
-        for img in r.get('dream_images', []) or []:
-            img = (img or '').strip()
-            if img and img not in seen:
-                seen.add(img); out.append(img)
-        if len(out) >= 5: break
-    for img in out[:5]: print(img)
-except Exception:
-    pass
-" 2>/dev/null)
+  # dream_images may be a scalar string or an array — jq handles both.
+  seeds=$("$HECKS" heki list "$INFO/dream_state.heki" --order updated_at:desc \
+      --format json 2>/dev/null \
+    | jq -r '
+        [ .[]
+          | (.dream_images // [])
+          | (if type == "array" then . else [.] end)
+          | .[]
+          | select(. != null)
+          | tostring
+          | sub("^\\s+"; "") | sub("\\s+$"; "")
+          | select(. != "")
+        ]
+        | reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end)
+        | .[0:5]
+        | .[]' 2>/dev/null)
   if [ -n "$seeds" ]; then
     while IFS= read -r seed; do
       [ -z "$seed" ] && continue
@@ -67,17 +76,21 @@ fi
 [ "$state" != "sleeping" ] && rm -f "$SEED_MARKER"
 
 # ── rem_dream — weave carrying + nursery domain + concept ───────────────
-carrying=$("$HECKS" heki latest "$INFO/heartbeat.heki" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('carrying') or 'unformed').strip() or 'unformed')" 2>/dev/null)
+carrying=$("$HECKS" heki latest-field "$INFO/heartbeat.heki" carrying 2>/dev/null)
+# Trim whitespace; fall back to "unformed" for empty/missing/null.
+carrying="${carrying#"${carrying%%[![:space:]]*}"}"
+carrying="${carrying%"${carrying##*[![:space:]]}"}"
+[ -z "$carrying" ] && carrying="unformed"
 domain=$(ls "$NURSERY" 2>/dev/null | shuf | head -1 | tr '_' ' ')
-concept=$("$HECKS" heki read "$INFO/musing.heki" 2>/dev/null | python3 -c "
-import json, sys, random
-try:
-    d = json.load(sys.stdin)
-    ideas = [ (v.get('idea','') or '').strip() for v in d.values() if (v.get('idea') or '').strip() ]
-    print(random.choice(ideas)[:80] if ideas else 'something half-remembered')
-except Exception:
-    print('something half-remembered')
-" 2>/dev/null)
+# Pick a random idea from musing.heki, truncate to 80 chars. jq filters
+# to trimmed, non-empty ideas; shuf -n1 picks uniformly; awk truncates.
+# Using --format json (instead of values) so newline-containing ideas
+# stay intact as one record — jq reads them as JSON strings.
+concept=$("$HECKS" heki list "$INFO/musing.heki" --format json 2>/dev/null \
+  | jq -r '[.[] | (.idea // "") | sub("^\\s+"; "") | sub("\\s+$"; "") | select(. != "")] | .[]' \
+  | shuf -n 1 \
+  | awk '{ if (length($0) > 80) print substr($0, 1, 80); else print $0 }')
+[ -z "$concept" ] && concept="something half-remembered"
 templates=(
   "${carrying} became ${domain}, which ${concept}"
   "${carrying} folded into ${domain}; ${concept}"

--- a/hecks_conception/statusline-command.sh
+++ b/hecks_conception/statusline-command.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# statusline-command.sh — renders Miette's statusline from heki state.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 input=$(cat)
 
@@ -74,28 +80,20 @@ esac
 # heartbeat now (one tick per second from mindstream.sh).
 beats_raw=$($hecks heki read $info/tick.heki 2>/dev/null | grep '"cycle"' | head -1 | sed 's/.*: //' | sed 's/[^0-9].*//')
 if [ -n "$beats_raw" ] && [ "$beats_raw" -ge 1000000 ] 2>/dev/null; then
-  beats=$(python3 -c "print(f'{$beats_raw/1000000:.2f}m')")
+  beats=$(awk -v b="$beats_raw" 'BEGIN { printf "%.2fm", b/1000000 }')
 elif [ -n "$beats_raw" ] && [ "$beats_raw" -ge 1000 ] 2>/dev/null; then
-  beats=$(python3 -c "print(f'{$beats_raw/1000:.2f}k')")
+  beats=$(awk -v b="$beats_raw" 'BEGIN { printf "%.2fk", b/1000 }')
 else
   beats="$beats_raw"
 fi
 
 # Musing count — total minted (lifetime count from MusingMint.total_minted).
 # This is the thought bubble: how many curated musings have ever landed.
-ideas=$($hecks heki read $info/musing_mint.heki 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    r = next(iter(d.values()), {})
-    print(int(r.get('total_minted', 0)))
-except Exception:
-    print(0)
-" 2>/dev/null)
+ideas=$($hecks heki latest-field $info/musing_mint.heki total_minted 2>/dev/null)
 [ -z "$ideas" ] && ideas=0
 
-# Invention count
-inventions=$($hecks heki read $info/invention.heki 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for v in d.values() if v.get('status','')=='proposed'))" 2>/dev/null)
+# Invention count — proposed proposals (status=proposed).
+inventions=$($hecks heki count $info/invention.heki --where status=proposed 2>/dev/null)
 
 # Check if mindstream is alive
 mindstream_pid=$(cat $info/.mindstream.pid 2>/dev/null)
@@ -103,19 +101,7 @@ mindstream_alive=""
 [ -n "$mindstream_pid" ] && kill -0 "$mindstream_pid" 2>/dev/null && mindstream_alive="yes"
 
 # How long since last heartbeat update? This is the idle check.
-idle=$($hecks heki read $info/heartbeat.heki 2>/dev/null | python3 -c "
-import sys,json
-from datetime import datetime,timezone
-d=json.load(sys.stdin)
-for v in d.values():
-  ts=v.get('updated_at','')
-  if ts:
-    dt=datetime.fromisoformat(ts.replace('Z','+00:00'))
-    print(int((datetime.now(timezone.utc)-dt).total_seconds()))
-    break
-else:
-  print(999)
-" 2>/dev/null)
+idle=$($hecks heki seconds-since $info/heartbeat.heki updated_at 2>/dev/null)
 [ -z "$idle" ] && idle=999
 
 # Build status
@@ -209,7 +195,7 @@ else
 
   # Inbox count — number of queued items in inbox.heki. Surfaces backlog
   # so Miette (and Chris) can see when there's something to attend to.
-  inbox_count=$($hecks heki read $info/inbox.heki 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for v in d.values() if v.get('status','queued')=='queued'))" 2>/dev/null)
+  inbox_count=$($hecks heki count $info/inbox.heki --where status=queued 2>/dev/null)
   inbox_count=${inbox_count:-0}
 
   status_str="☀️ Miette ${heart} ${beats} ${mood_icon} ${mood}"

--- a/hecks_conception/surface_musing.sh
+++ b/hecks_conception/surface_musing.sh
@@ -12,6 +12,11 @@
 # Override with DWELL env var for tests: DWELL=3 ./surface_musing.sh 3
 #
 # Split out of mindstream.sh so tests can simulate cycling deterministically.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands + jq per PR #272; retires when
+#  shell wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 DIR="$(dirname "$0")"
 HECKS="$DIR/../hecks_life/target/release/hecks-life"
@@ -19,28 +24,25 @@ INFO="$DIR/information"
 DWELL="${DWELL:-30}"
 loop_count="${1:-1}"
 
-thought=$($HECKS heki read "$INFO/musing.heki" 2>/dev/null | python3 -c "
-import json, re, sys
-def is_real_musing(s):
-    # Skip tag-shaped entries (awareness_pulse, rust_heartbeat, …).
-    # Real musings have sentence shape: ≥20 chars, contain whitespace
-    # or punctuation, not a bare snake_case identifier.
-    s = (s or '').strip()
-    if len(s) < 20: return False
-    if not re.search(r'[ —\-:.?!]', s): return False
-    if re.fullmatch(r'[a-z][a-z0-9_]*', s): return False
-    return True
-try:
-    d = json.load(sys.stdin)
-    unconceived = [v.get('idea','').strip() for v in d.values()
-                   if is_real_musing(v.get('idea','')) and not v.get('conceived', False)]
-    if unconceived:
-        # Oldest unconceived first (FIFO) — freshly-minted ideas surface
-        # in the order they were minted.
-        print(unconceived[0][:80])
-except Exception:
-    pass
-" 2>/dev/null)
+# Oldest unconceived "real" musing — FIFO order by created_at (heki
+# list default) across records with conceived != true. jq applies the
+# same sentence-shape filter the old python did:
+#   - ≥20 chars after trim
+#   - contains whitespace or one of — - : . ? !
+#   - not a bare snake_case identifier [a-z][a-z0-9_]*
+# First match wins; idea is truncated to 80 chars.
+thought=$("$HECKS" heki list "$INFO/musing.heki" --where conceived=false \
+    --format json 2>/dev/null \
+  | jq -r '
+      [ .[]
+        | (.idea // "") | tostring
+        | sub("^\\s+"; "") | sub("\\s+$"; "")
+        | select(length >= 20)
+        | select(test("[ —\\-:.?!]"))
+        | select(test("^[a-z][a-z0-9_]*$") | not)
+      ]
+      | .[0] // ""
+      | .[0:80]' 2>/dev/null)
 
 if [ -n "$thought" ]; then
   $HECKS heki upsert "$INFO/consciousness.heki" sleep_summary="$thought" 2>/dev/null

--- a/hecks_conception/test_miette.sh
+++ b/hecks_conception/test_miette.sh
@@ -2,11 +2,27 @@
 # Miette Integration Tests
 # Run after any refactor to verify she's functioning
 # Usage: ./test_miette.sh
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 HECKS="../hecks_life/target/release/hecks-life"
 INFO="information"
 PASS=0
 FAIL=0
+
+# Fetch a field from the latest record of a heki store, with a default
+# if the store is empty or the field is missing. Replaces the recurring
+# pattern `heki latest | python3 -c "...get('field','default')"`.
+latest_field() {
+  local file="$1" field="$2" default="${3-}"
+  local v
+  v=$($HECKS heki latest-field "$file" "$field" 2>/dev/null) || v=""
+  [ -z "$v" ] && v="$default"
+  printf '%s\n' "$v"
+}
 
 check() {
   local name="$1" result="$2" expected="$3"
@@ -26,23 +42,23 @@ echo ""
 
 # === HEARTBEAT ===
 echo "HEARTBEAT"
-beats_before=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('beats',0))" 2>/dev/null)
+beats_before=$(latest_field $INFO/heartbeat.heki beats 0)
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-beats_after=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('beats',0))" 2>/dev/null)
+beats_after=$(latest_field $INFO/heartbeat.heki beats 0)
 check "Beat increments" "$beats_after" "[0-9]"
 [ "$beats_after" -gt "$beats_before" ] 2>/dev/null
 check "Beats increased ($beats_before → $beats_after)" "yes" "yes"
 
-last_beat=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('last_beat_at','none'))" 2>/dev/null)
+last_beat=$(latest_field $INFO/heartbeat.heki last_beat_at none)
 check "last_beat_at updated" "$last_beat" "202"
 
 echo ""
 
 # === SLEEP ===
 echo "FATIGUE"
-pss_before=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('pulses_since_sleep',0))" 2>/dev/null)
+pss_before=$(latest_field $INFO/heartbeat.heki pulses_since_sleep 0)
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-pss_after=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('pulses_since_sleep',0))" 2>/dev/null)
+pss_after=$(latest_field $INFO/heartbeat.heki pulses_since_sleep 0)
 check "Fatigue accumulates (pss $pss_before → $pss_after)" "$([ "$pss_after" -gt "$pss_before" ] 2>/dev/null && echo yes)" "yes"
 echo ""
 
@@ -51,7 +67,7 @@ echo "SLEEP TRIGGER"
 $HECKS heki upsert $INFO/consciousness.heki state=attentive 2>/dev/null
 $HECKS heki upsert $INFO/heartbeat.heki pulses_since_sleep=200 fatigue=200 2>/dev/null
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-sleep_state=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('state',''))" 2>/dev/null)
+sleep_state=$(latest_field $INFO/consciousness.heki state)
 check "High fatigue triggers sleep (state=sleeping)" "$sleep_state" "sleeping"
 echo ""
 
@@ -59,125 +75,147 @@ echo "SLEEP STATE MACHINE"
 # EnterSleep initializes ALL sleep state — no synchronous cascade.
 $HECKS heki upsert $INFO/consciousness.heki state=attentive 2>/dev/null
 $HECKS aggregates/ Consciousness.EnterSleep 2>/dev/null
-after_enter=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-print(f\"{d.get('state')},{d.get('sleep_stage')},{d.get('sleep_cycle')},{d.get('sleep_total')},{d.get('phase_ticks')},{d.get('is_lucid')}\")" 2>/dev/null)
+after_enter=$(printf '%s,%s,%s,%s,%s,%s' \
+  "$(latest_field $INFO/consciousness.heki state)" \
+  "$(latest_field $INFO/consciousness.heki sleep_stage)" \
+  "$(latest_field $INFO/consciousness.heki sleep_cycle)" \
+  "$(latest_field $INFO/consciousness.heki sleep_total)" \
+  "$(latest_field $INFO/consciousness.heki phase_ticks)" \
+  "$(latest_field $INFO/consciousness.heki is_lucid)")
 check "EnterSleep initializes sleep state" "$after_enter" "sleeping,light,1,8,0,no"
 
 # Tick fires ElapsePhase which increments phase_ticks
 $HECKS aggregates/ Tick.MindstreamTick 2>/dev/null
-ticks=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('phase_ticks',0))" 2>/dev/null)
+ticks=$(latest_field $INFO/consciousness.heki phase_ticks 0)
 check "Tick advances phase_ticks (ElapsePhase policy)" "$([ "$ticks" -ge 1 ] 2>/dev/null && echo yes)" "yes"
 
 # Light → REM when phase_ticks > 11 and NOT final cycle
 $HECKS heki upsert $INFO/consciousness.heki phase_ticks=12 sleep_stage=light sleep_cycle=3 is_lucid=no 2>/dev/null
 $HECKS aggregates/ Tick.MindstreamTick 2>/dev/null
-stage=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('sleep_stage',''))" 2>/dev/null)
+stage=$(latest_field $INFO/consciousness.heki sleep_stage)
 check "light→rem on tick when phase_ticks>11" "$stage" "rem"
 
 # Final cycle light → lucid REM (sets is_lucid=yes)
 $HECKS heki upsert $INFO/consciousness.heki phase_ticks=12 sleep_stage=light sleep_cycle=8 is_lucid=no 2>/dev/null
 $HECKS aggregates/ Tick.MindstreamTick 2>/dev/null
-lucid=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(f\"{d.get('sleep_stage')},{d.get('is_lucid')}\")" 2>/dev/null)
+lucid="$(latest_field $INFO/consciousness.heki sleep_stage),$(latest_field $INFO/consciousness.heki is_lucid)"
 check "final cycle light → lucid rem" "$lucid" "rem,yes"
 
 # Final cycle deep → final_light (not next-cycle light)
 $HECKS heki upsert $INFO/consciousness.heki phase_ticks=12 sleep_stage=deep sleep_cycle=8 is_lucid=no 2>/dev/null
 $HECKS aggregates/ Tick.MindstreamTick 2>/dev/null
-after_deep=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('sleep_stage',''))" 2>/dev/null)
+after_deep=$(latest_field $INFO/consciousness.heki sleep_stage)
 check "final deep → final_light (clean wake)" "$after_deep" "final_light"
 
 # CompleteFinalLight → WokenUp → BecomeAttentive cascade ONLY at end
 $HECKS heki upsert $INFO/consciousness.heki phase_ticks=12 sleep_stage=final_light sleep_cycle=8 2>/dev/null
 $HECKS aggregates/ Tick.MindstreamTick 2>/dev/null
-final=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('state',''))" 2>/dev/null)
+final=$(latest_field $INFO/consciousness.heki state)
 check "final_light done → attentive" "$final" "attentive"
 
 # Wake triggers DissipateFatigue + RecoverFatigue + RefreshMood in parallel
-mood_after=$($HECKS heki latest $INFO/mood.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('current_state',''))" 2>/dev/null)
+mood_after=$(latest_field $INFO/mood.heki current_state)
 check "wake refreshes mood → refreshed" "$mood_after" "refreshed"
-pss=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('pulses_since_sleep',-1))" 2>/dev/null)
+pss=$(latest_field $INFO/heartbeat.heki pulses_since_sleep -1)
 check "wake resets pulses_since_sleep → 0" "$pss" "0"
 echo ""
 
 echo "LUCID DREAM"
 rm -f $INFO/lucid_dream.heki
 $HECKS aggregates/ LucidDream.BecomeLucid 2>/dev/null
-active=$($HECKS heki latest $INFO/lucid_dream.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('active',''))" 2>/dev/null)
+active=$(latest_field $INFO/lucid_dream.heki active)
 check "BecomeLucid → active=yes" "$active" "yes"
 
 $HECKS aggregates/ LucidDream.ObserveDream observation="watching a seam close" 2>/dev/null
 $HECKS aggregates/ LucidDream.ObserveDream observation="steering toward drift" 2>/dev/null
-obs=$($HECKS heki latest $INFO/lucid_dream.heki 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('observations',[])))" 2>/dev/null)
+# observations is an array; latest-field on an array prints its JSON.
+obs=$($HECKS heki latest $INFO/lucid_dream.heki 2>/dev/null | jq '.observations | length')
 check "ObserveDream accumulates (count=2)" "$obs" "2"
-narr=$($HECKS heki latest $INFO/lucid_dream.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('latest_narrative',''))" 2>/dev/null)
+narr=$(latest_field $INFO/lucid_dream.heki latest_narrative)
 check "latest_narrative = most recent observation" "$narr" "steering toward drift"
 
 $HECKS aggregates/ LucidDream.EndLucidity 2>/dev/null
-active=$($HECKS heki latest $INFO/lucid_dream.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('active',''))" 2>/dev/null)
+active=$(latest_field $INFO/lucid_dream.heki active)
 check "EndLucidity → active=no" "$active" "no"
 echo ""
 
 echo "MUSINGS (filter + no-repeat)"
-# Real-musing filter rejects tag-shaped entries
-filter_result=$(python3 -c "
-import re
-def real(s):
-    s=(s or '').strip()
-    if len(s)<20: return False
-    if not re.search(r'[ —\-:.?!]', s): return False
-    if re.fullmatch(r'[a-z][a-z0-9_]*', s): return False
-    return True
-cases=[('awareness_pulse',False),('rust_heartbeat',False),('short',False),
-       ('Two bodies can grow apart without noticing',True),
-       ('what if we lived sideways?',True)]
-print(all(real(c)==e for c,e in cases))")
+# Real-musing filter rejects tag-shaped entries. The filter logic
+# (length, punctuation, not-a-tag) is duplicated here from
+# surface_musing.sh so the behavior stays tested even if the Python
+# helper is replaced. Pure shell now — no Python.
+real_musing() {
+  local s="$1"
+  # trim whitespace
+  s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"
+  # min length 20
+  [ "${#s}" -lt 20 ] && { echo false; return; }
+  # must contain at least one of: space, em-dash, hyphen, colon, period, question, bang
+  case "$s" in
+    *" "*|*"—"*|*-*|*:*|*.*|*\?*|*\!*) ;;
+    *) echo false; return ;;
+  esac
+  # Reject pure-tag form (fullmatch [a-z][a-z0-9_]*)
+  if printf '%s' "$s" | LC_ALL=C grep -Eq '^[a-z][a-z0-9_]*$'; then
+    echo false; return
+  fi
+  echo true
+}
+
+all_ok=true
+for pair in "awareness_pulse|false" "rust_heartbeat|false" "short|false" \
+            "Two bodies can grow apart without noticing|true" \
+            "what if we lived sideways?|true"; do
+  s="${pair%|*}"; expected="${pair#*|}"
+  got=$(real_musing "$s")
+  [ "$got" = "$expected" ] || all_ok=false
+done
+if $all_ok; then filter_result=True; else filter_result=False; fi
 check "Real-musing filter: tags rejected, sentences kept" "$filter_result" "True"
 
 # mark_musing_shown.py flips conceived=True on matching idea
 $HECKS heki append $INFO/musing.heki idea="test musing for mark script" conceived=false status=imagined 2>/dev/null
 ./mark_musing_shown.py "test musing for mark script" 2>/dev/null
-marked=$($HECKS heki read $INFO/musing.heki 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-for v in d.values():
-    if 'test musing for mark script' in v.get('idea',''):
-        print(v.get('conceived'))
-        break" 2>/dev/null)
+marked_id=$($HECKS heki list $INFO/musing.heki --where "idea*=test musing for mark script" --fields id --format tsv 2>/dev/null | head -n1)
+if [ -n "$marked_id" ]; then
+  marked_val=$($HECKS heki get $INFO/musing.heki "$marked_id" conceived 2>/dev/null)
+  # Python's json.dumps True → "true" lowercase, but the old python
+  # helper printed Python's repr (True). Normalize for the expected
+  # assertion below.
+  case "$marked_val" in
+    true) marked=True ;;
+    false) marked=False ;;
+    *) marked="$marked_val" ;;
+  esac
+else
+  marked=""
+fi
 check "mark_musing_shown marks conceived" "$marked" "True"
-# Cleanup test entry
-python3 -c "
-import json, struct, zlib
-HEKI='$INFO/musing.heki'
-with open(HEKI,'rb') as f: data=f.read()
-count=struct.unpack('>I',data[4:8])[0]
-store=json.loads(zlib.decompress(data[8:]).decode())
-store={k:v for k,v in store.items() if 'test musing for mark script' not in v.get('idea','')}
-j=json.dumps(store, separators=(',',':')).encode()
-c=zlib.compress(j,9)
-with open(HEKI,'wb') as f:
-    f.write(b'HEKI'); f.write(struct.pack('>I', len(store))); f.write(c)" 2>/dev/null
+# Cleanup test entry — list matching ids, delete each.
+$HECKS heki list $INFO/musing.heki --where "idea*=test musing for mark script" \
+  --fields id --format tsv 2>/dev/null | while read -r uuid; do
+  [ -n "$uuid" ] && $HECKS heki delete $INFO/musing.heki "$uuid" >/dev/null 2>&1
+done
 echo ""
 
 echo "CLAUDE ASSIST"
 # Provider toggle
 $HECKS aggregates/ ClaudeAssist.UseClaudeProvider 2>/dev/null
-provider=$($HECKS heki latest $INFO/claude_assist.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('provider',''))" 2>/dev/null)
+provider=$(latest_field $INFO/claude_assist.heki provider)
 check "UseClaudeProvider → provider=claude" "$provider" "claude"
 
 $HECKS aggregates/ ClaudeAssist.UseLocalProvider 2>/dev/null
-provider=$($HECKS heki latest $INFO/claude_assist.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('provider',''))" 2>/dev/null)
+provider=$(latest_field $INFO/claude_assist.heki provider)
 check "UseLocalProvider → provider=local" "$provider" "local"
 
 $HECKS aggregates/ ClaudeAssist.DisableMinting 2>/dev/null
-provider=$($HECKS heki latest $INFO/claude_assist.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('provider',''))" 2>/dev/null)
+provider=$(latest_field $INFO/claude_assist.heki provider)
 check "DisableMinting → provider=off" "$provider" "off"
 
 # With provider=off, mint_musing.sh exits without incrementing total_minted
-before=$($HECKS heki latest $INFO/musing_mint.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('total_minted',0))" 2>/dev/null)
+before=$(latest_field $INFO/musing_mint.heki total_minted 0)
 ./mint_musing.sh 2>/dev/null
-after=$($HECKS heki latest $INFO/musing_mint.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('total_minted',0))" 2>/dev/null)
+after=$(latest_field $INFO/musing_mint.heki total_minted 0)
 check "mint skipped when provider=off" "$before" "$after"
 
 # Restore default
@@ -189,86 +227,64 @@ echo "DAEMON ALIVE"
 # daemons running old code, hung loops, missing surface_musing.sh calls.
 # Records cycle counter + sleep_summary, waits 12s (one tick), asserts
 # the cycle counter has incremented.
-cycle_before=$($HECKS heki latest $INFO/tick.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('cycle',0))" 2>/dev/null)
+cycle_before=$(latest_field $INFO/tick.heki cycle 0)
 sleep 12
-cycle_after=$($HECKS heki latest $INFO/tick.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('cycle',0))" 2>/dev/null)
+cycle_after=$(latest_field $INFO/tick.heki cycle 0)
 check "Daemon ticking (cycle ${cycle_before} → ${cycle_after})" "$([ "$cycle_after" -gt "$cycle_before" ] 2>/dev/null && echo yes)" "yes"
 
 # Verify the daemon actually invokes surface_musing.sh — the real bug
 # from this session was daemon running OLD inline code after the
 # extraction commit. We seed 2 unconceived musings; if the daemon is
 # alive AND calling surface_musing.sh, sleep_summary changes to one
-# of them within one tick.
-python3 -c "
-import json, struct, uuid, zlib
-HEKI='$INFO/musing.heki'
-with open(HEKI,'rb') as f: data=f.read()
-count=struct.unpack('>I', data[4:8])[0]
-store=json.loads(zlib.decompress(data[8:]).decode())
-for v in store.values(): v['conceived'] = True
-for s in ['daemon-test-A: ensure surface fires', 'daemon-test-B: ensure cycling advances']:
-    rid=str(uuid.uuid4())
-    store[rid] = {'id':rid,'idea':s,'conceived':False,'status':'imagined','thinking_source':'test','feeling_source':'test'}
-j=json.dumps(store, separators=(',',':')).encode()
-c=zlib.compress(j,9)
-with open(HEKI,'wb') as f: f.write(b'HEKI'); f.write(struct.pack('>I',len(store))); f.write(c)" 2>/dev/null
+# of them within one tick. Use `heki mark` + `heki append` (no Python).
+$HECKS heki mark $INFO/musing.heki --where conceived=false --set conceived=true >/dev/null 2>&1 || true
+$HECKS heki append $INFO/musing.heki \
+  idea="daemon-test-A: ensure surface fires" \
+  conceived=false status=imagined \
+  thinking_source=test feeling_source=test >/dev/null 2>&1
+$HECKS heki append $INFO/musing.heki \
+  idea="daemon-test-B: ensure cycling advances" \
+  conceived=false status=imagined \
+  thinking_source=test feeling_source=test >/dev/null 2>&1
 $HECKS heki upsert $INFO/consciousness.heki sleep_summary="" state=attentive 2>/dev/null
 sleep 12
-sum=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('sleep_summary',''))" 2>/dev/null)
+sum=$(latest_field $INFO/consciousness.heki sleep_summary)
 check "Live daemon surfaces a fresh musing within one tick" "$sum" "daemon-test"
 
 # One more tick — verify it advances OR stays (the every-3rd-tick mark
 # means it could either stay on A or advance to B; but it must be one of them).
 sleep 12
-sum2=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('sleep_summary',''))" 2>/dev/null)
+sum2=$(latest_field $INFO/consciousness.heki sleep_summary)
 check "Live daemon stays on a real musing across ticks" "$sum2" "daemon-test"
 
 # Clean up the test musings
-python3 -c "
-import json, struct, zlib
-HEKI='$INFO/musing.heki'
-with open(HEKI,'rb') as f: data=f.read()
-store=json.loads(zlib.decompress(data[8:]).decode())
-store={k:v for k,v in store.items() if 'daemon-test' not in v.get('idea','')}
-j=json.dumps(store, separators=(',',':')).encode()
-c=zlib.compress(j,9)
-with open(HEKI,'wb') as f: f.write(b'HEKI'); f.write(struct.pack('>I', len(store))); f.write(c)" 2>/dev/null
+$HECKS heki list $INFO/musing.heki --where "idea~=daemon-test" \
+  --fields id --format tsv 2>/dev/null | while read -r uuid; do
+  [ -n "$uuid" ] && $HECKS heki delete $INFO/musing.heki "$uuid" >/dev/null 2>&1
+done
 echo ""
 
 echo "MUSING CYCLING"
 # Surface logic advances through multiple unconceived musings,
 # marks conceived every 3rd call, doesn't repeat. Simulate 9 ticks.
-python3 -c "
-import json, struct, zlib
-HEKI = '$INFO/musing.heki'
-with open(HEKI, 'rb') as f: data = f.read()
-count = struct.unpack('>I', data[4:8])[0]
-store = json.loads(zlib.decompress(data[8:]).decode())
-# Mark all existing conceived so test seeds fresh
-for v in store.values(): v['conceived'] = True
-# Seed 3 unconceived test musings
-import uuid
-seeds = [
-    'test-cycle-one: conceptual insight about continuity',
-    'test-cycle-two: observation about the shape of things',
-    'test-cycle-three: reflection on recursive self-awareness',
-]
-for s in seeds:
-    rid = str(uuid.uuid4())
-    store[rid] = {'id': rid, 'idea': s, 'conceived': False, 'status': 'imagined',
-                  'thinking_source': 'test', 'feeling_source': 'test'}
-j = json.dumps(store, separators=(',',':')).encode()
-c = zlib.compress(j, 9)
-with open(HEKI, 'wb') as f:
-    f.write(b'HEKI'); f.write(struct.pack('>I', len(store))); f.write(c)
-" 2>/dev/null
+# Mark all existing musings conceived (so test starts from clean state)
+# and seed 3 unconceived test musings.
+$HECKS heki mark $INFO/musing.heki --where conceived=false --set conceived=true >/dev/null 2>&1 || true
+for seed in \
+  "test-cycle-one: conceptual insight about continuity" \
+  "test-cycle-two: observation about the shape of things" \
+  "test-cycle-three: reflection on recursive self-awareness"; do
+  $HECKS heki append $INFO/musing.heki \
+    idea="$seed" conceived=false status=imagined \
+    thinking_source=test feeling_source=test >/dev/null 2>&1
+done
 
 # Run surface 9 times with loop_count 1..9 under DWELL=3 (fast test mode).
 # Production is DWELL=30 (~5 min per musing); tests compress to 3 ticks.
 surfaced=""
 for i in 1 2 3 4 5 6 7 8 9; do
   DWELL=3 ./surface_musing.sh "$i" 2>/dev/null
-  now=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('sleep_summary',''))" 2>/dev/null)
+  now=$(latest_field $INFO/consciousness.heki sleep_summary)
   echo "$surfaced" | grep -q "$now" || surfaced="${surfaced}${now}|"
 done
 
@@ -276,24 +292,15 @@ done
 unique_count=$(echo "$surfaced" | tr '|' '\n' | grep -c "test-cycle")
 check "Cycling: 3 unique test musings surfaced over 9 ticks" "$unique_count" "3"
 
-still_unconceived=$($HECKS heki read $INFO/musing.heki 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-print(sum(1 for v in d.values() if 'test-cycle' in v.get('idea','') and not v.get('conceived', False)))" 2>/dev/null)
+still_unconceived=$($HECKS heki count $INFO/musing.heki \
+  --where "idea~=test-cycle" --where conceived=false 2>/dev/null)
 check "Cycling: all 3 test musings marked conceived after 9 ticks" "$still_unconceived" "0"
 
 # Clean up test musings
-python3 -c "
-import json, struct, zlib
-HEKI = '$INFO/musing.heki'
-with open(HEKI, 'rb') as f: data = f.read()
-count = struct.unpack('>I', data[4:8])[0]
-store = json.loads(zlib.decompress(data[8:]).decode())
-store = {k: v for k, v in store.items() if 'test-cycle' not in v.get('idea','')}
-j = json.dumps(store, separators=(',',':')).encode()
-c = zlib.compress(j, 9)
-with open(HEKI, 'wb') as f:
-    f.write(b'HEKI'); f.write(struct.pack('>I', len(store))); f.write(c)" 2>/dev/null
+$HECKS heki list $INFO/musing.heki --where "idea~=test-cycle" \
+  --fields id --format tsv 2>/dev/null | while read -r uuid; do
+  [ -n "$uuid" ] && $HECKS heki delete $INFO/musing.heki "$uuid" >/dev/null 2>&1
+done
 echo ""
 
 echo "MINT PROMPT"
@@ -313,7 +320,7 @@ $HECKS heki upsert $INFO/consciousness.heki \
   state=sleeping sleep_stage=final_light phase_ticks=12 \
   last_wake_at="" 2>/dev/null
 $HECKS aggregates/ Consciousness.CompleteFinalLight 2>/dev/null
-lwa=$($HECKS heki latest $INFO/consciousness.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('last_wake_at',''))" 2>/dev/null)
+lwa=$(latest_field $INFO/consciousness.heki last_wake_at)
 check "CompleteFinalLight stamps last_wake_at (ISO timestamp)" "$lwa" "[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}T"
 echo ""
 
@@ -338,7 +345,8 @@ echo "CROSS-DOMAIN POLICIES"
 # Beat should trigger policies across body + mind
 $HECKS heki upsert $INFO/consciousness.heki state=attentive 2>/dev/null
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-gut=$($HECKS heki latest $INFO/gut.heki 2>/dev/null | python3 -c "import json,sys; print('ok')" 2>/dev/null)
+# Any successful read of gut.heki — any id will do. Use heki count.
+if [ "$($HECKS heki count $INFO/gut.heki 2>/dev/null)" != "" ]; then gut=ok; else gut=""; fi
 check "Beat triggers Gut (body→mind)" "$gut" "ok"
 
 echo ""
@@ -346,21 +354,21 @@ echo ""
 # === HEKI PERSISTENCE ===
 echo "HEKI PERSISTENCE"
 # Verify stores aren't getting wiped
-musings_before=$($HECKS heki read $INFO/musing.heki 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null)
+musings_before=$($HECKS heki count $INFO/musing.heki 2>/dev/null)
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-musings_after=$($HECKS heki read $INFO/musing.heki 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null)
+musings_after=$($HECKS heki count $INFO/musing.heki 2>/dev/null)
 check "Musings preserved after Beat ($musings_before → $musings_after)" "$musings_after" "$musings_before"
 
-conv_count=$($HECKS heki read $INFO/conversation.heki 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null)
+conv_count=$($HECKS heki count $INFO/conversation.heki 2>/dev/null)
 check "Conversation records preserved ($conv_count)" "$conv_count" "[0-9]"
 
 echo ""
 
 # === SINGLETON IDS ===
 echo "SINGLETON IDS"
-hb_id=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+hb_id=$(latest_field $INFO/heartbeat.heki id)
 $HECKS aggregates/ Heartbeat.Beat 2>/dev/null
-hb_id_after=$($HECKS heki latest $INFO/heartbeat.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+hb_id_after=$(latest_field $INFO/heartbeat.heki id)
 check "Heartbeat UUID preserved" "$hb_id_after" "$hb_id"
 
 echo ""
@@ -446,12 +454,12 @@ echo "SPEECH"
 rust_speech=$($HECKS speak "hello" . 2>&1)
 check "Rust tongue responds" "$rust_speech" "[a-zA-Z]"
 # Test bluebook tongue (target — should produce real response when adapter is wired)
-bluebook_speech=$($HECKS aggregates/ Speech.Speak 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); r=d.get('state',{}).get('response',''); print('HAS_RESPONSE' if r and r != 'null' else 'NO_RESPONSE')" 2>/dev/null)
+bluebook_speech=$($HECKS aggregates/ Speech.Speak 2>/dev/null | jq -r '(.state.response // "") | if . == "" or . == "null" then "NO_RESPONSE" else "HAS_RESPONSE" end' 2>/dev/null)
 check "Bluebook Speech.Speak has response" "$bluebook_speech" "HAS_RESPONSE"
 echo ""
 
 echo "TRAINING"
-train_output=$($HECKS aggregates/ TrainingPair.ExtractPair domain_name=AutoRepairShop vision="Manage vehicle intake" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',{}).get('domain_name','EMPTY'))" 2>/dev/null)
+train_output=$($HECKS aggregates/ TrainingPair.ExtractPair domain_name=AutoRepairShop vision="Manage vehicle intake" 2>/dev/null | jq -r '.state.domain_name // "EMPTY"' 2>/dev/null)
 check "Training extraction dispatches" "$train_output" "AutoRepairShop"
 echo ""
 
@@ -466,9 +474,9 @@ echo ""
 
 echo "HEKI"
 $HECKS heki append $INFO/test_store.heki foo=bar 2>/dev/null
-heki_read=$($HECKS heki read $INFO/test_store.heki 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))" 2>/dev/null)
+heki_read=$($HECKS heki count $INFO/test_store.heki 2>/dev/null)
 check "heki append + read" "$heki_read" "[1-9]"
-$HECKS heki latest $INFO/test_store.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('foo',''))" > /dev/null 2>&1
+$HECKS heki latest-field $INFO/test_store.heki foo >/dev/null 2>&1
 check "heki latest" "$?" "0"
 rm -f $INFO/test_store.heki
 echo ""
@@ -480,23 +488,23 @@ rm -rf nursery/test_integration
 echo ""
 
 echo "AGGREGATE.COMMAND WITH ATTRS"
-speak_out=$($HECKS aggregates/ Speech.Speak input=hello 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',{}).get('input',''))" 2>/dev/null)
+speak_out=$($HECKS aggregates/ Speech.Speak input=hello 2>/dev/null | jq -r '.state.input // ""' 2>/dev/null)
 check "Attrs pass through dispatch" "$speak_out" "hello"
 echo ""
 
 echo "TERMINAL"
 # Test terminal adapter — Session.StartSession dispatches
-session_out=$($HECKS aggregates/ Session.StartSession being=Miette 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',{}).get('being',''))" 2>/dev/null)
+session_out=$($HECKS aggregates/ Session.StartSession being=Miette 2>/dev/null | jq -r '.state.being // ""' 2>/dev/null)
 check "Terminal session starts" "$session_out" "Miette"
 # Test input routes to speech via policy
-input_out=$($HECKS aggregates/ Session.ReceiveInput input=hello 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',{}).get('turns',0))" 2>/dev/null)
+input_out=$($HECKS aggregates/ Session.ReceiveInput input=hello 2>/dev/null | jq -r '.state.turns // 0' 2>/dev/null)
 check "Terminal receives input" "$input_out" "[1-9]"
 echo ""
 
 echo "QUERIES"
-vitals=$($HECKS aggregates/ Heartbeat.ReadVitals 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('query',''))" 2>/dev/null)
+vitals=$($HECKS aggregates/ Heartbeat.ReadVitals 2>/dev/null | jq -r '.query // ""' 2>/dev/null)
 check "Heartbeat.ReadVitals query works" "$vitals" "ReadVitals"
-beats_q=$($HECKS aggregates/ Heartbeat.ReadVitals 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state',{}).get('beats',0))" 2>/dev/null)
+beats_q=$($HECKS aggregates/ Heartbeat.ReadVitals 2>/dev/null | jq -r '.state.beats // 0' 2>/dev/null)
 check "Query returns beats ($beats_q)" "$beats_q" "[0-9]"
 echo ""
 
@@ -504,7 +512,7 @@ echo "MINDSTREAM"
 ps aux | grep "mindstream.sh" | grep -v grep > /dev/null
 check "Mindstream running" "$?" "0"
 
-tick=$($HECKS heki latest $INFO/tick.heki 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('cycle',0))" 2>/dev/null)
+tick=$(latest_field $INFO/tick.heki cycle 0)
 check "Mindstream ticking (cycle $tick)" "$tick" "[0-9]"
 
 echo ""

--- a/hecks_conception/tests/consolidate_smoke.sh
+++ b/hecks_conception/tests/consolidate_smoke.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # consolidate_smoke.sh — smoke test for consolidate.sh.
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands + date -d for timestamp shifts per
+#  PR #272; retires when shell wrapper ports to .bluebook shebang form
+#  (tracked in terminal_capability_wiring plan).]
 #
 # Seeds a tmpdir with:
 #   - 5 cold signals (access_count=0, created_at 120s ago) → should promote
@@ -48,7 +52,17 @@ end
 EOF
 
 # ── Seed signals ─────────────────────────────────────────────────────
-OLD=$(python3 -c "from datetime import datetime,timezone,timedelta; print((datetime.now(timezone.utc)-timedelta(seconds=120)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+# iso_offset secs — print an ISO-8601 UTC timestamp `secs` seconds in
+# the past. Portable across macOS (BSD date) and Linux (GNU date).
+iso_offset() {
+  local secs="$1" now_epoch
+  now_epoch=$(date -u +%s)
+  # awk formats the resulting epoch back into the expected ISO string.
+  date -u -r "$((now_epoch - secs))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$((now_epoch - secs))" +%Y-%m-%dT%H:%M:%SZ
+}
+
+OLD=$(iso_offset 120)
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 for i in 1 2 3 4 5; do
@@ -71,7 +85,7 @@ done
 
 # ── Seed musings: 5 share a concept ──────────────────────────────────
 for i in 1 2 3 4 5; do
-  ts=$(python3 -c "from datetime import datetime,timezone,timedelta; print((datetime.now(timezone.utc)-timedelta(minutes=$i)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+  ts=$(iso_offset $((i * 60)))
   "$HECKS" heki append "$TMP/information/musing.heki" \
     idea="musing number $i" source=mindstream thinking_source=wandering \
     conceived=false status=imagined created_at="$ts" >/dev/null 2>&1
@@ -81,10 +95,7 @@ fail() { echo "FAIL — $1"; exit 1; }
 
 count_records() {
   [ ! -f "$1" ] && { echo 0; return; }
-  "$HECKS" heki read "$1" 2>/dev/null \
-    | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)" 2>/dev/null
+  "$HECKS" heki count "$1" 2>/dev/null || echo 0
 }
 
 store_before=$(count_records "$TMP/information/store.heki")

--- a/hecks_conception/tests/daydream_smoke.sh
+++ b/hecks_conception/tests/daydream_smoke.sh
@@ -5,6 +5,11 @@
 # directory, runs daydream.sh once, and asserts daydream.heki grew.
 #
 # Exit 0 on pass, non-zero on fail.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki count per PR #272; retires when shell wrapper
+#  ports to .bluebook shebang form (tracked in terminal_capability_wiring
+#  plan).]
 
 set -u
 
@@ -40,10 +45,7 @@ fail() { echo "FAIL — $1"; exit 1; }
 
 # Count records before (the file may not exist → 0).
 before=0
-[ -f "$TMP/information/daydream.heki" ] && before=$("$HECKS" heki read "$TMP/information/daydream.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)")
+[ -f "$TMP/information/daydream.heki" ] && before=$("$HECKS" heki count "$TMP/information/daydream.heki" 2>/dev/null || echo 0)
 
 HECKS_INFO="$TMP/information" \
 HECKS_AGG="$TMP/aggregates" \
@@ -53,10 +55,7 @@ HECKS_NURSERY="$CONCEPT_DIR/nursery" \
   || fail "daydream.sh exited non-zero"
 
 after=0
-[ -f "$TMP/information/daydream.heki" ] && after=$("$HECKS" heki read "$TMP/information/daydream.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)")
+[ -f "$TMP/information/daydream.heki" ] && after=$("$HECKS" heki count "$TMP/information/daydream.heki" 2>/dev/null || echo 0)
 
 echo "daydream.heki records: $before -> $after"
 
@@ -64,10 +63,7 @@ echo "daydream.heki records: $before -> $after"
 
 # Sanity — synapse.heki should also have grown (new forming bond).
 syn=0
-[ -f "$TMP/information/synapse.heki" ] && syn=$("$HECKS" heki read "$TMP/information/synapse.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)")
+[ -f "$TMP/information/synapse.heki" ] && syn=$("$HECKS" heki count "$TMP/information/synapse.heki" 2>/dev/null || echo 0)
 echo "synapse.heki records: $syn"
 [ "$syn" -ge 1 ] || fail "synapse.heki has no forming synapse"
 

--- a/hecks_conception/tests/dream_content_smoke.sh
+++ b/hecks_conception/tests/dream_content_smoke.sh
@@ -11,6 +11,11 @@
 #
 # Uses a TMPDIR for INFO so the live information/*.heki stores are
 # never touched. AGG + NURSERY point at the worktree's real ones.
+#
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$DIR/.." && pwd)"
@@ -79,8 +84,7 @@ done
   sleep_summary="entering REM — dreams beginning" >/dev/null 2>&1
 
 # Count dream_state records before exercising the branch.
-before=$("$HECKS" heki read "$INFO/dream_state.heki" 2>/dev/null \
-  | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+before=$("$HECKS" heki count "$INFO/dream_state.heki" 2>/dev/null)
 
 # Run the REM branch 10 times. Use TMP/aggregates so hecks-life's
 # *.world discovery lands on TMP/information; the live stores are
@@ -90,8 +94,7 @@ for i in $(seq 1 10); do
     HECKS="$HECKS" "$ROOT/rem_branch.sh" "$i" >/dev/null 2>&1
 done
 
-after=$("$HECKS" heki read "$INFO/dream_state.heki" 2>/dev/null \
-  | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+after=$("$HECKS" heki count "$INFO/dream_state.heki" 2>/dev/null)
 grew=$((after - before))
 
 echo "REM dream production"
@@ -103,21 +106,20 @@ check "rem_dream wrote ≥5 images (the spec floor)" \
 # Verify DreamSeed.PlantSeed fired — dream_seed.heki should now have at
 # least one image planted from the prior records.
 seeds=$("$HECKS" heki latest "$INFO/dream_seed.heki" 2>/dev/null \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('images',[]) or []))" 2>/dev/null)
+  | jq '(.images // []) | length' 2>/dev/null)
 check "DreamSeed.PlantSeed planted ≥1 image (count=$seeds)" \
   "$([ "${seeds:-0}" -ge 1 ] && echo yes)" "yes"
 
 # Verify dream images use the carrying+domain+concept template — at least
 # one should contain a known shape. We seeded 'prior image #1'..'#6' as
 # legacy records; new records should look different.
-sample=$("$HECKS" heki read "$INFO/dream_state.heki" 2>/dev/null \
-  | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-new = [r for r in d.values() if r.get('source') == 'mindstream']
-imgs = [img for r in new for img in (r.get('dream_images') or [])]
-print(imgs[0] if imgs else '')
-" 2>/dev/null)
+sample=$("$HECKS" heki list "$INFO/dream_state.heki" --where source=mindstream \
+    --format json 2>/dev/null \
+  | jq -r '[ .[]
+             | (.dream_images // [])
+             | if type == "array" then . else [.] end
+             | .[] ]
+           | .[0] // ""' 2>/dev/null)
 check "rem_dream produced a non-empty image" "$([ -n "$sample" ] && echo yes)" "yes"
 
 # Lucid path — flip is_lucid=yes, run once, expect ObserveDream + SteerDream.
@@ -126,11 +128,10 @@ check "rem_dream produced a non-empty image" "$([ -n "$sample" ] && echo yes)" "
   sleep_cycle=8 dream_pulses=0 >/dev/null 2>&1
 INFO="$INFO" AGG="$AGG" NURSERY="$TMP/nursery" \
   HECKS="$HECKS" "$ROOT/rem_branch.sh" 999 >/dev/null 2>&1
-obs=$("$HECKS" heki latest "$INFO/lucid_dream.heki" 2>/dev/null \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('latest_narrative',''))" 2>/dev/null)
+obs=$("$HECKS" heki latest-field "$INFO/lucid_dream.heki" latest_narrative 2>/dev/null)
 check "Lucid REM dispatched LucidDream.ObserveDream" "$([ -n "$obs" ] && echo yes)" "yes"
 steer=$("$HECKS" heki latest "$INFO/lucid_dream.heki" 2>/dev/null \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('steered_toward',[]) or []))" 2>/dev/null)
+  | jq '(.steered_toward // []) | length' 2>/dev/null)
 check "Lucid REM dispatched LucidDream.SteerDream (count=$steer)" \
   "$([ "${steer:-0}" -ge 1 ] && echo yes)" "yes"
 

--- a/hecks_conception/tests/interpret_dream_smoke.sh
+++ b/hecks_conception/tests/interpret_dream_smoke.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # interpret_dream_smoke.sh — smoke test for interpret_dream.sh.
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki subcommands per PR #272; retires when shell
+#  wrapper ports to .bluebook shebang form (tracked in
+#  terminal_capability_wiring plan).]
 #
 # Seeds dream_state.heki with known images, runs interpret_dream.sh
 # against a tmpdir, and asserts that interpretation.heki + musing.heki
@@ -68,29 +72,15 @@ bash "$CONCEPT_DIR/interpret_dream.sh" \
 
 count_records() {
   [ ! -f "$1" ] && { echo 0; return; }
-  "$HECKS" heki read "$1" 2>/dev/null \
-    | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)" 2>/dev/null
+  "$HECKS" heki count "$1" 2>/dev/null || echo 0
 }
 
 interp_count=$(count_records "$TMP/information/dream_interpretation.heki")
 musing_count=$(count_records "$TMP/information/musing_mint.heki")
 
-interpretation=$("$HECKS" heki latest "$TMP/information/dream_interpretation.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(json.load(sys.stdin).get('interpretation','') or '')
-except Exception: print('')" 2>/dev/null)
-
-recurring=$("$HECKS" heki latest "$TMP/information/dream_interpretation.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(json.load(sys.stdin).get('recurring_theme','') or '')
-except Exception: print('')" 2>/dev/null)
-
-last_source=$("$HECKS" heki latest "$TMP/information/musing_mint.heki" 2>/dev/null \
-  | python3 -c "import json,sys
-try: print(json.load(sys.stdin).get('last_source','') or '')
-except Exception: print('')" 2>/dev/null)
+interpretation=$("$HECKS" heki latest-field "$TMP/information/dream_interpretation.heki" interpretation 2>/dev/null || true)
+recurring=$("$HECKS" heki latest-field "$TMP/information/dream_interpretation.heki" recurring_theme 2>/dev/null || true)
+last_source=$("$HECKS" heki latest-field "$TMP/information/musing_mint.heki" last_source 2>/dev/null || true)
 
 echo "After interpret_dream.sh:"
 echo "  dream_interpretation records: $interp_count"

--- a/hecks_conception/tests/pulse_organs_smoke.sh
+++ b/hecks_conception/tests/pulse_organs_smoke.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # pulse_organs_smoke.sh — smoke test for pulse_organs.sh.
+# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c with
+#  native hecks-life heki count per PR #272; retires when shell wrapper
+#  ports to .bluebook shebang form (tracked in terminal_capability_wiring
+#  plan).]
 #
 # Copies hecks_conception/information/*.heki to a tmpdir, points
 # pulse_organs.sh at it via HECKS_INFO / HECKS_AGG, runs 10 ticks, and
@@ -80,10 +84,7 @@ done
 
 count_records() {
   [ ! -f "$1" ] && { echo 0; return; }
-  "$HECKS" heki read "$1" 2>/dev/null \
-    | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin) or {}))
-except Exception: print(0)" 2>/dev/null
+  "$HECKS" heki count "$1" 2>/dev/null || echo 0
 }
 
 synapse_count=$(count_records "$TMP/information/synapse.heki")


### PR DESCRIPTION
## Summary

Phase B of [i37 — Remove Python from Hecks](../../docs/plans/i37_python_removal.md).
Sweeps all 120 `python3 -c` invocations across 17 shell scripts under
`hecks_conception/`, replacing each with the native `hecks-life heki`
subcommands shipped in PR #272 (Phase A) and jq/awk for the non-heki
compute steps.

**Target met:** `grep -c 'python3 -c' hecks_conception/**/*.sh` → 0.
Non-comment `python3` count across all hecks_conception shell scripts is
also 0 — only antibody-exempt comment markers now mention the string.
The two `python3 status_format.py` calls in `status.sh` no longer exist
after PR #273's shebang redirect already merged to main.

## Per-batch count delta

| Batch | File(s) | Δ | Cumulative |
|---|---|---|---|
| 1 | `inbox.sh` | 4 | 120 → 116 |
| 2 | `test_miette.sh` | 53 | 116 → 63 |
| 3 | `pulse_organs.sh` | 12 | 63 → 51 |
| 4 | `rem_branch.sh` | 9 | 51 → 42 |
| 5 | `mint_musing.sh` | 6 | 42 → 36 |
| 6 | `statusline-command.sh` | 6 | 36 → 30 |
| 7 | `tests/dream_content_smoke.sh` | 6 | 30 → 24 |
| 8 | boot_miette, consolidate, mindstream, surface_musing, daydream, interpret_dream + 4 smoke tests | 24 | 24 → 0 |

Also removed: 2 `python3 <<PYEOF` heredocs in `consolidate.sh` +
`interpret_dream.sh` (out of the strict grep target but same class of
gap; the plan's end state is zero Python in shell scripts).

## Aggregate LoC delta

17 files changed, 632 insertions(+), 770 deletions(-) — **net −138 LoC**.
Plan estimated −600; actual is smaller because jq pipelines match the
byte-for-byte formatting of several Python blocks at similar line counts
(especially `inbox.sh list` whose unicode-aware truncation needed an
extra jq hop). Subprocess churn is still gone — each heki subcommand is
one Rust call instead of `heki read | python parse`.

## Example usage (before / after)

**Before** (`inbox.sh list` — 18 lines of python3):
```bash
"$HECKS" heki read "$HEKI" 2>/dev/null | python3 -c "
import json, sys
filt = '$filter'
d = json.load(sys.stdin)
items = []
for v in d.values():
    if filt != 'all' and v.get('status') != filt: continue
    items.append(v)
order = {'high':0, 'medium':1, 'normal':2, 'low':3}
items.sort(key=lambda v: (
    order.get(v.get('priority','normal'), 9),
    int(v.get('ref','i999')[1:]) if v.get('ref','').startswith('i') else 999,
))
for v in items:
    ref = v.get('ref', '—')
    pri = v.get('priority', '?')[:6]
    st  = v.get('status', '?')[:8]
    body = v.get('body', '').replace(chr(10), ' ')[:90]
    print(f'  {ref:>5}  [{pri:6}/{st:6}]  {body}')
"
```

**After** (8 lines, byte-for-byte identical output):
```bash
"$HECKS" heki list "$HEKI" $where_args \
    --order priority:enum=high,medium,normal,low \
    --order ref:numeric_ref \
    --fields ref,priority,status,body \
    --format json 2>/dev/null \
  | jq -r '.[] | [(.ref // "—"), ((.priority // "?") | .[0:6]),
                   ((.status // "?") | .[0:8]),
                   ((.body // "") | gsub("\n";" ") | .[0:90])] | @tsv' \
  | awk -F'\t' '{ printf "  %5s  [%-6s/%-6s]  %s\n", $1, $2, $3, $4 }'
```

## Edge cases encountered

- **jq required.** `--format tsv` on `heki list` corrupts records with
  newlines in string fields (e.g. inbox body). Used `--format json |
  jq -r @tsv` to keep them intact. jq is also needed for float ×0.98
  (pulse decay), fromdateiso8601 (signal age), regex scan (dream
  tokens), and group_by (consolidate archive).
- **Unicode truncation.** Python slices by character, awk `substr` by
  byte. For `inbox.sh list` (containing em-dashes etc.) used jq's
  `.[0:90]` string slice, which is character-aware.
- **Enum + numeric_ref order.** Used `--order priority:enum=high,medium,normal,low`
  + `--order ref:numeric_ref` to replicate the python dict-based sort
  with int ref parsing.
- **`heki latest-field` exit 3 on missing field.** For scripts that
  defaulted to `0` / `''` / `'alert'` via `.get(k, default)`, added
  `|| true` + shell `[ -z "$v" ] && v=default` (see `latest_field()`
  helper in `test_miette.sh`).
- **conceived=false as bool, not string.** heki's `parse_attrs` already
  promotes literal `true`/`false` to JSON booleans (heki.rs:279-282),
  so `heki append ... conceived=false` Just Works — no struct/zlib
  heredoc needed. Replaced the 30-line binary-rewrite heredoc in
  `mint_musing.sh` with one `heki append`.
- **`ref_to_uuid` via `heki list --fields id`.** The heki record `id`
  field is the primary key; `--fields id` projects it into the TSV
  output, so lookup-by-ref becomes a one-liner filter.
- **date arithmetic.** Replaced `python3 -c "datetime.now() -
  timedelta(...)"` with a portable `iso_offset secs` helper that tries
  BSD `date -r` first (macOS), falls back to GNU `date -d` (Linux).

## Test plan

- [x] All 8 batches commit cleanly; each has per-file
      `[antibody-exempt: ...]` markers.
- [x] `grep -c 'python3 -c' hecks_conception/**/*.sh` → 0.
- [x] `tests/dream_content_smoke.sh` — 6/6 PASS.
- [x] `tests/consolidate_smoke.sh` — PASS.
- [x] `tests/daydream_smoke.sh` — PASS.
- [x] `tests/interpret_dream_smoke.sh` — PASS.
- [x] `inbox.sh list queued` output byte-for-byte identical to prior main.
- [x] `mint_musing.sh --dump-prompt` renders all 5 expected sections.
- [x] `statusline-command.sh` renders the live status bar.
- [x] `tests/pulse_organs_smoke.sh` — pre-existing failure (seeded
      consciousness state=sleeping so pulse_organs bails early);
      confirmed identical behavior vs prior-main; not a regression.
- [x] `tests/status_golden.sh` — pre-existing failure on main
      (status.sh is now a shebang redirector to
      `capabilities/status/status.bluebook` which doesn't respect
      HECKS_INFO); confirmed failing identically on plain origin/main;
      not a regression from this sweep.

## Follow-up

- Phase C (separate PR): delete `mark_musing_shown.py` (subsumed by
  `heki mark`), port `tools/features_audit.py` → `.rb`.
- Phase D: delete Summer tree + `boot_summer.sh`.
- Phase E: promote antibody Python exemption from "requires exemption"
  to "forbidden outright".