### PR TITLE
chore(nursery): migrate 24 bluebooks — parity batch 3

### DIFF
--- a/hecks_conception/nursery/advertising_generation/advertising_generation.bluebook
+++ b/hecks_conception/nursery/advertising_generation/advertising_generation.bluebook
@@ -79,7 +79,7 @@ Hecks.bluebook "AdvertisingGeneration", version: "2026.04.11.1" do
     attribute :audience, String
     attribute :budget, Float
     attribute :duration, String
-    list_of(AdAssignment) :templates
+    attribute :templates, list_of(AdAssignment)
     attribute :status, String
 
     value_object "AdAssignment" do
@@ -211,7 +211,7 @@ Hecks.bluebook "AdvertisingGeneration", version: "2026.04.11.1" do
     attribute :visual_style, String
     attribute :color_emphasis, String
     attribute :photography_style, String
-    list_of(String) :forbidden_terms
+    attribute :forbidden_terms, list_of(String)
 
     command "SetDirection" do
       role "Owner"

--- a/hecks_conception/nursery/autonomous_rescue/autonomous_rescue.bluebook
+++ b/hecks_conception/nursery/autonomous_rescue/autonomous_rescue.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "AutonomousRescue", version: "2026.04.13.1" do
     attribute :location, String
     attribute :status, String
     attribute :survivors_found, Integer
-    list_of(MissionPhase) :phases
+    attribute :phases, list_of(MissionPhase)
 
     value_object "MissionPhase" do
       attribute :phase_name, String
@@ -63,7 +63,7 @@ Hecks.bluebook "AutonomousRescue", version: "2026.04.13.1" do
     attribute :status, String
     attribute :battery_percent, Float
     reference_to(RescueMission, as: :mission)
-    list_of(ScanResult) :scans
+    attribute :scans, list_of(ScanResult)
 
     value_object "ScanResult" do
       attribute :scan_type, String
@@ -128,7 +128,7 @@ Hecks.bluebook "AutonomousRescue", version: "2026.04.13.1" do
     attribute :battery_percent, Float
     attribute :status, String
     reference_to(SurvivorBeacon, as: :target_beacon)
-    list_of(NavigationLog) :nav_log
+    attribute :nav_log, list_of(NavigationLog)
 
     value_object "NavigationLog" do
       attribute :timestamp, String
@@ -285,7 +285,7 @@ Hecks.bluebook "AutonomousRescue", version: "2026.04.13.1" do
     attribute :map_version, String
     attribute :status, String
     attribute :sectors_mapped, Integer
-    list_of(DebrisSector) :sectors
+    attribute :sectors, list_of(DebrisSector)
 
     value_object "DebrisSector" do
       attribute :sector_id, String

--- a/hecks_conception/nursery/bed_and_breakfast/bed_and_breakfast.bluebook
+++ b/hecks_conception/nursery/bed_and_breakfast/bed_and_breakfast.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "BedAndBreakfast", version: "2026.04.13.1" do
     attribute :max_guests, Integer
     attribute :nightly_rate, Float
     attribute :status, String
-    list_of(Amenity) :amenities
+    attribute :amenities, list_of(Amenity)
 
     value_object "Amenity" do
       attribute :name, String
@@ -99,7 +99,7 @@ Hecks.bluebook "BedAndBreakfast", version: "2026.04.13.1" do
   aggregate "BreakfastMenu", "The morning meal offering for guests" do
     attribute :menu_id, String
     attribute :date, String
-    list_of(Course) :courses
+    attribute :courses, list_of(Course)
     attribute :status, String
 
     value_object "Course" do

--- a/hecks_conception/nursery/blood_supply_chain/blood_supply_chain.bluebook
+++ b/hecks_conception/nursery/blood_supply_chain/blood_supply_chain.bluebook
@@ -82,7 +82,7 @@ Hecks.bluebook "BloodSupplyChain", version: "2026.04.13.1" do
     attribute :blood_type, String
     attribute :quantity_units, Float
     attribute :status, String
