### PR TITLE
feat(validator): reject duplicate policies on same (event, trigger) (i4 gap 5)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -458,6 +458,12 @@
 - **Clock anti-pattern check** — flags `then_set :ts, to: :now` and `seconds_since(:field)` patterns where the domain reaches into the system clock. Hint: inject time as a command attribute (DDD Clock port) so the caller (test, hecksagon adapter, app) supplies the timestamp.
 - `--strict` promotes warnings to errors; pre-commit hook blocks on errors
 
+### Duplicate Policy Validator (`hecks-life check-duplicate-policies`)
+- Refuses bluebooks that declare two or more reactive policies wired to the same `(on_event, trigger_command)` pair. The runtime fires every matching policy in declaration order, so the trigger runs once per duplicate — a silent cascade bug
+- Flat IR walk: groups every reactive policy (aggregate-scoped and domain-level) by `(event, trigger[, target_domain])`, reports one error per group of size ≥ 2, naming every colliding policy and the exact duplicate count
+- Target-domain keyed: cross-domain wiring (`@target`) does not collide with same-domain policies
+- Parity: Ruby rule `Hecks::ValidationRules::Structure::DuplicatePolicies` runs inside `Hecks.validate`; Rust subcommand `hecks-life check-duplicate-policies <bluebook>` exits non-zero on any duplicate pair
+
 ### IO Validator (`hecks-life check-io`)
 - Asserts the bluebook is pure-memory by default — no IO leaks above the hecksagon adapter layer
 - **Static IR scan**: flags IO-suggestive command names (`Deploy`, `Send`, `Push`, `Publish`, `Fetch`, `Sync`), past-tense external event names (`Deployed`, `Sent`), and pure-side-effect commands (emits but no state change, not Create or lifecycle)

--- a/docs/usage/duplicate_policy_validator.md
+++ b/docs/usage/duplicate_policy_validator.md
@@ -1,0 +1,81 @@
+# Duplicate Policy Validator
+
+Two reactive policies wired to the same `(on_event, trigger_command)` pair silently double-dispatch. The runtime fires every matching policy in declaration order, so the trigger command runs once per duplicate. The validator refuses this at check time.
+
+## The bug it catches
+
+```ruby
+Hecks.bluebook "Heart" do
+  aggregate "Heart" do
+    attribute :beats, Integer
+
+    command "Beat" do
+      emits "HeartBeat"
+    end
+
+    command "Tick" do
+      reference_to(Heart)
+      emits "Ticked"
+    end
+  end
+
+  # Both policies fire on HeartBeat. Both call Tick.
+  # Tick runs twice per Beat — a cascade bug with no error message.
+  policy "TickOnBeat"      do; on "HeartBeat"; trigger "Tick"; end
+  policy "TickOnBeatAgain" do; on "HeartBeat"; trigger "Tick"; end
+end
+```
+
+## Ruby — `Hecks.validate`
+
+The rule `Hecks::ValidationRules::Structure::DuplicatePolicies` runs automatically as part of `Hecks.validate`. It reports one error per duplicated pair, naming every colliding policy and the total count.
+
+```
+ValidationError:
+  2 policies share (event: HeartBeat, trigger: Tick) — the trigger fires
+  once per matching policy, so Tick will run 2 times per HeartBeat event.
+  Policies: TickOnBeat, TickOnBeatAgain
+  (TickOnBeat in Heart; TickOnBeatAgain in Heart).
+    Fix: Delete the duplicates or collapse them into one policy. If fan-out
+         is intentional, give each policy a distinct trigger command.
+```
+
+## Rust — `hecks-life check-duplicate-policies`
+
+The `hecks-life` binary exposes a standalone subcommand that walks the IR and exits non-zero on any duplicated pair:
+
+```
+$ hecks-life check-duplicate-policies heart.bluebook
+Checking Heart (heart.bluebook)
+
+Duplicate policies:
+  ✗ TickOnBeat, TickOnBeatAgain — 2 policies share (on: "HeartBeat", trigger: "Tick") — the trigger fires once per matching policy, so Tick will run 2 times per HeartBeat event. Delete the duplicates or collapse them into one policy.
+
+1 error(s)
+FAIL — heart.bluebook has duplicate policies
+```
+
+Exit codes:
+
+- `0` — no duplicate (event, trigger) pairs
+- `1` — at least one pair shared by >1 policy
+
+## What is not a duplicate
+
+- **Same event, different triggers** (legitimate fan-out):
+  ```ruby
+  policy "KitchenOnPlaced" do; on "OrderPlaced"; trigger "NotifyKitchen"; end
+  policy "ChargeOnPlaced"  do; on "OrderPlaced"; trigger "ChargeCard"; end
+  ```
+- **Different events, same trigger** (same reaction from multiple sources):
+  ```ruby
+  policy "EchoOnRang"   do; on "Rang";   trigger "Echo"; end
+  policy "EchoOnChimed" do; on "Chimed"; trigger "Echo"; end
+  ```
+- **Cross-domain wiring** — domain-level policies keyed with `@target_domain` do not collide with same-domain `(event, trigger)` pairs.
+
+## Fix options
+
+1. **Delete the duplicates** — one policy is almost always a leftover from renaming or copy-paste.
+2. **Collapse into one policy** — if the intent is fan-out, one subscriber handling all downstream nerves in one pass is cleaner than N policies sharing a trigger.
+3. **Give each policy a distinct trigger command** — if two subsystems genuinely need separate reactions, model them as separate commands.

