### PR TITLE
chore(nursery): migrate 19 bluebooks — inline list_of blocks to value_object (parity)

### DIFF
--- a/hecks_conception/nursery/auction_strategy/auction_strategy.bluebook
+++ b/hecks_conception/nursery/auction_strategy/auction_strategy.bluebook
@@ -120,11 +120,13 @@ Hecks.bluebook "AuctionStrategy", version: "2026.04.13.1" do
       attribute :payoff_b, Float
     end
 
-    list_of "PayoffEntry" do
+    value_object "PayoffEntry" do
       attribute :opponent_strategy, String
       attribute :my_payoff, Float
       attribute :opponent_payoff, Float
     end
+
+    list_of(PayoffEntry)
 
     command "DefineStrategy" do
       role "Analyst"

--- a/hecks_conception/nursery/cinema_audio/cinema_audio.bluebook
+++ b/hecks_conception/nursery/cinema_audio/cinema_audio.bluebook
@@ -134,11 +134,13 @@ Hecks.bluebook "CinemaAudio", version: "2026.04.13.1" do
       attribute :level_db, Float
     end
 
-    list_of "CorrectionFilter" do
+    value_object "CorrectionFilter" do
       attribute :frequency_hz, Float
       attribute :gain_db, Float
       attribute :q_factor, Float
     end
+
+    list_of(CorrectionFilter)
 
     command "RunCalibration" do
       role "Technician"

--- a/hecks_conception/nursery/cognitive_support/cognitive_support.bluebook
+++ b/hecks_conception/nursery/cognitive_support/cognitive_support.bluebook
@@ -148,11 +148,13 @@ Hecks.bluebook "CognitiveSupport", version: "2026.04.13.1" do
       attribute :function, String
     end
 
-    list_of "FatigueIndicator" do
+    value_object "FatigueIndicator" do
       attribute :indicator_name, String
       attribute :value, Float
       attribute :threshold, Float
     end
+
+    list_of(FatigueIndicator)
 
     command "AssessFatigue" do
       role "System"

--- a/hecks_conception/nursery/cultural_resource_mgmt/cultural_resource_mgmt.bluebook
+++ b/hecks_conception/nursery/cultural_resource_mgmt/cultural_resource_mgmt.bluebook
@@ -126,11 +126,13 @@ Hecks.bluebook "CulturalResourceMgmt", version: "2026.04.13.1" do
     attribute :end_date, String
     attribute :status, String
 
-    list_of "WorkZone" do
+    value_object "WorkZone" do
       attribute :zone_id, String
       attribute :activity, String
       attribute :archaeological_clearance, String
     end
+
+    list_of(WorkZone)
 
     command "PlanPhase" do
       role "ProjectManager"

--- a/hecks_conception/nursery/elevator_physics/elevator_physics.bluebook
+++ b/hecks_conception/nursery/elevator_physics/elevator_physics.bluebook
@@ -256,12 +256,14 @@ Hecks.bluebook "ElevatorPhysics", version: "2026.04.13.1" do
       attribute :pass_fail, String
     end
 
-    list_of "DeficiencyReport" do
+    value_object "DeficiencyReport" do
       attribute :component, String
       attribute :deficiency, String
       attribute :severity, String
       attribute :corrective_action, String
     end
+
+    list_of(DeficiencyReport)
 
     command "ConductInspection" do
       role "Inspector"

--- a/hecks_conception/nursery/flight_weather/flight_weather.bluebook
+++ b/hecks_conception/nursery/flight_weather/flight_weather.bluebook
@@ -63,11 +63,13 @@ Hecks.bluebook "FlightWeather", version: "2026.04.13.1" do
       attribute :distance_nm, Float
     end
 
-    list_of "AlternateAirport" do
+    value_object "AlternateAirport" do
       attribute :airport_code, String
       attribute :distance_nm, Float
       attribute :weather_status, String
     end
+
+    list_of(AlternateAirport)
 
     command "FileFlightPlan" do
       role "Dispatcher"

