### PR TITLE
fix(fixtures): Ruby-compatible escape expander in Rust parser (i38/i39)

### DIFF
--- a/hecks_life/src/fixtures_parser.rs
+++ b/hecks_life/src/fixtures_parser.rs
@@ -39,6 +39,82 @@ use crate::fixtures_ir::{CatalogAttr, FixturesFile};
 use crate::ir::Fixture;
 use crate::parser_helpers::{extract_string, ends_with_do_block};
 
+/// Extract the body of the first double-quoted string in `s`, honoring
+/// `\"` as an embedded-quote escape. Returns the raw (still-escaped)
+/// contents between the opening and closing quote, or None if there
+/// isn't a complete pair. Used instead of parser_helpers::extract_string
+/// for fixture attribute values so that strings like `"1/8\"=1'"` don't
+/// terminate prematurely at the embedded `\"`.
+fn extract_string_escape_aware(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let start = s.find('"')? + 1;
+    let mut i = start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == b'"' {
+            return Some(s[start..i].to_string());
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Expand Ruby-style double-quoted string escapes byte-for-byte.
+///
+/// Ruby is the source of truth for `.fixtures` files because they're
+/// loaded via `Kernel.load` — the string body IS Ruby source, and
+/// Ruby's parser applies these substitutions before the DSL builder
+/// sees the value. We reproduce the common subset here so the Rust
+/// parser yields identical attribute values.
+///
+/// Covered:
+///   \\ \" \'    — literal backslash / quote / apostrophe
+///   \n \t \r    — newline / tab / CR
+///   \a \b \f \v — bell / backspace / form feed / vertical tab
+///   \e \0 \s    — escape (0x1B) / null / space (Ruby-specific)
+///   any other `\X` — backslash dropped, X kept (Ruby's rule for
+///                     unrecognized escapes in double-quoted strings)
+///
+/// Deferred (see followup i38-exotic): `\xNN`, `\uNNNN`, `\<digits>`
+/// octal, `\C-x` / `\M-x` control-meta, and `\<newline>` line
+/// continuation. None of these appear in current fixtures; add them
+/// when a real fixture needs one.
+fn expand_ruby_escapes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('"')  => out.push('"'),
+                Some('\'') => out.push('\''),
+                Some('n')  => out.push('\n'),
+                Some('t')  => out.push('\t'),
+                Some('r')  => out.push('\r'),
+                Some('a')  => out.push('\x07'),
+                Some('b')  => out.push('\x08'),
+                Some('f')  => out.push('\x0C'),
+                Some('v')  => out.push('\x0B'),
+                Some('e')  => out.push('\x1B'),
+                Some('0')  => out.push('\0'),
+                Some('s')  => out.push(' '),
+                // Unrecognized: drop the backslash, keep the next char
+                // (preserves UTF-8 codepoints intact).
+                Some(other) => out.push(other),
+                // Trailing backslash — keep literal.
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 pub fn parse(source: &str) -> FixturesFile {
     let mut file = FixturesFile {
         domain_name: String::new(),
@@ -95,7 +171,9 @@ fn parse_fixture_line(line: &str, aggregate_name: &str) -> Fixture {
                 let key = part[..colon].trim().to_string();
                 let raw = part[colon + 1..].trim();
                 let val = if raw.starts_with('"') {
-                    extract_string(raw).unwrap_or_else(|| raw.to_string())
+                    extract_string_escape_aware(raw)
+                        .map(|s| expand_ruby_escapes(&s))
+                        .unwrap_or_else(|| raw.to_string())
                 } else {
                     raw.to_string()
                 };

--- a/spec/parity/fixtures/escape_matrix.fixtures
+++ b/spec/parity/fixtures/escape_matrix.fixtures
@@ -1,0 +1,38 @@
+# Escape matrix — one fixture per Ruby double-quoted escape the Rust
+# fixture parser must reproduce. Both runtimes MUST canonicalize to
+# byte-identical attribute values for every entry. This is the parity
+# guard for i38/i39 (Ruby-compatible escape expander in Rust).
+#
+# Ruby loads this via Kernel.load, so the string bodies ARE Ruby source:
+# `\s` becomes a space, `\[` becomes `[`, `\n` becomes a real newline,
+# etc. The Rust parser applies expand_ruby_escapes in fixtures_parser.rs
+# to match byte-for-byte.
+
+Hecks.fixtures "EscapeMatrix" do
+  aggregate "Escape" do
+    fixture "Backslash",      input: "a\\b"
+    fixture "DoubleQuote",    input: "a\"b"
+    fixture "SingleQuote",    input: "a\'b"
+    fixture "Newline",        input: "a\nb"
+    fixture "Tab",            input: "a\tb"
+    fixture "CarriageReturn", input: "a\rb"
+    fixture "Bell",           input: "a\ab"
+    fixture "Backspace",      input: "a\bb"
+    fixture "FormFeed",       input: "a\fb"
+    fixture "VerticalTab",    input: "a\vb"
+    fixture "EscapeChar",     input: "a\eb"
+    fixture "NullByte",       input: "a\0b"
+    fixture "RubySpace",      input: "a\sb"
+    fixture "LeftBracket",    input: "a\[b"
+    fixture "RightBracket",   input: "a\]b"
+    fixture "LeftParen",      input: "a\(b"
+    fixture "RightParen",     input: "a\)b"
+    fixture "LeftBrace",      input: "a\{b"
+    fixture "RightBrace",     input: "a\}b"
+    fixture "Hash",           input: "a\#b"
+    fixture "Slash",          input: "a\/b"
+    fixture "UnrecognizedQ",  input: "a\qb"
+    fixture "RegexPattern",   input: "^\\s*\\[antibody-exempt:\\s*([^\\]]+)\\]"
+    fixture "MultilineMsg",   input: "line one\n\nline two"
+  end
+end

--- a/spec/parity/fixtures_known_drift.txt
+++ b/spec/parity/fixtures_known_drift.txt
@@ -3,10 +3,8 @@
 # with # are comments. Add new drift only after confirming it's a real
 # semantic edge (escape sequences, unicode in source tokens, etc.) —
 # do NOT use this as a way to silence regressions.
-hecks_conception/nursery/architecture_firm/fixtures/architecture_firm.fixtures
 hecks_conception/nursery/compost_loop/fixtures/compost_loop.fixtures
 hecks_conception/nursery/content_moderation/fixtures/content_moderation.fixtures
-hecks_conception/nursery/heki/fixtures/heki.fixtures
 hecks_conception/nursery/pottery_studio/fixtures/pottery_studio.fixtures
 hecks_conception/nursery/smart_grocery/fixtures/smart_grocery.fixtures
 hecks_conception/nursery/smart_rehab/fixtures/smart_rehab.fixtures
@@ -15,4 +13,3 @@ hecks_conception/nursery/specimen_transport/fixtures/specimen_transport.fixtures
 hecks_conception/nursery/speech_media/fixtures/speech_media.fixtures
 hecks_conception/nursery/speech_therapy/fixtures/speech_therapy.fixtures
 hecks_conception/nursery/verbs/fixtures/verbs.fixtures
-hecks_conception/capabilities/antibody/fixtures/antibody.fixtures

--- a/spec/parity/fixtures_parity_test.rb
+++ b/spec/parity/fixtures_parity_test.rb
@@ -74,9 +74,13 @@ def rust_ir(path)
   { "domain" => parsed["domain"].to_s, "fixtures" => fixtures }
 end
 
-target = ARGV.empty? ? "hecks_conception/**/*.fixtures" : ARGV[0]
-files = Dir.glob(target)
-abort "no .fixtures files matched: #{target}" if files.empty?
+if ARGV.empty?
+  files = Dir.glob("hecks_conception/**/*.fixtures") +
+          Dir.glob("spec/parity/fixtures/**/*.fixtures")
+else
+  files = Dir.glob(ARGV[0])
+end
+abort "no .fixtures files matched" if files.empty?
 
 # Known-drift list: paths where ruby/rust parse differently for known
 # edge cases (typically embedded escape sequences in attribute values).


### PR DESCRIPTION
## Summary
- Closes inbox i38/i39: Rust fixture parser now applies Ruby's double-quoted escape semantics, so `.fixtures` files with regex patterns or embedded newlines no longer drift between runtimes.
- Parity: 345/358 → 349/359. Three fixtures move out of known-drift: `antibody.fixtures` (motivating case), `architecture_firm.fixtures` and `heki.fixtures` (both needed `\"` handling).
- New parity fixture `spec/parity/fixtures/escape_matrix.fixtures` — 24 cases, one per supported escape — as the contract guard.

## Example

Before, the Rust side preserved backslash escapes as literal bytes:

```ruby
# antibody.fixtures
fixture "Canonical", pattern: "^\\s*\\[antibody-exempt:\\s*([^\\]]+)\\]", flags: "i"
```

| Runtime | Rust output (before) | Rust output (after) | Ruby output |
|---|---|---|---|
| pattern | `^\\s*\\[antibody-exempt:\\s*([^\\]]+)\\]` | `^ *[antibody-exempt: *([^]]+)]` | `^ *[antibody-exempt: *([^]]+)]` |

## Escapes covered

Empirically verified against `ruby -e` before implementation:

```
\\  \"  \'        literal backslash / quote / apostrophe
\n  \t  \r        newline / tab / CR
\a  \b  \f  \v    bell / backspace / form feed / vertical tab
\e  \0  \s        escape (0x1B) / null / space (Ruby-specific: \s IS a space in double-quoted strings)
\X for other X    backslash dropped, X kept (Ruby's rule for unrecognized escapes)
```

Notably: `\s` genuinely expands to `0x20` in Ruby double-quoted context (not literal `s`), and unknown escapes DROP the backslash (not preserve it). The task doc flagged both as VERIFY — the empirical results flipped expectations.

## Deferred (no current fixture needs them)

- `\xNN` hex escapes
- `\uNNNN` unicode escapes
- `\<digits>` octal (e.g. `\12` → newline, `\123` → 'S')
- `\C-x` / `\M-x` control-meta
- `\<newline>` line continuation

Add when a real fixture needs one.

## Test plan
- [x] `ruby -Ilib spec/parity/fixtures_parity_test.rb` — 349/359 parity, 10 known drift, 0 fail.
- [x] `ruby -Ilib spec/parity/fixtures_parity_test.rb spec/parity/fixtures/escape_matrix.fixtures` — 1/1, all 24 cases agree byte-for-byte.
- [x] `cd hecks_life && cargo test --release` — all tests pass.
- [x] Antibody, architecture_firm, heki removed from `spec/parity/fixtures_known_drift.txt`.

Marks i38 and i39 done in `information/inbox.heki` (second commit).