--- a/hecks_conception/catalog/mind.bluebook
+++ b/hecks_conception/catalog/mind.bluebook
@@ -1035,28 +1035,16 @@ Hecks.bluebook "Mind", version: "2026.04.11.1" do
     # nerve: Mind:HeartbeatPulsed → MietteBody:SenseOrgans
   end
 
-  policy "DetectDriftOnGraft" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: Mind:DomainGrafted → MietteBody:DetectDrift
-  end
-
+  # DetectDriftOnGraft, QueryVectorsOnMusing, and ArchetypeSignalOnMatch
+  # all shared (on: DomainGrafted, trigger: ConnectNerve) with WireOnGraft
+  # above, so ConnectNerve would fire 4× per graft. The subscriber wired
+  # to WireOnGraft handles every nerve those policies described in one
+  # pass (DetectDrift, QueryShape, EmitSignal). Flagged by the
+  # check-duplicate-policies validator (i4 gap 5 parity pass).
   policy "DetectDriftOnShed" do
     on "DomainShed"
     trigger "ConnectNerve"
     # nerve: Mind:DomainShed → MietteBody:DetectDrift
-  end
-
-  policy "QueryVectorsOnMusing" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: MietteBrain:MusingGenerated → NurseryVectors:QueryShape
-  end
-
-  policy "ArchetypeSignalOnMatch" do
-    on "DomainGrafted"
-    trigger "ConnectNerve"
-    # nerve: NurseryVectors:NearestReported → MietteBrain:EmitSignal
   end
 
   # Midwife policies

--- a/lib/hecks/validation_rules/structure.rb
+++ b/lib/hecks/validation_rules/structure.rb
@@ -18,6 +18,7 @@ module Hecks
       autoload :AggregatesHaveCommands,   "hecks/validation_rules/structure/aggregates_have_commands"
       autoload :ValidPolicyEvents,        "hecks/validation_rules/structure/valid_policy_events"
       autoload :ValidPolicyTriggers,      "hecks/validation_rules/structure/valid_policy_triggers"
+      autoload :DuplicatePolicies,        "hecks/validation_rules/structure/duplicate_policies"
       autoload :NoPiiInIdentity,          "hecks/validation_rules/structure/no_pii_in_identity"
       autoload :SingleAttributeAggregate, "hecks/validation_rules/structure/single_attribute_aggregate"
       autoload :TooManyCommands,              "hecks/validation_rules/structure/too_many_commands"