--- a/hecks_conception/nursery/geological_mining/geological_mining.bluebook
+++ b/hecks_conception/nursery/geological_mining/geological_mining.bluebook
@@ -66,11 +66,13 @@ Hecks.bluebook "GeologicalMining", version: "2026.04.13.1" do
       attribute :depth_extent_m, Float
     end
 
-    list_of "MineralAssociation" do
+    value_object "MineralAssociation" do
       attribute :mineral_name, String
       attribute :grade_pct, Float
       attribute :relationship, String
     end
+
+    list_of(MineralAssociation)
 
     command "DelineateOreBody" do
       role "Geologist"

--- a/hecks_conception/nursery/geriatric_pharmacy/geriatric_pharmacy.bluebook
+++ b/hecks_conception/nursery/geriatric_pharmacy/geriatric_pharmacy.bluebook
@@ -63,12 +63,14 @@ Hecks.bluebook "GeriatricPharmacy", version: "2026.04.13.1" do
       attribute :stage, String
     end
 
-    list_of "ActiveMedication" do
+    value_object "ActiveMedication" do
       attribute :medication_name, String
       attribute :dose_mg, Float
       attribute :frequency, String
       attribute :route, String
     end
+
+    list_of(ActiveMedication)
 
     command "AdmitResident" do
       role "Nurse"

--- a/hecks_conception/nursery/marine_navigation/marine_navigation.bluebook
+++ b/hecks_conception/nursery/marine_navigation/marine_navigation.bluebook
@@ -76,12 +76,14 @@ Hecks.bluebook "MarineNavigation", version: "2026.04.13.1" do
       attribute :gust_factor, Float
     end
 
-    list_of "StormAlert" do
+    value_object "StormAlert" do
       attribute :alert_type, String
       attribute :severity, String
       attribute :region, String
       attribute :issued_at, String
     end
+
+    list_of(StormAlert)
 
     command "IssueForecast" do
       role "Meteorologist"
@@ -211,12 +213,14 @@ Hecks.bluebook "MarineNavigation", version: "2026.04.13.1" do
       attribute :eta_hours, Float
     end
 
-    list_of "RouteSegment" do
+    value_object "RouteSegment" do
       attribute :from_waypoint, String
       attribute :to_waypoint, String
       attribute :distance_nm, Float
       attribute :current_assist_knots, Float
     end
+
+    list_of(RouteSegment)
 
     command "PlanRoute" do
       role "Navigator"

--- a/hecks_conception/nursery/planetarium/planetarium.bluebook
+++ b/hecks_conception/nursery/planetarium/planetarium.bluebook
@@ -118,12 +118,14 @@ Hecks.bluebook "Planetarium", version: "2026.04.13.1" do
     attribute :narration_type, String
     attribute :status, String
 
-    list_of "ShowSegment" do
+    value_object "ShowSegment" do
       attribute :segment_name, String
       attribute :duration_sec, Integer
       attribute :celestial_focus, String
       attribute :narration_text, String
     end
+
+    list_of(ShowSegment)
 
     value_object "VisualEffect" do
       attribute :effect_name, String

--- a/hecks_conception/nursery/pollination_service/pollination_service.bluebook
+++ b/hecks_conception/nursery/pollination_service/pollination_service.bluebook
@@ -133,11 +133,13 @@ Hecks.bluebook "PollinationService", version: "2026.04.13.1" do
     attribute :hive_count, Integer
     attribute :status, String
 
-    list_of "DeploymentEntry" do
+    value_object "DeploymentEntry" do
       attribute :hive_id, String
       attribute :deploy_date, String
       attribute :retrieve_date, String
     end
+
+    list_of(DeploymentEntry)
 
     command "PollinatePlan" do
       role "Coordinator"

--- a/hecks_conception/nursery/pool_chemistry/pool_chemistry.bluebook
+++ b/hecks_conception/nursery/pool_chemistry/pool_chemistry.bluebook
@@ -111,12 +111,14 @@ Hecks.bluebook "PoolChemistry", version: "2026.04.13.1" do
       attribute :contact_time_min, Float
     end
 
-    list_of "DosingStep" do
+    value_object "DosingStep" do
       attribute :step_number, Integer
       attribute :chemical, String
       attribute :amount_ml, Float
       attribute :timing, String
     end
