### PR TITLE
fix(conceiver): --force no longer invents broken cascade setups (i4 gap 6)

### DIFF
--- a/hecks_life/src/behaviors_conceiver/generator.rs
+++ b/hecks_life/src/behaviors_conceiver/generator.rs
@@ -302,33 +302,52 @@ fn emit_cascade_test(
             for cc in create_chain { prerequisites.push(emit_setup(agg, cc)); }
         }
     }
-    // Cascade tests need EVERY aggregate the cascade will hop through to
+    // Cascade tests need every aggregate the cascade will hop through to
     // exist before dispatch — direct cross-refs aren't enough. Walk the
     // static cascade and gather every aggregate any triggered command
-    // references; emit a create for each (deduped, in dependency order).
+    // references; pick a safe bootstrap for each (deduped, in dependency
+    // order).
+    //
+    // "Safe" means: the picked command isn't itself a cascade-triggered
+    // command that carries a lifecycle transition. Pre-running such a
+    // command would advance the target aggregate past the `from_state`
+    // its cascade-hop expects, so the cascade's own dispatch is refused.
+    // (i4 gap 6 — CloudflareDeploy's Deployment aggregate had ProvisionD1
+    // picked as bootstrap, pre-advancing state to "provisioned" before
+    // the cascade's ProvisionD1 could transition from "pending".)
+    // [antibody-exempt: fixing the behaviors conceiver per i4 gaps 6+7; retires when conceivers port to a bluebook-dispatched form]
     let cascade_aggs = aggregates_touched_by_cascade(domain, cmd, agg);
