### PR TITLE
chore(nursery): migrate 35 bluebooks — Gate A final sweep (parity batch 5)

### DIFF
--- a/hecks_conception/nursery/alans_engine_additive_business/hecks/distribution.bluebook
+++ b/hecks_conception/nursery/alans_engine_additive_business/hecks/distribution.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "Distribution", version: "2026.04.11.1" do
     attribute :channel_type, String
     attribute :account_id, String
     attribute :edi_capable, String
-    list_of(String) :active_skus
+    attribute :active_skus, list_of(String)
     attribute :status, String
 
     command "RegisterChannel" do
@@ -45,7 +45,7 @@ Hecks.bluebook "Distribution", version: "2026.04.11.1" do
     attribute :order_number, String
     attribute :channel, String
     attribute :customer, String
-    list_of(OrderItem) :items
+    attribute :items, list_of(OrderItem)
     attribute :purchase_order_number, String
     attribute :advance_ship_notice, String
     attribute :total, Float

--- a/hecks_conception/nursery/alans_engine_additive_business/hecks/formulation.bluebook
+++ b/hecks_conception/nursery/alans_engine_additive_business/hecks/formulation.bluebook
@@ -7,8 +7,8 @@ Hecks.bluebook "Formulation", version: "2026.04.11.1" do
     attribute :version, String
     attribute :brand, String
     attribute :product_type, String
-    list_of(Ingredient) :ingredients
-    list_of(String) :performance_claims
+    attribute :ingredients, list_of(Ingredient)
+    attribute :performance_claims, list_of(String)
     attribute :viscosity_grade, String
     attribute :base_oil_type, String
     attribute :viscosity_index, Float

--- a/hecks_conception/nursery/alans_engine_additive_business/hecks/pricing.bluebook
+++ b/hecks_conception/nursery/alans_engine_additive_business/hecks/pricing.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "Pricing", version: "2026.04.11.1" do
     attribute :distributor_price, Float
     attribute :jobber_price, Float
     attribute :retail_margin_target, Float
-    list_of(ChannelPrice) :channel_prices
+    attribute :channel_prices, list_of(ChannelPrice)
     attribute :effective_date, String
     attribute :status, String
 
@@ -73,8 +73,8 @@ Hecks.bluebook "Pricing", version: "2026.04.11.1" do
   aggregate "PricingPolicy", "MAP enforcement rules, promotional windows, and volume discount tiers" do
     attribute :name, String
     attribute :map_enforcement_level, String
-    list_of(PromotionalWindow) :promotional_windows
-    list_of(VolumeTier) :volume_discount_tiers
+    attribute :promotional_windows, list_of(PromotionalWindow)
+    attribute :volume_discount_tiers, list_of(VolumeTier)
     attribute :status, String
 
     value_object "PromotionalWindow" do

--- a/hecks_conception/nursery/assisted_living/assisted_living.bluebook
+++ b/hecks_conception/nursery/assisted_living/assisted_living.bluebook
@@ -95,7 +95,7 @@ Hecks.bluebook "AssistedLiving" do
   aggregate "CarePlan", "An individualized plan of daily care for a resident" do
     attribute :resident_name, String
     attribute :created_date, String
-    list_of(CareTask) :tasks
+    attribute :tasks, list_of(CareTask)
     attribute :dietary_needs, String
     attribute :status, String
     reference_to Resident
@@ -146,7 +146,7 @@ Hecks.bluebook "AssistedLiving" do
     attribute :scheduled_time, String
     attribute :location, String
     attribute :capacity, Integer
-    list_of(Participant) :participants
+    attribute :participants, list_of(Participant)
 
     value_object "Participant" do
       attribute :resident_name, String
@@ -180,7 +180,7 @@ Hecks.bluebook "AssistedLiving" do
 
   aggregate "MedicationSchedule", "A timed medication regimen for a resident" do
     attribute :resident_name, String
-    list_of(ScheduledDose) :doses
+    attribute :doses, list_of(ScheduledDose)
     attribute :status, String
     reference_to Resident
 

--- a/hecks_conception/nursery/bakery_production/bakery_production.bluebook
+++ b/hecks_conception/nursery/bakery_production/bakery_production.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "BakeryProduction", version: "2026.04.13.1" do
     attribute :prep_minutes, Integer
     attribute :bake_minutes, Integer
     attribute :bake_temp_f, Float
-    list_of(Ingredient) :ingredients
+    attribute :ingredients, list_of(Ingredient)
 
     value_object "Ingredient" do
       attribute :name, String
@@ -107,7 +107,7 @@ Hecks.bluebook "BakeryProduction", version: "2026.04.13.1" do
     attribute :customer_name, String
     attribute :order_date, String
     attribute :pickup_date, String