+
+    list_of(DosingStep)
 
     command "PrescribeDose" do
       role "Technician"

--- a/hecks_conception/nursery/school_lunch/school_lunch.bluebook
+++ b/hecks_conception/nursery/school_lunch/school_lunch.bluebook
@@ -68,11 +68,13 @@ Hecks.bluebook "SchoolLunch", version: "2026.04.13.1" do
       attribute :allergen_flag, String
     end
 
-    list_of "AllergenWarning" do
+    value_object "AllergenWarning" do
       attribute :allergen_type, String
       attribute :severity, String
       attribute :source_ingredient, String
     end
+
+    list_of(AllergenWarning)
 
     command "PlanMenuItem" do
       role "Chef"
@@ -124,13 +126,15 @@ Hecks.bluebook "SchoolLunch", version: "2026.04.13.1" do
     attribute :total_budget, Float
     attribute :status, String
 
-    list_of "DailyMeal" do
+    value_object "DailyMeal" do
       attribute :day, String
       attribute :entree, String
       attribute :side, String
       attribute :fruit, String
       attribute :milk, String
     end
+
+    list_of(DailyMeal)
 
     command "PlanWeeklyMenu" do
       role "Nutritionist"

--- a/hecks_conception/nursery/secure_payments/secure_payments.bluebook
+++ b/hecks_conception/nursery/secure_payments/secure_payments.bluebook
@@ -139,11 +139,13 @@ Hecks.bluebook "SecurePayments", version: "2026.04.13.1" do
       attribute :score, Float
     end
 
-    list_of "SuspiciousPattern" do
+    value_object "SuspiciousPattern" do
       attribute :pattern_name, String
       attribute :confidence, Float
       attribute :description, String
     end
+
+    list_of(SuspiciousPattern)
 
     command "RaiseFraudAlert" do
       role "System"

--- a/hecks_conception/nursery/solar_optics/solar_optics.bluebook
+++ b/hecks_conception/nursery/solar_optics/solar_optics.bluebook
@@ -125,12 +125,14 @@ Hecks.bluebook "SolarOptics", version: "2026.04.13.1" do
       attribute :afternoon_shade_hours, Float
     end
 
-    list_of "Obstruction" do
+    value_object "Obstruction" do
       attribute :type, String
       attribute :height_m, Float
       attribute :distance_m, Float
       attribute :azimuth_deg, Float
     end
+
+    list_of(Obstruction)
 
     command "AnalyzeShading" do
       role "Engineer"

--- a/hecks_conception/nursery/stormwater_management/stormwater_management.bluebook
+++ b/hecks_conception/nursery/stormwater_management/stormwater_management.bluebook
@@ -71,12 +71,14 @@ Hecks.bluebook "StormwaterManagement", version: "2026.04.13.1" do
       attribute :capacity_cms, Float
     end
 
-    list_of "Inlet" do
+    value_object "Inlet" do
       attribute :inlet_id, String
       attribute :latitude, Float
       attribute :longitude, Float
       attribute :inlet_type, String
     end
+
+    list_of(Inlet)
 
     command "MapDrainNetwork" do
       role "Engineer"

--- a/hecks_conception/nursery/volcanic_ash_aviation/volcanic_ash_aviation.bluebook
+++ b/hecks_conception/nursery/volcanic_ash_aviation/volcanic_ash_aviation.bluebook
@@ -73,11 +73,13 @@ Hecks.bluebook "VolcanicAshAviation", version: "2026.04.13.1" do
       attribute :spread_rate_km2_hr, Float
     end
 
-    list_of "AffectedAirspace" do
+    value_object "AffectedAirspace" do
       attribute :fir_name, String
       attribute :overlap_pct, Float
       attribute :severity, String
     end
+
+    list_of(AffectedAirspace)
 
     command "TrackAshCloud" do
       role "System"

--- a/hecks_conception/nursery/warehouse_robotics/warehouse_robotics.bluebook
+++ b/hecks_conception/nursery/warehouse_robotics/warehouse_robotics.bluebook
@@ -89,12 +89,14 @@ Hecks.bluebook "WarehouseRobotics", version: "2026.04.13.1" do
     attribute :assigned_robot, String
     attribute :status, String
 