+    let triggered_in_cascade = commands_triggered_by_cascade(domain, cmd);
     for target_agg_name in &cascade_aggs {
         // Skip the test's own aggregate — its create is already handled.
         if target_agg_name == &agg.name { continue; }
         if let Some(target_agg) = domain.aggregates.iter().find(|a| &a.name == target_agg_name) {
-            if let Some(create) = pick_create_command(target_agg) {
+            if let Some(create) = pick_safe_bootstrap(target_agg, &triggered_in_cascade) {
                 prerequisites.push(emit_setup(target_agg, create));
             }
+            // else: no safe bootstrap exists — skip. The runtime
+            // auto-creates singletons on first dispatch, so the cascade
+            // handles creation when its own trigger fires.
         }
     }
 
-    // Walk the cascade once more, this time chaining through each
-    // cross-aggregate's lifecycle so triggered commands find their
-    // target in the right state. The Create above proves the record
-    // exists; this loop satisfies any `given { status == "X" }` gate
-    // the cascade will hit when it hops over. Chain order is preserved
-    // (prerequisites first, transition commands last) because we push
-    // sequentially rather than insert(0, ...).
-    let triggered_per_agg = cross_aggregate_triggered(domain, cmd, agg);
-    for (target_agg_name, triggered_cmds) in &triggered_per_agg {
+    // Then, for each cross-aggregate, chain through any preconditions the
+    // cascade-triggered commands need that the cascade WON'T satisfy.
+    // `plan_setup_chain_filtered` skips producers that would pre-advance
+    // a cascade-triggered lifecycle transition — e.g. in restaurant_
+    // reservations, the precondition `status == "waiting"` on NotifyParty
+    // is satisfied by AddToWaitlist, which IS cascade-triggered but has
+    // no lifecycle transition, so it's safe to pre-run. In CloudflareDeploy
+    // the precondition on MarkLive (state=="ui_live") is produced by
+    // DeployPages, which is cascade-triggered AND a lifecycle transition,
+    // so the chain leaves it to the cascade. (i4 gap 6.)
+    // [antibody-exempt: fixing the behaviors conceiver per i4 gaps 6+7; retires when conceivers port to a bluebook-dispatched form]
+    for target_agg_name in &cascade_aggs {
+        if target_agg_name == &agg.name { continue; }
         let Some(target_agg) = domain.aggregates.iter().find(|a| &a.name == target_agg_name) else { continue };
-        for triggered in triggered_cmds {
-            let chain = match plan_setup_chain(domain, target_agg, triggered, 5, &mut Vec::new()) {
+        for triggered_name in &triggered_in_cascade {
+            let Some(triggered) = target_agg.commands.iter().find(|c| &c.name == triggered_name) else { continue };
+            let chain = match plan_setup_chain_filtered(domain, target_agg, triggered, 5, &mut Vec::new(), &triggered_in_cascade) {
                 SetupPlan::Chain(c) => c,
                 SetupPlan::Unsatisfiable => continue,
             };
@@ -463,6 +482,77 @@ fn pick_create_command(agg: &Aggregate) -> Option<&Command> {
     agg.commands.iter().find(is_bootstrap)
 }
 
+/// Pick a bootstrap command for `agg` that's safe as a cascade-test
+/// pre-setup: not a cascade-triggered command that ALSO carries a
+/// lifecycle transition. Pre-running such a command advances the
+/// aggregate past the from_state its cascade-hop expects, refusing the
+/// cascade's own dispatch. Returns None when only unsafe bootstraps
+/// exist; the runtime then auto-creates the singleton on first cascade
+/// dispatch, which correctly starts at default lifecycle state.
+///
+/// Example (CloudflareDeploy): the Deployment aggregate's only non-
+/// self-ref commands are the cascade-triggered `ProvisionD1`, `Apply-
+/// Migrations`, `DeployWorker`, `DeployPages`. All carry lifecycle
+/// transitions, so this returns None — the cascade itself bootstraps
+/// Deployment at "pending" via its own ProvisionD1 dispatch.
+///
+/// Counter-example (Console): the Speaker aggregate's bootstrap
+/// `TalkWith` IS a lifecycle transition ("none" → "active") but is
+/// NOT cascade-triggered by `RecordMessage`. Picking it is fine:
+/// pre-running advances Speaker past default, but `LearnAboutSpeaker`
+/// (the cascade-triggered Speaker command) has no from_state gate, so
+/// it dispatches cleanly. (i4 gap 6.)
+fn pick_safe_bootstrap<'a>(
+    agg: &'a Aggregate,
+    triggered_in_cascade: &BTreeSet<String>,
+) -> Option<&'a Command> {
+    let is_bootstrap = |c: &&Command| self_ref_for(agg, c).is_none();
+    let is_safe = |c: &&Command| -> bool {
+        if !triggered_in_cascade.contains(&c.name) { return true; }
+        if let Some(lc) = &agg.lifecycle {
+            return !lc.transitions.iter().any(|t| t.command == c.name);
+        }
+        true
+    };
+
+    let prefixes = ["Create", "Define", "Place", "Register", "Open",
+                    "Plan", "Spawn", "Boot", "Start", "Initialize",
+                    "Seed", "Provision", "Issue"];
+    for prefix in &prefixes {
+        if let Some(c) = agg.commands.iter()
+            .find(|c| c.name.starts_with(prefix) && is_bootstrap(c) && is_safe(c))
+        {
+            return Some(c);
+        }
+    }
+    agg.commands.iter().find(|c| is_bootstrap(c) && is_safe(c))
+}
+
+/// Collect every command name that will be dispatched by the cascade
+/// rooted at `cmd` (following emit → policy → trigger edges). Used by
+/// `pick_safe_bootstrap` and `plan_setup_chain_filtered` to avoid
+/// choosing pre-setups the cascade would also run. (i4 gap 6.)
+fn commands_triggered_by_cascade(domain: &Domain, cmd: &Command) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut stack: Vec<String> = Vec::new();
+    if let Some(ev) = &cmd.emits {
+        for p in &domain.policies {
+            if &p.on_event == ev { stack.push(p.trigger_command.clone()); }
+        }
+    }
+    while let Some(name) = stack.pop() {
+        if !out.insert(name.clone()) { continue; }
+        if let Some((_, c)) = find_cmd_with_agg(domain, &name) {
+            if let Some(ev) = &c.emits {
+                for p in &domain.policies {
+                    if &p.on_event == ev { stack.push(p.trigger_command.clone()); }
+                }
+            }
+        }
+    }
+    out
+}
+
 /// Plan a chain of commands that puts `agg` into the state `target_cmd`
 /// requires. Preconditions come from two sources:
 ///   • `target_cmd.givens` — equality predicates like `status == "X"`
@@ -536,6 +626,81 @@ fn plan_setup_chain<'a>(
                     unsatisfiable = true;
                     break;
                 }
+            }
+        }
+    }
+
+    visited.pop();
+    if unsatisfiable { SetupPlan::Unsatisfiable } else { SetupPlan::Chain(chain) }
+}
+
+/// Same as `plan_setup_chain` but skips producer candidates that would
+/// conflict with a cascade's own dispatch. A producer is skipped iff it's
+/// in `exclude` (cascade-triggered) AND carries a lifecycle transition
+/// on `agg`. The double condition is important:
+///   * Cascade-triggered only → safe to pre-run when the command has
+///     no lifecycle transition (e.g. AddToWaitlist in restaurant_
+///     reservations: cascade-triggered via TableOccupied, but no
+///     lifecycle transition, so pre-running doesn't advance state).
+///   * Cascade-triggered AND lifecycle-transition → pre-running
+///     advances state past the from_state the cascade expects, so
+///     leave it to the cascade (e.g. DeployPages for MarkLive's
+///     precondition in CloudflareDeploy).
+/// When the only producer is excluded, the precondition is left unmet —
+/// correct for cascade tests because the cascade runs the producer
+/// itself during event propagation. (i4 gap 6.)
+fn plan_setup_chain_filtered<'a>(
+    domain: &'a Domain,
+    agg: &'a Aggregate,
+    target_cmd: &'a Command,
+    depth: usize,
+    visited: &mut Vec<&'a str>,
+    exclude: &BTreeSet<String>,
+) -> SetupPlan<'a> {
+    if depth == 0 { return SetupPlan::Chain(Vec::new()); }
+    if visited.contains(&target_cmd.name.as_str()) { return SetupPlan::Chain(Vec::new()); }
+    visited.push(target_cmd.name.as_str());
+    let mut chain: Vec<&Command> = Vec::new();
+    let mut produced: ProducedState = ProducedState::default();
+    let mut unsatisfiable = false;
+
+    let is_cascade_triggered_transition = |p: &&Command| -> bool {
+        if !exclude.contains(&p.name) { return false; }
+        if let Some(lc) = &agg.lifecycle {
+            return lc.transitions.iter().any(|t| t.command == p.name);
+        }
+        false
+    };
+
+    for pre in collect_preconditions(agg, target_cmd) {
+        if produced.satisfies(&pre) { continue; }
+        if precondition_default_holds(agg, &pre) { continue; }
+        let producer = find_producer(domain, agg, &pre)
+            .filter(|p| !is_cascade_triggered_transition(p));
+        match producer {
+            Some(producer) => {
+                let sub_chain = match plan_setup_chain_filtered(domain, agg, producer, depth - 1, visited, exclude) {
+                    SetupPlan::Chain(sub) => sub,
+                    SetupPlan::Unsatisfiable => {
+                        unsatisfiable = true;
+                        break;
+                    }
+                };
+                for sub in sub_chain {
+                    if !chain.iter().any(|c| c.name == sub.name) {
+                        chain.push(sub);
+                        produced.absorb(agg, sub);
+                    }
+                }
+                if !chain.iter().any(|c| c.name == producer.name) {
+                    chain.push(producer);
+                    produced.absorb(agg, producer);
+                }
+            }
+            None => {
+                // No non-excluded producer — the cascade itself will
+                // satisfy this precondition, or there's genuinely no
+                // producer. Either way, leave it unchained.
             }
         }
     }
