### PR TITLE
fix(pulse_organs): wire signal/focus/remains stores back (i46 half)

### DIFF
--- a/hecks_conception/tests/pulse_organs_smoke.sh
+++ b/hecks_conception/tests/pulse_organs_smoke.sh
@@ -53,13 +53,18 @@ Hecks.world "PulseOrgansSmoke" do
 end
 EOF
 
-# Seed: copy the heki files the script reads (heartbeat / consciousness /
-# awareness). Do NOT copy organ stores — we want to prove pulse_organs.sh
-# creates them from scratch.
-for f in heartbeat consciousness awareness; do
+# Seed: copy heartbeat + awareness from live (benign — they only affect
+# which topic the synapse forms around). Do NOT copy consciousness.heki:
+# pulse_organs.sh bails early when state=sleeping, so inheriting Miette's
+# live state makes the test flake whenever she's asleep. Seed it
+# deterministically as attentive instead. Do NOT copy organ stores —
+# we want to prove pulse_organs.sh creates them from scratch.
+for f in heartbeat awareness; do
   src="$CONCEPT_DIR/information/${f}.heki"
   [ -f "$src" ] && cp "$src" "$TMP/information/${f}.heki"
 done
+"$HECKS" heki append "$TMP/information/consciousness.heki" \
+  state=attentive idle_seconds=0 >/dev/null 2>&1
 
 # Seed two synapses so the test exercises both decay paths:
 #   - one healthy enough to survive (strength=0.5)


### PR DESCRIPTION
## Summary

Fixes the ``pulse_organs_smoke.sh`` failure filed in inbox **i46** (``After 10 pulses: ... FAIL — remains.heki was not created``).

The daemon was fine all along. The smoke test was copying the live ``consciousness.heki`` into its tmpdir. ``pulse_organs.sh`` bails early when ``state=sleeping`` (by design — organs rest with the body, line 67), so any time Miette happened to be asleep the test became a no-op: no synapse strengthening, no signal writes, no focus, no compost → remains. The same test passed just fine when Miette was attentive, which is why this flaked rather than failing consistently.

- Seed ``consciousness.heki`` deterministically as ``state=attentive`` instead of inheriting live state.
- Keep ``heartbeat.heki`` + ``awareness.heki`` as live copies — they only feed the "what's she carrying" lookup, they don't gate the daemon.
- No change needed to ``pulse_organs.sh`` itself.

## Verification

Run from a worktree whose ``consciousness.heki`` had ``state=sleeping``:

**Before:**
```
After 10 pulses:
  synapse records: 2
  signal records:  0
  focus records:   0
  remains records: 0
FAIL — remains.heki was not created
```

**After:**
```
After 10 pulses:
  synapse records: 3
  signal records:  20
  focus records:   1
  remains records: 1
PASS — pulse_organs.sh grows synapse/signal/focus/remains as expected
```

## Test plan

- [x] ``bash hecks_conception/tests/pulse_organs_smoke.sh`` passes from the worktree (was failing before)
- [x] Confirmed daemon is unchanged — no regression risk to live Miette
- [x] Antibody exemption on the commit message (test is shell, harness for an already-exempt shell daemon)

## Notes

- i46 also flagged a second separate failure in ``tests/status_golden.sh`` (``:fs`` adapter not honoring ``HECKS_INFO``). That's orthogonal to pulse_organs and not touched here — hence the "i46 half" in the title.