-    list_of(TransportLeg) :legs
+    attribute :legs, list_of(TransportLeg)
     value_object "TransportLeg" do
       attribute :carrier, String
       attribute :departure_time, String

--- a/hecks_conception/nursery/bookstore_inventory/bookstore_inventory.bluebook
+++ b/hecks_conception/nursery/bookstore_inventory/bookstore_inventory.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "BookstoreInventory", version: "2026.04.13.1" do
     attribute :price, Float
     attribute :quantity_on_hand, Integer
     attribute :status, String
-    list_of(Edition) :editions
+    attribute :editions, list_of(Edition)
 
     specification "LowStock" do
       satisfied_by { quantity_on_hand < 5 }
@@ -62,7 +62,7 @@ Hecks.bluebook "BookstoreInventory", version: "2026.04.13.1" do
   aggregate "Author", "A writer whose works the store carries" do
     attribute :name, String
     attribute :biography, String
-    list_of(PublishedWork) :published_works
+    attribute :published_works, list_of(PublishedWork)
 
     value_object "PublishedWork" do
       attribute :title, String
@@ -94,7 +94,7 @@ Hecks.bluebook "BookstoreInventory", version: "2026.04.13.1" do
     attribute :label, String
     attribute :capacity, Integer
     attribute :current_count, Integer
-    list_of(ShelfSlot) :slots
+    attribute :slots, list_of(ShelfSlot)
 
     specification "Full" do
       satisfied_by { current_count >= capacity }
@@ -141,7 +141,7 @@ Hecks.bluebook "BookstoreInventory", version: "2026.04.13.1" do
   aggregate "Order", "A customer purchase — one or more titles being bought" do
     attribute :order_number, String
     attribute :customer_name, String
-    list_of(LineItem) :line_items
+    attribute :line_items, list_of(LineItem)
     attribute :total, Float
     attribute :status, String
 

--- a/hecks_conception/nursery/chiro_quality/chiro_quality.bluebook
+++ b/hecks_conception/nursery/chiro_quality/chiro_quality.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "ChiroQuality", version: "2026.04.13.1" do
     attribute :chief_complaint, String
     attribute :visit_date, String
     attribute :status, String
-    list_of(Adjustment) :adjustments
+    attribute :adjustments, list_of(Adjustment)
     value_object "Adjustment" do
       attribute :technique, String
       attribute :region, String

--- a/hecks_conception/nursery/community_garden/community_garden.bluebook
+++ b/hecks_conception/nursery/community_garden/community_garden.bluebook
@@ -95,7 +95,7 @@ Hecks.bluebook "CommunityGarden" do
     attribute :quantity, Integer
     attribute :storage_location, String
     attribute :status, String
-    list_of(LendingRecord) :lending_history
+    attribute :lending_history, list_of(LendingRecord)
 
     value_object "LendingRecord" do
       attribute :borrower_name, String
@@ -191,7 +191,7 @@ Hecks.bluebook "CommunityGarden" do
     attribute :organizer, String
     attribute :expected_attendees, Integer
     attribute :status, String
-    list_of(EventTask) :tasks
+    attribute :tasks, list_of(EventTask)
 
     value_object "EventTask" do
       attribute :task_name, String

--- a/hecks_conception/nursery/crisis_aviation/crisis_aviation.bluebook
+++ b/hecks_conception/nursery/crisis_aviation/crisis_aviation.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     attribute :affected_region, String
     attribute :severity, String
     attribute :status, String
-    list_of(AffectedSystem) :affected_systems
+    attribute :affected_systems, list_of(AffectedSystem)
     value_object "AffectedSystem" do
       attribute :system_type, String
       attribute :impact_level, String
@@ -59,7 +59,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     attribute :range_nm, Integer
     attribute :status, String
     reference_to(CrisisEvent, as: :assigned_crisis)
-    list_of(MissionLog) :missions
+    attribute :missions, list_of(MissionLog)
     value_object "MissionLog" do
       attribute :mission_type, String
       attribute :origin, String
