### PR TITLE
docs(plans): i42 catalog-dialect + i43 cross-bluebook behaviors

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -20,6 +20,8 @@ agents — trust the decisions, don't re-derive them.
 | [i30_differential_fuzzer.md](i30_differential_fuzzer.md) | i30 | Not started |
 | [i36_computed_views.md](i36_computed_views.md) | i36 | Not started; architectural (projection DSL + 10 commits) |
 | [i37_python_removal.md](i37_python_removal.md) | i37 | Phase A shipped (PR #272); Phase B+ unblocked |
+| [i42_catalog_dialect.md](i42_catalog_dialect.md) | i42 | Not started; retires 4 shape-only aggregates from PR #267 |
+| [i43_cross_bluebook_behaviors.md](i43_cross_bluebook_behaviors.md) | i43 | Not started; additive `.behaviors` DSL extension (10 commits) |
 | [terminal_capability_wiring.md](terminal_capability_wiring.md) | — | Follow-up to PR #263 |
 
 ## Dependencies between plans

--- a/docs/plans/i42_catalog_dialect.md
+++ b/docs/plans/i42_catalog_dialect.md
@@ -1,0 +1,330 @@
+# i42 — Catalog-dialect: retire shape-only aggregates
+
+Source: inbox `i42` + plan by planning agent on 2026-04-22.
+
+## 1. Current state (why the transitional pattern is wrong)
+
+PR #267 landed four shape-only aggregates in
+`hecks_conception/capabilities/antibody/antibody.bluebook` lines 217-244:
+
+- `FlaggedExtension` — one `:ext, String` attribute. No commands, no
+  lifecycle, no policies.
+- `ShebangMapping` — `:match, :ext`. Same.
+- `ExemptionPattern` — `:pattern, :flags, :anchor`. Same.
+- `TestCase` — `:touched_files, :message, :expected`. Same.
+
+Each exists purely so the rows in
+`hecks_conception/capabilities/antibody/fixtures/antibody.fixtures`
+resolve against a declared schema. PR #258's orphan inventory flagged
+them as "all refs orphan"; PR #267 silenced the audit by declaring
+the schemas as aggregates.
+
+This is a DDD smell in three ways:
+
+1. **Aggregates without commands aren't aggregates.** A DDD aggregate
+   is a consistency boundary around state-mutating behavior. These
+   four have no state mutations — their "state" is loaded once from
+   fixtures and never changes.
+2. **The orphan audit got satisfied, not solved.** The audit ensures
+   every fixture row has a declared schema. Shape-only aggregates
+   satisfy that check mechanically but re-introduce the rule they
+   violate: every declared aggregate should have behavior.
+3. **Downstream generators will hallucinate behavior.** The Go/Ruby
+   codegens emit CRUD scaffolding for every aggregate. Shape-only
+   aggregates will produce `CreateTestCase`, `UpdateFlaggedExtension`,
+   etc. — noise that nobody will ever call.
+
+The real fix is a first-class DSL form for **fixture-only reference
+tables that self-declare their row schema** — a "catalog" is not an
+aggregate, it's a lookup table with a shape.
+
+## 2. Syntax shape
+
+**Chosen: Option B — extend `.fixtures` with a `schema:` kwarg on
+`aggregate`.**
+
+```ruby
+Hecks.fixtures "Antibody" do
+  aggregate "FlaggedExtension", schema: { ext: String } do
+    fixture "Ruby", ext: "rb"
+    fixture "Rust", ext: "rs"
+  end
+
+  aggregate "ShebangMapping", schema: { match: String, ext: String } do
+    fixture "Ruby", match: "ruby", ext: "rb"
+  end
+end
+```
+
+The `schema:` kwarg, when present, signals: "this aggregate is a
+catalog — no bluebook declaration required, the schema here is
+authoritative." Absence preserves today's behavior.
+
+### Why Option B over Option A (`Hecks.catalog`)
+
+**Option A surface area:**
+- New top-level DSL keyword (`Hecks.catalog`).
+- New registry slot (`Hecks.last_catalog_file`).
+- Potentially new file extension (`.catalog`).
+- New Rust parser entry point + `CatalogFile` IR.
+- New parity contract, new parity test harness, new `dump-catalog` CLI.
+
+**Option B additions:**
+- A third argument path in `FixturesBuilder#aggregate` (kwarg).
+- A `schema` field on `FixturesFile` — serialized by existing `dump-fixtures`.
+- A parse-line extension in `fixtures_parser.rs`.
+
+**Migration friction.** Option A forces file renames
+(`antibody.fixtures` → `antibody.catalog`) + path updates in every
+loader. Option B is a pure in-file edit.
+
+**Decision: Option B.** Option A is worth revisiting if we grow a
+*third* kind of self-declaring catalog (enum tables, constant packs),
+but for the i42 case, Option B covers it with ~5x less plumbing.
+
+## 3. Parser work
+
+### 3.1 Ruby DSL (`lib/hecks/dsl/fixtures_builder.rb`)
+
+```ruby
+def aggregate(name, schema: nil, &block)
+  @current_aggregate = name.to_s
+  @schemas[@current_aggregate] = normalize_schema(schema) if schema
+  instance_eval(&block) if block
+  @current_aggregate = nil
+end
+
+private
+
+def normalize_schema(schema)
+  schema.map { |k, v| { name: k.to_s, type: v.to_s } }
+end
+```
+
+`FixturesFile` grows a `catalogs` field:
+
+```ruby
+class FixturesFile
+  attr_reader :name, :fixtures, :catalogs
+  def initialize(name:, fixtures: [], catalogs: {})
+    @name = name
+    @fixtures = fixtures
+    @catalogs = catalogs
+  end
+end
+```
+
+### 3.2 Rust parser (`hecks_life/src/fixtures_parser.rs`)
+
+```rust
+} else if line.starts_with("aggregate ") && ends_with_do_block(line) {
+    current_agg = extract_string(line);
+    if let Some(schema) = extract_schema_kwarg(line) {
+        file.catalogs.insert(current_agg.clone().unwrap(), schema);
+    }
+    depth += 1;
+}
+```
+
+`FixturesFile` grows:
+
+```rust
+pub struct FixturesFile {
+    pub domain_name: String,
+    pub fixtures: Vec<Fixture>,
+    pub catalogs: BTreeMap<String, Vec<CatalogAttr>>,
+}
+
+pub struct CatalogAttr {
+    pub name: String,
+    pub type_name: String,
+}
+```
+
+### 3.3 Parity constraints
+
+Both parsers must produce structurally identical output. Extend
+`spec/parity/fixtures_parity_test.rb` to compare `catalogs` maps.
+Drift on either side is a hard fail.
+
+## 4. Runtime — catalogs stay catalogs
+
+**Chosen: catalogs are NOT hoisted into the aggregate registry.**
+
+The alternative — "hoist a catalog's schema into the aggregate
+registry as a synthetic aggregate" — re-creates the problem we're
+solving. Codegen would generate CRUD, validator would emit events,
+etc.
+
+What *does* happen at runtime:
+
+- **`FixturesLoader#apply`**: if `fixtures_file.catalogs[agg_name]`
+  declares a schema, synthesise a lightweight read-only "catalog
+  repository" and seed rows into it. Keyed access works, commands
+  do not.
+- **Bluebook registry** (`Hecks.loaded_bluebooks`) does NOT grow
+  entries for catalogs.
+- **Codegen** ignores catalogs entirely.
+- **Validator**: new rule handles catalog schema vs row validation.
+
+**Runtime API:**
+- `rt.catalogs[name]` returns `Hash<label, AggregateState>` (read-only)
+- `rt.repositories[name]` remains aggregate-only (separate slot
+  prevents accidental writes)
+
+## 5. Consumer audit — what reverts
+
+### 5.1 The 4 shape-only aggregates (delete)
+
+`hecks_conception/capabilities/antibody/antibody.bluebook` lines 204-244:
+- `FlaggedExtension` aggregate
+- `ShebangMapping` aggregate
+- `ExemptionPattern` aggregate
+- `TestCase` aggregate
+- Enclosing "CONFIG CATALOGS" comment block
+
+Net deletion: ~42 lines.
+
+### 5.2 The fixtures file (extend)
+
+`hecks_conception/capabilities/antibody/fixtures/antibody.fixtures` —
+each `aggregate "X" do` grows a `schema:` kwarg:
+
+```ruby
+aggregate "FlaggedExtension", schema: { ext: String } do
+aggregate "ShebangMapping",   schema: { match: String, ext: String } do
+aggregate "ExemptionPattern", schema: { pattern: String, flags: String, anchor: String } do
+aggregate "TestCase",         schema: { touched_files: list_of(String),
+                                        message: String,
+                                        expected: String } do
+```
+
+Net addition: ~4 lines.
+
+### 5.3 Rust antibody shim
+
+No existing consumer. When it lands, it reads catalogs via
+`runtime.catalogs["FlaggedExtension"]`.
+
+### 5.4 Behaviors file (unchanged)
+
+Zero changes — antibody tests target CommitCheck, BranchScan,
+StagedCheck, not the catalog aggregates.
+
+## 6. Parity coverage
+
+Add `spec/parity/fixtures/catalog_basic.fixtures`:
+
+```ruby
+Hecks.fixtures "CatalogParitySuite" do
+  aggregate "Color", schema: { hex: String, name: String } do
+    fixture "Red",   hex: "#FF0000", name: "Red"
+    fixture "Green", hex: "#00FF00", name: "Green"
+  end
+end
+```
+
+And `spec/parity/fixtures/catalog_edge_cases.fixtures`:
+- Single-row catalog
+- Schema with `list_of(String)`
+- Catalog + plain aggregate in one file
+
+Extend `spec/parity/fixtures_parity_test.rb` to compare `catalogs` maps.
+Zero drift is the acceptance bar.
+
+## 7. Orphan audit update
+
+Add `lib/hecks/validation_rules/structure/fixture_aggregate_refs.rb`:
+
+```ruby
+class FixtureAggregateRefs < BaseRule
+  def errors
+    result = []
+    fixtures_file = find_fixtures_for(@domain)
+    return result unless fixtures_file
+
+    fixtures_file.fixtures.each do |fix|
+      next if aggregate_declared?(@domain, fix.aggregate_name)
+      next if catalog_declared?(fixtures_file, fix.aggregate_name)
+      result << "Fixture '#{fix.name}' references aggregate " \
+                "'#{fix.aggregate_name}' which is neither declared in " \
+                "the bluebook nor as a catalog schema."
+    end
+    result
+  end
+end
+```
+
+Companion `CatalogSchemaCoverage` rule verifies every row supplies
+every declared schema attribute.
+
+## 8. Commit sequence + LoC estimate
+
+1. `feat(fixtures-ir): FixturesFile.catalogs + CatalogAttr` — ~40 LoC
+2. `feat(fixtures-builder): schema: kwarg on aggregate (Ruby)` — ~25 LoC
+3. `feat(fixtures-parser): parse schema: kwarg (Rust)` — ~60 LoC
+4. `feat(dump-fixtures): emit catalogs in JSON` — ~15 LoC
+5. `test(parity): catalog_basic + catalog_edge_cases fixtures` — ~45 LoC
+6. `feat(fixtures-loader): read-only catalog repos` — ~40 LoC
+7. `feat(validation): FixtureAggregateRefs + CatalogSchemaCoverage` — ~60 LoC
+8. `refactor(antibody.fixtures): add schema: to 4 aggregates` — ~10 LoC
+9. `refactor(antibody.bluebook): delete 4 shape-only aggregates` — ~42 LoC removed
+10. `docs(orphan-inventory): regenerate — zero orphans` — ~15 LoC
+11. `test(antibody.behaviors): spot-check catalog accessible` — ~20 LoC
+12. `docs(plans): close i42; inbox mark done` — ~5 LoC
+
+**Total: ~300 LoC added, ~60 LoC deleted (net ~+240 LoC).**
+
+## 9. Risks
+
+### 9.1 Parser ambiguity on `schema:` kwarg
+
+Line-based `starts_with` scanner breaks on multi-line schema.
+*Mitigation*: constrain to single-line schema in v1. Multi-line is v2.
+
+### 9.2 `list_of(Type)` inside schema
+
+Parentheses inside the `{ ... }` confuse comma-splitting.
+*Mitigation*: reuse `split_top_level_commas`. Add unit test.
+
+### 9.3 Backward compat with existing 356 `.fixtures` files
+
+`schema: nil` default + conditional Rust parsing guarantees no
+breakage.
+*Mitigation*: CI runs full parity suite; zero drift is the bar.
+
+### 9.4 Codegen hallucinating catalogs as aggregates
+
+Future refactor might try to unify aggregates and catalogs.
+*Mitigation*: runtime separation (`rt.repositories` vs `rt.catalogs`)
+is a deliberate fence. Document it.
+
+### 9.5 Runtime catalog API not load-bearing yet
+
+Antibody has no Rust shim today. We might under-specify the read API.
+*Mitigation*: implement minimum viable API
+(`rt.catalogs[name]`). Ship shim in a follow-up.
+
+### 9.6 BTreeMap ordering
+
+Rust BTreeMap preserves iteration order; Ruby Hash is
+insertion-ordered.
+*Mitigation*: sort by aggregate name before serialization in the
+parity harness.
+
+## Key answers
+
+- **New file extension needed?** No. `.fixtures` + `schema:` kwarg.
+- **Catalogs register as aggregates at runtime?** No. Separate slot.
+- **Existing `.fixtures` usage changes?** No — `schema:` is opt-in.
+- **When does runtime read a catalog?** Only when code asks
+  (`rt.catalogs["FlaggedExtension"]`). Today nothing asks — antibody's
+  Rust shim is the first intended consumer (deferred).
+
+### Critical Files for Implementation
+
+- `lib/hecks/dsl/fixtures_builder.rb`
+- `hecks_life/src/fixtures_parser.rs`
+- `hecks_life/src/fixtures_ir.rs`
+- `lib/hecks/behaviors/fixtures_loader.rb`
+- `hecks_conception/capabilities/antibody/antibody.bluebook`

--- a/docs/plans/i43_cross_bluebook_behaviors.md
+++ b/docs/plans/i43_cross_bluebook_behaviors.md
@@ -1,0 +1,306 @@
+# Plan — i43: cross-bluebook `.behaviors` dialect (`loads`)
+
+## 1. Current state + why the gap hurts
+
+The `.behaviors` runner (Ruby `bin/hecks-behaviors` + Rust `hecks-life behaviors`)
+boots ONE `Domain` per test from a single `.bluebook` source. Its cascade
+engine (`PolicyDrain` / `drain_policies`) will follow policies to any
+aggregate **inside that domain**, but `across "Pulse"` hops to a policy
+defined in a *sibling* bluebook are invisible — the sibling file was
+never parsed, its policies are not in `domain.policies`, and the event
+goes nowhere.
+
+Coverage grid today:
+
+|                                          | single-bluebook cascade | cross-bluebook cascade |
+|------------------------------------------|-------------------------|------------------------|
+| `.behaviors` `expect emits: [...]`       | ✓ (PR #261 era)         | ✗ (retires the PR)     |
+| `bash tests/*_smoke.sh`                  | redundant               | ✓ (the workaround)     |
+| Ruby/Rust parity (`spec/parity/...`)     | ✓                       | n/a                    |
+| Generator static prediction              | ✓                       | ✓ (already crosses)    |
+
+PR history this plan resolves:
+
+- **PR #261** — moved `BodyPulse` fan-out behind `across "Pulse"`.
+- **PR #277** — narrowed `mindstream.behaviors` to `["Ticked"]` because
+  the single-bluebook runner can't see `Pulse.Emit` fire.
+- **PR #282** — shipped `tests/pulse_fanout_smoke.sh` (106 LoC shell)
+  to recover end-to-end coverage.
+- **PR #281** — added auto-loading of sibling `.fixtures`.
+
+`BodyPulse` subscribers (grep of `on "BodyPulse"`): 15+ downstream
+policies across `sleep`, `body`, `being`, `mindstream`, `status_bar`,
+`heart`. One test file that can't see any of them. The shell script is
+the scar tissue this plan removes.
+
+## 2. Chosen syntax
+
+```ruby
+Hecks.behaviors "Mindstream" do
+  vision "..."
+  loads "body", "being", "sleep", "pulse"   # NEW — zero or more
+
+  test "Tick fans out across the body" do
+    tests "MindstreamTick", on: "Tick", kind: :cascade
+    then_events_include "BodyPulse", "FatigueAccumulated",
+                        "SynapsesPruned", "NerveConnected"
+  end
+end
+```
+
+### Design decisions
+
+1. **Keyword `loads`** (plural verb, plural args). Matches Ruby DSL idiom.
+   Rejected alternatives: `includes` (conflicts with Ruby `include`),
+   `spans` (too abstract), `imports` (not DSL-native).
+
+2. **String resolution: file-system-adjacent, not registry.**
+   `loads "pulse"` looks for:
+   1. `<dir(test_file)>/pulse.bluebook` — sibling file (dominant case)
+   2. `<cwd>/aggregates/pulse.bluebook` — catalog-level
+   3. Hard-error with a useful message naming both paths tried
+
+   No `.world` config, no env var. File system IS the registry.
+
+3. **Own-aggregate not repeated.** `mindstream.behaviors` still loads
+   `mindstream.bluebook` implicitly by naming convention. `loads "pulse"`
+   adds pulse on top.
+
+4. **New assertion: `then_events_include`, set-membership.**
+   Cross-bluebook cascades hop through N policies whose relative ordering
+   is a runtime-drain-order detail, not a semantic contract. Set membership
+   avoids flakes on incidental ordering changes. Superset is fine.
+
+5. **`expect emits: [...]` preserved unchanged** (order-strict, intra-aggregate).
+
+6. **No change to `tests ..., kind: :cascade`.** Orthogonal to `loads`.
+
+### Alternatives rejected
+
+- `.world`-file config with bluebook glob — too much machinery, violates locality.
+- Global bluebook registry loaded once per process — bad for parallel tests.
+- Auto-discover by event name — magic, hard to reason about.
+
+## 3. Runner changes
+
+### 3.1 Ruby — `lib/hecks/behaviors/runner.rb`
+
+Extend `Runner.run` with `extra_bluebooks:` keyword arg. In `run_one`,
+compose a single `Domain` by concatenating `.aggregates`, `.policies`,
+`.value_objects`, and `.queries` from each loaded bluebook.
+
+Collision detection: aggregate name appearing in two loaded bluebooks
+is a hard error.
+
+~40 LoC + ~15 LoC helper in `lib/hecks/behaviors/domain_merger.rb`.
+
+### 3.2 Rust — `hecks_life/src/behaviors_runner.rs`
+
+Mirror: `extra_sources: &[&str]` parameter. In `run_one`:
+
+```rust
+let mut domain = parser::parse(source_text);
+for extra in extra_sources {
+    let extra_domain = parser::parse(extra);
+    domain.aggregates.extend(extra_domain.aggregates);
+    domain.policies.extend(extra_domain.policies);
+    domain.value_objects.extend(extra_domain.value_objects);
+}
+```
+
+~50 LoC + collision helper.
+
+### 3.3 CLI glue
+
+- `bin/hecks-behaviors`: after loading the test file, resolve each name
+  in `Hecks.last_test_suite.loads` via `DomainMerger.resolve_path`,
+  pass loader callbacks to `Runner.run`.
+- `hecks_life/src/main.rs`: same resolution, pass `&[String]` source
+  texts to `run_suite_with_fixtures_and_loads`.
+
+### 3.4 Event-bus behavior
+
+`PolicyDrain` (Ruby) and `drain_policies` (Rust) walk
+`domain.policies` matching on `ev[:name]`. With merged domain, cross-
+bluebook hops drain automatically, zero runtime changes beyond domain
+composition. The `across "X"` marker stays metadata (parsed but unused
+at drain time — already the case today).
+
+## 4. Parser changes
+
+### 4.1 Ruby — `lib/hecks/dsl/test_suite_builder.rb`
+
+```ruby
+def loads(*names)
+  @loads.concat(names.map(&:to_s))
+end
+```
+
+Add `loads` field to `lib/hecks/bluebook_model/structure/test_suite.rb`.
+Add `then_events_include` DSL method to `lib/hecks/dsl/test_builder.rb`.
+
+### 4.2 Rust — `hecks_life/src/behaviors_parser.rs`
+
+Extend top-level parser:
+
+```rust
+else if line.starts_with("loads") {
+    for name in extract_all_strings(line) {
+        suite.loads.push(name);
+    }
+}
+```
+
+Extend `interpret_test_line` with `then_events_include` → new
+`test.events_include: Vec<String>`.
+
+### 4.3 IR
+
+- `TestSuite.loads: Vec<String>` (Rust) / `Structure::TestSuite#loads: Array<String>` (Ruby)
+- `Test.events_include: Vec<String>` / `Test#events_include`
+
+## 5. Event-log design — global, not per-bluebook
+
+Current event bus is already a single ordered `Vec<Event>` on
+`Runtime`. It's oblivious to which bluebook a policy came from.
+That's exactly right with merged domain.
+
+`pre_event_count` snapshot marks the boundary: any event with
+index >= pre_event_count fired in response to the test command.
+`then_events_include` applies same skip, set membership only considers
+in-scope events.
+
+Per-bluebook logs with cross-refs rejected — YAGNI for the assertion
+primitives. Could tag events with source-bluebook later if debugging
+demands it.
+
+## 6. Setup chains across bluebooks
+
+PR #281 already auto-loads each bluebook's sibling `.fixtures`. With
+merged domain, fixtures concatenate into the same repositories map
+(keyed by aggregate name). Cross-bluebook cascade finds pre-seeded
+records naturally. No new explicit-setup DSL pressure.
+
+## 7. Parity contract
+
+New fixture set: `spec/parity/behaviors/`:
+
+- `01_single.bluebook` + `.behaviors` — no `loads`, baseline.
+- `02_loads/two_aggregates.bluebook` — primary.
+- `02_loads/sibling.bluebook` — loaded sibling with cross-bluebook policy.
+- `02_loads/two_aggregates.behaviors` — uses `loads "sibling"`, asserts
+  cross-bluebook cascade via both `expect emits:` and `then_events_include`.
+- `03_fixture_seed/` — across-bluebook with `.fixtures` preseeding.
+
+Extend `spec/parity/behaviors_parity_test.rb` to exercise these.
+Seed `spec/parity/behaviors_known_drift.txt` empty — any cross-runner
+divergence breaks pre-commit.
+
+## 8. Consumer audit
+
+### Reverts
+
+| File | Action | LoC |
+|---|---|---|
+| `hecks_conception/tests/pulse_fanout_smoke.sh` | DELETE | −106 |
+| `hecks_conception/aggregates/mindstream.behaviors` | restore full cascade (PR #277 undo) + add `loads "pulse", "body", "being", "sleep"` | +6 / −2 |
+
+`mindstream.behaviors` replaces `expect emits: ["Ticked"]` with
+`then_events_include "Ticked", "BodyPulse", "FatigueAccumulated",
+"SynapsesPruned", "NerveConnected"`.
+
+### Coverage gains (opportunity)
+
+Grep of `across "X"` in bluebooks with companion `.behaviors`:
+
+- `awareness.behaviors` — crosses to Dream, StatusBar, Suggestion, Memory, MietteBody
+- `interpretation.behaviors` — crosses to Suggestion
+- `memory.behaviors` — crosses to Dream
+- `conception.behaviors` — crosses to Catalog
+- `bulk_generator.behaviors` — crosses to Census
+- `console.behaviors` — crosses to Memory
+- `catalog/mind.behaviors` — crosses to Dream, StatusBar, Suggestion, Memory
+
+Opportunity, not scope. This plan ships the mechanism; authors add
+`loads` as they choose. Mindstream is the only file this plan actively
+migrates (to prove the mechanism + delete the shell).
+
+## 9. Commit sequence
+
+| # | Commit | LoC |
+|---|--------|-----|
+| 1 | `docs(plans/i43)` | +450 |
+| 2 | `inbox(i43): reference plan` | ~5 |
+| 3 | `feat(behaviors-ir): TestSuite#loads + Test#events_include` | +40 |
+| 4 | `feat(behaviors-parser): parse loads + then_events_include` | +80 |
+| 5 | `feat(behaviors-dsl): TestSuiteBuilder#loads + then_events_include` | +30 |
+| 6 | `feat(behaviors-runner): merge loaded bluebooks into single Domain` | +130 |
+| 7 | `feat(behaviors-runner): then_events_include set-membership` | +40 |
+| 8 | `test(parity/behaviors): 01_single, 02_loads, 03_fixture_seed` | +100 |
+| 9 | `refactor(mindstream.behaviors): restore full cascade via loads` | +6 / −2 |
+| 10 | `chore: delete pulse_fanout_smoke.sh` | 0 / −106 |
+
+**Net:** ~426 added, 108 removed.
+
+### Sequencing
+
+- Commits 3–5 can ship as a no-op DSL extension PR if preferred.
+- Commit 6 is the load-bearing one; both runners must land together.
+- Commit 9 proves value. Commit 10 only after commit 9 is verified green in CI.
+
+## 10. Risks
+
+### R1. Event-ordering flakes in `then_events_include`
+
+Mitigation: document as default for cross-bluebook tests; reserve
+strict `emits:` for intra-aggregate ladders.
+
+### R2. Cross-bluebook aggregate name collision
+
+Mitigation: hard error with both source paths. Author renames.
+
+### R3. `pre_event_count` boundary drift from fixture seeding
+
+Mitigation: `FixturesLoader.apply` today uses direct state mutation,
+not dispatch. Assert with a unit test: "fixtures seed zero events."
+
+### R4. Re-parsing N bluebooks per test = slowness
+
+Mitigation: measure. Expected <200ms growth. If painful, parse each
+once and clone Domain per test. Defer.
+
+### R5. Parity divergence under unusual syntax (symbols vs strings)
+
+Mitigation: normalize to strings on both sides. Parity test uses
+strings everywhere.
+
+### R6. Backward compat: files without `loads` must behave identically
+
+Mitigation: explicit test in commit 6 asserts bit-identical verdicts
+pre- and post-change for zero-`loads` files.
+
+## 11. Open questions (not blockers)
+
+1. `loads` inside `test` block too? No user demand; keep suite-level only.
+2. Namespaced loads (`loads "aggregates/body"`)? Defer — resolve by
+   file-walk, hard-error if ambiguous.
+3. Should `expect emits:` also skip fixture-seed boundary? Already does.
+
+## 12. Acceptance criteria
+
+- [ ] Both runners accept `loads "X"` in test files
+- [ ] `then_events_include` asserts set membership, parity-green
+- [ ] `mindstream.behaviors` with `loads` passes on both runners
+      (same verdicts as deleted smoke shell)
+- [ ] `pulse_fanout_smoke.sh` deleted
+- [ ] `spec/parity/behaviors_parity_test.rb` passes with new fixtures
+- [ ] Any `.behaviors` file without `loads` produces unchanged verdicts
+- [ ] Aggregate-name collision hard-errors with both paths in message
+
+### Critical Files for Implementation
+
+- `lib/hecks/behaviors/runner.rb`
+- `hecks_life/src/behaviors_runner.rs`
+- `hecks_life/src/behaviors_parser.rs`
+- `lib/hecks/dsl/test_suite_builder.rb`
+- `hecks_conception/aggregates/mindstream.behaviors`


### PR DESCRIPTION
Two architectural plans for tonight's inbox-emptying work.

## i42 — catalog-dialect

Retires the 4 shape-only aggregates PR #267 added to `antibody.bluebook`. Chose **Option B** (schema: kwarg on `.fixtures` aggregate) over **Option A** (new `Hecks.catalog` DSL) — 5x less plumbing, zero file renames, single parser entry point.

12 commits, ~300 LoC net.

## i43 — cross-bluebook behaviors

Additive `.behaviors` DSL: `loads "body", "pulse"` lets a test scenario span multiple bluebooks. New `then_events_include` assertion (set-membership) captures cross-bluebook cascades without flaking on incidental ordering.

Retires `pulse_fanout_smoke.sh` (PR #282's 106-LoC shell workaround). Mindstream.behaviors gets its full cascade assertion back.

10 commits, ~420 LoC net.