### PR TITLE
feat(fixtures): catalog-dialect parser (i42 commits 1-4; no consumers yet)

### DIFF
--- a/hecks_life/src/fixtures_ir.rs
+++ b/hecks_life/src/fixtures_ir.rs
@@ -15,12 +15,37 @@
 //! `ir::Fixture`) — same shape, same downstream consumers (heki seed
 //! loader, behaviors test setups). What changes is *where* fixtures
 //! live (their own file, no longer mixed into the source bluebook).
+//!
+//! The `catalogs` map is the i42 catalog-dialect extension: an
+//! aggregate declared with a `schema:` kwarg on the `aggregate` line
+//! is a fixture-only reference table ("catalog") that carries its own
+//! row schema, so no bluebook declaration is needed. Aggregates
+//! without `schema:` behave exactly as before (catalogs map stays
+//! empty for those).
+
+use std::collections::BTreeMap;
 
 use crate::ir::Fixture;
 
 /// A parsed .fixtures file. The `domain_name` matches the source
 /// bluebook's `Hecks.bluebook "X"` so a runtime can pair them up.
+///
+/// `catalogs` is keyed by aggregate name (matching each catalog's
+/// `aggregate "X", schema: { … } do`) and holds the declared row
+/// schema. BTreeMap gives deterministic iteration order — the parity
+/// contract needs Ruby/Rust emissions to diff cleanly.
 pub struct FixturesFile {
     pub domain_name: String,
     pub fixtures: Vec<Fixture>,
+    pub catalogs: BTreeMap<String, Vec<CatalogAttr>>,
+}
+
+/// One attribute in a catalog's row schema. `name` is the attribute
+/// key as it appears in fixture rows (`ext:` → `"ext"`); `type_name`
+/// is the declared Ruby-ish type token verbatim (`"String"`,
+/// `"Integer"`, `"list_of(String)"`) so the parity harness can diff
+/// Ruby and Rust output character-for-character.
+pub struct CatalogAttr {
+    pub name: String,
+    pub type_name: String,
 }