-    list_of(OrderLine) :items
+    attribute :items, list_of(OrderLine)
     attribute :status, String
 
     value_object "OrderLine" do

--- a/hecks_conception/nursery/bicycle_shop/bicycle_shop.bluebook
+++ b/hecks_conception/nursery/bicycle_shop/bicycle_shop.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "BicycleShop", version: "2026.04.13.1" do
     attribute :frame_size, String
     attribute :price, Float
     attribute :status, String
-    list_of(ComponentSpec) :components
+    attribute :components, list_of(ComponentSpec)
 
     value_object "ComponentSpec" do
       attribute :component_name, String
@@ -54,7 +54,7 @@ Hecks.bluebook "BicycleShop", version: "2026.04.13.1" do
     attribute :issue, String
     attribute :estimate, Float
     attribute :status, String
-    list_of(RepairStep) :steps
+    attribute :steps, list_of(RepairStep)
 
     value_object "RepairStep" do
       attribute :description, String

--- a/hecks_conception/nursery/blog/blog.bluebook
+++ b/hecks_conception/nursery/blog/blog.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
     attribute :body, String
     attribute :excerpt, String
     attribute :author_name, String
-    list_of(String) :tags
+    attribute :tags, list_of(String)
     attribute :published_at, String
     attribute :status, String
 
@@ -18,7 +18,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
       attribute :title, String
       attribute :body, String
       attribute :author_name, String
-      list_of(String) :tags
+      attribute :tags, list_of(String)
       emits "PostDrafted"
       then_set :title, to: :title
       then_set :body, to: :body
@@ -33,7 +33,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
       reference_to(Post)
       attribute :title, String
       attribute :body, String
-      list_of(String) :tags
+      attribute :tags, list_of(String)
       given { status == "draft" }
       emits "PostEdited"
       then_set :title, to: :title

--- a/hecks_conception/nursery/blog/hecks/blog.bluebook
+++ b/hecks_conception/nursery/blog/hecks/blog.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
     attribute :body, String
     attribute :excerpt, String
     attribute :author_name, String
-    list_of(String) :tags
+    attribute :tags, list_of(String)
     attribute :published_at, String
     attribute :status, String
 
@@ -18,7 +18,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
       attribute :title, String
       attribute :body, String
       attribute :author_name, String
-      list_of(String) :tags
+      attribute :tags, list_of(String)
       emits "PostDrafted"
       then_set :title, to: :title
       then_set :body, to: :body
@@ -33,7 +33,7 @@ Hecks.bluebook "Blog", version: "2026.04.11.1" do
       reference_to(Post)
       attribute :title, String
       attribute :body, String
-      list_of(String) :tags
+      attribute :tags, list_of(String)
       given { status == "draft" }
       emits "PostEdited"
       then_set :title, to: :title

--- a/hecks_conception/nursery/brain_training/brain_training.bluebook
+++ b/hecks_conception/nursery/brain_training/brain_training.bluebook
@@ -40,7 +40,7 @@ Hecks.bluebook "BrainTraining", version: "2026.04.13.1" do
     attribute :difficulty, String
     attribute :levels, Integer
     attribute :status, String
-    list_of(GameLevel) :game_levels
+    attribute :game_levels, list_of(GameLevel)
     value_object "GameLevel" do
       attribute :level_number, Integer
       attribute :time_limit_seconds, Float
@@ -106,7 +106,7 @@ Hecks.bluebook "BrainTraining", version: "2026.04.13.1" do
   aggregate "TrainingPlan", "A personalized brain training plan based on cognitive profile" do
     attribute :plan_id, String
     attribute :participant_id, String
-    list_of(PlanItem) :items
+    attribute :items, list_of(PlanItem)
     attribute :status, String
     value_object "PlanItem" do
       attribute :game_id, String

--- a/hecks_conception/nursery/chiropractic/chiropractic.bluebook
+++ b/hecks_conception/nursery/chiropractic/chiropractic.bluebook
@@ -44,7 +44,7 @@ Hecks.bluebook "Chiropractic" do
     attribute :patient_name, String
     attribute :adjustment_date, String
     attribute :technique, String
-    list_of(SegmentAdjusted) :segments
+    attribute :segments, list_of(SegmentAdjusted)
     attribute :pain_before, Integer
     attribute :pain_after, Integer
     attribute :notes, String
@@ -166,7 +166,7 @@ Hecks.bluebook "Chiropractic" do
   aggregate "Invoice", "A billing record for chiropractic services rendered" do
     attribute :patient_name, String
     attribute :service_date, String
