### PR TITLE
feat(dsl): add missing Ruby builder methods for nursery parity (i31 part 1)

### DIFF
--- a/docs/usage/dsl_reference.md
+++ b/docs/usage/dsl_reference.md
@@ -357,9 +357,12 @@ end
 | Operation | Syntax | Effect |
 |-----------|--------|--------|
 | Set | `then_set :field, to: value` | Assign value (literal or `:attribute_ref`) |
+| Set (positional) | `then_set :field, value` | Shorthand for Set; bare literal (bool/number/symbol) |
 | Append | `then_set :field, append: value` | Add to list |
 | Increment | `then_set :field, increment: n` | Add n to numeric field |
 | Decrement | `then_set :field, decrement: n` | Subtract n from numeric field |
+
+The positional form is accepted for parity with the Rust line-scanner (`then_set :online, true` → `{op: set, value: "true"}`). Use the keyword form for string values — strings MUST use `to: "..."` so both runtimes agree on the canonical IR.
 
 **`then_toggle`** — Toggle a boolean string field between `"true"` and `"false"`.
 

--- a/lib/hecks/dsl/aggregate_builder.rb
+++ b/lib/hecks/dsl/aggregate_builder.rb
@@ -235,6 +235,19 @@ module Hecks
         @crud = true
       end
 
+      # Accept-and-ignore: legacy nursery bluebooks inline `fixture` calls
+      # inside `aggregate` blocks. The canonical location is a sibling
+      # `.fixtures` file (see `Hecks.fixtures` DSL). Rust's line-scanner
+      # silently skips these — this matches that behavior so parity passes
+      # while migration continues. The `io_validator` surfaces stragglers.
+      #
+      #   aggregate "Pizza" do
+      #     fixture "Margherita", name: "Margherita"   # no-op here
+      #   end
+      def fixture(*_args, **_kwargs, &_block)
+        # no-op — canonical home is a `.fixtures` file
+      end
+
       # Build the Aggregate IR object, inferring events from commands.
       #
       # @return [BluebookModel::Structure::Aggregate]

--- a/lib/hecks/dsl/bluebook_builder.rb
+++ b/lib/hecks/dsl/bluebook_builder.rb
@@ -351,6 +351,34 @@ module Hecks
         # no-op
       end
 
+      # Accept-and-ignore: legacy nursery bluebooks declare `lifecycle` at
+      # the top level (outside any `aggregate` block). The canonical DSL
+      # attaches `lifecycle` to a specific aggregate. Rust's line-scanner
+      # ignores top-level lifecycle — this mirrors that behavior so parity
+      # passes while migration continues.
+      #
+      #   Hecks.bluebook "Acoustics" do
+      #     aggregate "Room" do ... end
+      #     lifecycle "AcousticDesign" do ... end  # no-op here
+      #   end
+      def lifecycle(*_args, **_kwargs, &_block)
+        # no-op — canonical location is inside `aggregate`
+      end
+
+      # Accept-and-ignore: legacy nursery bluebooks declare `event` at the
+      # top level (outside any `aggregate` block). The canonical DSL
+      # attaches explicit events to a specific aggregate. Rust's
+      # line-scanner silently skips top-level `event` lines — mirroring
+      # that behavior keeps parity green while migration continues.
+      #
+      #   Hecks.bluebook "Quality" do
+      #     aggregate "Test" do ... end
+      #     event "TestRun"     # no-op here
+      #   end
+      def event(*_args, **_kwargs, &_block)
+        # no-op — canonical location is inside `aggregate`
+      end
+
       # Define a read model (view) projected from domain events.
       #
       # Read models are denormalized projections built by applying event

--- a/lib/hecks/dsl/command_builder.rb
+++ b/lib/hecks/dsl/command_builder.rb
@@ -124,11 +124,22 @@ module Hecks
         )
       end
 