-    list_of "PickItem" do
+    value_object "PickItem" do
       attribute :sku, String
       attribute :location, String
       attribute :quantity, Integer
       attribute :picked_status, String
     end
+
+    list_of(PickItem)
 
     command "GeneratePickList" do
       role "System"

--- a/hecks_conception/nursery/water_microbiology/water_microbiology.bluebook
+++ b/hecks_conception/nursery/water_microbiology/water_microbiology.bluebook
@@ -60,11 +60,13 @@ Hecks.bluebook "WaterMicrobiology", version: "2026.04.13.1" do
       attribute :incubation_hours, Integer
     end
 
-    list_of "Identification" do
+    value_object "Identification" do
       attribute :method, String
       attribute :result, String
       attribute :confidence_pct, Float
     end
+
+    list_of(Identification)
 
     command "CultureSample" do
       role "Microbiologist"


### PR DESCRIPTION
## Summary

Follow-up to PR #305 (tonight's first nursery parity batch). PR #305's agent identified 22 files using inline `list_of "X" do ... end` blocks that the Rust parser accepts but the Ruby parser rejects with:

    Error in aggregate '...': Use bare constant X instead of string "X" in list_of

This PR extracts each inline block into a sibling `value_object "X" do ... end` declaration and replaces the reference with the bare-constant form `list_of(X)`.

### Pattern

Before:
```ruby
aggregate "DosingPlan" do
  attribute :status, String

  list_of "DosingStep" do
    attribute :step_number, Integer
    attribute :chemical, String
  end
end
```

After:
```ruby
aggregate "DosingPlan" do
  attribute :status, String

  value_object "DosingStep" do
    attribute :step_number, Integer
    attribute :chemical, String
  end

  list_of(DosingStep)
end
```

### Migrated (19 files, 20 blocks)

- auction_strategy (PayoffEntry)
- cinema_audio (CorrectionFilter)
- cognitive_support (FatigueIndicator)
- cultural_resource_mgmt (WorkZone)
- elevator_physics (DeficiencyReport)
- flight_weather (AlternateAirport)
- geological_mining (MineralAssociation)
- geriatric_pharmacy (ActiveMedication)
- marine_navigation (StormAlert, RouteSegment)
- planetarium (ShowSegment)
- pollination_service (DeploymentEntry)
- pool_chemistry (DosingStep)
- school_lunch (AllergenWarning, DailyMeal)
- secure_payments (SuspiciousPattern)
- solar_optics (Obstruction)
- stormwater_management (Inlet)
- volcanic_ash_aviation (AffectedAirspace)
- warehouse_robotics (PickItem)
- water_microbiology (Identification)

### Skipped — acronym-casing drift (separate fix class)

Three target files have the migration cleanly applied locally but revert because their aggregate names contain acronyms that hit a second, independent drift class — Ruby emits `dna_profile`, Rust emits `d_n_a_profile`:

| File | Aggregate | Acronym |
|---|---|---|
| animal_genetics | DNAProfile | DNA |
| scientific_pest_mgmt | IPMPlan | IPM |
| thermal_comfort | HVACEquipment | HVAC |

This is the same class PR #305's agent already flagged for air_cargo (`ULDPallet`) and customs_brokerage. Keeping scope tight per the tasking; these three plus the existing two are a follow-up batch once the acronym rule is reconciled (inbox-worthy if not already filed).

### Parity

- Before (this branch's base = origin/main, post-#285): 237/500 match, nursery 112/375
- After: 256/500 match, nursery 131/375 (+19)
- Synthetic/real/capabilities/catalog/misc: unchanged 100%
- Soft-drift count dropped from 263 to 244

## Test plan

- [x] `ruby -Ilib spec/parity/parity_test.rb` — all 19 migrated files show ✓, non-nursery sections still 100%, exit 0
- [x] No other files touched (antibody hook confirmed bluebook-only)
- [ ] Merger: rebase on top of #305 if it lands first (no file overlap expected)