@@ -111,7 +111,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     attribute :power_status, String
     attribute :accessibility, String
     attribute :status, String
-    list_of(DepartmentStatus) :departments
+    attribute :departments, list_of(DepartmentStatus)
     value_object "DepartmentStatus" do
       attribute :department_name, String
       attribute :operational_status, String
@@ -160,7 +160,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     attribute :substations_online, Integer
     attribute :substations_total, Integer
     attribute :grid_status, String
-    list_of(GeneratorDeployment) :generators
+    attribute :generators, list_of(GeneratorDeployment)
     value_object "GeneratorDeployment" do
       attribute :generator_id, String
       attribute :deployed_to, String
@@ -206,7 +206,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     reference_to(HospitalStatus, as: :target_hospital)
     attribute :rationale, String
     attribute :status, String
-    list_of(ScoringFactor) :factors
+    attribute :factors, list_of(ScoringFactor)
     value_object "ScoringFactor" do
       attribute :factor_name, String
       attribute :weight, Float
@@ -241,7 +241,7 @@ Hecks.bluebook "CrisisAviation", version: "2026.04.13.1" do
     attribute :queue_id, String
     reference_to(CrisisEvent, as: :crisis)
     attribute :status, String
-    list_of(PriorityEntry) :entries
+    attribute :entries, list_of(PriorityEntry)
     value_object "PriorityEntry" do
       attribute :patient_name, String
       attribute :acuity_level, String

--- a/hecks_conception/nursery/domain_compression/hecks/discovery.bluebook
+++ b/hecks_conception/nursery/domain_compression/hecks/discovery.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "Discovery", version: "2026.04.14.1" do
     attribute :pattern_signature, String
     attribute :cohesion_score, Float
     attribute :member_count, Integer
-    list_of(String) :member_domains
+    attribute :member_domains, list_of(String)
 
     command "DiscoverClusters" do
       role "Analyst"
@@ -49,7 +49,7 @@ Hecks.bluebook "Discovery", version: "2026.04.14.1" do
     attribute :aggregate_template_count, Integer
     attribute :command_template_count, Integer
     attribute :occurrence_count, Integer
-    list_of(String) :example_domains
+    attribute :example_domains, list_of(String)
 
     command "ExtractPrimitive" do
       role "Analyst"

--- a/hecks_conception/nursery/domain_narration/domain_narration.bluebook
+++ b/hecks_conception/nursery/domain_narration/domain_narration.bluebook
@@ -6,7 +6,7 @@ Hecks.bluebook "DomainNarration", version: "2026.04.13.1" do
 
   aggregate "Workflow", "An inferred step-by-step usage guide built from commands and policies" do
     attribute :domain_name, String
-    list_of(WorkflowStep) :steps
+    attribute :steps, list_of(WorkflowStep)
 
     value_object "WorkflowStep" do
       attribute :position, Integer
@@ -16,7 +16,7 @@ Hecks.bluebook "DomainNarration", version: "2026.04.13.1" do
       attribute :role, String
       attribute :emitted_event, String
       attribute :triggered_command, String
-      list_of(ExamplePair) :example_pairs
+      attribute :example_pairs, list_of(ExamplePair)
     end
 
     value_object "ExamplePair" do
@@ -55,7 +55,7 @@ Hecks.bluebook "DomainNarration", version: "2026.04.13.1" do
 
   aggregate "PolicyChain", "A traced cascade of policy reactions — command emits event, policy listens, triggers next command" do
     attribute :origin_command, String
-    list_of(ChainLink) :links
+    attribute :links, list_of(ChainLink)
     attribute :depth, Integer
 
     value_object "ChainLink" do

--- a/hecks_conception/nursery/donor_recruitment/donor_recruitment.bluebook
+++ b/hecks_conception/nursery/donor_recruitment/donor_recruitment.bluebook
@@ -38,7 +38,7 @@ Hecks.bluebook "DonorRecruitment", version: "2026.04.13.1" do
     attribute :budget, Float
     attribute :target_donors, Integer
     attribute :status, String
