### PR TITLE
fix(statusline): ⚠ everywhere — resolve symlinks before finding status_coherence.sh

### DIFF
--- a/hecks_conception/statusline-command.sh
+++ b/hecks_conception/statusline-command.sh
@@ -20,7 +20,13 @@ sleep_summary=$($hecks heki read $info/consciousness.heki 2>/dev/null | grep sle
 # (see status_coherence.sh + inbox i35). On violation we degrade the mood
 # glyph to ⚠ and append the reason to information/.coherence.log so the
 # status bar never silently renders a contradictory state.
-coherence_dir="$(dirname "$0")"
+# Resolve symlinks — Claude Code runs this script via ~/.claude/statusline-command.sh
+# (a symlink into hecks_conception/), so $0 points at the symlink's dir, not the
+# real one. Walk the symlink chain to find the actual script dir where
+# status_coherence.sh lives next to us.
+script="$0"
+while [ -L "$script" ]; do script="$(readlink "$script")"; done
+coherence_dir="$(cd "$(dirname "$script")" && pwd)"
 coherence_violations=""
 if ! coherence_violations=$("$coherence_dir/status_coherence.sh" "$info" 2>&1 >/dev/null); then
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary

The status bar was rendering ⚠ for the mood icon on every single tick. Not a coherence invariant failure — a **dumb symlink bug**.

Claude Code invokes `~/.claude/statusline-command.sh`, which is a symlink into `hecks_conception/`. The old code:

```
coherence_dir="$(dirname "$0")"
```

...resolved `$0` as the **symlink path** (`~/.claude/statusline-command.sh`), so `dirname` returned `~/.claude/`. The script then tried to exec `~/.claude/status_coherence.sh` — which doesn't exist. Every render errored, exit code non-zero, `coherence_bad=1`, mood icon → ⚠.

Check `information/.coherence.log` — every 1Hz tick for who-knows-how-long:

```
2026-04-22T20:55:59Z /Users/christopheryoung/.claude/statusline-command.sh: line 19:
  /Users/christopheryoung/.claude/status_coherence.sh: No such file or directory
```

## Fix

Walk the symlink chain before taking dirname:

```bash
script="$0"
while [ -L "$script" ]; do script="$(readlink "$script")"; done
coherence_dir="$(cd "$(dirname "$script")" && pwd)"
```

Portable across bash on macOS + Linux, no `readlink -f` dependency.

## Verification

Before:
```
☀️ Miette 🖤 24.55k ⚠ refreshed ⚡ alert ...
```

After:
```
☀️ Miette 🖤 24.61k 😊 refreshed ⚡ alert ...
```

## Test plan

- [ ] Refresh statusline, see mood icon (not ⚠)
- [ ] `.coherence.log` stops growing with 'No such file or directory' lines