--- a/hecks_life/src/fixtures_parser.rs
+++ b/hecks_life/src/fixtures_parser.rs
@@ -24,7 +24,11 @@ use crate::ir::Fixture;
 use crate::parser_helpers::{extract_string, ends_with_do_block};
 
 pub fn parse(source: &str) -> FixturesFile {
-    let mut file = FixturesFile { domain_name: String::new(), fixtures: vec![] };
+    let mut file = FixturesFile {
+        domain_name: String::new(),
+        fixtures: vec![],
+        catalogs: std::collections::BTreeMap::new(),
+    };
     let lines: Vec<&str> = source.lines().collect();
     let mut i = 0;
     let mut current_agg: Option<String> = None;

--- a/hecks_life/src/fixtures_parser.rs
+++ b/hecks_life/src/fixtures_parser.rs
@@ -18,8 +18,24 @@
 //! The first positional arg of `fixture` is the label (Fixture::name);
 //! everything after is k:v attributes. The enclosing `aggregate "X"`
 //! block sets aggregate_name on each fixture inside.
+//!
+//! i42 catalog-dialect extension: an `aggregate` line may carry a
+//! `schema:` kwarg whose value is an inline `{ k: Type, ... }` hash
+//! literal. When present, the aggregate is a "catalog" — a
+//! fixture-only reference table declaring its own row schema. The
+//! schema is parsed into a `Vec<CatalogAttr>` and stored under the
+//! aggregate's name in `FixturesFile::catalogs`. Aggregates without
+//! `schema:` parse exactly as before.
+//!
+//!   aggregate "FlaggedExtension", schema: { ext: String } do
+//!     fixture "Ruby", ext: "rb"
+//!   end
+//!
+//! v1 constraint: single-line schema only. Multi-line schemas
+//! (opening `{` on the aggregate line, closing `}` on a later line)
+//! are not supported yet — see the plan's risk 9.1.
 
-use crate::fixtures_ir::FixturesFile;
+use crate::fixtures_ir::{CatalogAttr, FixturesFile};
 use crate::ir::Fixture;
 use crate::parser_helpers::{extract_string, ends_with_do_block};
 
@@ -43,6 +59,11 @@ pub fn parse(source: &str) -> FixturesFile {
             depth += 1;
         } else if line.starts_with("aggregate ") && ends_with_do_block(line) {
             current_agg = extract_string(line);
+            if let Some(agg) = current_agg.clone() {
+                if let Some(schema) = extract_schema_kwarg(line) {
+                    file.catalogs.insert(agg, schema);
+                }
+            }
             depth += 1;
         } else if line.starts_with("fixture ") {
             if let Some(agg) = &current_agg {
@@ -128,4 +149,214 @@ fn escaped_at(s: &str, i: usize) -> bool {
         j -= 1;
     }
     count % 2 == 1
+}
+
+/// Extract the `schema: { k: Type, ... }` kwarg from an `aggregate`
+/// line. Returns None when the kwarg is absent. Single-line only
+/// (v1 constraint); a multi-line `{ ... }` spanning several source
+/// lines parses as absent.
+///
+/// Parse shape:
+///   aggregate "X", schema: { ext: String } do
+///                  ^^^^^^^^ ^^^^^^^^^^^^^
+///                  |        |
+///                  |        +-- inside {...}: top-level-comma-split
+///                  |            pairs of `k: Type`, where Type is a
+///                  |            verbatim token (may contain parens
+///                  |            and commas — `list_of(String)` — so
+///                  |            we reuse split_top_level_commas to
+///                  |            respect nested brackets/parens).
+///                  +-- we scan from after the first top-level comma
+///                      on the aggregate line (the one separating the
+///                      positional name from kwargs).
+fn extract_schema_kwarg(line: &str) -> Option<Vec<CatalogAttr>> {
+    // Find the first top-level comma after the aggregate's name —
+    // that separates `aggregate "X"` from its kwargs. Top-level
+    // matters because a future bluebook form could theoretically
+    // embed commas in `"strings"` inside the name slot; current
+    // names are PascalCase but we keep the code honest.
+    let comma_pos = first_top_level_comma(line)?;
+    let after_comma = &line[comma_pos + 1..];
+    let schema_pos = after_comma.find("schema:")?;
+    let after_schema = &after_comma[schema_pos + "schema:".len()..];
+
+    // Find the opening `{` after `schema:` and its balanced `}`.
+    let open = after_schema.find('{')?;
+    let close = matching_close_brace(after_schema, open)?;
+    let body = &after_schema[open + 1..close];
+
+    let mut attrs = Vec::new();
+    for part in split_top_level_commas(body) {
+        let part = part.trim();
+        if part.is_empty() { continue; }
+        // Each pair is `name: Type`. We split on the first top-level
+        // colon so the type token (which never legitimately contains
+        // a `:`) is preserved intact even if future types do.
+        let colon = part.find(':')?;
+        let name = part[..colon].trim().to_string();
+        let type_name = part[colon + 1..].trim().to_string();
+        if name.is_empty() || type_name.is_empty() { return None; }
+        attrs.push(CatalogAttr { name, type_name });
+    }
+    Some(attrs)
+}
+
+/// Locate the first `,` at bracket/paren depth 0 and outside any
+/// string literal. Used to find where positional args end and kwargs
+/// begin on the aggregate line.
+fn first_top_level_comma(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_str = false;
+    for (i, c) in s.char_indices() {
+        match c {
+            '"' if !escaped_at(s, i) => in_str = !in_str,
+            '[' | '{' | '(' if !in_str => depth += 1,
+            ']' | '}' | ')' if !in_str => depth -= 1,
+            ',' if !in_str && depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Given `s` and the byte index of an opening `{`, return the byte
+/// index of the matching closing `}` — respecting nested braces and
+/// skipping string literals. Returns None if unbalanced (which in v1
+/// means the schema spans multiple lines; we decline to parse it).
+fn matching_close_brace(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.get(open) != Some(&b'{') { return None; }
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut i = open;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        match c {
+            '"' if !escaped_at(s, i) => in_str = !in_str,
+            '{' if !in_str => depth += 1,
+            '}' if !in_str => {
+                depth -= 1;
+                if depth == 0 { return Some(i); }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tiny helper: parse a source snippet and return the catalogs
+    // map. Keeps the assertion surface focused on the i42 add.
+    fn catalogs_of(source: &str) -> std::collections::BTreeMap<String, Vec<(String, String)>> {
+        parse(source).catalogs
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().map(|a| (a.name, a.type_name)).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn schema_kwarg_records_one_catalog_attr() {
+        let src = r#"
+            Hecks.fixtures "Antibody" do
+              aggregate "FlaggedExtension", schema: { ext: String } do
+                fixture "Ruby", ext: "rb"
+              end
+            end
+        "#;
+        let cats = catalogs_of(src);
+        assert_eq!(cats.len(), 1);
+        assert_eq!(cats.get("FlaggedExtension").unwrap(),
+                   &vec![("ext".into(), "String".into())]);
+    }
+
+    #[test]
+    fn no_schema_kwarg_means_no_catalog_entry() {
+        // Pre-i42 shape — unchanged behavior.
+        let src = r#"
+            Hecks.fixtures "Pizzas" do
+              aggregate "Pizza" do
+                fixture "Margherita", name: "Margherita"
+              end
+            end
+        "#;
+        assert!(catalogs_of(src).is_empty());
+    }
+
+    #[test]
+    fn schema_kwarg_records_multiple_attrs_in_order() {
+        let src = r#"
+            Hecks.fixtures "Antibody" do
+              aggregate "ShebangMapping", schema: { match: String, ext: String } do
+                fixture "Ruby", match: "ruby", ext: "rb"
+              end
+            end
+        "#;
+        let cats = catalogs_of(src);
+        assert_eq!(cats.get("ShebangMapping").unwrap(), &vec![
+            ("match".into(), "String".into()),
+            ("ext".into(),   "String".into()),
+        ]);
+    }
+
+    #[test]
+    fn schema_kwarg_handles_list_of_parens() {
+        // `list_of(String)` has a comma-free inner but the parens
+        // must nest correctly so a schema like
+        // `{ items: list_of(String), name: String }` splits on the
+        // top-level comma only — not on a comma inside the parens.
+        let src = r#"
+            Hecks.fixtures "Antibody" do
+              aggregate "TestCase", schema: { items: list_of(String), name: String } do
+                fixture "Sample", items: ["a"], name: "sample"
+              end
+            end
+        "#;
+        let cats = catalogs_of(src);
+        assert_eq!(cats.get("TestCase").unwrap(), &vec![
+            ("items".into(), "list_of(String)".into()),
+            ("name".into(),  "String".into()),
+        ]);
+    }
+
+    #[test]
+    fn nested_fixture_block_does_not_confuse_aggregate_scan() {
+        // A fixture line that happens to contain `schema:` or nested
+        // blocks shouldn't bleed into catalogs; only `aggregate` lines
+        // feed the catalog extractor.
+        let src = r#"
+            Hecks.fixtures "Mixed" do
+              aggregate "Pizza" do
+                fixture "Margherita", name: "Margherita"
+              end
+            end
+        "#;
+        let ff = parse(src);
+        assert!(ff.catalogs.is_empty());
+        assert_eq!(ff.fixtures.len(), 1);
+        assert_eq!(ff.fixtures[0].aggregate_name, "Pizza");
+    }
+
+    #[test]
+    fn plain_and_catalog_aggregates_coexist() {
+        let src = r##"
+            Hecks.fixtures "Mixed" do
+              aggregate "Pizza" do
+                fixture "Margherita", name: "Margherita"
+              end
+              aggregate "Color", schema: { hex: String } do
+                fixture "Red", hex: "#FF0000"
+              end
+            end
+        "##;
+        let ff = parse(src);
+        assert_eq!(ff.catalogs.len(), 1);
+        assert!(ff.catalogs.contains_key("Color"));
+        assert!(!ff.catalogs.contains_key("Pizza"));
+        // Fixtures from both aggregates still land in the flat list.
+        assert_eq!(ff.fixtures.len(), 2);
+    }
 }

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
         let path = args.get(2).expect("usage: hecks-life dump-fixtures <file.fixtures>");
         let source = std::fs::read_to_string(path).expect("cannot read");
         let file = hecks_life::fixtures_parser::parse(&source);
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "domain": file.domain_name,
             "fixtures": file.fixtures.iter().map(|f| {
                 let mut attrs = serde_json::Map::new();
@@ -135,6 +135,22 @@ fn main() {
                 })
             }).collect::<Vec<_>>(),
         });
+        // i42: emit a `catalogs` key only when the file actually
+        // declares catalog schemas. Absent-key preserves the pre-i42
+        // payload shape for the ~356 existing .fixtures files, so
+        // downstream consumers that don't care about catalogs see
+        // exactly the same JSON they saw before.
+        if !file.catalogs.is_empty() {
+            let mut catalogs = serde_json::Map::new();
+            for (agg, attrs) in &file.catalogs {
+                let rows: Vec<serde_json::Value> = attrs.iter().map(|a| {
+                    serde_json::json!({ "name": a.name, "type": a.type_name })
+                }).collect();
+                catalogs.insert(agg.clone(), serde_json::Value::Array(rows));
+            }
+            payload.as_object_mut().unwrap()
+                .insert("catalogs".into(), serde_json::Value::Object(catalogs));
+        }
         println!("{}", serde_json::to_string_pretty(&payload).unwrap());
         return;
     }

--- a/lib/hecks/dsl/fixtures_builder.rb
+++ b/lib/hecks/dsl/fixtures_builder.rb
@@ -60,15 +60,25 @@ module Hecks
       # IR shape returned by the builder. Same shape the Rust
       # `fixtures_ir::FixturesFile` produces, so parity tooling can
       # diff both directly.
+      #
+      # `catalogs` maps an aggregate name to its declared row schema
+      # (a list of `{name:, type:}` hashes). Present only for
+      # aggregates declared with the `schema:` kwarg — the i42
+      # catalog-dialect form for fixture-only reference tables.
+      # Absent-or-empty preserves today's behavior.
       class FixturesFile
-        attr_reader :name, :fixtures
-        def initialize(name:, fixtures: [])
+        attr_reader :name, :fixtures, :catalogs
+        def initialize(name:, fixtures: [], catalogs: {})
           @name = name
           @fixtures = fixtures
+          @catalogs = catalogs
         end
 
         def ==(other)
-          other.is_a?(FixturesFile) && name == other.name && fixtures == other.fixtures
+          other.is_a?(FixturesFile) &&
+            name == other.name &&
+            fixtures == other.fixtures &&
+            catalogs == other.catalogs
         end
       end
     end

--- a/lib/hecks/dsl/fixtures_builder.rb
+++ b/lib/hecks/dsl/fixtures_builder.rb
@@ -30,13 +30,24 @@ module Hecks
       def initialize(name)
         @name = name
         @fixtures = []
+        @catalogs = {}
       end
 
       # Scope the inner `fixture` calls to one aggregate type. `name`
       # is the aggregate's PascalCase name, matching the source
       # bluebook's `aggregate "X" do`.
-      def aggregate(name, &block)
+      #
+      # `schema:` is the i42 catalog-dialect extension. When present,
+      # the aggregate is a "catalog" — a fixture-only reference table
+      # that self-declares its row schema, so no bluebook declaration
+      # is required. Absence preserves today's behavior exactly.
+      #
+      #   aggregate "FlaggedExtension", schema: { ext: String } do
+      #     fixture "Ruby", ext: "rb"
+      #   end
+      def aggregate(name, schema: nil, &block)
         @current_aggregate = name.to_s
+        @catalogs[@current_aggregate] = normalize_schema(schema) if schema
         instance_eval(&block) if block
         @current_aggregate = nil
       end
@@ -54,7 +65,19 @@ module Hecks
       end
 
       def build
-        FixturesFile.new(name: @name, fixtures: @fixtures)
+        FixturesFile.new(name: @name, fixtures: @fixtures, catalogs: @catalogs)
+      end
+
+      private
+
+      # Normalize `{ ext: String, match: String }` into the same shape
+      # the Rust parser emits: an ordered list of `{name:, type:}`
+      # hashes. Values are stringified via the constant's name so
+      # `String` → "String", `list_of(String)` → the literal return
+      # value (typically "list_of(String)" from whatever shorthand
+      # helper the caller has in scope — here we defensively `to_s`).
+      def normalize_schema(schema)
+        schema.map { |k, v| { name: k.to_s, type: v.to_s } }
       end
 
       # IR shape returned by the builder. Same shape the Rust

--- a/spec/hecks/dsl/fixtures_builder_catalog_spec.rb
+++ b/spec/hecks/dsl/fixtures_builder_catalog_spec.rb
@@ -1,0 +1,104 @@
+# spec/hecks/dsl/fixtures_builder_catalog_spec.rb
+#
+# Contract for Hecks::DSL::FixturesBuilder's `schema:` kwarg — the
+# i42 catalog-dialect surface. When an aggregate declares `schema:`,
+# the builder collects the row-shape declaration into `FixturesFile#catalogs`
+# keyed by aggregate name. When `schema:` is absent, the catalogs
+# map stays empty — the pre-i42 shape.
+#
+# Parity contract (spec/parity/fixtures_parity_test.rb) owns the
+# Ruby/Rust output diff. This spec owns the Ruby-side surface: what
+# `schema:` accepts, how it normalizes, and what the builder returns.
+#
+# [antibody-exempt: spec for .fixtures DSL builder — the builder is
+#  the Ruby half of the catalog-dialect parser pair; tests live
+#  alongside the builder they protect.]
+#
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+require "hecks/dsl/fixtures_builder"
+
+RSpec.describe Hecks::DSL::FixturesBuilder do
+  describe "#aggregate with schema:" do
+    it "records a normalized catalog schema keyed by aggregate name" do
+      builder = described_class.new("Antibody")
+      builder.aggregate("FlaggedExtension", schema: { ext: String }) do
+      end
+
+      file = builder.build
+      expect(file.catalogs).to eq(
+        "FlaggedExtension" => [{ name: "ext", type: "String" }],
+      )
+    end
+
+    it "normalizes multiple attrs in declaration order" do
+      builder = described_class.new("Antibody")
+      builder.aggregate("ShebangMapping",
+                        schema: { match: String, ext: String }) do
+      end
+
+      file = builder.build
+      expect(file.catalogs["ShebangMapping"]).to eq([
+        { name: "match", type: "String" },
+        { name: "ext",   type: "String" },
+      ])
+    end
+
+    it "leaves catalogs empty when schema: is omitted (pre-i42 shape)" do
+      builder = described_class.new("Pizzas")
+      builder.aggregate("Pizza") do
+        # no schema:, no fixtures — still the pre-i42 shape
+      end
+
+      file = builder.build
+      expect(file.catalogs).to eq({})
+    end
+
+    it "collects fixtures for a catalog aggregate alongside the schema" do
+      builder = described_class.new("Antibody")
+      builder.aggregate("FlaggedExtension", schema: { ext: String }) do
+        fixture "Ruby", ext: "rb"
+        fixture "Rust", ext: "rs"
+      end
+
+      file = builder.build
+      expect(file.catalogs["FlaggedExtension"]).to eq([
+        { name: "ext", type: "String" },
+      ])
+      expect(file.fixtures.size).to eq(2)
+      expect(file.fixtures.map(&:name)).to eq(%w[Ruby Rust])
+    end
+
+    it "mixes plain aggregates and catalogs in one file" do
+      builder = described_class.new("Mixed")
+      builder.aggregate("Pizza") do
+        # no schema — plain aggregate, fixtures resolve against bluebook
+      end
+      builder.aggregate("Color", schema: { hex: String, name: String }) do
+        # schema — this is a catalog
+      end
+
+      file = builder.build
+      expect(file.catalogs.keys).to eq(["Color"])
+      expect(file.catalogs["Color"]).to eq([
+        { name: "hex",  type: "String" },
+        { name: "name", type: "String" },
+      ])
+    end
+  end
+
+  describe "FixturesFile equality" do
+    it "takes catalogs into account" do
+      a = Hecks::DSL::FixturesBuilder::FixturesFile.new(
+        name: "X", fixtures: [], catalogs: { "C" => [{ name: "k", type: "String" }] },
+      )
+      b = Hecks::DSL::FixturesBuilder::FixturesFile.new(
+        name: "X", fixtures: [], catalogs: { "C" => [{ name: "k", type: "String" }] },
+      )
+      c = Hecks::DSL::FixturesBuilder::FixturesFile.new(
+        name: "X", fixtures: [], catalogs: {},
+      )
+      expect(a).to eq(b)
+      expect(a).not_to eq(c)
+    end
+  end
+end

--- a/spec/parity/fixtures/catalog_smoke.fixtures
+++ b/spec/parity/fixtures/catalog_smoke.fixtures
@@ -1,0 +1,32 @@
+# spec/parity/fixtures/catalog_smoke.fixtures
+#
+# i42 smoke fixture — exercises the catalog-dialect (schema: kwarg on
+# aggregate) alongside a plain aggregate, so Ruby and Rust parsers
+# can be diffed end-to-end on the same file.
+#
+# Plain rows: pre-i42 shape.
+# Catalog rows: the new schema-carrying form.
+#
+# [antibody-exempt: parity-suite test input — not domain code; its
+#  sole role is to pin Ruby/Rust parser equivalence under the new
+#  catalog-dialect DSL surface.]
+Hecks.fixtures "CatalogSmoke" do
+  # Plain aggregate — no schema, behaves exactly as before.
+  aggregate "Pizza" do
+    fixture "Margherita", name: "Margherita", description: "Classic"
+    fixture "Pepperoni",  name: "Pepperoni",  description: "Spicy"
+  end
+
+  # Catalog — single-attr schema, two rows.
+  aggregate "FlaggedExtension", schema: { ext: String } do
+    fixture "Ruby", ext: "rb"
+    fixture "Rust", ext: "rs"
+  end
+
+  # Catalog — multi-attr schema, three rows.
+  aggregate "ShebangMapping", schema: { match: String, ext: String } do
+    fixture "Ruby",   match: "ruby",   ext: "rb"
+    fixture "Python", match: "python", ext: "py"
+    fixture "Bash",   match: "bash",   ext: "sh"
+  end
+end


### PR DESCRIPTION
## Summary

Foundation commits 1-4 of the [i42 catalog-dialect plan](https://github.com/chrisyoung/hecks/blob/56110f49/docs/plans/i42_catalog_dialect.md). Parser-only scope — adds the `schema:` kwarg to the `.fixtures` DSL on both the Ruby builder and the Rust parser, plus the IR slot and dump-fixtures JSON output. No runtime consumers yet (loader, validator, antibody migration land in commits 5-12 of the plan).

- **Commit 1 (`feat(fixtures-ir)`)**: `FixturesFile.catalogs` field + `CatalogAttr` struct on both sides, defaulting to empty.
- **Commit 2 (`feat(fixtures-builder)`)**: Ruby `aggregate` accepts `schema: { k: Type, ... }`. Absence preserves pre-i42 shape. 6 unit tests.
- **Commit 3 (`feat(fixtures-parser)`)**: Rust line-scanner extracts `schema:` kwarg from `aggregate "X", schema: { ... } do` lines. Respects nested parens (`list_of(String)`), string literals, and brace balance. 6 unit tests.
- **Commit 4 (`feat(dump-fixtures)`)**: `hecks-life dump-fixtures` emits a `catalogs` JSON key when schemas are present; omitted otherwise for byte-identical payloads on the ~356 existing `.fixtures` files.

Example DSL (what now parses on both sides):

```ruby
Hecks.fixtures "Antibody" do
  aggregate "FlaggedExtension", schema: { ext: String } do
    fixture "Ruby", ext: "rb"
    fixture "Rust", ext: "rs"
  end
end
```

## Test plan

- [x] `cargo test --release --lib` — 23/23 pass including 6 new `fixtures_parser::tests`
- [x] `cargo build --release` — clean (existing warnings only)
- [x] `rspec spec/hecks/dsl/fixtures_builder_catalog_spec.rb` — 6/6 pass
- [x] `ruby -Ilib spec/parity/fixtures_parity_test.rb` — 345/358 parity + 13 known drift, identical to baseline
- [x] `ruby -Ilib spec/parity/fixtures_parity_test.rb spec/parity/fixtures/catalog_smoke.fixtures` — 1/1 parity (toy catalog file)
- [x] Ruby and Rust produce structurally equivalent catalogs maps for `catalog_smoke.fixtures` (confirmed manually — same keys, same attr order, same type tokens)
- [x] Pre-commit hook (parity + lifecycle + conceiver parity) green on each of the 4 commits

## Scope cap

Commits 1-4 only. Runtime catalog repository, validation rules (`FixtureAggregateRefs`, `CatalogSchemaCoverage`), `antibody.fixtures` migration, `antibody.bluebook` shape-only aggregate removal, and parity harness extension to diff catalogs maps — all deferred to follow-up PRs per the plan.

## Notes

- BTreeMap chosen for Rust's catalog container to guarantee deterministic iteration; Ruby's Hash is already insertion-ordered. Parity harness will need to sort both sides when it adopts the catalog diff (commit 5 of the plan).
- v1 constraint: `schema:` must be single-line (plan risk 9.1). A multi-line `{ ... }` parses as absent rather than erroring — leaves the door open for v2 multi-line support without breaking existing callers.
- Each commit is antibody-clean with a per-commit exemption naming the DSL-parser category (parser extensions must travel in lockstep across Ruby and Rust until the DSL is self-hosting).