-    list_of(Keyword) :keywords
+    attribute :keywords, list_of(Keyword)
     value_object "Keyword" do
       attribute :term, String
       attribute :search_volume, Integer

--- a/hecks_conception/nursery/florist/florist.bluebook
+++ b/hecks_conception/nursery/florist/florist.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "Florist", version: "2026.04.13.1" do
     attribute :price, Float
     attribute :occasion, String
     attribute :status, String
-    list_of(StemSelection) :stems
+    attribute :stems, list_of(StemSelection)
 
     value_object "StemSelection" do
       attribute :flower_name, String
@@ -90,7 +90,7 @@ Hecks.bluebook "Florist", version: "2026.04.13.1" do
     attribute :event_date, String
     attribute :budget, Float
     attribute :status, String
-    list_of(EventPiece) :pieces
+    attribute :pieces, list_of(EventPiece)
 
     value_object "EventPiece" do
       attribute :arrangement_type, String

--- a/hecks_conception/nursery/grocery_store/grocery_store.bluebook
+++ b/hecks_conception/nursery/grocery_store/grocery_store.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "GroceryStore", version: "2026.04.13.1" do
     attribute :quantity, Integer
     attribute :expiration_date, String
     attribute :status, String
-    list_of(NutritionFact) :nutrition_facts
+    attribute :nutrition_facts, list_of(NutritionFact)
 
     value_object "NutritionFact" do
       attribute :nutrient, String
@@ -61,7 +61,7 @@ Hecks.bluebook "GroceryStore", version: "2026.04.13.1" do
     attribute :aisle_number, String
     attribute :category, String
     attribute :shelf_count, Integer
-    list_of(Planogram) :planograms
+    attribute :planograms, list_of(Planogram)
 
     value_object "Planogram" do
       attribute :sku, String
@@ -94,7 +94,7 @@ Hecks.bluebook "GroceryStore", version: "2026.04.13.1" do
     attribute :name, String
     attribute :contact_email, String
     attribute :delivery_schedule, String
-    list_of(SuppliedItem) :supplied_items
+    attribute :supplied_items, list_of(SuppliedItem)
 
     value_object "SuppliedItem" do
       attribute :sku, String

--- a/hecks_conception/nursery/heki/heki.bluebook
+++ b/hecks_conception/nursery/heki/heki.bluebook
@@ -92,8 +92,8 @@ Hecks.bluebook "Heki", version: "2026.04.11.2" do
 
   aggregate "Schema", "Embedded field definitions — the store describes itself" do
     attribute :store_name, String
-    list_of(FieldDef) :fields
-    list_of(String) :required_fields
+    attribute :fields, list_of(FieldDef)
+    attribute :required_fields, list_of(String)
 
     value_object "FieldDef" do
       attribute :name, String
@@ -104,8 +104,8 @@ Hecks.bluebook "Heki", version: "2026.04.11.2" do
       role "System"
       description "Declare the expected fields and types for a store — derived from the bluebook aggregate"
       attribute :store_name, String
-      list_of(FieldDef) :fields
-      list_of(String) :required_fields
+      attribute :fields, list_of(FieldDef)
+      attribute :required_fields, list_of(String)
       emits "SchemaDefined"
       then_set :store_name, to: :store_name
       then_set :fields, to: :fields

--- a/hecks_conception/nursery/hospital_power/hospital_power.bluebook
+++ b/hecks_conception/nursery/hospital_power/hospital_power.bluebook
@@ -116,7 +116,7 @@ Hecks.bluebook "HospitalPower", version: "2026.04.13.1" do
 
   aggregate "LoadShedPlan", "A plan for shedding non-critical loads during power shortage" do
     attribute :plan_id, String
-    list_of(ShedStep) :steps
+    attribute :steps, list_of(ShedStep)
     attribute :status, String
     value_object "ShedStep" do
       attribute :priority, Integer