-    list_of(LineItem) :line_items
+    attribute :line_items, list_of(LineItem)
     attribute :total_amount, Float
     attribute :insurance_claim_status, String
     attribute :payment_status, String

--- a/hecks_conception/nursery/dialysis/dialysis.bluebook
+++ b/hecks_conception/nursery/dialysis/dialysis.bluebook
@@ -62,7 +62,7 @@ Hecks.bluebook "Dialysis" do
     attribute :duration_minutes, Integer
     attribute :nurse_name, String
     attribute :status, String
-    list_of(VitalReading) :intra_vitals
+    attribute :intra_vitals, list_of(VitalReading)
     reference_to Patient
 
     value_object "VitalReading" do
@@ -160,7 +160,7 @@ Hecks.bluebook "Dialysis" do
     attribute :reorder_level, Integer
     attribute :supplier, String
     attribute :status, String
-    list_of(UsageRecord) :usage_history
+    attribute :usage_history, list_of(UsageRecord)
 
     specification "BelowReorderLevel" do
       satisfied_by { quantity_on_hand <= reorder_level }

--- a/hecks_conception/nursery/disaster_relief/disaster_relief.bluebook
+++ b/hecks_conception/nursery/disaster_relief/disaster_relief.bluebook
@@ -51,7 +51,7 @@ Hecks.bluebook "DisasterRelief" do
     attribute :capacity, Integer
     attribute :current_occupancy, Integer
     attribute :status, String
-    list_of(ShelterResource) :resources
+    attribute :resources, list_of(ShelterResource)
     reference_to Incident
 
     specification "AtCapacity" do
@@ -143,7 +143,7 @@ Hecks.bluebook "DisasterRelief" do
     attribute :quantity, Integer
     attribute :warehouse_location, String
     attribute :status, String
-    list_of(Shipment) :shipments
+    attribute :shipments, list_of(Shipment)
 
     value_object "Shipment" do
       attribute :destination, String

--- a/hecks_conception/nursery/elder_care/elder_care.bluebook
+++ b/hecks_conception/nursery/elder_care/elder_care.bluebook
@@ -91,7 +91,7 @@ Hecks.bluebook "ElderCare" do
     attribute :client_name, String
     attribute :caregiver_name, String
     attribute :week_starting, String
-    list_of(ScheduledVisit) :visits
+    attribute :visits, list_of(ScheduledVisit)
     attribute :status, String
     reference_to Client
     reference_to Caregiver
@@ -146,7 +146,7 @@ Hecks.bluebook "ElderCare" do
     attribute :frequency, String
     attribute :prescriber, String
     attribute :status, String
-    list_of(AdministrationLog) :log
+    attribute :log, list_of(AdministrationLog)
     reference_to Client
 
     value_object "AdministrationLog" do

--- a/hecks_conception/nursery/farmers_market/farmers_market.bluebook
+++ b/hecks_conception/nursery/farmers_market/farmers_market.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "FarmersMarket", version: "2026.04.13.1" do
     attribute :contact_phone, String
     attribute :product_type, String
     attribute :status, String
-    list_of(ProductOffering) :offerings
+    attribute :offerings, list_of(ProductOffering)
 
     value_object "ProductOffering" do
       attribute :product_name, String
@@ -130,7 +130,7 @@ Hecks.bluebook "FarmersMarket", version: "2026.04.13.1" do
     attribute :inspector_name, String
     attribute :inspection_date, String
     attribute :result, String
-    list_of(Finding) :findings
+    attribute :findings, list_of(Finding)
 
     value_object "Finding" do
       attribute :category, String

--- a/hecks_conception/nursery/food_bank/food_bank.bluebook
+++ b/hecks_conception/nursery/food_bank/food_bank.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "FoodBank" do
     attribute :weight_pounds, Float
     attribute :expiration_date, String
     attribute :status, String
-    list_of(DonatedItem) :items
+    attribute :items, list_of(DonatedItem)
 
     value_object "DonatedItem" do
       attribute :item_name, String
@@ -110,7 +110,7 @@ Hecks.bluebook "FoodBank" do
     attribute :households_served, Integer
     attribute :total_weight_distributed, Float
     attribute :status, String
-    list_of(DistributionLine) :lines
+    attribute :lines, list_of(DistributionLine)
 
     value_object "DistributionLine" do
       attribute :item_name, String
@@ -157,7 +157,7 @@ Hecks.bluebook "FoodBank" do
     attribute :availability, String
     attribute :hours_served, Integer
     attribute :status, String
-    list_of(Shift) :shifts
+    attribute :shifts, list_of(Shift)
 
     value_object "Shift" do
       attribute :shift_date, String

