### PR TITLE
feat(behaviors): parser support for loads + then_events_include (i43 commits 3-5; no consumers yet)

### DIFF
--- a/hecks_life/src/behaviors_conceiver/vector.rs
+++ b/hecks_life/src/behaviors_conceiver/vector.rs
@@ -104,6 +104,7 @@ mod tests {
             }).collect(),
             input: BTreeMap::new(),
             expect,
+            events_include: vec![],
         }
     }
 
@@ -119,6 +120,7 @@ mod tests {
                 mk_test("command", "Order", 1, Some("status")),
                 mk_test("command", "Order", 0, Some("refused")),
             ],
+            loads: vec![],
         };
         let v = extract_vector(&suite);
         assert_eq!(v[0], 5.0);                       // test_count

--- a/hecks_life/src/behaviors_ir.rs
+++ b/hecks_life/src/behaviors_ir.rs
@@ -12,6 +12,17 @@ pub struct TestSuite {
     pub name: String,
     pub vision: Option<String>,
     pub tests: Vec<Test>,
+    /// Sibling bluebooks the runner should merge into the test domain.
+    ///
+    /// Populated by `loads "pulse", "body"` in the `.behaviors` DSL. Each
+    /// entry is a bluebook name the runner resolves to a source file; the
+    /// resolved bluebook's aggregates/policies/value_objects merge into the
+    /// single Domain the tests execute against. Empty by default — every
+    /// pre-i43 `.behaviors` file parses with an empty Vec and behaves
+    /// identically to before.
+    ///
+    /// IR slot only in this commit: no consumer reads this field yet.
+    pub loads: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -30,6 +41,16 @@ pub struct Test {
     pub input: BTreeMap<String, String>,
     /// Assert-phase key/value pairs. Reserved keys: count, refused, <attr>_size.
     pub expect: BTreeMap<String, String>,
+    /// Set-membership assertion over events fired during the act phase.
+    ///
+    /// Populated by `then_events_include "BodyPulse", "FatigueAccumulated"`
+    /// in a test block. Complements strict-order `expect emits:` with a
+    /// superset check suited to cross-bluebook cascades whose event ordering
+    /// is a runtime-drain-order detail, not a semantic contract. Empty by
+    /// default — pre-i43 tests behave identically.
+    ///
+    /// IR slot only in this commit: no consumer reads this field yet.
+    pub events_include: Vec<String>,
 }
 
 #[derive(Debug)]

--- a/hecks_life/src/behaviors_parser.rs
+++ b/hecks_life/src/behaviors_parser.rs
@@ -37,6 +37,12 @@ pub fn parse(source: &str) -> TestSuite {
             if let Some(name) = extract_string(line) { suite.name = name; }
         } else if line.starts_with("vision") {
             if let Some(v) = extract_string(line) { suite.vision = Some(v); }
+        } else if line.starts_with("loads ") || line.starts_with("loads\t") || line == "loads" {
+            // `loads "a", "b", "c"` — zero or more quoted names. Empty
+            // `loads` with no arguments records nothing (same as absent).
+            for name in extract_all_strings(line) {
+                suite.loads.push(name);
+            }
         } else if line.starts_with("test ") || line.starts_with("test\t") {
             let (test, consumed) = parse_test(&lines[i..]);
             suite.tests.push(test);
@@ -47,6 +53,39 @@ pub fn parse(source: &str) -> TestSuite {
     }
 
     suite
+}
+
+/// Return every double-quoted substring on `line`, in source order. Used
+/// to pluck the variadic `"a", "b", "c"` argument list of `loads` and
+/// `then_events_include`. Honors backslash-escaped quotes inside strings.
+fn extract_all_strings(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            let mut j = i + 1;
+            let mut buf = String::new();
+            while j < bytes.len() && bytes[j] != b'"' {
+                if bytes[j] == b'\\' && j + 1 < bytes.len() {
+                    buf.push(bytes[j + 1] as char);
+                    j += 2;
+                } else {
+                    buf.push(bytes[j] as char);
+                    j += 1;
+                }
+            }
+            if j < bytes.len() {
+                out.push(buf);
+                i = j + 1;
+                continue;
+            } else {
+                break;
+            }
+        }
+        i += 1;
+    }
+    out
 }
 
 fn parse_test(lines: &[&str]) -> (Test, usize) {
@@ -108,6 +147,15 @@ fn interpret_test_line(line: &str, test: &mut Test) {
         test.input = parse_kwargs_only(line, "input");
     } else if line.starts_with("expect ") || line.starts_with("expect\t") || line == "expect" {
         test.expect = parse_kwargs_only(line, "expect");
+    } else if line.starts_with("then_events_include ")
+        || line.starts_with("then_events_include\t")
+        || line == "then_events_include"
+    {
+        // `then_events_include "A", "B", "C"` — set-membership assertion
+        // over events fired during the act phase. Variadic, zero or more.
+        for name in extract_all_strings(line) {
+            test.events_include.push(name);
+        }
     }
 }
 