--- a/hecks_conception/nursery/hotel_management/hotel_management.bluebook
+++ b/hecks_conception/nursery/hotel_management/hotel_management.bluebook
@@ -146,7 +146,7 @@ Hecks.bluebook "HotelManagement" do
   aggregate "Folio", "A guest's billing folio accumulating charges during their stay" do
     attribute :running_total, Float
     attribute :status, String
-    list_of(FolioCharge) :charges
+    attribute :charges, list_of(FolioCharge)
     reference_to(GuestStay)
 
     specification "HighSpend" do

--- a/hecks_conception/nursery/orthotics_fund/orthotics_fund.bluebook
+++ b/hecks_conception/nursery/orthotics_fund/orthotics_fund.bluebook
@@ -73,7 +73,7 @@ Hecks.bluebook "OrthoticsFund", version: "2026.04.13.1" do
     attribute :goal_amount, Float
     attribute :raised_amount, Float
     attribute :status, String
-    list_of(Pledge) :pledges
+    attribute :pledges, list_of(Pledge)
     value_object "Pledge" do
       attribute :donor_name, String
       attribute :amount, Float

--- a/hecks_conception/nursery/reentry_ecosystem/reentry_ecosystem.bluebook
+++ b/hecks_conception/nursery/reentry_ecosystem/reentry_ecosystem.bluebook
@@ -11,7 +11,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
     attribute :background_type, String
     attribute :risk_level, String
     attribute :status, String
-    list_of(ServiceNeed) :identified_needs
+    attribute :identified_needs, list_of(ServiceNeed)
     value_object "ServiceNeed" do
       attribute :category, String
       attribute :urgency, String
@@ -60,7 +60,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
     attribute :track_type, String
     attribute :institution, String
     attribute :status, String
-    list_of(CourseModule) :modules
+    attribute :modules, list_of(CourseModule)
     value_object "CourseModule" do
       attribute :module_name, String
       attribute :completion_status, String
@@ -107,7 +107,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
     attribute :address, String
     attribute :landlord_name, String
     attribute :status, String
-    list_of(StabilityCheck) :stability_checks
+    attribute :stability_checks, list_of(StabilityCheck)
     value_object "StabilityCheck" do
       attribute :check_date, String
       attribute :status, String
@@ -159,7 +159,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
     attribute :job_title, String
     attribute :start_date, String
     attribute :status, String
-    list_of(RetentionCheckIn) :check_ins
+    attribute :check_ins, list_of(RetentionCheckIn)
     value_object "RetentionCheckIn" do
       attribute :check_date, String
       attribute :employment_status, String
@@ -198,7 +198,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
     attribute :legal_need, String
     attribute :attorney_name, String
     attribute :status, String
-    list_of(CourtDate) :court_dates
+    attribute :court_dates, list_of(CourtDate)
     value_object "CourtDate" do
       attribute :date, String
       attribute :court_name, String
@@ -241,7 +241,7 @@ Hecks.bluebook "ReentryEcosystem", version: "2026.04.13.1" do
   aggregate "MilestoneTracker", "Cross-service milestone tracking — housing, education, employment, legal milestones in one view" do
     reference_to(ReentryCase, as: :case)
     attribute :overall_progress, String
-    list_of(Milestone) :milestones
+    attribute :milestones, list_of(Milestone)
     value_object "Milestone" do
       attribute :category, String
       attribute :description, String

--- a/hecks_conception/nursery/ski_resort/ski_resort.bluebook
+++ b/hecks_conception/nursery/ski_resort/ski_resort.bluebook
@@ -53,7 +53,7 @@ Hecks.bluebook "SkiResort", version: "2026.04.13.1" do
     attribute :length_km, Float
     attribute :groomed, String
     attribute :status, String
-    list_of(HazardMarker) :hazards
+    attribute :hazards, list_of(HazardMarker)
 
     value_object "HazardMarker" do
       attribute :hazard_type, String

--- a/hecks_conception/nursery/smart_facility/smart_facility.bluebook
+++ b/hecks_conception/nursery/smart_facility/smart_facility.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "SmartFacility", version: "2026.04.13.1" do
     attribute :room_number, String
     attribute :care_level, String
     attribute :status, String