--- a/hecks_conception/nursery/food_hall/food_hall.bluebook
+++ b/hecks_conception/nursery/food_hall/food_hall.bluebook
@@ -8,7 +8,7 @@ Hecks.bluebook "FoodHall", version: "2026.04.13.1" do
     attribute :cuisine_type, String
     attribute :contact_name, String
     attribute :status, String
-    list_of(HealthCertification) :certifications
+    attribute :certifications, list_of(HealthCertification)
 
     value_object "HealthCertification" do
       attribute :cert_type, String
@@ -76,7 +76,7 @@ Hecks.bluebook "FoodHall", version: "2026.04.13.1" do
   aggregate "HallMenu", "A consolidated menu displayed across the food hall" do
     attribute :menu_id, String
     attribute :vendor_id, String
-    list_of(DishListing) :dishes
+    attribute :dishes, list_of(DishListing)
     attribute :status, String
 
     value_object "DishListing" do

--- a/hecks_conception/nursery/furniture_showroom/furniture_showroom.bluebook
+++ b/hecks_conception/nursery/furniture_showroom/furniture_showroom.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "FurnitureShowroom", version: "2026.04.13.1" do
     attribute :material, String
     attribute :price, Float
     attribute :status, String
-    list_of(Dimension) :dimensions
+    attribute :dimensions, list_of(Dimension)
 
     value_object "Dimension" do
       attribute :measurement, String
@@ -55,7 +55,7 @@ Hecks.bluebook "FurnitureShowroom", version: "2026.04.13.1" do
   aggregate "ShowroomRoom", "A staged vignette that showcases furniture in context" do
     attribute :room_name, String
     attribute :style, String
-    list_of(StagedItem) :staged_items
+    attribute :staged_items, list_of(StagedItem)
     attribute :status, String
 
     value_object "StagedItem" do

--- a/hecks_conception/nursery/game_store/game_store.bluebook
+++ b/hecks_conception/nursery/game_store/game_store.bluebook
@@ -10,7 +10,7 @@ Hecks.bluebook "GameStore", version: "2026.04.13.1" do
     attribute :price, Float
     attribute :quantity, Integer
     attribute :age_rating, String
-    list_of(GameFeature) :features
+    attribute :features, list_of(GameFeature)
 
     value_object "GameFeature" do
       attribute :feature_name, String
@@ -64,7 +64,7 @@ Hecks.bluebook "GameStore", version: "2026.04.13.1" do
     attribute :entry_fee, Float
     attribute :date, String
     attribute :status, String
-    list_of(Participant) :participants
+    attribute :participants, list_of(Participant)
 
     value_object "Participant" do
       attribute :player_name, String

--- a/hecks_conception/nursery/golf_course/golf_course.bluebook
+++ b/hecks_conception/nursery/golf_course/golf_course.bluebook
@@ -55,7 +55,7 @@ Hecks.bluebook "GolfCourse", version: "2026.04.13.1" do
     attribute :seating_capacity, Integer
     attribute :rental_fee, Float
     attribute :status, String
-    list_of(MaintenanceLog) :maintenance_log
+    attribute :maintenance_log, list_of(MaintenanceLog)
 
     value_object "MaintenanceLog" do
       attribute :date, String
@@ -182,7 +182,7 @@ Hecks.bluebook "GolfCourse", version: "2026.04.13.1" do
     attribute :max_players, Integer
     attribute :entry_fee, Float
     attribute :status, String
-    list_of(TournamentPlayer) :players
+    attribute :players, list_of(TournamentPlayer)
 
     value_object "TournamentPlayer" do
       attribute :player_name, String

--- a/hecks_conception/nursery/gym_reservations/gym_reservations.bluebook
+++ b/hecks_conception/nursery/gym_reservations/gym_reservations.bluebook
@@ -67,8 +67,8 @@ Hecks.bluebook "GymReservations", version: "2026.04.13.1" do
   aggregate "Trainer", "A fitness instructor with certifications and availability windows" do
     attribute :name, String
     attribute :specialization, String
-    list_of(Certification) :certifications
-    list_of(String) :available_days
+    attribute :certifications, list_of(Certification)
+    attribute :available_days, list_of(String)
 
     value_object "Certification" do
       attribute :name, String
@@ -86,7 +86,7 @@ Hecks.bluebook "GymReservations", version: "2026.04.13.1" do
     command "PublishAvailability" do
       description "Publish which days a trainer can teach"
       reference_to(Trainer)
-      list_of(String) :available_days
+      attribute :available_days, list_of(String)
       emits "AvailabilityPublished"
     end
   end