-      def then_set(field, to: nil, append: nil, increment: nil, decrement: nil)
+      # Accepts both the canonical keyword form and a positional shorthand:
+      #
+      #   then_set :status, to: "placed"       # canonical
+      #   then_set :status, "placed"           # positional → Set op
+      #   then_set :in_standby, true           # positional → Set op
+      #   then_set :count, increment: 1        # canonical
+      #
+      # The positional form mirrors Rust's permissive line-scanner (see
+      # `hecks_life/src/parse_blocks.rs`). Rust treats `then_set :f, V` as
+      # `Set` with the bare value, so we do the same here for parity.
+      def then_set(field, positional = nil, to: nil, append: nil, increment: nil, decrement: nil)
         op, val = if !to.nil? then [:set, to]
                   elsif append then [:append, append]
                   elsif increment then [:increment, increment]
                   elsif decrement then [:decrement, decrement]
+                  elsif !positional.nil? then [:set, positional]
                   end
         @mutations << BluebookModel::Behavior::Mutation.new(
           field: field, operation: op, value: val

--- a/lib/hecks/dsl/policy_builder.rb
+++ b/lib/hecks/dsl/policy_builder.rb
@@ -76,6 +76,15 @@ module Hecks
         @target_domain = domain_name
       end
 
+      # Accept-and-ignore: some legacy nursery bluebooks mark cross-domain
+      # policies via `cross_domain true` inside the `policy` block. Rust's
+      # line-scanner silently skips the line; we do the same so parity
+      # passes. The canonical way to declare cross-domain targets is
+      # `across "TargetDomain"`.
+      def cross_domain(*_args, **_kwargs, &_block)
+        # no-op — canonical form is `across "Domain"`
+      end
+
       # Set whether this policy runs asynchronously.
       #
       # Async policies are enqueued for background processing rather than

--- a/spec/parity/bluebooks/16_then_set_positional.bluebook
+++ b/spec/parity/bluebooks/16_then_set_positional.bluebook
@@ -1,0 +1,27 @@
+Hecks.bluebook "ThenSetPositional", version: "2026.04.22.1" do
+  vision "Locks Ruby↔Rust parity for positional `then_set :field, value` form (booleans + numbers only — strings require keyword form)"
+
+  aggregate "Device", "Tracks device activation state" do
+    attribute :online, TrueClass, default: false
+    attribute :battery_pct, Float
+
+    command "Activate" do
+      role "Operator"
+      then_set :online, true
+      emits "Activated"
+    end
+
+    command "Deactivate" do
+      role "Operator"
+      then_set :online, false
+      emits "Deactivated"
+    end
+
+    command "Charge" do
+      role "Operator"
+      attribute :battery_pct, Float
+      then_set :battery_pct, 100.0
+      emits "Charged"
+    end
+  end
+end

--- a/spec/parity/bluebooks/17_legacy_top_level.bluebook
+++ b/spec/parity/bluebooks/17_legacy_top_level.bluebook
@@ -1,0 +1,29 @@
+Hecks.bluebook "LegacyTopLevel", version: "2026.04.22.1" do
+  vision "Locks Ruby↔Rust parity for legacy top-level forms that both runtimes accept-and-ignore: lifecycle/event at bluebook scope, fixture inside aggregate, cross_domain inside policy"
+
+  aggregate "Room" do
+    attribute :name, String
+
+    fixture "SampleRoom", name: "Studio"    # legacy — ignored both sides
+
+    command "DefineRoom" do
+      role "Architect"
+      attribute :name, String
+      emits "RoomDefined"
+    end
+  end
+
+  event "AmbientChanged"                    # top-level — ignored both sides
+
+  lifecycle "RoomSetup" do                  # top-level — ignored both sides
+    state "drafted"
+    state "occupied"
+    transition from: "drafted", to: "occupied", on: "RoomDefined"
+  end
+
+  policy "WireOnDefine" do
+    on "RoomDefined"
+    trigger "DefineRoom"
+    cross_domain true                       # legacy form — ignored
+  end
+end


### PR DESCRIPTION
## Summary

Extend the Ruby DSL builders to accept legacy DSL shapes that Rust's line-scanner already handles — unblocking nursery parity.

- `fixture` inside `aggregate` blocks → accept-and-ignore (was `NoMethodError`; 19 files)
- Top-level `lifecycle` and `event` in `Hecks.bluebook` → accept-and-ignore (was `NoMethodError`; 15 files)
- `cross_domain` inside `policy` blocks → accept-and-ignore (was `NoMethodError`; 1 file)
- Positional `then_set :field, value` (bool/number) → matches Rust's Set interpretation (was arity error; 5 files)

All four are strictly additive accept-and-ignore implementations — no new surface, no behavior change for existing valid bluebooks. Each mirrors what Rust's permissive line-scanner already does.

## Parity impact (from `origin/main` worktree baseline)

| Section | Before | After | Δ |
|---|---|---|---|
| Synthetic | 12/12 | 14/14 | +2 new fixtures |
| Nursery | 288/375 | 323/375 | **+35 files unblocked** |
| **Total** | **413/502** | **450/502** | **+37** |

Zero regressions. All 35 nursery unblocks are files that were only missing DSL surface — everything with a "missing Ruby DSL method" error before now parses.

In the main-branch local working tree (which has the Gate A/B nursery sweep in flight), this PR takes nursery from 288/375 → 368/375 (+80 files) because the sweep and this PR stack cleanly.

## Files unblocked (35)

acoustics, alans_engine_additive_business/hecks/quality, apiculture, archaeology, astronomy, cartography, cryptography, electrical, forensics, game_theory, genetics, hydrology, meteorology, neuroscience, nutrition, oceanography, pharmacology, repatriation_flights, restaurant_reservations, roast_science, robotics, roofing_company, rv_circuits, rv_power, train_scheduling, tree_service, upholstery, vet_housing, viticulture, volcanology, water_treatment, wedding_planning, welding_shop, woodworking, zoo_management

## Remaining nursery gaps (out of scope for i31 part 1)

- **42 syntax errors** — Gate A (ImplicitSyntax sweep; `bin/nursery-parity-sweep` handles these)
- **7 "Use bare constant"** — Gate B (strict-mode string → constant; same sweep tool)
- **2 drift** — Gate D (canonical IR divergence; individual investigation)
- **1 reference_to string** — Gate B

## Test plan

- [x] `ruby -Ilib spec/parity/parity_test.rb` — 450/502 match, 52 soft drift (only Gate A/B/D categories)
- [x] Synthetic fixtures `16_then_set_positional.bluebook` and `17_legacy_top_level.bluebook` both green
- [x] `bin/hecks verify` — no new failures (the 2 pre-existing failures are unrelated: `DslSerializer round-trip` and debug-binary path)
- [x] `ruby -Ilib examples/pizzas/pizzas.rb` — smoke test passes
- [x] Per-file LoC: bluebook_builder.rb 193, aggregate_builder.rb 200, command_builder.rb 126, policy_builder.rb 60 (code lines, excluding comments)

## Commits

- `c1766dec` feat(dsl): accept `fixture` inside aggregate blocks
- `5c4d4878` feat(dsl): accept top-level `lifecycle` and `event` in bluebook
- `f0b752d4` feat(dsl): accept `cross_domain` inside policy blocks
- `35dd8ffd` feat(dsl): accept positional `then_set :field, value` form
- `f6b742a4` parity: synthetic fixtures lock the new DSL shapes

## Example usage (unblocked)

```ruby
# Before: `undefined method 'lifecycle' for Hecks::DSL::BluebookBuilder`
Hecks.bluebook "Acoustics" do
  aggregate "Room" do ... end
  lifecycle "AcousticDesign" do                # now accepted (no-op)
    state "drafted"
    transition from: "drafted", to: "done", on: "Finished"
  end
end

# Before: `undefined method 'fixture' for Hecks::DSL::AggregateBuilder`
aggregate "Animal" do
  attribute :name, String
  fixture "Simba", name: "Lion"                # now accepted (no-op)
end

# Before: `wrong number of arguments (given 2, expected 1)`
command "Activate" do
  then_set :online, true                       # now accepted (Set op)
end
```