### PR TITLE
fix(inflector): Ruby-compatible snake_case for acronyms (i47)

### DIFF
--- a/hecks_life/src/behaviors_conceiver/generator.rs
+++ b/hecks_life/src/behaviors_conceiver/generator.rs
@@ -1457,10 +1457,5 @@ fn find_cmd_with_agg<'a>(domain: &'a Domain, cmd_name: &str) -> Option<(&'a Aggr
 }
 
 fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() && i > 0 { result.push('_'); }
-        result.push(c.to_lowercase().next().unwrap_or(c));
-    }
-    result
+    crate::parser_helpers::to_snake_case(s)
 }

--- a/hecks_life/src/parser_helpers.rs
+++ b/hecks_life/src/parser_helpers.rs
@@ -83,15 +83,115 @@ pub fn ends_with_do_block(line: &str) -> bool {
     false
 }
 
+/// Convert a string to snake_case.
+///
+/// Matches Ruby's ActiveSupport `#underscore` behavior for acronyms:
+/// consecutive uppercase letters are treated as a single acronym, so
+/// `DNAProfile` becomes `dna_profile` (not `d_n_a_profile`), and
+/// `APIEndpoint` becomes `api_endpoint`. An underscore is inserted:
+///   * before an uppercase letter preceded by a lowercase letter
+///     (normal word boundary, e.g. `CamelCase` -> `camel_case`), or
+///   * before an uppercase letter preceded by another uppercase letter
+///     AND followed by a lowercase letter (acronym-ending boundary,
+///     e.g. the `E` in `APIEndpoint`).
 pub fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
+    let chars: Vec<char> = s.chars().collect();
+    let mut result = String::with_capacity(s.len() + 4);
+    for i in 0..chars.len() {
+        let c = chars[i];
         if c.is_uppercase() && i > 0 {
-            result.push('_');
+            let prev = chars[i - 1];
+            let next = chars.get(i + 1).copied();
+            let prev_lower = prev.is_lowercase() || prev.is_ascii_digit();
+            let acronym_end = prev.is_uppercase()
+                && next.map(|n| n.is_lowercase()).unwrap_or(false);
+            if prev_lower || acronym_end {
+                result.push('_');
+            }
         }
-        result.push(c.to_lowercase().next().unwrap());
+        result.push(c.to_lowercase().next().unwrap_or(c));
     }
     result
+}
+
+#[cfg(test)]
+mod snake_case_tests {
+    use super::to_snake_case;
+
+    #[test]
+    fn simple_camel_case() {
+        assert_eq!(to_snake_case("CamelCase"), "camel_case");
+    }
+
+    #[test]
+    fn single_word_pascal() {
+        assert_eq!(to_snake_case("Pizza"), "pizza");
+    }
+
+    #[test]
+    fn all_lowercase_passthrough() {
+        assert_eq!(to_snake_case("dreiletter"), "dreiletter");
+    }
+
+    #[test]
+    fn pascal_with_no_internal_caps() {
+        assert_eq!(to_snake_case("Dreiletter"), "dreiletter");
+    }
+
+    #[test]
+    fn three_letter_leading_acronym() {
+        assert_eq!(to_snake_case("DNAProfile"), "dna_profile");
+    }
+
+    #[test]
+    fn uld_pallet() {
+        assert_eq!(to_snake_case("ULDPallet"), "uld_pallet");
+    }
+
+    #[test]
+    fn cbp_inspection() {
+        assert_eq!(to_snake_case("CBPInspection"), "cbp_inspection");
+    }
+
+    #[test]
+    fn ipm_plan() {
+        assert_eq!(to_snake_case("IPMPlan"), "ipm_plan");
+    }
+
+    #[test]
+    fn hvac_equipment() {
+        assert_eq!(to_snake_case("HVACEquipment"), "hvac_equipment");
+    }
+
+    #[test]
+    fn api_endpoint() {
+        assert_eq!(to_snake_case("APIEndpoint"), "api_endpoint");
+    }
+
+    #[test]
+    fn two_letter_leading_acronym() {
+        assert_eq!(to_snake_case("AIAnalysis"), "ai_analysis");
+    }
+
+    #[test]
+    fn trailing_acronym() {
+        assert_eq!(to_snake_case("DigitalID"), "digital_id");
+    }
+
+    #[test]
+    fn already_snake_case() {
+        assert_eq!(to_snake_case("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(to_snake_case(""), "");
+    }
+
+    #[test]
+    fn single_uppercase_letter() {
+        assert_eq!(to_snake_case("A"), "a");
+    }
 }
 
 // --- Shorthand syntax support ---

--- a/hecks_life/src/runtime/command_dispatch.rs
+++ b/hecks_life/src/runtime/command_dispatch.rs
@@ -190,10 +190,5 @@ fn parse_default(default: &str, attr_type: &str) -> Value {
 }
 
 fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() && i > 0 { result.push('_'); }
-        result.push(c.to_lowercase().next().unwrap());
-    }
-    result
+    crate::parser_helpers::to_snake_case(s)
 }