--- a/hecks_conception/nursery/hospice/hospice.bluebook
+++ b/hecks_conception/nursery/hospice/hospice.bluebook
@@ -45,7 +45,7 @@ Hecks.bluebook "Hospice" do
 
   aggregate "ComfortPlan", "An individualized plan focused on symptom relief and quality of life" do
     attribute :patient_name, String
-    list_of(SymptomIntervention) :interventions
+    attribute :interventions, list_of(SymptomIntervention)
     attribute :pain_management_approach, String
     attribute :spiritual_preferences, String
     attribute :status, String
@@ -96,7 +96,7 @@ Hecks.bluebook "Hospice" do
     attribute :family_contact_name, String
     attribute :patient_name, String
     attribute :relationship, String
-    list_of(SupportSession) :sessions
+    attribute :sessions, list_of(SupportSession)
     attribute :bereavement_status, String
     reference_to Patient
 

--- a/hecks_conception/nursery/hospital_it/hospital_it.bluebook
+++ b/hecks_conception/nursery/hospital_it/hospital_it.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "HospitalIT", version: "2026.04.13.1" do
     attribute :patient_name, String
     attribute :department, String
     attribute :record_status, String
-    list_of(ClinicalEntry) :entries
+    attribute :entries, list_of(ClinicalEntry)
 
     value_object "ClinicalEntry" do
       attribute :entry_type, String
@@ -128,7 +128,7 @@ Hecks.bluebook "HospitalIT", version: "2026.04.13.1" do
     attribute :tier, String
     attribute :rto_hours, Float
     attribute :rpo_hours, Float
-    list_of(RecoveryStep) :steps
+    attribute :steps, list_of(RecoveryStep)
     attribute :status, String
 
     value_object "RecoveryStep" do

--- a/hecks_conception/nursery/ice_cream_parlor/ice_cream_parlor.bluebook
+++ b/hecks_conception/nursery/ice_cream_parlor/ice_cream_parlor.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "IceCreamParlor", version: "2026.04.13.1" do
     attribute :description, String
     attribute :dairy_free, String
     attribute :available, String
-    list_of(FlavorNote) :tasting_notes
+    attribute :tasting_notes, list_of(FlavorNote)
 
     value_object "FlavorNote" do
       attribute :note, String
@@ -122,7 +122,7 @@ Hecks.bluebook "IceCreamParlor", version: "2026.04.13.1" do
     attribute :serving_id, String
     attribute :cone_type, String
     attribute :scoops, Integer
-    list_of(ScoopSelection) :selections
+    attribute :selections, list_of(ScoopSelection)
     attribute :total_price, Float
     attribute :status, String
 

--- a/hecks_conception/nursery/liquor_store/liquor_store.bluebook
+++ b/hecks_conception/nursery/liquor_store/liquor_store.bluebook
@@ -11,7 +11,7 @@ Hecks.bluebook "LiquorStore", version: "2026.04.13.1" do
     attribute :abv, Float
     attribute :price, Float
     attribute :quantity, Integer
-    list_of(TastingNote) :tasting_notes
+    attribute :tasting_notes, list_of(TastingNote)
 
     value_object "TastingNote" do
       attribute :aroma, String
@@ -95,7 +95,7 @@ Hecks.bluebook "LiquorStore", version: "2026.04.13.1" do
     attribute :date, String
     attribute :max_attendees, Integer
     attribute :current_attendees, Integer
-    list_of(PourSelection) :pours
+    attribute :pours, list_of(PourSelection)
     attribute :status, String
 
     value_object "PourSelection" do

--- a/hecks_conception/nursery/meal_delivery/meal_delivery.bluebook
+++ b/hecks_conception/nursery/meal_delivery/meal_delivery.bluebook
@@ -39,7 +39,7 @@ Hecks.bluebook "MealDelivery", version: "2026.04.13.1" do
   aggregate "MealPackage", "An assembled meal package for a recipient" do
     attribute :package_id, String
     attribute :recipient_id, String
-    list_of(MealComponent) :components
+    attribute :components, list_of(MealComponent)
     attribute :dietary_type, String
     attribute :status, String
     value_object "MealComponent" do
@@ -73,7 +73,7 @@ Hecks.bluebook "MealDelivery", version: "2026.04.13.1" do
     attribute :run_id, String
     attribute :courier_name, String
     attribute :date, String
-    list_of(DeliveryStop) :stops
+    attribute :stops, list_of(DeliveryStop)
     attribute :total_miles, Float
     attribute :status, String
     value_object "DeliveryStop" do