@@ -1183,10 +1348,12 @@ fn test_name(cmd: &Command, _agg: &Aggregate) -> String {
 /// will hop through is bootstrapped before dispatch.
 /// Collect every triggered command in the cascade, grouped by the
 /// aggregate that owns it — but only for aggregates other than the
-/// command's own. Used by `emit_cascade_test` to chain through
-/// cross-aggregate lifecycles before dispatch, so a cascade hop into
-/// `DeliverCommission given { status == "in_progress" }` finds the
-/// commission already in `in_progress` instead of `quoted`.
+/// command's own.
+///
+/// Superseded by `commands_triggered_by_cascade` + `plan_setup_chain_filtered`
+/// in the cascade-test builder. Kept for parity with the other conceiver
+/// and possible future use. (i4 gap 6.)
+#[allow(dead_code)]
 fn cross_aggregate_triggered<'a>(
     domain: &'a Domain,
     cmd: &'a Command,

--- a/hecks_life/tests/behaviors_conceiver_test.rs
+++ b/hecks_life/tests/behaviors_conceiver_test.rs
@@ -481,6 +481,131 @@ end
         "PrimeSource setup must come before OpenSource setup, got:\n{}", block);
 }
 
+#[test]
+fn cascade_test_does_not_pre_advance_triggered_lifecycle() {
+    // i4 gap 6: the generator used to pick `pick_create_command` for
+    // every cross-aggregate the cascade hops through. That function
+    // happily picks a cascade-triggered command that ALSO carries a
+    // lifecycle transition, which pre-advances state past the from_state
+    // the cascade expects. When the cascade's own dispatch of the same
+    // command then tries to transition, it's refused.
+    //
+    // Fixture mirrors CloudflareDeploy: Compile (Compilation) triggers
+    // a chain that eventually transitions Deployment pending → provisioned
+    // → migrated via ProvisionD1 / ApplyMigrations. The generated cascade
+    // test must NOT emit `setup "ProvisionD1"` or `setup "ApplyMigrations"`
+    // — doing so would advance Deployment past "pending" before the
+    // cascade's own ProvisionD1 dispatch, which would then be refused.
+    let source = r#"Hecks.bluebook "Fixture" do
+  aggregate "Compilation" do
+    attribute :source, String
+    command "Compile" do
+      attribute :source, String
+      emits "Compiled"
+      then_set :source, to: :source
+    end
+  end
+  aggregate "Deployment" do
+    attribute :status, String
+    command "ProvisionD1" do
+      emits "Provisioned"
+    end
+    command "ApplyMigrations" do
+      reference_to(Deployment)
+      emits "Migrated"
+    end
+    lifecycle :status, default: "pending" do
+      transition "ProvisionD1" => "provisioned", from: "pending"
+      transition "ApplyMigrations" => "migrated", from: "provisioned"
+    end
+  end
+  policy "ProvisionAfterCompile" do
+    on "Compiled"
+    trigger "ProvisionD1"
+  end
+  policy "MigrateAfterProvision" do
+    on "Provisioned"
+    trigger "ApplyMigrations"
+  end
+end
+"#;
+    let domain = parser::parse(source);
+    let out = generate_behaviors(&domain, None);
+    let cascade = out.split("test \"")
+        .find(|b| b.starts_with("Compile cascades"))
+        .expect("expected a Compile cascade test");
+    assert!(!cascade.contains("setup  \"ProvisionD1\""),
+        "cascade test must not pre-run the transitioning trigger \
+         ProvisionD1 (would advance Deployment past pending), got:\n{}",
+        cascade);
+    assert!(!cascade.contains("setup  \"ApplyMigrations\""),
+        "cascade test must not pre-run the transitioning trigger \
+         ApplyMigrations (would advance Deployment past provisioned), got:\n{}",
+        cascade);
+}
+
+#[test]
+fn cascade_test_still_pre_creates_referenced_cross_aggregate() {
+    // i4 gap 6 regression guard: the safe-bootstrap filter must STILL
+    // emit a bootstrap for a cross-aggregate the cascade references but
+    // whose bootstrap command is NOT cascade-triggered. Without this, the
+    // cascade's first reference to that aggregate would fail.
+    //
+    // Fixture mirrors Security: VerifySecret (HashedSecret) cascades via
+    // SecretVerified → GrantAccess (AccessGate). AccessGate's `GrantAccess`
+    // is cascade-triggered and has a lifecycle transition, but its ancestor
+    // `RequestAccess` is NOT cascade-triggered and is the only command
+    // that transitions status to "challenging". The cascade test must
+    // include `setup "RequestAccess"` so the cascade's GrantAccess finds
+    // AccessGate in the right state.
+    let source = r#"Hecks.bluebook "Fixture" do
+  aggregate "HashedSecret" do
+    attribute :name, String
+    command "StoreSecret" do
+      attribute :name, String
+      emits "SecretStored"
+    end
+    command "VerifySecret" do
+      reference_to(HashedSecret)
+      attribute :candidate, String
+      emits "SecretVerified"
+    end
+  end
+  aggregate "AccessGate" do
+    attribute :status, String
+    command "RequestAccess" do
+      emits "AccessRequested"
+      then_set :status, to: "challenging"
+    end
+    command "GrantAccess" do
+      reference_to(AccessGate)
+      given { status == "challenging" }
+      emits "AccessGranted"
+      then_set :status, to: "granted"
+    end
+    lifecycle :status, default: "locked" do
+      transition "RequestAccess" => "challenging", from: "locked"
+      transition "GrantAccess" => "granted", from: "challenging"
+    end
+  end
+  policy "GrantOnVerify" do
+    on "SecretVerified"
+    trigger "GrantAccess"
+  end
+end
+"#;
+    let domain = parser::parse(source);
+    let out = generate_behaviors(&domain, None);
+    let cascade = out.split("test \"")
+        .find(|b| b.starts_with("VerifySecret cascades"))
+        .expect("expected a VerifySecret cascade test");
+    assert!(cascade.contains("setup  \"RequestAccess\""),
+        "cascade test must pre-run the non-triggered producer \
+         (RequestAccess sets status=\"challenging\" so the cascade's \
+         GrantAccess finds the right state), got:\n{}",
+        cascade);
+}
+
 // ─── helpers ────────────────────────────────────────────────────────
 
 /// Slice the substring spanning a single `test "<cmd_name> ..."` block,