-    list_of(DailyNeed) :daily_needs
+    attribute :daily_needs, list_of(DailyNeed)
     value_object "DailyNeed" do
       attribute :need_type, String
       attribute :time_of_day, String
@@ -71,7 +71,7 @@ Hecks.bluebook "SmartFacility", version: "2026.04.13.1" do
   aggregate "ReminderSchedule", "A personalized reminder schedule for a resident" do
     attribute :schedule_id, String
     attribute :resident_id, String
-    list_of(ReminderItem) :items
+    attribute :items, list_of(ReminderItem)
     attribute :status, String
     value_object "ReminderItem" do
       attribute :reminder_type, String
@@ -100,7 +100,7 @@ Hecks.bluebook "SmartFacility", version: "2026.04.13.1" do
   aggregate "ActivityBoard", "A communal activity board showing daily events" do
     attribute :board_id, String
     attribute :date, String
-    list_of(Activity) :activities
+    attribute :activities, list_of(Activity)
     attribute :status, String
     value_object "Activity" do
       attribute :name, String

--- a/hecks_conception/nursery/smart_ot/smart_ot.bluebook
+++ b/hecks_conception/nursery/smart_ot/smart_ot.bluebook
@@ -82,7 +82,7 @@ Hecks.bluebook "SmartOT", version: "2026.04.13.1" do
     attribute :device_id, String
     attribute :duration_minutes, Float
     attribute :independence_level, String
-    list_of(Assist) :assists
+    attribute :assists, list_of(Assist)
     value_object "Assist" do
       attribute :assist_type, String
       attribute :device_used, String

--- a/hecks_conception/nursery/surf_shop/surf_shop.bluebook
+++ b/hecks_conception/nursery/surf_shop/surf_shop.bluebook
@@ -11,7 +11,7 @@ Hecks.bluebook "SurfShop", version: "2026.04.13.1" do
     attribute :volume_liters, Float
     attribute :price, Float
     attribute :status, String
-    list_of(FinSetup) :fin_setups
+    attribute :fin_setups, list_of(FinSetup)
 
     value_object "FinSetup" do
       attribute :fin_system, String

--- a/hecks_conception/nursery/tag_management/hecks/tag_management.bluebook
+++ b/hecks_conception/nursery/tag_management/hecks/tag_management.bluebook
@@ -53,7 +53,7 @@ Hecks.bluebook "TagManagement", version: "2026.04.11.1" do
     attribute :firing_order, Integer
     attribute :template, String
     attribute :custom_html, String
-    list_of(ConfigEntry) :config
+    attribute :config, list_of(ConfigEntry)
     attribute :consent_required, String
     attribute :status, String
 
@@ -151,7 +151,7 @@ Hecks.bluebook "TagManagement", version: "2026.04.11.1" do
     attribute :name, String
     attribute :trigger_type, String
     attribute :container_id, String
-    list_of(Condition) :conditions
+    attribute :conditions, list_of(Condition)
     attribute :description, String
 
     value_object "Condition" do

--- a/hecks_conception/nursery/therapy_music/therapy_music.bluebook
+++ b/hecks_conception/nursery/therapy_music/therapy_music.bluebook
@@ -40,7 +40,7 @@ Hecks.bluebook "TherapyMusic", version: "2026.04.13.1" do
     attribute :name, String
     attribute :target_bpm, Integer
     attribute :genre, String
-    list_of(Track) :tracks
+    attribute :tracks, list_of(Track)
     attribute :status, String
     value_object "Track" do
       attribute :title, String


### PR DESCRIPTION
## Summary

Third nursery parity batch. Mechanical sweep: `list_of(Type) :field` → `attribute :field, list_of(Type)`.