### PR DESCRIPTION
## Summary

Ruby's ActiveSupport `#underscore` treats consecutive uppercase letters as a single acronym (`DNAProfile` → `dna_profile`), while the Rust port inserted an underscore between every transition (`DNAProfile` → `d_n_a_profile`). Every nursery bluebook containing an acronym diverged. Ports the Ruby algorithm into the canonical `parser_helpers::to_snake_case` and delegates the two duplicate implementations to it.

## Algorithm

Insert an underscore before an uppercase letter when:
- the previous char is lowercase or a digit (normal word boundary, e.g. `CamelCase`), **or**
- the previous char is uppercase AND the next char is lowercase (acronym-ending boundary, e.g. the `E` in `APIEndpoint`).

## Files changed

- `hecks_life/src/parser_helpers.rs` — canonical impl + 15 unit tests
- `hecks_life/src/runtime/command_dispatch.rs` — delegate to canonical
- `hecks_life/src/behaviors_conceiver/generator.rs` — delegate to canonical

## Tests added (15, all pass)

| Input | Output |
| --- | --- |
| `CamelCase` | `camel_case` |
| `Pizza` | `pizza` |
| `dreiletter` | `dreiletter` |
| `Dreiletter` | `dreiletter` |
| `DNAProfile` | `dna_profile` |
| `ULDPallet` | `uld_pallet` |
| `CBPInspection` | `cbp_inspection` |
| `IPMPlan` | `ipm_plan` |
| `HVACEquipment` | `hvac_equipment` |
| `APIEndpoint` | `api_endpoint` |
| `AIAnalysis` | `ai_analysis` |
| `DigitalID` | `digital_id` |
| `already_snake` | `already_snake` |
| `""` | `""` |
| `A` | `a` |

Full suite: `cargo test --release` — all tests pass (32 pre-existing + 15 new).

## Nursery parity delta

Against `origin/main`:

- **Before fix:** 237/500 match (nursery soft: 112/375)
- **After fix:** 240/500 match (nursery soft: 115/375)
- **+3 nursery files unblocked** from pure acronym drift:
  - `hecks_conception/nursery/radiology_clouds/radiology_clouds.bluebook`
  - `hecks_conception/nursery/refugee_identity/refugee_identity.bluebook`
  - `hecks_conception/nursery/water_quality_api/water_quality_api.bluebook`

Other nursery bluebooks with acronyms remain blocked on upstream Ruby parser issues (undefined `fixture` method, `reference_to` string constants, syntax errors) that cascade before acronym drift would matter. Once those ship, additional acronym-bearing files will unblock automatically because this fix is already in place.

## Antibody

Marked `[antibody-exempt: Rust inflector port matching Ruby ActiveSupport — core runtime, not user script (i47)]` — this is core parser runtime, not a user script.

## Test plan

- [x] `cargo test --release` passes (all 32 pre-existing + 15 new)
- [x] `ruby -Ilib spec/parity/parity_test.rb` — 0 blocking failures, +3 nursery passes
- [x] Pizzas smoke: `hecks-life dump examples/pizzas/hecks/pizzas.bluebook` and Ruby load — both parse the same