### PR TITLE
fix(adapter:fs): honor HECKS_INFO env override for root (i46 half)

### DIFF
--- a/hecks_life/src/run_status/mod.rs
+++ b/hecks_life/src/run_status/mod.rs
@@ -114,7 +114,27 @@ fn stamp_aggregate(rt: &mut Runtime, r: &Report) {
 /// The `:fs` adapter's `root:` option anchors the heki store directory.
 /// When relative, we walk up from the script's directory looking for a
 /// directory that contains `<root>/` — that's the conception root.
+///
+/// Reads `HECKS_INFO` from the environment as an override. Tests (e.g.
+/// `status_golden.sh`) seed a tmpdir and export `HECKS_INFO=<tmpdir>`
+/// so status.sh reads from the seeded dir rather than live state.
 fn resolve_fs_root(adapter: &IoAdapter, script_path: &str) -> String {
+    let override_dir = std::env::var("HECKS_INFO").ok();
+    resolve_fs_root_with(adapter, script_path, override_dir.as_deref())
+}
+
+/// Pure core of [`resolve_fs_root`], factored out so tests can inject the
+/// override without mutating process-global env. When `env_override` is
+/// `Some(non-empty)`, it wins over the hecksagon's `root:` option and the
+/// script-dir walk; when unset or empty, behavior is unchanged.
+pub(crate) fn resolve_fs_root_with(
+    adapter: &IoAdapter,
+    script_path: &str,
+    env_override: Option<&str>,
+) -> String {
+    if let Some(v) = env_override {
+        if !v.is_empty() { return v.to_string(); }
+    }
     let root = adapter.options.iter().find(|(k, _)| k == "root")
         .map(|(_, v)| v.trim_matches('"').to_string())
         .unwrap_or_else(|| "information".to_string());
@@ -160,4 +180,38 @@ fn atty_stdout() -> bool {
     }
     #[cfg(not(unix))]
     { false }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hecksagon_ir::IoAdapter;
+
+    fn fs_adapter(root: &str) -> IoAdapter {
+        let mut a = IoAdapter::default();
+        a.kind = "fs".into();
+        a.options.push(("root".into(), format!("\"{}\"", root)));
+        a
+    }
+
+    #[test]
+    fn env_override_wins_over_hecksagon_root() {
+        let a = fs_adapter("information");
+        let out = resolve_fs_root_with(&a, "/tmp/x/script.bluebook", Some("/tmp/seeded"));
+        assert_eq!(out, "/tmp/seeded");
+    }
+
+    #[test]
+    fn empty_env_override_is_ignored() {
+        let a = fs_adapter("/abs/root");
+        let out = resolve_fs_root_with(&a, "/tmp/x/script.bluebook", Some(""));
+        assert_eq!(out, "/abs/root");
+    }
+
+    #[test]
+    fn absolute_root_used_when_no_override() {
+        let a = fs_adapter("/abs/root");
+        let out = resolve_fs_root_with(&a, "/tmp/x/script.bluebook", None);
+        assert_eq!(out, "/abs/root");
+    }
 }


### PR DESCRIPTION
## Summary

- `status.sh` dispatches to a hecksagon with `adapter :fs, root: \"information\"`. The runner walks up from script-dir to find `./information/`, always hitting live state.
- `hecks_conception/tests/status_golden.sh` seeds a tmpdir and exports `HECKS_INFO=<tmpdir>`, but the runner ignored it — so the test compared live state against the golden.
- Fix: teach `run_status::resolve_fs_root` to prefer `HECKS_INFO` when set and non-empty. Unchanged behavior when unset.

## Why Option B (dedicated env var) over Option A (template substitution)

- `grep \"adapter :fs\" hecks_conception/` → single consumer (status.hecksagon). Option A's generality buys nothing right now.
- The Rust runtime reads adapter options as raw strings via `IoAdapter::options` — template substitution at load time would touch the parser/IR and several more files. Out of the 30-50 LoC scope cap.
- Option B is ~2 lines of real logic in the one place that owns the resolution.

## Files changed

- `hecks_life/src/run_status/mod.rs` — `resolve_fs_root` now consults `HECKS_INFO`; factored pure core `resolve_fs_root_with(..., env_override)` for testability. +3 unit tests.

## Example usage

`bash
# test harness: seed a tmpdir, point status.sh at it, not live state
info=\$(mktemp -d)
hecks-life heki upsert \"\$info/identity.heki\" first_words=\"Miette\"
HECKS_INFO=\"\$info\" ./hecks_conception/status.sh --no-color
# -> reads from \$info/*.heki, not hecks_conception/information/

# no env var: unchanged
./hecks_conception/status.sh --no-color
# -> reads live hecks_conception/information/
`

## Test plan

- [x] 3 new unit tests in `run_status::tests` cover override-wins, empty-override-ignored, no-override-uses-absolute-root
- [x] Full cargo test suite green (175+ tests)
- [x] `bash hecks_conception/tests/status_golden.sh` now reads the seeded tmpdir (confirmed: `name: Miette` from tmpdir vs `name: Spring` from live). Golden text still mismatches on one line (`born_at: —` vs `born_at: golden-test`) because `render.rs::identity` hardcodes `born_at` to `\"—\"` — a pre-existing render bug, separate from the data-source issue this PR addresses.
- [x] Running `status.sh` with no `HECKS_INFO` set still reads live state unchanged.
- [x] No other `:fs` consumers — `grep -rn \"adapter :fs\" hecks_conception/` returns only `capabilities/status/status.hecksagon`.

## i46 note

The inbox ref i46 referenced in the task description doesn't yet exist in `inbox.heki` (last ref filed is i47). The `pulse_organs_smoke` companion concern mentioned in the task is unrelated to this fix — it uses a `.world` file to pin `heki/dir`, not the `:fs` adapter root. If i46 gets filed, the body can note the `status_golden` data-source piece is addressed by this PR.