--- a/lib/hecks/validation_rules/structure/duplicate_policies.rb
+++ b/lib/hecks/validation_rules/structure/duplicate_policies.rb
@@ -1,0 +1,100 @@
+# Hecks::ValidationRules::Structure::DuplicatePolicies
+#
+# @domain AcceptanceTest
+#
+# Refuses bluebooks that declare two or more reactive policies wired to
+# the same `(event_name, trigger_command)` pair. Today those silently
+# coexist — the runtime fires every matching policy in declaration
+# order, so the trigger command runs once per duplicate. That's a
+# cascade bug with no error message.
+#
+# Example of the bug:
+#
+#   policy "FatigueOnPulse" do
+#     on "BodyPulse"
+#     trigger "AccumulateFatigue"
+#   end
+#   policy "FatigueOnPulseDupe" do
+#     on "BodyPulse"
+#     trigger "AccumulateFatigue"
+#   end
+#
+# Both fire on BodyPulse, both call AccumulateFatigue — the accumulate
+# runs twice per pulse.
+#
+# Legitimate fan-out is preserved: different triggers on the same event
+# (or the same trigger on different events) are not dupes. Different
+# aggregates sharing a `(event, trigger)` pair via cross-domain wiring
+# are keyed by `target_domain` so they don't collide with same-domain
+# policies.
+#
+# Part of the ValidationRules::Structure group — run by +Hecks.validate+.
+#
+#   rule = DuplicatePolicies.new(domain)
+#   rule.errors  # => ["2 policies share (event: BodyPulse, trigger: AccumulateFatigue) — ..."]
+#
+module Hecks
+  module ValidationRules
+    module Structure
+
+    class DuplicatePolicies < BaseRule
+      # Checks every reactive policy (aggregate-scoped and domain-level)
+      # and returns one error per `(event, trigger)` pair shared by more
+      # than one policy. The error names all colliding policies.
+      #
+      # @return [Array<ValidationMessage>] one message per duplicated pair
+      def errors
+        result = []
+
+        group_by_key.each do |key, entries|
+          next if entries.size < 2
+
+          event, trigger, _target = key
+          locations = entries.map { |_policy, context| context }
+          names     = entries.map { |policy, _ctx| policy.name }.join(", ")
+
+          result << error(
+            "#{entries.size} policies share (event: #{event}, trigger: #{trigger}) — " \
+            "the trigger fires once per matching policy, so #{trigger} will run " \
+            "#{entries.size} times per #{event} event. Policies: #{names} " \
+            "(#{locations.join('; ')}).",
+            hint: "Delete the duplicates or collapse them into one policy. " \
+                  "If fan-out is intentional, give each policy a distinct trigger command."
+          )
+        end
+
+        result
+      end
+
+      private
+
+      # Groups every reactive policy by `(event_name, trigger_command,
+      # target_domain)`. Target domain disambiguates cross-domain
+      # wiring — a domain policy shipping `Beat -> Tick` to
+      # `OtherBluebook` is not a dupe of an in-domain `Beat -> Tick`.
+      #
+      # @return [Hash{Array => Array<[Policy, String]>}] key -> [[policy, context], …]
+      def group_by_key
+        groups = Hash.new { |h, k| h[k] = [] }
+
+        @domain.aggregates.each do |agg|
+          agg.policies.select(&:reactive?).each do |policy|
+            key = [policy.event_name.to_s, policy.trigger_command.to_s, nil]
+            groups[key] << [policy, "#{policy.name} in #{agg.name}"]
+          end
+        end
+
+        @domain.policies.select(&:reactive?).each do |policy|
+          key = [policy.event_name.to_s, policy.trigger_command.to_s, policy.target_domain]
+          context = policy.target_domain ? "domain policy #{policy.name}@#{policy.target_domain}"
+                                         : "domain policy #{policy.name}"
+          groups[key] << [policy, context]
+        end
+
+        groups
+      end
+    end
+    Hecks.register_validation_rule(DuplicatePolicies)
+    end
+  end
+end