--- a/hecks_conception/nursery/mental_health_clinic/mental_health_clinic.bluebook
+++ b/hecks_conception/nursery/mental_health_clinic/mental_health_clinic.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "MentalHealthClinic" do
     attribute :referral_source, String
     attribute :emergency_contact, String
     attribute :status, String
-    list_of(PresentingConcern) :concerns
+    attribute :concerns, list_of(PresentingConcern)
 
     value_object "PresentingConcern" do
       attribute :description, String
@@ -128,7 +128,7 @@ Hecks.bluebook "MentalHealthClinic" do
     attribute :client_name, String
     attribute :diagnosis, String
     attribute :start_date, String
-    list_of(Goal) :goals
+    attribute :goals, list_of(Goal)
     attribute :status, String
     reference_to Client
 

--- a/hecks_conception/nursery/nutrition_app/nutrition_app.bluebook
+++ b/hecks_conception/nursery/nutrition_app/nutrition_app.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "NutritionApp", version: "2026.04.13.1" do
     attribute :user_name, String
     attribute :goal, String
     attribute :daily_calories, Integer
-    list_of(PlannedMeal) :meals
+    attribute :meals, list_of(PlannedMeal)
     attribute :status, String
     value_object "PlannedMeal" do
       attribute :meal_type, String
@@ -43,7 +43,7 @@ Hecks.bluebook "NutritionApp", version: "2026.04.13.1" do
     attribute :user_name, String
     attribute :date, String
     attribute :total_calories, Integer
-    list_of(LogEntry) :entries
+    attribute :entries, list_of(LogEntry)
     value_object "LogEntry" do
       attribute :food_name, String
       attribute :calories, Integer

--- a/hecks_conception/nursery/physical_therapy/physical_therapy.bluebook
+++ b/hecks_conception/nursery/physical_therapy/physical_therapy.bluebook
@@ -7,7 +7,7 @@ Hecks.bluebook "PhysicalTherapy" do
     attribute :diagnosis, String
     attribute :insurance_id, String
     attribute :status, String
-    list_of(Limitation) :limitations
+    attribute :limitations, list_of(Limitation)
 
     value_object "Limitation" do
       attribute :body_region, String
@@ -104,7 +104,7 @@ Hecks.bluebook "PhysicalTherapy" do
     attribute :therapist_name, String
     attribute :scheduled_date, String
     attribute :status, String
-    list_of(SessionExercise) :exercises_performed
+    attribute :exercises_performed, list_of(SessionExercise)
     attribute :notes, String
     reference_to Patient
 

--- a/hecks_conception/nursery/record_store/record_store.bluebook
+++ b/hecks_conception/nursery/record_store/record_store.bluebook
@@ -11,7 +11,7 @@ Hecks.bluebook "RecordStore", version: "2026.04.13.1" do
     attribute :condition, String
     attribute :price, Float
     attribute :quantity, Integer
-    list_of(TrackListing) :tracks
+    attribute :tracks, list_of(TrackListing)
 
     value_object "TrackListing" do
       attribute :track_number, Integer
@@ -65,7 +65,7 @@ Hecks.bluebook "RecordStore", version: "2026.04.13.1" do
     attribute :name, String
     attribute :genre, String
     attribute :biography, String
-    list_of(Discography) :discography
+    attribute :discography, list_of(Discography)
 
     value_object "Discography" do
       attribute :album_title, String

--- a/hecks_conception/nursery/relief_logistics/relief_logistics.bluebook
+++ b/hecks_conception/nursery/relief_logistics/relief_logistics.bluebook
@@ -6,7 +6,7 @@ Hecks.bluebook "ReliefLogistics", version: "2026.04.13.1" do
     attribute :request_id, String
     attribute :disaster_type, String
     attribute :location_name, String
-    list_of(SupplyItem) :items
+    attribute :items, list_of(SupplyItem)
     attribute :urgency, String
     attribute :status, String
     value_object "SupplyItem" do
@@ -113,7 +113,7 @@ Hecks.bluebook "ReliefLogistics", version: "2026.04.13.1" do
     attribute :site_name, String
     attribute :beneficiaries, Integer
     attribute :status, String
-    list_of(DistributionPoint) :points
+    attribute :points, list_of(DistributionPoint)
     value_object "DistributionPoint" do
       attribute :location_name, String
       attribute :people_served, Integer

--- a/hecks_conception/nursery/safe_haven/safe_haven.bluebook
+++ b/hecks_conception/nursery/safe_haven/safe_haven.bluebook
@@ -6,7 +6,7 @@ Hecks.bluebook "SafeHaven", version: "2026.04.13.1" do
     attribute :plan_id, String
     attribute :client_code, String
     attribute :advocate_name, String
