### PR TITLE
docs(plans): refine i23 LLM + reshape i27 NurseryHealth + file i28 recommendation

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -14,9 +14,10 @@ agents — trust the decisions, don't re-derive them.
 |---|---|---|
 | [i3_moment_consciousness.md](i3_moment_consciousness.md) | i3 | PR-0 + PR-a shipped; PR-b..PR-f remain |
 | [i11_pr1_tongue_speak.md](i11_pr1_tongue_speak.md) | i11 | PR 0 shipped; PR 1 unblocked |
-| [i23_llm_adapter.md](i23_llm_adapter.md) | i23 | Not started; prereq for i11 PR 3+ |
+| [i23_llm_adapter.md](i23_llm_adapter.md) | i23 | Refined 2026-04-22 (Stage A Ruby, ~2600 LoC, 9 commits); prereq for i11 PR 3+ |
 | [i25_loss_function.md](i25_loss_function.md) | i25 | Not started |
-| [i27_nursery_viability.md](i27_nursery_viability.md) | i27 | Not started |
+| [i27_nursery_viability.md](i27_nursery_viability.md) | i27 | Refined 2026-04-22 as NurseryHealth capability (7 commits, ~900 LoC) |
+| [i28_adapter_keyword.md](i28_adapter_keyword.md) | i28 | Recommends Option D: upgrade `external` with `adapter:` kwarg (or close as no-op) |
 | [i30_differential_fuzzer.md](i30_differential_fuzzer.md) | i30 | Not started |
 | [i36_computed_views.md](i36_computed_views.md) | i36 | Not started; architectural (projection DSL + 10 commits) |
 | [i37_python_removal.md](i37_python_removal.md) | i37 | Phase A shipped (PR #272); Phase B+ unblocked |

--- a/docs/plans/i23_llm_adapter.md
+++ b/docs/plans/i23_llm_adapter.md
@@ -1,90 +1,219 @@
 # i23 — `adapter :llm` as first-class runtime capability
 
-Source: inbox `i23` + plan by Agent a041108 on 2026-04-22.
+Source: inbox `i23` + plans by Agent a041108 (v1, 91 lines) + Agent a2297124 (refined 2026-04-22).
 
-## ⚠ Reality check before implementing
+> **Status:** queued. Depends on nothing unshipped. Unblocks i11 PR 3+.
 
-**Chris uses Claude Max + CLI login, not API keys.** See the open decision at the top of `i11_pr1_tongue_speak.md`. The accounting model for `adapter :llm` should match: call/token-based usage caps, USD as telemetry only.
+## Reality check
 
-## What the adapter does
+Chris uses **Claude Max + CLI login**, not API keys. The `:claude`
+provider prefers CLI subprocess (`claude -p …`, subscription auth) and
+only falls back to Anthropic API when `ANTHROPIC_API_KEY` is set.
+Accounting model matches i11 PR 1: call/token caps, USD as telemetry only.
 
-Direct mirror of PR #251's `adapter :shell` — named, many-per-hecksagon, block-or-options form:
+Existing `hecks_life/src/runtime/adapter_llm.rs` (56 LoC, Ollama-only,
+hardcoded prompt) stays as parallel infra until Rust parity (Stage B).
+
+## §1 — Current state
+
+| Artifact | LoC | Status |
+|---|---|---|
+| `adapter_llm.rs` (Ollama-only) | 56 | Lives; Stage B replaces |
+| `mint_musing.sh` (claude/API/CLI/ollama switch) | 173 | First retirement target |
+| `spend.bluebook` + `circuit_breaker.bluebook` (PR #259) | 219 | No dispatcher consumes |
+| `inference.bluebook` | 95 | Exists; no execution |
+| `miette.world` (ollama config) | 10 | Hardcoded |
+
+**Why centralization matters:**
+- Provider switch is duplicated in mint_musing.sh. Next caller copies 40 LoC.
+- `Spend.RecordCall` exists but nothing calls it — **no record** of Claude calls today.
+- `CircuitBreaker` is orphaned. Outage = N timeouts, not 1-then-open.
+- Streaming isn't modeled. Statusline can't show "🤔 thinking" mid-call.
+- Prompt scaffolding is ad-hoc per caller (Ilya's "absorption" gap).
+
+## §2 — Hecksagon `adapter :llm` shape
+
+Direct mirror of PR #251's `adapter :shell`:
 
 ```ruby
-Hecks.hecksagon "..." do
-  adapter :llm, name: :speech do
-    provider_ref "information/claude_assist.heki"
-    fallback      :ollama, model: "llama3", url: "http://localhost:11434"
-    prompt do
-      scaffold :command_metadata
-      system   "You are Miette. Be concise."
-      max_tokens 400
-    end
-    stream        true
-    timeout       30
-    usage_ref     "aggregates/spend.bluebook"    # record via Spend.RecordCall
-    on_response   :response
-    on_tokens     :tokens_in, :tokens_out
+adapter :llm, name: :speech do
+  provider_ref "information/claude_assist.heki"   # runtime-switched
+  fallback     :ollama, model: "llama3", url: "http://localhost:11434"
+
+  prompt do
+    scaffold :command_metadata                    # auto from command
+    system   "You are Miette. Be concise."
+    persona_file "system_prompt.md"
+    max_tokens 400
+    temperature 0.7
   end
+
+  stream        true
+  timeout       30
+  output_format :text                             # :text | :json | :stream_json
+  usage_ref     "aggregates/spend.bluebook"       # RecordCall target
+  breaker_ref   :claude_api                       # CircuitBreaker kind
+  on_response   :response
+  on_tokens     :tokens_in, :tokens_out
+  on_stream     :stream_chunk                     # optional per-chunk command
 end
 ```
 
-## Three distinctions from `:shell`
+### Three distinctions from `:shell`
 
-1. **Provider switch** — claude/ollama/off chosen per-call from `claude_assist.heki` (not fixed binary)
-2. **Streaming** — chunk-yielding iterator, not `capture3`
-3. **Auto usage accounting** — every invocation triggers `Spend.RecordCall`
+1. **Provider switch** — `:claude`/`:ollama`/`:openai`/`:test`/`:off` runtime-chosen.
+2. **Streaming** — chunk-yielding iterator. Output: `:stream_json` (SSE) / `:json_lines`.
+3. **Auto usage accounting** — every call → `Spend.RecordCall`; failures → `CircuitBreaker.RecordFailure`.
 
-## Key decisions
+## §3 — Provider implementations
 
-- **`scaffold :command_metadata`** auto-builds the prompt from the triggering command's `description`, `guards`, `then_set` mutations, and state fields it reads. This is the "absorption" Ilya asked for — replaces the hardcoded `"You are Miette..."` in `adapter_llm.rs`.
-- **Provider abstraction**: `ClaudeProvider` + `OllamaProvider` behind a `LlmProvider` trait. Shared `StreamingResult` yields chunks.
-- **Security**: Claude CLI needs `HOME` + `PATH` in env (PR #251's `unsetenv_others: true` is too strict). Document this as a controlled relaxation.
-- **Replay cache hooks**: `HECKS_LLM_REPLAY` and `HECKS_LLM_CAPTURE` env vars for differential fuzzer (i30). No fuzzer-specific code in the DSL.
-- **Ruby-only in Stage A.** `hecks_life/` doesn't parse hecksagons (until PR #263's parser grows to cover `:llm`). Existing `adapter_llm.rs` stays untouched as parallel infra.
+### `:claude` (Ruby)
+- **CLI path (default)**: `claude -p --output-format stream-json …` via `Open3.popen3`, `unsetenv_others: true` + `HOME`+`PATH` pass-through. Parse stream-json; accumulate tokens from `message_stop`.
+- **API path** (`ANTHROPIC_API_KEY` present): Net::HTTP to `api.anthropic.com/v1/messages`, SSE parse for stream.
+- **Boot probe**: `claude --version`. On failure + provider=claude, mark degraded; dispatcher returns `LlmInvocationSkipped(reason: "provider_unavailable")`.
 
-## Files
+### `:ollama` (Ruby)
+HTTP client against `config.url || "http://localhost:11434"`. Stream: `response.read_body { |chunk| … }`, parse json_lines.
 
-NEW:
-- `lib/hecksagon/structure/llm_adapter.rb` (~120 LoC)
-- `lib/hecksagon/dsl/llm_adapter_builder.rb` (~140)
-- `lib/hecks/runtime/llm_dispatcher.rb` (~280)
-- `lib/hecks/runtime/llm_dispatcher/claude_provider.rb` + `ollama_provider.rb`
-- `lib/hecks/errors/llm_adapter_error.rb`
-- `docs/usage/llm_adapter.md`
-- `examples/llm_adapter/`
-- Specs for each
+### `:test` (Ruby) — **required for CI**
+- `@fixtures`: prompt_sha256 → canned response
+- Strict mode (CI, `HECKS_LLM_FIXTURE_STRICT=1`): unknown hash raises
+- Capture/replay via `HECKS_LLM_CAPTURE` / `HECKS_LLM_REPLAY` (i30 fuzzer hook)
 
-MODIFY:
-- `lib/hecksagon/dsl/hecksagon_builder.rb` (dispatch on `kind == :llm`)
-- `lib/hecksagon/structure/hecksagon.rb` (reader + lookup)
-- `lib/hecks/runtime.rb` (`#register_llm_adapter`, `#llm(name, **attrs)`)
-- `lib/hecks/runtime/boot.rb` (`wire_llm_adapters`)
+### `:openai` — deferred
 
-## Commit sequence (8)
+## §4 — Dispatcher pipeline
 
-1. `feat(hecksagon): add Structure::LlmAdapter value object`
-2. `feat(hecksagon): add LlmAdapterBuilder DSL`
+```
+LlmDispatcher.call(adapter, attrs)
+  1. resolve provider (provider_ref | provider | fallback)
+  2. resolve breaker kind (breaker_ref || "#{name}_api")
+  3. CircuitBreaker.IsOpen? → LlmInvocationSkipped(reason: "breaker_open")
+  4. Spend.IsOverBudget?    → LlmInvocationSkipped(reason: "budget_exceeded")
+  5. PromptScaffolder.build(command, attrs, scaffold_directive, system, persona)
+  6. provider.invoke(prompt, config)
+     ├─ success: Spend.RecordCall + CircuitBreaker.RecordSuccess + LlmInvocationCompleted
+     └─ failure: CircuitBreaker.RecordFailure + LlmInvocationFailed → raise
+```
+
+**Crash ordering**: provider success + RecordCall failure still emits
+LlmInvocationCompleted + returns response. Missing-record better than
+lost-response; reconcile daemon catches up.
+
+**Override bypass**: `override_active == "yes"` + `override_until >= now`
+skips IsOverBudget. Logs `LlmInvocationOverbudgetBypass`.
+
+## §5 — Bluebook call-site ergonomics
+
+**Implicit** (matches inference.bluebook):
+```ruby
+aggregate "Curator" do
+  attribute :idea, String
+  attribute :response, String       # :on_response target
+  attribute :tokens_in, Integer
+  attribute :tokens_out, Integer
+  command "CurateMusing" do
+    description "Generate a minted musing"
+    attribute :idea, String
+    emits "MusingCurated"
+  end
+end
+```
+Adapter resolves post-dispatch; if on_response empty + input non-empty, fires.
+
+**Explicit**: `app.llm(:curate, idea: "…")`.
+
+## §6 — PromptScaffolder
+
+For `scaffold :command_metadata`:
+```
+SYSTEM:
+You are dispatching the {Aggregate.Command} command.
+Description: {command.description}
+When to fire: {guards joined with "AND"}
+On success, you will set: {then_set pairs}
+State fields in scope: {reads}
+
+USER:
+{runtime attrs as labeled fields}
+```
+
+Deterministic (hash-stable for replay cache); PII-aware (strips
+`pii`-tagged fields via `aggregate_capabilities`).
+
+## §7 — Consumer audit (retirement targets)
+
+| Caller | LoC | Replacement |
+|---|---|---|
+| `mint_musing.sh` | 173 | `Curator.CurateMusing` via `adapter :llm, name: :curate` |
+| `adapter_llm.rs` | 56 | Stage B parallel Rust dispatcher |
+| Tongue.Speak (i11 PR 1) | — | `adapter :llm, name: :speak` follow-up |
+| Greeting / Daydream / REM / interpret_dream | shell | Opt-in `:llm` adapter |
+
+One retirement per follow-up PR.
+
+## §8 — Commit sequence (Stage A, Ruby-only)
+
+1. `feat(hecksagon): Structure::LlmAdapter value object`
+2. `feat(hecksagon): LlmAdapterBuilder DSL` (+ nested PromptBuilder)
 3. `feat(hecksagon): wire adapter :llm into HecksagonBuilder`
-4. `feat(runtime): LlmDispatcher with provider switch + streaming`
-5. `feat(runtime): token accounting via Spend.RecordCall`
-6. `feat(runtime): LLM replay/capture fuzzer hooks`
-7. `feat(runtime): boot-time llm-adapter registration + Runtime#llm`
-8. `docs: llm adapter reference + example + migration note`
+4. `feat(runtime): LlmDispatcher + TestProvider`
+5. `feat(runtime): ClaudeProvider + OllamaProvider`
+6. `feat(runtime): Spend + CircuitBreaker integration`
+7. `feat(runtime): PromptScaffolder + scaffold :command_metadata`
+8. `feat(runtime): boot-time registration + Runtime#llm`
+9. `docs: usage/llm_adapter.md + migration note`
 
-## LoC estimate
+Stage B (Rust parity): separate plan. Extends `hecksagon_ir.rs` +
+`hecksagon_parser.rs` with `:llm`; parallel `llm_dispatcher.rs`;
+replaces `adapter_llm.rs` resolve hook.
 
-~1,680 production + ~870 specs + ~210 docs = ~2,760 total.
+## §9 — LoC estimate
 
-## Risks
+| Area | Prod | Specs |
+|---|---|---|
+| Ruby IR + DSL | ~280 | ~240 |
+| Runtime (dispatcher + providers + scaffolder) | ~1,100 | ~540 |
+| Boot wiring + Runtime#llm | ~60 | ~60 |
+| Errors + replay hooks | ~80 | ~30 |
+| Docs | — | ~210 |
 
-- Streaming + Spend ordering on crash (partial records)
-- Claude CLI auth env whitelist relaxes PR #251's security posture
-- Prompt scaffolding leakage if guard code contains secrets — make scaffolding opt-in with metadata whitelist
-- Budget races under concurrent dispatch (serialize via command bus)
-- Fixture drift — add `HECKS_LLM_FIXTURE_STRICT` that errors on cache miss
+**Total Stage A: ~2,600 LoC.** Comparable to PR #251 (`adapter :shell`, ~2,400).
 
-## Relationship to i11
+## §10 — Risks
 
-i11 PR 3 (Capability.InvokeAgent) depends on this. i23 should land before i11 PR 3.
-i11 PR 1 (Tongue.Speak wired to Claude) can use `adapter :shell` directly, then migrate to `adapter :llm` in a follow-up — that's fine if PR 1 ships before i23. Ordering: i11 PR 1 first (simpler), i23, then i11 PR 3.
+1. **Streaming + Spend on partial crash** — under-counts failed-stream tokens; accepted.
+2. **Claude CLI env whitelist** — must pass `HOME`+`PATH`. Controlled relaxation in `LlmAdapter#env` defaults; `:shell`-level `unsetenv_others: true` stays strict.
+3. **Prompt scaffolding leakage** — opt-in metadata whitelist; `pii`-tagged fields stripped.
+4. **Budget races** — serialize via command bus.
+5. **Fixture drift** — `HECKS_LLM_FIXTURE_STRICT` errors on miss; regenerate via `HECKS_LLM_CAPTURE`.
+6. **Subscription auth expiry** — dispatcher emits `LlmInvocationFailed(reason: "auth_invalid")`, opens breaker. User re-runs `claude login`.
+7. **Infinite prompt loops** — scaffolder strips `on_response` from state before building prompt.
+8. **Rate limits** — breaker opens on 429. Exponential backoff on half-open probe is v2.
+
+## §11 — Relationship to i11
+
+- **i11 PR 1** (Tongue.Speak via `adapter :shell`) ships FIRST — simpler, no new adapter kind.
+- **i23** ships second — lands `adapter :llm` end-to-end. PR 1's `claude_speak` shell adapter becomes a candidate for migration to `:llm` (~5-line follow-up).
+- **i11 PR 3** (Capability.InvokeAgent) depends on i23.
+
+## §12 — Out of scope (Stage A)
+
+- Rust runtime parity (Stage B)
+- `:openai` (deferred to first use case)
+- Multi-turn conversation state (caller's job)
+- Tool-use / function-calling (i11 PR 3)
+- Vision/multimodal
+- Prompt caching (Anthropic API)
+
+## Critical files
+
+- `lib/hecksagon/dsl/hecksagon_builder.rb` — `adapter(kind, …)` dispatch
+- `lib/hecksagon/dsl/shell_adapter_builder.rb` — reference pattern
+- `lib/hecks/runtime/shell_dispatcher.rb` — reference dispatcher
+- `lib/hecks/runtime.rb` — `#register_shell_adapter` / `#shell` mirror
+- `lib/hecks/runtime/boot.rb` — `wire_shell_adapters` mirror
+- `hecks_conception/aggregates/spend.bluebook` — accounting
+- `hecks_conception/aggregates/circuit_breaker.bluebook` — gating
+- `hecks_conception/mint_musing.sh` — first retirement target
+- `hecks_life/src/runtime/adapter_llm.rs` — parallel Rust (until Stage B)

--- a/docs/plans/i27_nursery_viability.md
+++ b/docs/plans/i27_nursery_viability.md
@@ -1,101 +1,138 @@
-# i27 — Nursery viability metrics
+# i27 — Nursery Viability Metrics (NurseryHealth capability)
 
-Source: inbox `i27` + plan by Agent a31587a2 on 2026-04-22.
+Source: inbox `i27` + plan by Agent a31587a2 (v1) + Agent aa764fc9 (refined 2026-04-22).
 
-## ⚠ Adjustment needed before implementing
+> **Supersedes v1**: reshapes the audit from a shell/Ruby scanner into a
+> first-class `Hecks.bluebook "NurseryHealth"` capability per the
+> "audit-as-hecksagon" pattern. Python-ban (i37) concern is moot because
+> audit runs from Rust shim via `hecks-life nursery-health` subcommand.
 
-The original plan specified `nursery_scan.py` — **violates i37** (Python ban). Rewrite in Ruby or orchestrate via shell + `hecks-life heki` subcommands (PR #272 shipped). The viability logic is straightforward enough for either path.
+## Summary
 
-## What it does
+Nursery has **~357 domains** ranging from full workflows to one-aggregate
+sketches. Ilya's P-tier concern: README/FEATURES.md advertise breadth as
+strength, but a lot is aspirational. This plan ships viability classifier
+as a first-class bluebook capability (not a one-off script).
 
-Per-domain tabulation of nursery health. 375+ bluebooks under `nursery/`. Seven fields per record:
+## §1 — Current state
 
-| Field | Source |
-|---|---|
-| `domain` | directory name (relative path for nested) |
-| `rust_boot_ok` | `hecks-life parse <bluebook>` exits 0 |
-| `ruby_boot_ok` | `bin/hecks-behaviors --parse-only` exits 0 |
-| `fixtures_present` | sibling `fixtures/*.fixtures` non-empty |
-| `behaviors_present` | sibling `<name>.behaviors` exists |
-| `behaviors_pass` | enum: pass_both / pass_rust_only / fail / n/a |
-| `last_touched` | `git log -1 --format=%cI -- <path>` |
+- 357 first-level nursery dirs, 375 `.bluebook` files
+- 26 parse in both Ruby AND Rust
+- 349 Rust-only (all in i1/i2 Ruby DSL gap — not per-domain flaws)
+- 263 fixtures in parity `soft: true`
+- No signal today distinguishes rich from skeletal
 
-**Viability policy (v1, Rust-primary):**
+## §2 — Classifier buckets
+
+### Viable (all must hold)
+1. `rust_boot_ok` — every bluebook parses in Rust
+2. `aggregate_count >= 2`
+3. `has_cascade` — `then_set` targets another command's `given`, OR lifecycle transition gates another command
+4. `behaviors_present_and_pass` — sibling `.behaviors` + Rust runner exits 0
+5. `parity_ok` — fixtures not in `fixtures_known_drift.txt`
+
+### Partial
+`rust_boot_ok` + `aggregate_count >= 1`, at least one of
+{`has_cascade`, `behaviors_present`, `parity_ok`} false but NOT all three.
+
+### Stub
+`aggregate_count == 1` + `command_count <= 2` + no behaviors. Honest squatters.
+
+### Dead
+`rust_boot_ok` false. Rare; goes to antibody/repair, not viability report.
+
+### Orthogonal flags (not bucket-determining)
+- `ruby_boot_ok` / `ruby_dsl_gap` — captured, doesn't downgrade
+- `has_fixtures` (data-without-assertion Partials)
+- `last_touched_days` (stale Stub >90d = retirement signal)
+
+## §3 — NurseryHealth capability
+
+At `hecks_conception/capabilities/nursery_health/`. Four aggregates:
+
+**NurseryScan** — one sweep (totals, bucket counts, scanned_at). Command:
+`ScanNursery → NurseryScanned`.
+
+**NurseryDomain** — per-domain record. Lifecycle on `:classification`:
+`unknown → indexed → viable|partial|stub|dead`. Commands: `RecordBirth`,
+`ClassifyViable/Partial/Stub/Dead`.
+
+**ViabilityPolicy** — config aggregate, NO commands. Seeded via fixtures.
+Thresholds as seeded rows so tuning = fixture change, not code change.
+
+**NurseryKPI** — weekly rollup, command `RecordWeekly reference_to(NurseryScan)`.
+
+### Policies
+- `ClassifyAfterScan` on `NurseryScanned` → `ClassifyViable` (fanout in runtime)
+- `KpiAfterScan` on `NurseryScanned` → `RecordWeekly`
+
+## §4 — Runtime
+
+New `hecks_life/src/run_nursery_health.rs`, registered as subcommand:
+
 ```
-viable = rust_boot_ok AND ruby_boot_ok AND behaviors_present 
-         AND behaviors_pass ∈ {pass_both, pass_rust_only}
+hecks-life nursery-health scan   [--root <path>] [--policy <name>]
+hecks-life nursery-health report [--format json|text|badge]
+hecks-life nursery-health weekly [--week-of YYYY-WW]
 ```
 
-Ruby failures counted but not blocking until i1/i2 fully retired (they're closed via i24 but some residual may remain). Record `"viability_policy": "rust_primary"` in JSON output.
+### `scan` algorithm
+1. Resolve root, load ViabilityPolicy, read parity drift set
+2. Per domain dir: parse bluebooks, count aggregates/commands, detect cascade
+   (reuse `cascade::analyze`), run behaviors (reuse `behaviors_runner`), check
+   fixtures + parity, `last_touched` via shell adapter git log
+3. Apply classifier, dispatch lifecycle transition
+4. Upsert NurseryDomain records, append NurseryScan, emit `NurseryScanned`
 
-**KPIs**: viable_count, rust_green_count, ruby_green_count, has_fixtures_count, has_behaviors_count, stale_count (>30d), dead_count.
+### Performance
+Cold: ~8-15s (parity paths reused). With behaviors: ~25s. `--skip-behaviors`
+for structural-only.
 
-## Nursery aggregate
+## §5 — Reporting
 
-Add inside `aggregates/conception.bluebook` (Conception already owns the nursery vocabulary):
+1. **CLI**: `nursery-health report` (text default)
+2. **Statusline badge**: opt-in via StatusBar `show_nursery_viability` (reads cached NurseryScan, not expensive per-render)
+3. **Weekly sparkline**: `--sparkline` reads last 12 NurseryKPI records
 
-```
-aggregate "Nursery" do
-  attribute :domain_name, String
-  attribute :path, String
-  attribute :last_checked_at, String
-  attribute :rust_boot_ok, String
-  attribute :ruby_boot_ok, String
-  attribute :behaviors_pass, String
-  attribute :last_touched, String
-  attribute :consecutive_fail_count, Integer
+**NOT added**: blocking CI for viability. Visibility, not enforcement.
 
-  lifecycle :status, default: "gestating" do
-    transition "RecordBirth"    => "born",     from: "gestating"
-    transition "RecordViable"   => "viable",   from: "born"
-    transition "RecordViable"   => "viable",   from: "flagged"
-    transition "FlagRegression" => "flagged",  from: "viable"
-    transition "Retire"         => "retired",  from: "viable"
-    transition "Retire"         => "retired",  from: "flagged"
-  end
+## §6 — Commit sequence (7)
 
-  # Commands: RecordBirth, RecordViable, FlagRegression, Retire
-end
-```
+1. `feat(capabilities/nursery_health): bluebook + fixtures + hecksagon skeleton`
+2. `feat(nursery_health): Rust runtime shim for scan`
+3. `feat(nursery_health): report subcommand (text/json/badge)`
+4. `feat(nursery_health): weekly subcommand + KPI rollup`
+5. `feat(status_bar): opt-in nursery viability badge`
+6. `test(nursery_health): fixture nursery smoke + behaviors`
+7. `docs: FEATURES.md + close inbox i27`
 
-Cross-wire via policy: `on "IndexedInNursery" → trigger "RecordBirth"` in Conception.
+**Total ~900 LoC** (higher than v1's 650 — capability is reusable, introspectable, behavior-assertion-pinned).
 
-**Anti-flap rule**: require 2 consecutive failing runs before `FlagRegression` fires. Track `consecutive_fail_count` on the heki record.
+## §7 — Risks
 
-## Caching
-
-SHA-keyed cache in `information/nursery_stats.cache.json` keyed by `(path, git_sha_of_file)`. Subsequent runs only re-check changed files.
-
-- Cold: ~5min (all 375 domains, 2 boot checks each, parallelized `-P 8`)
-- Warm: ~25s
-
-## Weekly KPI
-
-Cron-style: Sunday 00:00 UTC, `weekly_viability.sh` runs `nursery stats --json`, appends to `information/kpi_viability.heki` with `{week_of, viable_count, total, rust_green, ruby_green}`. Sparkline in text report reads last 12 weeks.
-
-## Commit sequence (6)
-
-1. `feat(nursery): scanner + shell wrapper (Ruby, no Python)` — stats script + wrapper, emits JSON + colored text
-2. `feat(nursery): wire as hecks-life nursery subcommand`
-3. `feat(conception): Nursery aggregate with lifecycle + birth policy`
-4. `feat(nursery): lifecycle dispatch from scanner (RecordViable/FlagRegression with anti-flap)`
-5. `feat(nursery): weekly KPI + sparkline + smoke test`
-6. `docs: CLAUDE.md + close inbox i27`
-
-## LoC estimate
-
-~650 total (down from the Python version, since shell + hecks-life subcommands are denser).
+1. **False-positive has_cascade** — start narrow, tighten in follow-up
+2. **Gaming the metric** — min-aggregate-shape guard; `behaviors_pass_rust==true` forces real assertions; stale-stub report catches dead wood
+3. **Graduation from nursery** — scanner scope is `nursery/` only; dir move drops from scope. Log "graduation" when count drops without ClassifyDead
+4. **Behaviors runner cost** — `--skip-behaviors` escape
+5. **Ruby-DSL-gap drowning** — aggregate at top, per-domain omitted unless `--show-ruby-gap`. Goes away when i24 closes
+6. **Parity drift freshness** — union with last parity run's output log
 
 ## Key files
 
-- NEW: `hecks_conception/bin/nursery_stats.sh` (shell wrapper — swap the Python scanner for a Ruby one or use `hecks-life heki` subcommands directly)
-- MODIFY: `hecks_conception/aggregates/conception.bluebook` — add Nursery aggregate
-- NEW: Rust `hecks-life nursery` subcommand glue in `hecks_life/src/main.rs`
-- NEW: `tests/nursery_stats_smoke.sh` with fixture nursery
+### New
+- `hecks_conception/capabilities/nursery_health/{nursery_health.bluebook, .behaviors, .hecksagon, fixtures/nursery_health.fixtures, weekly.sh}`
+- `hecks_life/src/run_nursery_health.rs`
+- `tests/nursery_health_smoke.sh` + `tests/fixtures/mini_nursery/`
 
-## Risks
+### Modified
+- `hecks_life/src/main.rs` — register subcommand
+- `hecks_conception/capabilities/status_bar/status_bar.bluebook` — `show_nursery_viability`
+- `FEATURES.md`, `CLAUDE.md`, `docs/plans/INDEX.md`
 
-- **Python ban violation** — rewrite in Ruby (addressed above)
-- Ruby runner path drift (`bin/hecks-behaviors`) — feature-detect once at scanner start
-- Nested bluebook namespacing (`alans_engine_additive_business/hecks/*.bluebook`) — key by relative path
-- Lifecycle churn from boot flakiness (addressed by anti-flap rule)
+### Reused
+- `hecks_life/src/{parser.rs, ir.rs, cascade.rs, behaviors_runner.rs}`
+- `spec/parity/fixtures_known_drift.txt`, `NURSERY_BLUEBOOK_INVENTORY.md`
+
+## Dependencies
+
+None unshipped. i37 Phase A already available. i42/i43 optional.

--- a/docs/plans/i28_adapter_keyword.md
+++ b/docs/plans/i28_adapter_keyword.md
@@ -1,0 +1,220 @@
+# i28 — `adapter` keyword in DSL — DSL-vs-hecksagon boundary
+
+Source: inbox `i28` (Ilya review) + plan by Agent a302c082 on 2026-04-22.
+
+## Recommendation in one line
+
+**Soft-reject the bluebook-level `adapter` keyword. Upgrade the existing
+`external "Name"` declaration to accept an `adapter:` kwarg — the two-world
+split is already crisp; the only real gap is that a command doesn't name
+its adapter by symbol. Close `i28` as `recommendation-filed`; keep queued
+only if Chris overrides.**
+
+## §1 — Current state: the split is already crisp
+
+| File | Owns |
+|---|---|
+| `*.bluebook` | aggregates, commands, policies, events, guards, mutations, fixtures, lifecycle |
+| `*.hecksagon` | `adapter :memory/:fs/:stdout/:stdin/:shell/:env/:llm`, gates, subscriptions, capabilities, port contracts |
+
+Verified:
+- `lib/hecks/dsl/bluebook_builder.rb` has **no** `adapter` method
+- `lib/hecksagon/dsl/hecksagon_builder.rb#adapter` (L74) is the only dispatcher
+- `lib/hecks/runtime/boot.rb#wire_shell_adapters` (L185) — registers at boot
+- `hecks_life/src/runtime/adapter_registry.rs` — Rust mirror
+- `hecks_life/src/hecksagon_parser.rs` L65-95 — `adapter …` is hecksagon-only
+
+A command reaches an adapter **implicitly** via naming — CommandBus
+middleware, named shell lookup (`runtime.shell(:git_resolve_ref, …)`),
+or event fan-out. The command itself says nothing structural.
+
+### The gap Ilya named
+
+`status.bluebook` command `GenerateReport` says in its `description`
+string: "…reads every .heki store, checks mindstream via `:shell`, then
+writes through the `:stdout` adapter." Prose, not symbols. Grep for
+"which commands use the :llm adapter?" returns nothing structural.
+
+The real complaint is "a command can't name its adapter" — not "adapters
+aren't first-class."
+
+## §2 — Three options evaluated
+
+### Option A — `uses_adapter :llm` (declare use)
+
+```ruby
+command "PromptAI" do
+  attribute :input, String
+  attribute :output, String
+  uses_adapter :llm
+end
+```
+
+Pros: one-line, per-command, mirrors existing `external`.
+**Cons: duplicates what `external` already does.** Without extra binding
+it's documentation only.
+
+### Option B — `adapter :llm do command ... end` (bind)
+
+Pros: explicit binding, shorter per-command.
+**Cons (rejected):**
+- Collides with `HecksagonBuilder#adapter` keyword
+- Forces bluebook → hecksagon evaluation order inversion
+- Smuggles execution semantics into declarative side
+- Multi-level parser changes (Ruby + Rust)
+
+### Option C — Do nothing (close-as-note)
+
+Pros: zero surface change.
+Cons: `:shell` / `:llm` in descriptions stay prose.
+
+### Option D — **Chosen**: upgrade `external` with `adapter:` kwarg
+
+`CommandBuilder#external` already exists:
+```ruby
+def external(name)
+  @external_systems << Structure::ExternalSystem.new(name: name)
+end
+```
+
+Used by `examples/governance/*` as `external "Stripe"`. Today nominal,
+no runtime hook. Upgrade to:
+
+```ruby
+command "PromptAI" do
+  attribute :input, String
+  attribute :output, String
+  external :llm, adapter: :default, on_response: :output
+end
+```
+
+- `external :llm` declares outside-the-boundary reach
+- `adapter: :default` names the hecksagon adapter instance (mirrors i23's `name:`)
+- `on_response:` wires response attribute back — genuine binding
+
+### Why D
+
+1. **Preserves split.** `external` is already bluebook-side; names a *dependency*. Different from *declaring* the adapter (hecksagon) or *binding* at runtime.
+2. **Backwards compatible.** `external "Stripe"` still works.
+3. **Minimal surface.** One optional kwarg, not a new keyword.
+4. **Answers Ilya's critique.** Command can say "I use `:llm` adapter" structurally.
+5. **Matches runtime semantics.** Adapters resolved by symbol already.
+6. **No Rust churn.** `hecks_life` doesn't parse bluebooks yet; when it does, additive.
+
+## §3 — Parser changes (Option D)
+
+### Ruby
+
+**`lib/hecks/dsl/command_builder.rb`** — extend signature:
+```ruby
+def external(name, adapter: nil, on_response: nil, on_error: nil, **opts)
+  @external_systems << Structure::ExternalSystem.new(
+    name:        name.to_s,
+    adapter:     adapter&.to_sym,
+    on_response: on_response&.to_sym,
+    on_error:    on_error&.to_sym,
+    options:     opts.freeze
+  )
+end
+```
+
+**`lib/hecks/bluebook_model/structure/external_system.rb`** — add fields, sensible defaults.
+
+**Validation**: `Hecks.boot` time — if `adapter:` kind doesn't exist in
+any hecksagon's adapters, raise `Hecks::ValidationError` (fail fast).
+
+### Rust
+
+No change in Stage A — `hecks_life` doesn't parse bluebooks yet. When it
+does, lexer's `parse_hash_pairs` helper (L114) handles `:sym, key: val`.
+
+## §4 — Runtime wiring (Option D)
+
+New `lib/hecks/runtime/external_wiring.rb` (~60 LoC):
+
+```ruby
+def external_dispatch(command, aggregate)
+  command.class.external_systems.each do |ext|
+    next unless ext.adapter
+    response = case ext.adapter
+               when :shell  then shell(ext.options[:name], **command.attrs)
+               when :llm    then llm(ext.options[:name] || :default, prompt: command.attrs)
+               when :stdout then io(:stdout).write(template_fill(ext, aggregate))
+               when :fs     then fs_read(ext.options[:path])
+               else raise UnknownAdapterKind, ext.adapter
+               end
+    aggregate.public_send("#{ext.on_response}=", response) if ext.on_response && response
+  end
+rescue => e
+  ext.on_error ? aggregate.emit_event(ext.on_error, error: e.message) : raise
+end
+```
+
+Hook into `Runtime::CommandBus` as middleware: **after** guards pass, **before** mutations commit.
+
+## §5 — Relationship to i23
+
+**Sequencing:** i23 MUST land first. i23 defines `adapter :llm, name: :x`
+in hecksagon; i28 (Option D) references that name from bluebook.
+
+- i23 commit 7 exposes `runtime.llm(name, prompt:, …)`. i28's `external :llm, adapter: :default` calls `runtime.llm(:default, …)`.
+- `LlmAdapter#name` field is the lookup key for `external_wiring`.
+- If Option A/B ever chosen instead (overridden), i23 needs one extra hook: `LlmDispatcher#invoke_for_command(command_obj)` (~30 LoC).
+- If Option C chosen (no-op), i23 entirely unchanged.
+
+## §6 — Consumer audit
+
+If Option D ships, bluebooks to rewrite:
+
+| Bluebook | Commands | Adapters in prose |
+|---|---|---|
+| `capabilities/status/status.bluebook` | `GenerateReport` | `:shell` + `:stdout` |
+| `capabilities/antibody/antibody.bluebook` | `ValidateCommit`, `ScanBranch`, `CheckStaged` | 7 git shell adapters |
+| `capabilities/terminal/terminal.bluebook` | `Prompt.Speak` | `:stdout`/`:stdin` |
+| `capabilities/tongue/tongue.bluebook` | `Speak` | `:shell :claude_speak` → later `:llm` |
+| `aggregates/spend.bluebook` | `RecordCall` | implicit from policy |
+
+~8 command sites across ~5 files. ~40 lines added.
+
+If Option C, no rewrites; doc-only note in `docs/content/seam.md`.
+
+## §7 — Commit sequence
+
+### Option D (5 commits, ~220 LoC prod + ~180 specs)
+
+1. `feat(bluebook-dsl): external accepts adapter:/on_response:/on_error: kwargs`
+2. `feat(bluebook-dsl): ValidationError on unknown external :adapter kind`
+3. `feat(runtime): ExternalWiring dispatches external :adapter`
+4. `refactor(conception): migrate status + antibody bluebooks to external :<adapter>`
+5. `docs: external :adapter reference + CLAUDE.md note on split`
+
+### Option C (2 commits, rejection-with-note)
+
+1. `docs: clarify adapters are hecksagon-only; bluebook declares intent, not wiring`
+2. `inbox: close i28 as recommendation-filed (keep adapters hecksagon-only)`
+
+## §8 — Risks
+
+1. **DSL surface creep** — `external` already existed; kwargs not new keyword. Low.
+2. **Adapter namespace collisions** — per-hecksagon scoping carries over. `external :shell` without `adapter:` reverts to nominal (fine).
+3. **Nested-adapter resolution** — missing adapter in hecksagon = **fail fast at boot** (`Hecks::ValidationError`). Not runtime, not silent.
+4. **Circular resolution** — non-issue for Option D (Option B would have this).
+5. **Existing `external` users** — all 9 sites in `examples/governance/*` are single-arg. Backwards compatible.
+6. **Split erosion** — rule: kwargs describing HOW belong in hecksagon. Watcher lint step if needed.
+
+## §9 — Closing
+
+The split works. Only leak: command's adapter dependency lives in
+`description` string rather than structural symbol. Option D closes that
+leak with one kwarg. Options A and B would "fix" it by tearing open the seam.
+
+If Chris wants zero surface change, close `i28` with §3's rationale as
+the note.
+
+## Critical files
+
+- `lib/hecks/dsl/command_builder.rb`
+- `lib/hecks/bluebook_model/structure/external_system.rb`
+- `lib/hecks/runtime/adapter_wiring.rb`
+- `lib/hecksagon/dsl/hecksagon_builder.rb`
+- `docs/plans/i23_llm_adapter.md` (paired)


### PR DESCRIPTION
Three architectural plans from tonight's inbox-emptying.

- **i23** — LLM adapter, refined into 9-commit Stage A Ruby plan (~2600 LoC). Mirrors `adapter :shell` (PR #251). Claude CLI preferred (Max subscription); streaming + auto Spend/CircuitBreaker integration; PromptScaffolder for command-metadata scaffolding. Rust parity is Stage B.
- **i27** — reshaped from shell scanner into a NurseryHealth **bluebook capability**. Four aggregates, fixture-seeded thresholds, `hecks-life nursery-health {scan,report,weekly}` subcommands. ~900 LoC, 7 commits.
- **i28** — **recommends soft-rejecting** the bluebook-level `adapter` keyword. Split is already crisp; gap is that commands can't name their adapters structurally. Option D: upgrade `external` with `adapter:` kwarg (~40 LoC, backwards compatible). A/B alternatives rejected with reasoning.