### PR DESCRIPTION
## Summary

Fixes three known failure modes when `conceive-behaviors --force` regenerated an existing authored file:

1. **Pre-advanced lifecycle** — `pick_create_command` picked the first non-self-ref command for each cross-aggregate hop, which was often a cascade-triggered command carrying a lifecycle transition. Running it as pre-setup moved the target past the `from_state` the cascade expected, so the cascade was then refused.
2. **Missing non-triggered bootstrap** — silently dropping the bootstrap when its only candidate was cascade-triggered broke cases where a cross-aggregate reference needed a pre-existing record.
3. **Over-chaining through cross-aggregate lifecycle** — the generator planned a setup chain that walked backward through lifecycle transitions, emitting every upstream producer as a setup even when the cascade itself would run those producers.

## Fix

Replace `pick_create_command` + `cross_aggregate_triggered` with three helpers that consult the cascade's own triggered set. See commit message for API-level detail.

## Verification

- `behaviors_conceiver_test` binary: **14 passed, 0 failed** (includes 2 new lockdown tests)
- capabilities/security.bluebook: 9/9 matches agent's claim
- capabilities/circuit_breaker.bluebook: 7/9 — the 2 failures are pre-existing on main, not regressed

## Gap 7 note

Gap 7 (`size >= N` precondition via a new `MinSizeList` variant) was half-written when the agent timed out; discarded and will be filed separately.

## Test plan

- [ ] CI green
- [ ] cargo test --release --test behaviors_conceiver_test green