-    list_of(SafetyStep) :steps
+    attribute :steps, list_of(SafetyStep)
     attribute :status, String
     value_object "SafetyStep" do
       attribute :sequence, Integer
@@ -40,7 +40,7 @@ Hecks.bluebook "SafeHaven", version: "2026.04.13.1" do
     attribute :profile_id, String
     attribute :client_code, String
     attribute :threat_level, String
-    list_of(SecurityMeasure) :measures
+    attribute :measures, list_of(SecurityMeasure)
     attribute :status, String
     value_object "SecurityMeasure" do
       attribute :measure_type, String

--- a/hecks_conception/nursery/spa_and_wellness/spa_and_wellness.bluebook
+++ b/hecks_conception/nursery/spa_and_wellness/spa_and_wellness.bluebook
@@ -9,7 +9,7 @@ Hecks.bluebook "SpaAndWellness", version: "2026.04.13.1" do
     attribute :duration_minutes, Integer
     attribute :price, Float
     attribute :description, String
-    list_of(Contraindication) :contraindications
+    attribute :contraindications, list_of(Contraindication)
 
     value_object "Contraindication" do
       attribute :condition, String
@@ -47,7 +47,7 @@ Hecks.bluebook "SpaAndWellness", version: "2026.04.13.1" do
     attribute :therapist_id, String
     attribute :name, String
     attribute :license_number, String
-    list_of(Specialty) :specialties
+    attribute :specialties, list_of(Specialty)
 
     value_object "Specialty" do
       attribute :treatment_type, String
@@ -150,7 +150,7 @@ Hecks.bluebook "SpaAndWellness", version: "2026.04.13.1" do
   aggregate "WellnessPackage", "A bundled set of treatments sold at a discount" do
     attribute :package_id, String
     attribute :name, String
-    list_of(IncludedTreatment) :treatments
+    attribute :treatments, list_of(IncludedTreatment)
     attribute :package_price, Float
     attribute :status, String
 

--- a/hecks_conception/nursery/specimen_transport/specimen_transport.bluebook
+++ b/hecks_conception/nursery/specimen_transport/specimen_transport.bluebook
@@ -42,7 +42,7 @@ Hecks.bluebook "SpecimenTransport", version: "2026.04.13.1" do
     attribute :dest_lab, String
     attribute :target_temp_c, Float
     attribute :status, String
-    list_of(TempLog) :temp_logs
+    attribute :temp_logs, list_of(TempLog)
     value_object "TempLog" do
       attribute :timestamp, String
       attribute :temp_c, Float
@@ -85,7 +85,7 @@ Hecks.bluebook "SpecimenTransport", version: "2026.04.13.1" do
   aggregate "CustodyRecord", "A chain of custody record for specimen handling" do
     attribute :record_id, String
     attribute :specimen_id, String
-    list_of(HandlerEntry) :handlers
+    attribute :handlers, list_of(HandlerEntry)
     attribute :status, String
     value_object "HandlerEntry" do
       attribute :handler_name, String

--- a/hecks_conception/nursery/speech_therapy/speech_therapy.bluebook
+++ b/hecks_conception/nursery/speech_therapy/speech_therapy.bluebook
@@ -86,7 +86,7 @@ Hecks.bluebook "SpeechTherapy" do
     attribute :pathologist_name, String
     attribute :session_date, String
     attribute :session_type, String
-    list_of(ActivityRecord) :activities
+    attribute :activities, list_of(ActivityRecord)
     attribute :notes, String
     attribute :status, String
     reference_to Client
@@ -170,7 +170,7 @@ Hecks.bluebook "SpeechTherapy" do
     attribute :client_name, String
     attribute :assessment_tool, String
     attribute :assessment_date, String
-    list_of(SubtestResult) :subtest_results
+    attribute :subtest_results, list_of(SubtestResult)
     attribute :composite_score, Integer
     attribute :severity_rating, String
     reference_to Client

--- a/hecks_conception/nursery/veteran_services/veteran_services.bluebook
+++ b/hecks_conception/nursery/veteran_services/veteran_services.bluebook
@@ -42,7 +42,7 @@ Hecks.bluebook "VeteranServices" do
     attribute :filing_date, String
     attribute :description, String
     attribute :status, String
-    list_of(ClaimDocument) :documents
+    attribute :documents, list_of(ClaimDocument)
     reference_to Veteran
 
     value_object "ClaimDocument" do
@@ -139,7 +139,7 @@ Hecks.bluebook "VeteranServices" do
     attribute :capacity, Integer
     attribute :enrolled_count, Integer
     attribute :status, String
-    list_of(ProgramSession) :sessions
+    attribute :sessions, list_of(ProgramSession)
 
     value_object "ProgramSession" do
       attribute :session_date, String