@@ -192,4 +240,133 @@ pub fn is_behaviors_source(source: &str) -> bool {
         return t.starts_with("Hecks.behaviors");
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn suite_src(body: &str) -> String {
+        format!(
+            "Hecks.behaviors \"Pizzas\" do\n  vision \"v\"\n{}end\n",
+            body
+        )
+    }
+
+    #[test]
+    fn loads_single_name_records_one_entry() {
+        let src = suite_src("  loads \"pulse\"\n");
+        let suite = parse(&src);
+        assert_eq!(suite.loads, vec!["pulse".to_string()]);
+    }
+
+    #[test]
+    fn loads_multiple_names_records_them_in_order() {
+        let src = suite_src("  loads \"body\", \"being\", \"sleep\"\n");
+        let suite = parse(&src);
+        assert_eq!(
+            suite.loads,
+            vec!["body".to_string(), "being".to_string(), "sleep".to_string()]
+        );
+    }
+
+    #[test]
+    fn no_loads_line_leaves_loads_empty() {
+        let src = suite_src(
+            "  test \"Create sets name\" do\n    \
+              tests \"CreatePizza\", on: \"Pizza\"\n    \
+              input  name: \"M\"\n    \
+              expect name: \"M\"\n  end\n",
+        );
+        let suite = parse(&src);
+        assert!(suite.loads.is_empty(), "loads should default to empty");
+    }
+
+    #[test]
+    fn then_events_include_single_name_records_one_entry() {
+        let src = suite_src(
+            "  test \"Cascade fires\" do\n    \
+              tests \"Tick\", on: \"Mindstream\"\n    \
+              input  at: \"T0\"\n    \
+              then_events_include \"BodyPulse\"\n  end\n",
+        );
+        let suite = parse(&src);
+        assert_eq!(suite.tests.len(), 1);
+        assert_eq!(suite.tests[0].events_include, vec!["BodyPulse".to_string()]);
+    }
+
+    #[test]
+    fn then_events_include_multiple_names_in_order() {
+        let src = suite_src(
+            "  test \"Cascade fires\" do\n    \
+              tests \"Tick\", on: \"Mindstream\"\n    \
+              input  at: \"T0\"\n    \
+              then_events_include \"BodyPulse\", \"FatigueAccumulated\", \"SynapsesPruned\"\n  end\n",
+        );
+        let suite = parse(&src);
+        assert_eq!(
+            suite.tests[0].events_include,
+            vec![
+                "BodyPulse".to_string(),
+                "FatigueAccumulated".to_string(),
+                "SynapsesPruned".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_then_events_include_leaves_events_include_empty() {
+        let src = suite_src(
+            "  test \"Plain\" do\n    \
+              tests \"CreatePizza\", on: \"Pizza\"\n    \
+              input  name: \"M\"\n    \
+              expect name: \"M\"\n  end\n",
+        );
+        let suite = parse(&src);
+        assert!(suite.tests[0].events_include.is_empty());
+    }
+
+    #[test]
+    fn suite_with_loads_plus_mixed_tests() {
+        // Suite-level loads, one test with then_events_include, another without.
+        let src = "Hecks.behaviors \"Mindstream\" do\n  \
+          vision \"v\"\n  \
+          loads \"pulse\", \"body\"\n  \
+          test \"Fans out\" do\n    \
+            tests \"Tick\", on: \"Mindstream\"\n    \
+            input  at: \"T0\"\n    \
+            then_events_include \"BodyPulse\", \"FatigueAccumulated\"\n  \
+          end\n  \
+          test \"Plain\" do\n    \
+            tests \"CreateNote\", on: \"Mindstream\"\n    \
+            input  body: \"hi\"\n    \
+            expect body: \"hi\"\n  \
+          end\n\
+          end\n";
+        let suite = parse(src);
+        assert_eq!(
+            suite.loads,
+            vec!["pulse".to_string(), "body".to_string()]
+        );
+        assert_eq!(suite.tests.len(), 2);
+        assert_eq!(
+            suite.tests[0].events_include,
+            vec!["BodyPulse".to_string(), "FatigueAccumulated".to_string()]
+        );
+        assert!(suite.tests[1].events_include.is_empty());
+    }
+
+    #[test]
+    fn extract_all_strings_handles_multiple_tokens() {
+        assert_eq!(
+            extract_all_strings("loads \"a\", \"b\", \"c\""),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_all_strings_empty_when_no_quotes() {
+        let r: Vec<String> = extract_all_strings("loads");
+        assert!(r.is_empty());
+    }
 }

--- a/hecks_life/src/behaviors_parser.rs
+++ b/hecks_life/src/behaviors_parser.rs
@@ -25,6 +25,7 @@ pub fn parse(source: &str) -> TestSuite {
         name: String::new(),
         vision: None,
         tests: vec![],
+        loads: vec![],
     };
     let lines: Vec<&str> = source.lines().collect();
     let mut i = 0;
@@ -59,6 +60,7 @@ fn parse_test(lines: &[&str]) -> (Test, usize) {
         setups: vec![],
         input: BTreeMap::new(),
         expect: BTreeMap::new(),
+        events_include: vec![],
     };
 
     let mut i = 1;

--- a/hecks_life/tests/behaviors_loads_parity_test.rs
+++ b/hecks_life/tests/behaviors_loads_parity_test.rs
@@ -1,0 +1,39 @@
+//! behaviors_loads_parity_test — toy i43 parse-parity fixture (Rust half)
+//!
+//! Parses `spec/parity/behaviors/loads_parse_smoke.behaviors` and asserts
+//! that suite.loads and test.events_include match the values declared in
+//! the file. The Ruby half lives in
+//! `spec/hecks/dsl/loads_parse_smoke_parity_spec.rb` — together they
+//! prove both parsers produce equivalent IR for the new i43 DSL forms.
+//!
+//! No runtime consumer yet (commits 3-5 are parser-only). When the
+//! merge-domain runner lands (commit 6 of the plan), this fixture
+//! gains a sibling `.bluebook` and joins the full behaviors parity
+//! suite.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture_path() -> PathBuf {
+    // Cargo runs tests from the hecks_life crate root.
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.push("spec/parity/behaviors/loads_parse_smoke.behaviors");
+    p
+}
+
+#[test]
+fn rust_parser_records_loads_and_then_events_include() {
+    let src = fs::read_to_string(fixture_path())
+        .expect("read loads_parse_smoke.behaviors");
+    let suite = hecks_life::behaviors_parser::parse(&src);
+
+    assert_eq!(suite.name, "LoadsParseSmoke");
+    assert_eq!(suite.loads, vec!["foo".to_string()]);
+    assert_eq!(suite.tests.len(), 1);
+    assert_eq!(
+        suite.tests[0].events_include,
+        vec!["Bar".to_string()],
+        "Rust parser must populate test.events_include from then_events_include"
+    );
+}

--- a/lib/hecks/bluebook_model/structure/test.rb
+++ b/lib/hecks/bluebook_model/structure/test.rb
@@ -29,17 +29,27 @@ module Hecks
     module Structure
       class Test
         attr_reader :description, :tests_command, :on_aggregate, :kind,
-                    :setups, :input, :expect
+                    :setups, :input, :expect, :events_include
 
+        # @return [Array<String>] set-membership assertion over events fired
+        #
+        # Populated by `then_events_include "BodyPulse", "FatigueAccumulated"`
+        # in a `.behaviors` test block. Complements strict-order `expect emits:`
+        # with a superset check suited to cross-bluebook cascades whose event
+        # ordering is a runtime-drain-order detail, not a semantic contract.
+        # Empty by default — pre-i43 tests behave identically.
+        #
+        # IR slot only in this commit: no consumer reads this field yet.
         def initialize(description:, tests_command:, on_aggregate:, kind: :command,
-                       setups: [], input: {}, expect: {})
-          @description   = description
-          @tests_command = tests_command
-          @on_aggregate  = on_aggregate
-          @kind          = kind.to_sym
-          @setups        = setups
-          @input         = input
-          @expect        = expect
+                       setups: [], input: {}, expect: {}, events_include: [])
+          @description    = description
+          @tests_command  = tests_command
+          @on_aggregate   = on_aggregate
+          @kind           = kind.to_sym
+          @setups         = setups
+          @input          = input
+          @expect         = expect
+          @events_include = events_include
         end
 
         def ==(other)
@@ -50,12 +60,14 @@ module Hecks
             kind == other.kind &&
             setups == other.setups &&
             input == other.input &&
-            expect == other.expect
+            expect == other.expect &&
+            events_include == other.events_include
         end
         alias eql? ==
 
         def hash
-          [description, tests_command, on_aggregate, kind, setups, input, expect].hash
+          [description, tests_command, on_aggregate, kind, setups,
+           input, expect, events_include].hash
         end
       end
 

--- a/lib/hecks/bluebook_model/structure/test_suite.rb
+++ b/lib/hecks/bluebook_model/structure/test_suite.rb
@@ -29,22 +29,36 @@ module Hecks
         # @return [Array<Test>] the individual tests in this suite
         attr_reader :tests
 
-        def initialize(name:, vision: nil, tests: [])
+        # @return [Array<String>] sibling bluebooks to load into the test domain
+        #
+        # Populated by `loads "pulse", "body"` in the `.behaviors` DSL. Each
+        # entry is a bluebook name resolved to a file by the runner; the
+        # resolved bluebook's aggregates/policies/value_objects merge into
+        # the single Domain the tests execute against. Empty by default —
+        # every pre-i43 `.behaviors` file parses with an empty list and
+        # behaves identically to before.
+        #
+        # IR slot only in this commit: no consumer reads this field yet.
+        attr_reader :loads
+
+        def initialize(name:, vision: nil, tests: [], loads: [])
           @name = name
           @vision = vision
           @tests = tests
+          @loads = loads
         end
 
         def ==(other)
           other.is_a?(TestSuite) &&
             name == other.name &&
             vision == other.vision &&
-            tests == other.tests
+            tests == other.tests &&
+            loads == other.loads
         end
         alias eql? ==
 
         def hash
-          [name, vision, tests].hash
+          [name, vision, tests, loads].hash
         end
       end
     end

--- a/lib/hecks/dsl/test_builder.rb
+++ b/lib/hecks/dsl/test_builder.rb
@@ -14,13 +14,14 @@ module Hecks
   module DSL
     class TestBuilder
       def initialize(description)
-        @description   = description
-        @tests_command = nil
-        @on_aggregate  = nil
-        @kind          = :command
-        @setups        = []
-        @input         = {}
-        @expect        = {}
+        @description    = description
+        @tests_command  = nil
+        @on_aggregate   = nil
+        @kind           = :command
+        @setups         = []
+        @input          = {}
+        @expect         = {}
+        @events_include = []
       end
 
       def tests(command, on:, kind: :command)
@@ -43,15 +44,32 @@ module Hecks
         @expect = assertions
       end
 
+      # Assert the act-phase event log is a superset of these names.
+      #
+      #   then_events_include "BodyPulse", "FatigueAccumulated"
+      #
+      # Complements strict-order `expect emits:` — use this for
+      # cross-bluebook cascades where relative event ordering is a
+      # drain-order detail, not a semantic contract. Append-only so
+      # multiple lines accumulate; order in the list is irrelevant to
+      # the assertion but preserved for readable diagnostics.
+      #
+      # No consumer in this commit; the IR field is populated so the
+      # runtime assertion logic (commit 7 of the plan) can read it.
+      def then_events_include(*event_names)
+        @events_include.concat(event_names.map(&:to_s))
+      end
+
       def build
         BluebookModel::Structure::Test.new(
-          description:   @description,
-          tests_command: @tests_command,
-          on_aggregate:  @on_aggregate,
-          kind:          @kind,
-          setups:        @setups,
-          input:         @input,
-          expect:        @expect,
+          description:    @description,
+          tests_command:  @tests_command,
+          on_aggregate:   @on_aggregate,
+          kind:           @kind,
+          setups:         @setups,
+          input:          @input,
+          expect:         @expect,
+          events_include: @events_include,
         )
       end
     end

--- a/lib/hecks/dsl/test_builder.rb
+++ b/lib/hecks/dsl/test_builder.rb
@@ -51,13 +51,26 @@ module Hecks
       # Complements strict-order `expect emits:` — use this for
       # cross-bluebook cascades where relative event ordering is a
       # drain-order detail, not a semantic contract. Append-only so
-      # multiple lines accumulate; order in the list is irrelevant to
-      # the assertion but preserved for readable diagnostics.
+      # multiple lines accumulate; declaration order is preserved for
+      # diagnostic output but is irrelevant to the set-membership check
+      # itself. Mirrors the Rust parser's `test.events_include.push`
+      # order, keeping Ruby/Rust parity byte-for-byte.
+      #
+      # Validation — empty strings are rejected at DSL-build time so
+      # the assertion never looks for a blank event name. A blank
+      # argument (after `to_s`) raises ArgumentError with the full
+      # list for context.
       #
       # No consumer in this commit; the IR field is populated so the
       # runtime assertion logic (commit 7 of the plan) can read it.
       def then_events_include(*event_names)
-        @events_include.concat(event_names.map(&:to_s))
+        normalized = event_names.map(&:to_s)
+        if (blank = normalized.find { |n| n.strip.empty? })
+          raise ArgumentError,
+                "then_events_include: event name cannot be blank " \
+                "(got #{blank.inspect} in #{normalized.inspect})"
+        end
+        @events_include.concat(normalized)
       end
 
       def build

--- a/lib/hecks/dsl/test_suite_builder.rb
+++ b/lib/hecks/dsl/test_suite_builder.rb
@@ -25,6 +25,7 @@ module Hecks
         @name   = name
         @vision = nil
         @tests  = []
+        @loads  = []
       end
 
       def vision(text)
@@ -37,9 +38,24 @@ module Hecks
         @tests << builder.build
       end
 
+      # Declare sibling bluebooks to merge into the test domain.
+      #
+      #   loads "pulse", "body"
+      #
+      # Each name is a bluebook — the `.behaviors` runner resolves it
+      # to a file, parses it, and merges its aggregates/policies/
+      # value_objects into the single Domain tests execute against.
+      # Append-only so multiple `loads` lines accumulate.
+      #
+      # No consumer in this commit; the IR field is populated so the
+      # runtime merge-domain logic (commit 6) can read it.
+      def loads(*names)
+        @loads.concat(names.map(&:to_s))
+      end
+
       def build
         BluebookModel::Structure::TestSuite.new(
-          name: @name, vision: @vision, tests: @tests,
+          name: @name, vision: @vision, tests: @tests, loads: @loads,
         )
       end
     end

--- a/lib/hecks/dsl/test_suite_builder.rb
+++ b/lib/hecks/dsl/test_suite_builder.rb
@@ -45,12 +45,26 @@ module Hecks
       # Each name is a bluebook — the `.behaviors` runner resolves it
       # to a file, parses it, and merges its aggregates/policies/
       # value_objects into the single Domain tests execute against.
-      # Append-only so multiple `loads` lines accumulate.
+      # Append-only so multiple `loads` lines accumulate; declaration
+      # order is preserved and mirrors the Rust parser's
+      # `suite.loads.push` order, keeping Ruby/Rust parity byte-for-byte
+      # on every `.behaviors` fixture.
+      #
+      # Validation — empty strings are rejected at DSL-build time so the
+      # runner never tries to resolve the empty name to a file path.
+      # A blank argument (after `to_s`) raises ArgumentError with the
+      # full names list for context.
       #
       # No consumer in this commit; the IR field is populated so the
       # runtime merge-domain logic (commit 6) can read it.
       def loads(*names)
-        @loads.concat(names.map(&:to_s))
+        normalized = names.map(&:to_s)
+        if (blank = normalized.find { |n| n.strip.empty? })
+          raise ArgumentError,
+                "loads: bluebook name cannot be blank (got #{blank.inspect} " \
+                "in #{normalized.inspect})"
+        end
+        @loads.concat(normalized)
       end
 
       def build

--- a/spec/hecks/dsl/loads_parse_smoke_parity_spec.rb
+++ b/spec/hecks/dsl/loads_parse_smoke_parity_spec.rb
@@ -1,0 +1,40 @@
+# spec/hecks/dsl/loads_parse_smoke_parity_spec.rb
+#
+# Ruby half of the i43 parse-parity toy fixture. Loads
+# `spec/parity/behaviors/loads_parse_smoke.behaviors` via the Ruby
+# DSL and asserts suite.loads + test.events_include contain the
+# same values the Rust side asserts in
+# `hecks_life/tests/behaviors_loads_parity_test.rs`. Together they
+# prove both parsers produce equivalent IR for the new i43 DSL
+# forms, commits 3-5 scope.
+#
+# [antibody-exempt: parse-parity proof for .behaviors DSL — the Ruby
+#  half of the toy fixture cross-check; no runner consumer yet.]
+#
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+require "hecks"
+require "hecks/dsl/test_suite_builder"
+
+RSpec.describe "i43 loads_parse_smoke.behaviors — Ruby parse" do
+  let(:fixture) do
+    File.expand_path(
+      "../../parity/behaviors/loads_parse_smoke.behaviors", __dir__,
+    )
+  end
+
+  it "exists (Rust side reads the same file)" do
+    expect(File).to be_file(fixture)
+  end
+
+  it "parses suite.loads and test.events_include via Hecks.behaviors" do
+    Hecks.instance_variable_set(:@last_test_suite, nil)
+    Kernel.load(fixture)
+    suite = Hecks.last_test_suite
+
+    expect(suite).not_to be_nil
+    expect(suite.name).to eq("LoadsParseSmoke")
+    expect(suite.loads).to eq(["foo"])
+    expect(suite.tests.size).to eq(1)
+    expect(suite.tests[0].events_include).to eq(["Bar"])
+  end
+end

--- a/spec/hecks/dsl/test_suite_builder_loads_spec.rb
+++ b/spec/hecks/dsl/test_suite_builder_loads_spec.rb
@@ -1,0 +1,163 @@
+# spec/hecks/dsl/test_suite_builder_loads_spec.rb
+#
+# Contract for Hecks::DSL::TestSuiteBuilder#loads and
+# Hecks::DSL::TestBuilder#then_events_include — the i43 cross-bluebook
+# behaviors DSL surface (commits 3-5 of the plan, parser-only scope).
+#
+# When a `.behaviors` suite declares `loads "pulse", "body"`, those
+# names land on TestSuite#loads in declaration order. When a test
+# inside the suite declares `then_events_include "BodyPulse", ...`,
+# those names land on Test#events_include. Both fields are empty by
+# default — pre-i43 `.behaviors` files build identically.
+#
+# Parity contract (spec/parity/behaviors_parity_test.rb) owns the
+# Ruby/Rust output diff. This spec owns the Ruby-side surface: what
+# the builder methods accept, how they validate, and what the IR
+# contains afterwards.
+#
+# [antibody-exempt: spec for .behaviors DSL builder — the builder is
+#  the Ruby half of the loads/then_events_include parser pair; tests
+#  live alongside the builder they protect.]
+#
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+require "hecks/bluebook_model/structure/test_suite"
+require "hecks/bluebook_model/structure/test"
+require "hecks/dsl/test_suite_builder"
+
+RSpec.describe Hecks::DSL::TestSuiteBuilder do
+  describe "#loads" do
+    it "records a single bluebook name" do
+      builder = described_class.new("Mindstream")
+      builder.loads("pulse")
+
+      expect(builder.build.loads).to eq(["pulse"])
+    end
+
+    it "records multiple names in declaration order" do
+      builder = described_class.new("Mindstream")
+      builder.loads("pulse", "body", "being")
+
+      expect(builder.build.loads).to eq(%w[pulse body being])
+    end
+
+    it "accumulates across multiple calls" do
+      builder = described_class.new("Mindstream")
+      builder.loads("pulse")
+      builder.loads("body", "being")
+
+      expect(builder.build.loads).to eq(%w[pulse body being])
+    end
+
+    it "leaves loads empty when not called (pre-i43 shape)" do
+      builder = described_class.new("Pizzas")
+
+      expect(builder.build.loads).to eq([])
+    end
+
+    it "coerces non-string args via to_s" do
+      builder = described_class.new("Mindstream")
+      builder.loads(:pulse)
+
+      expect(builder.build.loads).to eq(["pulse"])
+    end
+
+    it "raises ArgumentError on an empty string" do
+      builder = described_class.new("Mindstream")
+
+      expect { builder.loads("pulse", "") }.to raise_error(
+        ArgumentError, /bluebook name cannot be blank/
+      )
+    end
+
+    it "raises ArgumentError on a whitespace-only string" do
+      builder = described_class.new("Mindstream")
+
+      expect { builder.loads("   ") }.to raise_error(
+        ArgumentError, /bluebook name cannot be blank/
+      )
+    end
+  end
+end
+
+RSpec.describe Hecks::DSL::TestBuilder do
+  describe "#then_events_include" do
+    def build_test(&block)
+      b = Hecks::DSL::TestBuilder.new("desc")
+      b.tests "SomeCmd", on: "SomeAgg"
+      b.instance_eval(&block)
+      b.build
+    end
+
+    it "records a single event name" do
+      test = build_test { then_events_include "BodyPulse" }
+      expect(test.events_include).to eq(["BodyPulse"])
+    end
+
+    it "records multiple names in declaration order" do
+      test = build_test do
+        then_events_include "BodyPulse", "FatigueAccumulated", "SynapsesPruned"
+      end
+      expect(test.events_include).to eq(
+        %w[BodyPulse FatigueAccumulated SynapsesPruned],
+      )
+    end
+
+    it "accumulates across multiple calls" do
+      test = build_test do
+        then_events_include "BodyPulse"
+        then_events_include "FatigueAccumulated", "SynapsesPruned"
+      end
+      expect(test.events_include).to eq(
+        %w[BodyPulse FatigueAccumulated SynapsesPruned],
+      )
+    end
+
+    it "leaves events_include empty when not called (pre-i43 shape)" do
+      test = build_test { input name: "x" }
+      expect(test.events_include).to eq([])
+    end
+
+    it "coerces non-string args via to_s" do
+      test = build_test { then_events_include :BodyPulse }
+      expect(test.events_include).to eq(["BodyPulse"])
+    end
+
+    it "raises ArgumentError on an empty string" do
+      expect {
+        build_test { then_events_include "BodyPulse", "" }
+      }.to raise_error(ArgumentError, /event name cannot be blank/)
+    end
+
+    it "raises ArgumentError on a whitespace-only string" do
+      expect {
+        build_test { then_events_include "  " }
+      }.to raise_error(ArgumentError, /event name cannot be blank/)
+    end
+  end
+end
+
+RSpec.describe "Hecks.behaviors DSL integration for loads + then_events_include" do
+  it "builds a suite with loads at the top and then_events_include inside tests" do
+    builder = Hecks::DSL::TestSuiteBuilder.new("Mindstream")
+    builder.vision "Cross-bluebook cascade coverage"
+    builder.loads "pulse", "body"
+    builder.test "Tick fans out across the body" do
+      tests "Tick", on: "Mindstream"
+      input at: "T0"
+      then_events_include "BodyPulse", "FatigueAccumulated"
+    end
+    builder.test "Plain single-aggregate test (no cascade)" do
+      tests "CreateNote", on: "Mindstream"
+      input body: "hi"
+      expect body: "hi"
+    end
+
+    suite = builder.build
+    expect(suite.loads).to eq(%w[pulse body])
+    expect(suite.tests.size).to eq(2)
+    expect(suite.tests[0].events_include).to eq(
+      %w[BodyPulse FatigueAccumulated],
+    )
+    expect(suite.tests[1].events_include).to eq([])
+  end
+end

--- a/spec/parity/behaviors/loads_parse_smoke.behaviors
+++ b/spec/parity/behaviors/loads_parse_smoke.behaviors
@@ -1,0 +1,23 @@
+# spec/parity/behaviors/loads_parse_smoke.behaviors
+#
+# Toy i43 parse-parity fixture. Exercises the two new DSL forms
+# (`loads` and `then_events_include`) on both the Ruby builder and
+# the Rust parser, proving they produce equivalent IR.
+#
+# No runner consumer exists in this PR (commits 3-5 are parser-only,
+# commit 6 lands the merge-domain runtime in a follow-up), so this
+# file is exercised purely at parse time. Once the runtime merge
+# lands, this fixture gains a matching `loads_parse_smoke.bluebook`
+# sibling and joins spec/parity/behaviors_parity_test.rb.
+#
+Hecks.behaviors "LoadsParseSmoke" do
+  vision "Proves i43 loads + then_events_include parse identically in Ruby and Rust"
+
+  loads "foo"
+
+  test "records the suite-level loads and per-test events_include" do
+    tests "Tick", on: "Clock"
+    input at: "T0"
+    then_events_include "Bar"
+  end
+end


### PR DESCRIPTION
## Summary

Foundation commits 3-5 of the [i43 cross-bluebook behaviors plan](https://github.com/chrisyoung/hecks/blob/miette/plan-i42-catalog-dialect/docs/plans/i43_cross_bluebook_behaviors.md). Parser-only scope — adds the `loads` (suite-level, variadic) and `then_events_include` (per-test, variadic) DSL forms on both the Ruby builder and the Rust parser, plus the IR slots. No runtime consumers yet (merge-domain runner is commit 6 of the plan, `mindstream.behaviors` migration is commit 9, `pulse_fanout_smoke.sh` deletion is commit 10 — all deferred to follow-up PRs).

Same shape as PR #309's i42 parser-only scaffolding.

- **Commit 3 (`feat(behaviors-ir)`)**: `TestSuite#loads` + `Test#events_include` fields on both sides, defaulting to empty.
- **Commit 4 (`feat(behaviors-parser)`)**: Ruby `TestSuiteBuilder#loads(*names)` + `TestBuilder#then_events_include(*names)`. Rust line-scanners for both, with new `extract_all_strings` helper for the variadic `"a", "b", "c"` tail. 9 new cargo unit tests.
- **Commit 5 (`feat(behaviors-dsl)`)**: empty-string validation, richer doc comments, 15 rspec examples, and a toy parse-parity fixture (`spec/parity/behaviors/loads_parse_smoke.behaviors`) verified by both a cargo integration test and an rspec spec to prove byte-equivalent parse IR.

## Example DSL (what now parses on both sides)

```ruby
Hecks.behaviors "Mindstream" do
  vision "Cross-bluebook cascade coverage"
  loads "pulse", "body"

  test "Tick fans out across the body" do
    tests "Tick", on: "Mindstream"
    input at: "T0"
    then_events_include "BodyPulse", "FatigueAccumulated", "SynapsesPruned"
  end
end
```

## Test plan

- [x] `cargo test --release` clean — 26 lib tests pass (9 new), all integration tests pass (1 new: `behaviors_loads_parity_test`)
- [x] `bundle exec rspec spec/hecks/dsl/` — 17/17 (15 new in `test_suite_builder_loads_spec.rb`, 2 new in `loads_parse_smoke_parity_spec.rb`)
- [x] `ruby -Ilib spec/parity/behaviors_parity_test.rb` — 3/3, unchanged from baseline
- [x] Every existing `.behaviors` file parses identically — no divergence in the parity sample
- [x] Toy fixture proves Ruby and Rust produce matching IR (`loads == ["foo"]`, `events_include == ["Bar"]`)
- [x] Pre-commit hook (parity + lifecycle + conceiver parity) green on each of the 3 commits

## Scope cap

Commits 3-5 only. The load-bearing merge-domain runner (commit 6), `then_events_include` set-membership assertion consumer (commit 7), extended parity fixtures (commit 8), `mindstream.behaviors` migration (commit 9), and `pulse_fanout_smoke.sh` deletion (commit 10) all land in follow-up PRs per the plan's sequencing note.

## Notes

- Each commit carries a per-change `[antibody-exempt: ...]` marker naming the DSL-parser category — parser extensions must travel in lockstep across Ruby and Rust until the DSL is self-hosting.
- `extract_all_strings` (new helper in `behaviors_parser.rs`) respects backslash-escaped quotes, mirroring the string-literal handling already in `split_top_level_commas`.
- Validation is DSL-side only: both builders raise `ArgumentError` on an empty/whitespace-only string, catching typos (`loads "pulse", ""`) before the runner tries to resolve them.
- The toy parity fixture is parse-only. When the merge-domain runner lands (commit 6), it gains a sibling `.bluebook` and joins `spec/parity/behaviors_parity_test.rb` for full end-to-end parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)