Nursery parity: **112/375 → 136/375** (+24). Hard parity unchanged (125/125). Verified against origin/main (pre-#305, pre-#307).

## Scope note — different error class than #305 / #307

PR #305 migrated 23 files on the strict-mode arg swaps (`reference_to "X"` → `reference_to(X)`, `list_of "X"` → `list_of(X)`). PR #307 extracted 19 files of inline `list_of "X" do ... end` blocks into `value_object` + bare-constant `list_of(X)`. Between them they cleared the entire 66-file strict-mode pool, minus 5 acronym-casing blockers (inbox i47).

This batch picks up the adjacent pattern from `docs/plans/i31_expand_parity_coverage.md` — **Gate A**, the 173 ImplicitSyntax files where Ruby errors with `syntax error, unexpected ':'` on:

```ruby
list_of(TargetingRule) :targeting_rules
```

The fix is identical-flavor mechanical: move the symbol onto an `attribute`:

```ruby
attribute :targeting_rules, list_of(TargetingRule)
```

Rust accepts both shapes; Ruby only the latter. 24 files, each independently verified to produce identical canonical IR in Ruby and Rust after the swap.

## Drift pattern fixed

| Pattern | Count |
|---|---|
| `list_of(Type) :field` → `attribute :field, list_of(Type)` | 55 sites across 24 files |

Diff: **+55 / -55** (24 files). Well under the 600-line cap.

## Files migrated (24)

- advertising_generation (2 sites)
- autonomous_rescue (4)
- bed_and_breakfast (2)
- blood_supply_chain (1)
- bookstore_inventory (4)
- chiro_quality (1)
- community_garden (2)
- crisis_aviation (6)
- domain_compression/hecks/discovery (2)
- domain_narration (3)
- donor_recruitment (1)
- florist (2)
- grocery_store (3)
- heki (4)
- hospital_power (1)
- hotel_management (1)
- orthotics_fund (1)
- reentry_ecosystem (6)
- ski_resort (1)
- smart_facility (3)
- smart_ot (1)
- surf_shop (1)
- tag_management/hecks/tag_management (2)
- therapy_music (1)

## Candidates skipped

- **5 files with acronym-casing blockers** (noted, filed as inbox i47): air_cargo/ULDPallet, customs_brokerage/CBPInspection, animal_genetics/DNAProfile, scientific_pest_mgmt/IPMPlan, thermal_comfort/HVACEquipment.
- **Files where top-level `lifecycle`/`cross_domain`/`event` methods fire before the list_of swap can take effect.** Belongs to Gate C (Ruby DSL catch-up, ~33 files in the plan). Examples skipped: ad_tech_platform, mobile_app_store, payment_gateway, cloud_hosting, data_center, dev_ops_pipeline, email_marketing, content_moderation, digital_signage, crowdfunding_platform, api_marketplace, streaming_platform, saa_s_platform, network_operations, freelance_marketplace, domain_registrar, e_learning, online_auction, qa_test_lab, seo_agency, medical_media, universal_domain_pattern.
- **Files with `fixture` errors at the aggregate level.** Also Gate C. Examples: urban_forestry, wildlife_forensics, route_optimization, ux_research, youth_mentoring, vet_training, thrift_store, ticketing_platform, web_accessibility, urban_farm, relief_workers, zero_waste_farm, governed_operations, rv_wiring_sheet, vision_api.

## Interesting drift patterns newly observed

- No new pattern classes surfaced. Every file in this batch passes parity after the single mechanical swap. The pattern is well-typed: a single regex `/^(\s*)list_of\(([^)]+)\)[ \t]+:(\w+)[ \t]*$/` caught all 55 sites cleanly without false positives.
- Gate A is much denser than I expected: 173 candidate files in the nursery, and ~60% of them pass with just the swap. The other ~40% hit Gate C blockers (lifecycle/fixture/event) that fire first. A companion batch after Gate C could likely clear another 60-80 files with this same swap.

## Test plan

- [x] `ruby -Ilib spec/parity/parity_test.rb` — nursery 136/375, hard 125/125, exit code matches main
- [x] Each of the 24 named files shows ✓ in the parity run
- [x] Antibody hook passes on all 24 files (all edits are `.bluebook`)
- [x] Diff size: 110 lines (+55 -55), under 600-line cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)