### PR DESCRIPTION
## Summary

Fifth and final Gate A mechanical swap sweep. Continues PRs #305, #307, #311, #313.

    list_of(Type) :field  ->  attribute :field, list_of(Type)

Rust parser accepts both shapes; Ruby only the latter. 35 files, 77 sites, +77/-77 (154 diff lines total). Each file independently verified to produce identical canonical IR in Ruby and Rust after the single mechanical transform.

No file overlap with PRs #305, #307, #311, #313.

## Parity delta

- **Before** (origin/main, pre-#305/#307/#311/#313): nursery **112/375**, total 237/500
- **After this branch alone**: nursery **147/375** (+35), total 272/500
- **Stacked projection** with #305 (+23) + #307 (+19) + #311 (+24) + #313 (+28) + this (+35): **241/375 nursery**

## Files migrated (35, 77 sites)

| File | Sites |
|---|---|
| alans_engine_additive_business/hecks/distribution | 2 |
| alans_engine_additive_business/hecks/formulation | 2 |
| alans_engine_additive_business/hecks/pricing | 3 |
| assisted_living | 3 |
| bakery_production | 2 |
| bicycle_shop | 2 |
| blog/blog | 3 |
| blog/hecks/blog | 3 |
| brain_training | 2 |
| chiropractic | 2 |
| dialysis | 2 |
| disaster_relief | 2 |
| elder_care | 2 |
| farmers_market | 2 |
| food_bank | 3 |
| food_hall | 2 |
| furniture_showroom | 2 |
| game_store | 2 |
| golf_course | 2 |
| gym_reservations | 3 |
| hospice | 2 |
| hospital_it | 2 |
| ice_cream_parlor | 2 |
| liquor_store | 2 |
| meal_delivery | 2 |
| mental_health_clinic | 2 |
| nutrition_app | 2 |
| physical_therapy | 2 |
| record_store | 2 |
| relief_logistics | 2 |
| safe_haven | 2 |
| spa_and_wellness | 3 |
| specimen_transport | 2 |
| speech_therapy | 2 |
| veteran_services | 2 |

### Example diff

```diff
-    list_of(DonatedItem) :items
+    attribute :items, list_of(DonatedItem)
```

## Method

1. Started from the 173 nursery files matching `/^(\s*)list_of\(([^)]+)\)[ \t]+:(\w+)[ \t]*$/`.
2. Subtracted the 94 files already migrated by PRs #305, #307, #311, #313.
3. Excluded 4 files known to have acronym-casing drift (i47): `dental_saa_s`, `saa_s_platform`, `io_t_platform`, `dev_ops_pipeline`.
4. Applied the mechanical swap to the remaining 117 candidates, ran parity: 79 passed cleanly with just the swap; 38 still have secondary drift (Gate C `lifecycle`/`fixture`/`event` top-level, plus a few aggregate-level issues).
5. Reset all files, then greedy-picked the top 35 passing files (cap: 35 files, ≤290 additions ≈ 580 diff lines). Actual: 77 swaps / 154 diff lines — well under cap.
6. Re-applied the swap to only those 35 files and confirmed each shows `✓` in the parity output.

## Gate A pool remaining

From the original 173:
- 24 migrated by #311
- 28 migrated by #313
- 35 migrated by this PR
- **~44 more pure-Gate-A passes** still ready for another identical-flavor batch (though mostly 2-swap files now — diminishing size per file)
- ~38 files still need Gate C or acronym-casing fixes first

Not quite "Gate A cleared" — one more ~30-file batch 6 is possible before the remainder intermingles with Gate C and acronym blockers.

## Drift classes observed in non-passing candidates

No new drift classes. Same three buckets as prior batches:
- `undefined method 'lifecycle' for an instance of Hecks::DSL::BluebookBuilder` (Gate C — needs `lifecycle` / `fixture` / `event` as top-level constructs)
- Acronym casing (i47) — `a_p_i_endpoint` vs `api_endpoint`
- A handful of per-file `reference_to requires a constant, not a string`, `Use bare constant … in list_of`, or `syntax error, unexpected ':'` at a different line — these need individual attention, not a bulk pattern.

## Test plan

- [x] `ruby -Ilib spec/parity/parity_test.rb` — nursery 147/375, hard 125/125, exit code matches main
- [x] Each of the 35 named files shows ✓ in the parity run
- [x] Antibody hook passes on all 35 files (all edits are `.bluebook`)
- [x] Diff size: 154 lines (+77 -77), far under 600-line cap
- [x] 35 files, at the upper end of the 25-35 scope cap