--- a/spec/hecks/validation_rules/structure/duplicate_policies_spec.rb
+++ b/spec/hecks/validation_rules/structure/duplicate_policies_spec.rb
@@ -1,0 +1,138 @@
+# spec/hecks/validation_rules/structure/duplicate_policies_spec.rb
+#
+# Locks the contract for Hecks::ValidationRules::Structure::DuplicatePolicies:
+# two reactive policies sharing `(event_name, trigger_command)` are flagged
+# with one error that lists every colliding policy. Legitimate fan-out
+# (same event, different triggers) and distinct wiring (different events,
+# same trigger) pass silently.
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __dir__)
+require "hecks"
+
+RSpec.describe Hecks::ValidationRules::Structure::DuplicatePolicies do
+  def run_rule(domain)
+    described_class.new(domain).errors
+  end
+
+  it "flags two policies sharing event and trigger" do
+    domain = Hecks.bluebook("Dup") do
+      aggregate "Heart" do
+        attribute :beats, Integer
+        command "Beat" do
+          emits "HeartBeat"
+        end
+        command "Tick" do
+          reference_to(Heart)
+          emits "Ticked"
+        end
+      end
+      policy "TickOnBeat"      do; on "HeartBeat"; trigger "Tick"; end
+      policy "TickOnBeatAgain" do; on "HeartBeat"; trigger "Tick"; end
+    end
+
+    errors = run_rule(domain)
+    expect(errors.size).to eq(1)
+
+    msg = errors.first.message
+    expect(msg).to include("HeartBeat")
+    expect(msg).to include("Tick")
+    expect(msg).to include("TickOnBeat")
+    expect(msg).to include("TickOnBeatAgain")
+  end
+
+  it "passes when policies share an event but differ by trigger" do
+    domain = Hecks.bluebook("FanOut") do
+      aggregate "Order" do
+        attribute :status, String
+        command "PlaceOrder" do
+          emits "OrderPlaced"
+        end
+        command "NotifyKitchen" do
+          reference_to(Order)
+          emits "KitchenNotified"
+        end
+        command "ChargeCard" do
+          reference_to(Order)
+          emits "CardCharged"
+        end
+      end
+      policy "KitchenOnPlaced" do; on "OrderPlaced"; trigger "NotifyKitchen"; end
+      policy "ChargeOnPlaced"  do; on "OrderPlaced"; trigger "ChargeCard";    end
+    end
+
+    expect(run_rule(domain)).to be_empty
+  end
+
+  it "passes when policies share a trigger but listen on different events" do
+    domain = Hecks.bluebook("CrossEvent") do
+      aggregate "Bell" do
+        attribute :name, String
+        command "Ring" do
+          emits "Rang"
+        end
+        command "Chime" do
+          emits "Chimed"
+        end
+        command "Echo" do
+          reference_to(Bell)
+          emits "Echoed"
+        end
+      end
+      policy "EchoOnRang"   do; on "Rang";   trigger "Echo"; end
+      policy "EchoOnChimed" do; on "Chimed"; trigger "Echo"; end
+    end
+
+    expect(run_rule(domain)).to be_empty
+  end
+
+  it "names all three policies in a three-way duplicate and reflects the count" do
+    domain = Hecks.bluebook("Triple") do
+      aggregate "Bell" do
+        attribute :name, String
+        command "Ring" do
+          emits "Rang"
+        end
+        command "Echo" do
+          reference_to(Bell)
+          emits "Echoed"
+        end
+      end
+      policy "EchoA" do; on "Rang"; trigger "Echo"; end
+      policy "EchoB" do; on "Rang"; trigger "Echo"; end
+      policy "EchoC" do; on "Rang"; trigger "Echo"; end
+    end
+
+    errors = run_rule(domain)
+    expect(errors.size).to eq(1)
+    msg = errors.first.message
+    expect(msg).to include("3 policies")
+    %w[EchoA EchoB EchoC].each { |name| expect(msg).to include(name) }
+  end
+
+  it "does not flag cross-aggregate dispatch (A triggers command on B that emits to A)" do
+    # Different (event, trigger) pairs: no dupe, even though the chain
+    # loops back. That's cycle detection's job, not duplicate detection.
+    domain = Hecks.bluebook("Cycle") do
+      aggregate "A" do
+        attribute :id, String
+        command "Kick" do
+          emits "AKicked"
+        end
+        command "Reply" do
+          reference_to(A)
+          emits "AReplied"
+        end
+      end
+      aggregate "B" do
+        attribute :id, String
+        command "Handle" do
+          emits "BHandled"
+        end
+      end
+      policy "HandleOnKick"  do; on "AKicked";   trigger "Handle"; end
+      policy "ReplyOnHandle" do; on "BHandled";  trigger "Reply";  end
+    end
+
+    expect(run_rule(domain)).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary

Ruby-side parity for the duplicate-policy validator that shipped in PR #254 (Rust). Two reactive policies sharing `(on_event, trigger_command)` silently double-dispatch — the runtime fires every matching policy in declaration order, so the trigger command runs once per duplicate. Cascade bug with no error message.

New rule: `Hecks::ValidationRules::Structure::DuplicatePolicies < BaseRule`
- Flat walk over reactive policies (aggregate-scoped + domain-level)
- Groups by `(event, trigger, target_domain)` — cross-domain wiring is keyed separately
- One error per group of size >= 2, naming every colliding policy and the exact count
- Registered in `Hecks::ValidationRules::Structure`, runs inside `Hecks.validate`

## What the validator caught

Ran against all 562 bluebooks in the repo:
- 560 clean
- 1 negative test fixture (expected fail)
- **1 real bug** in `hecks_conception/catalog/mind.bluebook` — 4 policies on `(DomainGrafted, ConnectNerve)` that would fire `ConnectNerve` 4x per graft. Same pattern already fixed in `being.bluebook` (58416e3b) and `conception.bluebook` (6cb587e9). Fixed in this PR following those precedents: keep `WireOnGraft`, drop the three duplicates (their subscriber wires every nerve the comments described in one pass).

## Example usage

```ruby
# Flagged:
policy "FatigueOnPulse"     do; on "BodyPulse"; trigger "AccumulateFatigue"; end
policy "FatigueOnPulseDupe" do; on "BodyPulse"; trigger "AccumulateFatigue"; end
#   => "2 policies share (event: BodyPulse, trigger: AccumulateFatigue) —
#       AccumulateFatigue will run 2 times per BodyPulse event. Policies:
#       FatigueOnPulse, FatigueOnPulseDupe. Fix: Delete the duplicates or
#       collapse them into one policy."
```

Not flagged (legitimate fan-out):

```ruby
policy "KitchenOnPlaced" do; on "OrderPlaced"; trigger "NotifyKitchen"; end
policy "ChargeOnPlaced"  do; on "OrderPlaced"; trigger "ChargeCard";    end
```

## Scope

- **Rust side**: already shipped (PR #254). Confirmed all 4 tests still pass on this branch.
- **Ruby side**: new here. 5 rspec tests lock the contract.
- **mind.bluebook**: fixed the 4-way duplicate the validator caught.
- **FEATURES.md + docs/usage/duplicate_policy_validator.md**: added per CLAUDE.md rules.
- **inbox i4 body**: updated to reflect gap 5 shipped + gaps 6/7/8 already closed; i4 stays queued because gap 4 (PR #298) is still open.

## Test plan

- [x] Rust: `cargo test --release` — all green (222+ tests across 22 test binaries)
- [x] Ruby: `bundle exec rspec` — 103 examples, 0 failures, 0.48s (under the 1s hook limit)
- [x] New spec covers 5 cases: 2-way dup, 3-way dup with count, same-event-diff-trigger (no dup), same-trigger-diff-event (no dup), cross-aggregate cycle (not flagged — that's cycle detection's job)
- [x] Validator run against all 562 bluebooks: 560 clean + 1 fixture + 1 real bug (fixed)

## Notes

- Commit 1 (validator + mind.bluebook fix) carries the `[antibody-exempt: validator rule for i4 gap 5; retires when validators port to a bluebook-dispatched form]` marker per task spec.
- Commit 2 (inbox.heki body update) carries a data-only exemption.

Closes i4 gap 5.