### PR TITLE
feat(DSL): parsed hecksagon + world, retire Kernel.load (i7)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Run fixtures parity suite (Ruby ↔ Rust)
         run: bundle exec ruby -Ilib spec/parity/fixtures_parity_test.rb
 
+      - name: Run hecksagon parity suite (Ruby ↔ Rust)
+        run: bundle exec ruby -Ilib spec/parity/hecksagon_parity_test.rb
+
+      - name: Run world parity suite (Ruby ↔ Rust)
+        run: bundle exec ruby -Ilib spec/parity/world_parity_test.rb
+
       - name: Lifecycle validator across all bluebooks
         run: |
           BAD=""

--- a/bin/antibody-check
+++ b/bin/antibody-check
@@ -118,6 +118,32 @@ def filter_code_files(paths)
   end
 end
 
+# i7: forbid new `Kernel.load` (or bare `load(...)`) calls against any of
+# the five DSL extensions. Those five must be parsed, not executed.
+# Returns the list of "path:lineno: source" triples that violate the
+# rule, scanning ONLY the paths given (so we're looking at what this
+# commit/branch touched, never existing code).
+DSL_LOAD_PATTERN = /(?:Kernel\.)?load\s*[( ]\s*["'][^"']*\.(?:hecksagon|world|bluebook|behaviors|fixtures)["']/.freeze
+
+def kernel_load_violations(paths)
+  violations = []
+  paths.each do |p|
+    next unless File.file?(p) && File.readable?(p)
+    ext = File.extname(p).delete_prefix(".").downcase
+    next unless %w[rb rs py sh].include?(ext)
+    File.foreach(p).with_index(1) do |line, ln|
+      next unless line =~ DSL_LOAD_PATTERN
+      # Whitelist spec/parity/*_test.rb — those intentionally exercise
+      # the old Kernel.load path to prove the NEW loader matches it.
+      next if p.start_with?("spec/parity/")
+      # Whitelist the Loader itself — it owns the one allowed caller.
+      next if p.end_with?("lib/hecksagon/loader.rb")
+      violations << "#{p}:#{ln}: #{line.strip}"
+    end
+  end
+  violations
+end
+
 options = { base: "origin/main", staged: false, message_file: nil,
             list_only: false, each_commit: false }
 OptionParser.new do |o|
@@ -183,6 +209,20 @@ touched =
     touched_files(base_ref, base_ref.nil?)
   end
 code    = filter_code_files(touched)
+
+# i7 rule: any new Kernel.load / load(...) targeting a DSL extension is
+# a hard stop. No exemption — this is the "5/5 parsed, not executed"
+# antibody moment; re-opening the hole is always a regression.
+dsl_load_hits = kernel_load_violations(touched)
+unless dsl_load_hits.empty?
+  puts ""
+  puts "✗ antibody: Kernel.load on DSL file(s) is forbidden"
+  dsl_load_hits.each { |h| puts "    #{h}" }
+  puts ""
+  puts "  Route through Hecksagon::Loader.load / .load_world, or the"
+  puts "  matching parser on the Rust side. DSLs are parsed, not executed."
+  exit 1
+end
 
 if code.empty?
   puts "✓ antibody: no non-bluebook files touched"

--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -20,6 +20,8 @@ REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 HECKS_LIFE="$REPO/hecks_life/target/release/hecks-life"
 CONCEPTION_DIR="$REPO/hecks_conception"
 PARITY_TEST="$REPO/spec/parity/parity_test.rb"
+HECKSAGON_PARITY_TEST="$REPO/spec/parity/hecksagon_parity_test.rb"
+WORLD_PARITY_TEST="$REPO/spec/parity/world_parity_test.rb"
 
 # ── Gate 1: parity ────────────────────────────────────────────────
 # Ruby DSL parser and Rust hecks-life parser must agree on every
@@ -34,6 +36,30 @@ if [ -z "$PARITY_SKIP" ] && [ -f "$PARITY_TEST" ]; then
         echo "add the fixture path to spec/parity/known_drift.txt."
         echo ""
         echo "Re-run: ruby -Ilib spec/parity/parity_test.rb"
+        exit 1
+    fi
+fi
+
+# ── Gate 1b: hecksagon + world parity ────────────────────────────
+# Same contract as Gate 1, but for the .hecksagon and .world DSLs
+# (see spec/parity/{hecksagon,world}_known_drift.txt for allowed drift).
+if [ -z "$PARITY_SKIP" ] && [ -f "$HECKSAGON_PARITY_TEST" ]; then
+    if ! (cd "$REPO" && ruby -Ilib "$HECKSAGON_PARITY_TEST" >/tmp/hecksagon_parity.out 2>&1); then
+        echo "COMMIT BLOCKED: hecksagon parity suite failed."
+        echo ""
+        tail -40 /tmp/hecksagon_parity.out
+        echo ""
+        echo "Re-run: ruby -Ilib spec/parity/hecksagon_parity_test.rb"
+        exit 1
+    fi
+fi
+if [ -z "$PARITY_SKIP" ] && [ -f "$WORLD_PARITY_TEST" ]; then
+    if ! (cd "$REPO" && ruby -Ilib "$WORLD_PARITY_TEST" >/tmp/world_parity.out 2>&1); then
+        echo "COMMIT BLOCKED: world parity suite failed."
+        echo ""
+        tail -40 /tmp/world_parity.out
+        echo ""
+        echo "Re-run: ruby -Ilib spec/parity/world_parity_test.rb"
         exit 1
     fi
 fi

--- a/docs/narrative.md
+++ b/docs/narrative.md
@@ -296,6 +296,35 @@ Use AI to write the DSL. Use Hecks to guarantee the architecture holds.
 
 ---
 
+## 10.5 DSL Parity — 5/5 Parsed, Not Executed
+
+Five source languages live in a Hecks project:
+
+- `.bluebook`   — domain modeling (aggregates, commands, queries, policies)
+- `.hecksagon`  — hexagonal architecture wiring (adapters, gates, subscriptions)
+- `.fixtures`   — test data + catalog schemas
+- `.behaviors`  — behavioral tests
+- `.world`      — runtime configuration + strategic descriptors
+
+Every one of them is **parsed**, not evaluated. The Rust runtime parses
+directly from text into IR and never sees Ruby. The Ruby loader path
+gates every file through an allow-list of DSL keywords before
+`Kernel.load` — anything outside the list raises
+`Hecksagon::UnsafeHecksagonError` with the offending line.
+
+This matters because the source of truth must be trustworthy. A DSL
+that silently accepts arbitrary Ruby is not a DSL — it is a Ruby DSL
+*plus* an unrestricted code execution vector. One malicious
+`.hecksagon` file, one `system("rm -rf /")`, and the guarantee is gone.
+
+Parity contracts in `spec/parity/` lock each DSL down: Ruby and Rust
+must produce byte-equivalent canonical JSON for every shipped file,
+or the commit is blocked. Known drift is listed per-file in
+`*_known_drift.txt` with a concrete reason and a named fix owner;
+every allowed drift is a TODO, not a forever-exception.
+
+---
+
 ## 11. Close
 
 Here's what we just did:

--- a/hecks_conception/miette.hecksagon
+++ b/hecks_conception/miette.hecksagon
@@ -17,5 +17,5 @@ Hecks.hecksagon "Miette" do
   capabilities :language
   capabilities :actions
 
-  persistence :information, dir: File.join(__dir__, "information")
+  persistence :information, dir: "information"
 end

--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -32,6 +32,8 @@ pub mod fixtures_parser;
 pub mod hecksagon_helpers;
 pub mod hecksagon_ir;
 pub mod hecksagon_parser;
+pub mod world_ir;
+pub mod world_parser;
 pub mod run;
 pub mod run_status;
 pub mod run_stdin_loop;

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -155,6 +155,14 @@ fn main() {
         return;
     }
 
+    if command == "dump-world" {
+        let path = args.get(2).expect("usage: hecks-life dump-world <file.world>");
+        let source = std::fs::read_to_string(path).expect("cannot read");
+        let world = hecks_life::world_parser::parse(&source);
+        println!("{}", serde_json::to_string_pretty(&dump_world_json(&world)).unwrap());
+        return;
+    }
+
     if command == "cascade" {
         let path = args.get(2).expect("usage: hecks-life cascade <bluebook>");
         let source = std::fs::read_to_string(path).expect("cannot read");
@@ -1141,6 +1149,33 @@ fn print_kv(recs: &[&heki::Record], fields: &[String]) {
     }
 }
 
+/// Canonical JSON for a `.world` file — matches the shape the Ruby
+/// parity harness emits for `Hecksagon::Structure::World#to_canonical_h`.
+fn dump_world_json(world: &hecks_life::world_ir::World) -> serde_json::Value {
+    let concerns: Vec<serde_json::Value> = world.concerns.iter().map(|c| {
+        serde_json::json!({
+            "name": c.name,
+            "description": c.description,
+        })
+    }).collect();
+    let mut configs = serde_json::Map::new();
+    for cfg in &world.configs {
+        let mut obj = serde_json::Map::new();
+        for (k, v) in &cfg.values {
+            obj.insert(k.clone(), serde_json::Value::String(v.clone()));
+        }
+        configs.insert(cfg.name.clone(), serde_json::Value::Object(obj));
+    }
+    serde_json::json!({
+        "name":     world.name,
+        "purpose":  world.purpose,
+        "vision":   world.vision,
+        "audience": world.audience,
+        "concerns": concerns,
+        "configs":  configs,
+    })
+}
+
 /// Derive the being name from argv[0].
 /// "miette" or "/path/to/miette" -> "Miette"
 /// "summer" or "/path/to/summer" -> "Summer"
@@ -1169,36 +1204,18 @@ fn find_world_file(dir: &std::path::Path) -> Option<std::path::PathBuf> {
     matches.into_iter().next()
 }
 
-/// Read ollama config from the project's *.world file — returns (model, url) if configured.
+/// Read ollama config from the project's *.world file — returns
+/// (model, url) if configured. Routes through world_parser so there is
+/// one canonical shape for all .world consumers.
 fn find_world_ollama_config(agg_path: &str) -> Option<(String, String)> {
     let parent = std::path::Path::new(agg_path).parent()?;
     let world_path = find_world_file(parent)?;
     let content = fs::read_to_string(&world_path).ok()?;
-    let mut in_ollama = false;
-    let mut model = None;
-    let mut url = None;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("ollama") && trimmed.contains("do") { in_ollama = true; }
-        if in_ollama {
-            if trimmed.starts_with("model") {
-                if let Some(s) = trimmed.find('"') {
-                    if let Some(e) = trimmed[s+1..].find('"') {
-                        model = Some(trimmed[s+1..s+1+e].to_string());
-                    }
-                }
-            }
-            if trimmed.starts_with("url") {
-                if let Some(s) = trimmed.find('"') {
-                    if let Some(e) = trimmed[s+1..].find('"') {
-                        url = Some(trimmed[s+1..s+1+e].to_string());
-                    }
-                }
-            }
-            if trimmed == "end" { in_ollama = false; }
-        }
-    }
-    Some((model?, url?))
+    let world = hecks_life::world_parser::parse(&content);
+    let cfg = world.config_for("ollama")?;
+    let model = cfg.get("model")?.to_string();
+    let url   = cfg.get("url")?.to_string();
+    Some((model, url))
 }
 
 /// Boot the hecksagon and run the terminal adapter.
@@ -1230,29 +1247,17 @@ fn run_terminal(project_dir: &str, being: &str) {
     hecks_life::runtime::adapter_terminal::run(&mut rt, being);
 }
 
-/// Find the heki dir from the project's *.world file — look in parent of the given path.
-/// Parses: `heki do\n  dir "information"\nend`
+/// Find the heki dir from the project's *.world file — look in parent of
+/// the given path. Routes through world_parser so the .world grammar has
+/// exactly one definition.
 fn find_world_heki_dir(aggregates_path: &str) -> Option<String> {
     let parent = std::path::Path::new(aggregates_path).parent()?;
     let world_path = find_world_file(parent)?;
     let content = fs::read_to_string(&world_path).ok()?;
-    // Simple parse: find `dir "..."` inside `heki do...end`
-    let mut in_heki = false;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("heki") && trimmed.contains("do") { in_heki = true; }
-        if in_heki && trimmed.starts_with("dir") {
-            // Extract quoted string
-            if let Some(start) = trimmed.find('"') {
-                if let Some(end) = trimmed[start+1..].find('"') {
-                    let dir = &trimmed[start+1..start+1+end];
-                    return Some(parent.join(dir).to_string_lossy().into());
-                }
-            }
-        }
-        if in_heki && trimmed == "end" { in_heki = false; }
-    }
-    None
+    let world = hecks_life::world_parser::parse(&content);
+    let heki = world.config_for("heki")?;
+    let dir = heki.get("dir")?;
+    Some(parent.join(dir).to_string_lossy().into_owned())
 }
 
 /// Dispatch a command through the hecksagon — merge all bluebooks, find the command, run it.
@@ -1403,7 +1408,8 @@ fn print_usage() {
     eprintln!("  boot       Full boot: hydrate + nerves + prompt gen");
     eprintln!("  daemon     Run background daemons (pulse, daydream, sleep)");
     eprintln!("  hydrate    Load .heki stores and print vital signs");
-    eprintln!("  heki       Read/write .heki binary stores\n");
+    eprintln!("  heki       Read/write .heki binary stores");
+    eprintln!("  dump-world Parse a .world file and emit canonical JSON\n");
     eprintln!("Heki subcommands:");
     eprintln!("  heki read   <file>           Dump store as JSON");
     eprintln!("  heki latest <file>           Show latest record");

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -163,6 +163,14 @@ fn main() {
         return;
     }
 
+    if command == "dump-hecksagon" {
+        let path = args.get(2).expect("usage: hecks-life dump-hecksagon <file.hecksagon>");
+        let source = std::fs::read_to_string(path).expect("cannot read");
+        let hex = hecks_life::hecksagon_parser::parse(&source);
+        println!("{}", serde_json::to_string_pretty(&dump_hecksagon_json(&hex)).unwrap());
+        return;
+    }
+
     if command == "cascade" {
         let path = args.get(2).expect("usage: hecks-life cascade <bluebook>");
         let source = std::fs::read_to_string(path).expect("cannot read");
@@ -1149,6 +1157,57 @@ fn print_kv(recs: &[&heki::Record], fields: &[String]) {
     }
 }
 
+/// Canonical JSON for a `.hecksagon` file — matches the shape the Ruby
+/// parity harness emits for `Hecksagon::Structure::Hecksagon#to_canonical_h`.
+///
+/// Only the subset the Rust IR models is included: name, persistence,
+/// subscriptions, shell_adapters, io_adapters, gates. Ruby-side fields
+/// outside that set (capabilities, concerns, annotations, context_map,
+/// etc.) are intentionally NOT in the canonical shape — files that
+/// depend on them go in hecksagon_known_drift.txt.
+fn dump_hecksagon_json(hex: &hecks_life::hecksagon_ir::Hecksagon) -> serde_json::Value {
+    let gates: Vec<serde_json::Value> = hex.gates.iter().map(|g| {
+        serde_json::json!({
+            "aggregate": g.aggregate,
+            "role":      g.role,
+            "allowed":   g.allowed_commands,
+        })
+    }).collect();
+    let io_adapters: Vec<serde_json::Value> = hex.io_adapters.iter().map(|io| {
+        let opts: Vec<serde_json::Value> = io.options.iter().map(|(k, v)| {
+            serde_json::json!([k, v])
+        }).collect();
+        serde_json::json!({
+            "kind":      io.kind,
+            "options":   opts,
+            "on_events": io.on_events,
+        })
+    }).collect();
+    let shell_adapters: Vec<serde_json::Value> = hex.shell_adapters.iter().map(|sa| {
+        let env: Vec<serde_json::Value> = sa.env.iter().map(|(k, v)| {
+            serde_json::json!([k, v])
+        }).collect();
+        serde_json::json!({
+            "name":          sa.name,
+            "command":       sa.command,
+            "args":          sa.args,
+            "output_format": sa.output_format,
+            "timeout":       sa.timeout,
+            "working_dir":   sa.working_dir,
+            "env":           env,
+            "ok_exit":       sa.ok_exit,
+        })
+    }).collect();
+    serde_json::json!({
+        "name":           hex.name,
+        "persistence":    hex.persistence,
+        "subscriptions":  hex.subscriptions,
+        "io_adapters":    io_adapters,
+        "shell_adapters": shell_adapters,
+        "gates":          gates,
+    })
+}
+
 /// Canonical JSON for a `.world` file — matches the shape the Ruby
 /// parity harness emits for `Hecksagon::Structure::World#to_canonical_h`.
 fn dump_world_json(world: &hecks_life::world_ir::World) -> serde_json::Value {
@@ -1409,7 +1468,8 @@ fn print_usage() {
     eprintln!("  daemon     Run background daemons (pulse, daydream, sleep)");
     eprintln!("  hydrate    Load .heki stores and print vital signs");
     eprintln!("  heki       Read/write .heki binary stores");
-    eprintln!("  dump-world Parse a .world file and emit canonical JSON\n");
+    eprintln!("  dump-world Parse a .world file and emit canonical JSON");
+    eprintln!("  dump-hecksagon  Parse a .hecksagon file and emit canonical JSON\n");
     eprintln!("Heki subcommands:");
     eprintln!("  heki read   <file>           Dump store as JSON");
     eprintln!("  heki latest <file>           Show latest record");

--- a/hecks_life/src/world_ir.rs
+++ b/hecks_life/src/world_ir.rs
@@ -8,18 +8,22 @@
 //!
 //!   Family A — runtime/extension config (miette.world, hecks_appeal.world):
 //!
-//!     Hecks.world "Miette" do
-//!       heki   do; dir "information" end
-//!       ollama do; model "bluebook-architect"; url "http://..." end
-//!     end
+//! ```text
+//! Hecks.world "Miette" do
+//!   heki   do; dir "information" end
+//!   ollama do; model "bluebook-architect"; url "http://..." end
+//! end
+//! ```
 //!
 //!   Family B — strategic descriptors (nursery/*.world):
 //!
-//!     Hecks.world "DomainConception" do
-//!       purpose "..."
-//!       vision  "..."
-//!       concern "CompletenessAtBirth" do; description "..." end
-//!     end
+//! ```text
+//! Hecks.world "DomainConception" do
+//!   purpose "..."
+//!   vision  "..."
+//!   concern "CompletenessAtBirth" do; description "..." end
+//! end
+//! ```
 //!
 //! The IR carries both shapes so a single parser covers the lot.
 

--- a/hecks_life/src/world_ir.rs
+++ b/hecks_life/src/world_ir.rs
@@ -1,0 +1,75 @@
+//! World IR — Rust mirror of Hecksagon::Structure::World for .world files.
+//!
+//! A .world declares runtime configuration — extension options, heki data
+//! location, strategic descriptors — that sits alongside the .bluebook
+//! (domain definition) and .hecksagon (wiring) files.
+//!
+//! Two families of .world file exist in-tree today:
+//!
+//!   Family A — runtime/extension config (miette.world, hecks_appeal.world):
+//!
+//!     Hecks.world "Miette" do
+//!       heki   do; dir "information" end
+//!       ollama do; model "bluebook-architect"; url "http://..." end
+//!     end
+//!
+//!   Family B — strategic descriptors (nursery/*.world):
+//!
+//!     Hecks.world "DomainConception" do
+//!       purpose "..."
+//!       vision  "..."
+//!       concern "CompletenessAtBirth" do; description "..." end
+//!     end
+//!
+//! The IR carries both shapes so a single parser covers the lot.
+
+/// A .world file parsed into IR.
+#[derive(Debug, Default, Clone)]
+pub struct World {
+    /// Declared inside `Hecks.world "Name" do`.
+    pub name: String,
+    /// `purpose "..."` — strategic intent, one-liner.
+    pub purpose: Option<String>,
+    /// `vision "..."` — longer-horizon direction.
+    pub vision: Option<String>,
+    /// `audience "..."` — who the world is for.
+    pub audience: Option<String>,
+    /// `concern "Name" do; description "..." end` entries.
+    pub concerns: Vec<Concern>,
+    /// Extension config blocks — one entry per `extension_name do ... end`
+    /// (heki, ollama, sqlite, claude, websocket, static_assets, ...).
+    /// Order preserved from source.
+    pub configs: Vec<ExtensionConfig>,
+}
+
+/// `concern "Name" do; description "..." end`.
+#[derive(Debug, Default, Clone)]
+pub struct Concern {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// `ext_name do; key value; ... end` — a single extension config block.
+#[derive(Debug, Default, Clone)]
+pub struct ExtensionConfig {
+    /// Block name: `heki`, `ollama`, `sqlite`, `claude`, ...
+    pub name: String,
+    /// Ordered key/value pairs. Values are stored as their source tokens
+    /// (quoted strings have their quotes stripped; ints/floats/bools stay
+    /// as their textual form; string arrays are stored as JSON-ish text).
+    pub values: Vec<(String, String)>,
+}
+
+impl World {
+    /// Look up an extension config block by name.
+    pub fn config_for(&self, name: &str) -> Option<&ExtensionConfig> {
+        self.configs.iter().find(|c| c.name == name)
+    }
+}
+
+impl ExtensionConfig {
+    /// Look up a value by key within this block.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.values.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+    }
+}

--- a/hecks_life/src/world_parser.rs
+++ b/hecks_life/src/world_parser.rs
@@ -1,0 +1,267 @@
+//! World parser — reads .world files into the World IR.
+//!
+//! Line-oriented in the same idiom as hecksagon_parser. Recognizes the
+//! canonical shapes used by the Ruby DSL builder and the files shipped
+//! under hecks_conception/ and lib/hecks/.../appeal.
+//!
+//! Grammar:
+//!
+//!   file        := 'Hecks.world' STRING 'do' stmt* 'end'
+//!   stmt        := scalar | extension_block | concern_block
+//!   scalar      := SCALAR_KEY STRING              // purpose|vision|audience
+//!   extension_block := IDENT 'do' kv* 'end'       // heki|ollama|sqlite|...
+//!   concern_block   := 'concern' STRING 'do' kv* 'end'
+//!   kv          := IDENT (STRING | INT | FLOAT | BOOL | ARRAY)
+//!
+//! No method calls, no interpolation, no ENV[], no File.join. The parser
+//! is deliberately dumb — it only knows how to scoop key/value scalars
+//! out of the nested blocks the DSL builder supports.
+
+use crate::hecksagon_helpers::{between_quotes, strip_quotes};
+use crate::world_ir::*;
+
+/// Lowest-cost source detection — skip blank lines and `#` comments,
+/// then check the first non-empty line.
+pub fn is_world_source(source: &str) -> bool {
+    for line in source.lines() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') { continue; }
+        return t.starts_with("Hecks.world");
+    }
+    false
+}
+
+const SCALAR_KEYS: &[&str] = &["purpose", "vision", "audience"];
+
+pub fn parse(source: &str) -> World {
+    let mut world = World::default();
+    let source = crate::parser::strip_shebang(source);
+    let raw: Vec<&str> = source.lines().collect();
+
+    let mut i = 0;
+    while i < raw.len() {
+        let line = raw[i].trim();
+
+        if line.is_empty() || line.starts_with('#') {
+            i += 1;
+            continue;
+        }
+
+        if line.starts_with("Hecks.world") {
+            if let Some(n) = between_quotes(line) { world.name = n; }
+            i += 1;
+            continue;
+        }
+
+        // Scalar statements: purpose/vision/audience "…"
+        if let Some(k) = scalar_key(line) {
+            if let Some(v) = between_quotes(line) {
+                match k {
+                    "purpose"  => world.purpose  = Some(v),
+                    "vision"   => world.vision   = Some(v),
+                    "audience" => world.audience = Some(v),
+                    _ => {}
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // concern "Name" do ... end
+        if line.starts_with("concern ") || line.starts_with("concern\"") {
+            let (concern, consumed) = parse_concern(&raw[i..]);
+            if let Some(c) = concern { world.concerns.push(c); }
+            i += consumed;
+            continue;
+        }
+
+        // Extension block: IDENT do ... end
+        if let Some(ext_name) = extension_block_header(line) {
+            let (cfg, consumed) = parse_extension_block(&raw[i..], &ext_name);
+            if let Some(c) = cfg { world.configs.push(c); }
+            i += consumed;
+            continue;
+        }
+
+        // Top-level `end` closing the Hecks.world block, or anything else
+        // we don't recognize.
+        i += 1;
+    }
+
+    world
+}
+
+/// If the line is a top-level scalar statement (purpose/vision/audience),
+/// return its key. Otherwise None.
+fn scalar_key(line: &str) -> Option<&'static str> {
+    for k in SCALAR_KEYS {
+        if line.starts_with(&format!("{} ", k)) || line.starts_with(&format!("{}\"", k)) {
+            return Some(*k);
+        }
+    }
+    None
+}
+
+/// If the line is `IDENT do` (or `IDENT do\n...`), return the ident.
+/// Otherwise None. Skips scalar keys and `concern`.
+fn extension_block_header(line: &str) -> Option<String> {
+    let t = line.trim();
+    // Must end with `do` (possibly followed by `; ... end` on one line).
+    // Find the first whitespace — that's the ident boundary.
+    let rest = t;
+    let ident_end = rest.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(rest.len());
+    if ident_end == 0 { return None; }
+    let ident = &rest[..ident_end];
+    if SCALAR_KEYS.contains(&ident) || ident == "concern" || ident == "end"
+        || ident == "Hecks" {
+        return None;
+    }
+    // Must have a `do` after the ident (same line or the next token).
+    let after = rest[ident_end..].trim_start();
+    if after == "do" || after.starts_with("do ") || after.starts_with("do;") || after == "do\n" {
+        return Some(ident.to_string());
+    }
+    // Inline single-line form: `heki do; dir "x" end` — already handled
+    // above since `after` will start with `do;`. Final fallback: the
+    // word "do" appears after the ident with optional whitespace.
+    if after.starts_with("do") {
+        let next = after.chars().nth(2);
+        if next.map_or(true, |c| c.is_whitespace() || c == ';') {
+            return Some(ident.to_string());
+        }
+    }
+    None
+}
+
+/// Parse `concern "Name" do; description "..." end`. Returns the concern
+/// and the number of source lines consumed.
+fn parse_concern(lines: &[&str]) -> (Option<Concern>, usize) {
+    let first = lines[0].trim();
+    let mut concern = Concern::default();
+    if let Some(n) = between_quotes(first) { concern.name = n; }
+
+    // Inline-form: everything fits on one line (`concern "X" do; ... end`).
+    if first.ends_with("end") && first.contains("do") {
+        absorb_inline_block_body(first, &mut |k, v| {
+            if k == "description" { concern.description = Some(v); }
+        });
+        return (if concern.name.is_empty() { None } else { Some(concern) }, 1);
+    }
+
+    let mut i = 1;
+    let mut depth = if first.trim_end().ends_with("do") { 1 } else { 0 };
+    while i < lines.len() && depth > 0 {
+        let t = lines[i].trim();
+        if t == "end" { depth -= 1; i += 1; continue; }
+        if t.is_empty() || t.starts_with('#') { i += 1; continue; }
+        // Nested `do` inside a concern is not grammar-legal — but keep
+        // the depth counter honest anyway.
+        if ends_with_do(t) { depth += 1; }
+        if let Some((k, v)) = parse_kv_line(t) {
+            if k == "description" { concern.description = Some(v); }
+        }
+        i += 1;
+    }
+
+    if concern.name.is_empty() { (None, i) } else { (Some(concern), i) }
+}
+
+/// Parse `IDENT do ... end` — return ExtensionConfig + lines consumed.
+fn parse_extension_block(lines: &[&str], name: &str) -> (Option<ExtensionConfig>, usize) {
+    let first = lines[0].trim();
+    let mut cfg = ExtensionConfig { name: name.to_string(), values: vec![] };
+
+    // Inline: `ext do; key "val"; key2 "val2" end`
+    if first.ends_with("end") && first.contains("do") {
+        absorb_inline_block_body(first, &mut |k, v| {
+            cfg.values.push((k, v));
+        });
+        return (Some(cfg), 1);
+    }
+
+    let mut i = 1;
+    let mut depth = if ends_with_do(first) { 1 } else { 0 };
+    while i < lines.len() && depth > 0 {
+        let t = lines[i].trim();
+        if t == "end" { depth -= 1; i += 1; continue; }
+        if t.is_empty() || t.starts_with('#') { i += 1; continue; }
+        if ends_with_do(t) { depth += 1; i += 1; continue; }
+        if let Some((k, v)) = parse_kv_line(t) {
+            cfg.values.push((k, v));
+        }
+        i += 1;
+    }
+
+    (Some(cfg), i)
+}
+
+/// Does this line end with `do` (trailing whitespace ignored)?
+fn ends_with_do(line: &str) -> bool {
+    let t = line.trim_end();
+    t == "do" || t.ends_with(" do")
+}
+
+/// Parse a single `key value` line. Values can be:
+///   - quoted strings  "foo"
+///   - integers        123
+///   - floats          1.5
+///   - booleans        true/false
+///   - arrays          ["a", "b"]
+fn parse_kv_line(line: &str) -> Option<(String, String)> {
+    let t = line.trim().trim_end_matches(';');
+    let ident_end = t.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+    if ident_end == 0 { return None; }
+    let key = t[..ident_end].to_string();
+    let rest = t[ident_end..].trim();
+    if rest.is_empty() { return None; }
+    Some((key, render_value(rest)))
+}
+
+/// Render a raw value token as canonical text. Strings unwrap their
+/// quotes; everything else is preserved verbatim (after trimming).
+fn render_value(raw: &str) -> String {
+    let t = raw.trim().trim_end_matches(';').trim();
+    if t.starts_with('"') && t.ends_with('"') && t.len() >= 2 {
+        return strip_quotes(t);
+    }
+    t.to_string()
+}
+
+/// Walk an inline `do; k v; k v end` body and invoke `visitor(k, v)` for
+/// each pair. The body is whatever sits between `do` and the trailing
+/// `end` on a single line.
+fn absorb_inline_block_body(line: &str, visitor: &mut dyn FnMut(String, String)) {
+    let t = line.trim();
+    let Some(after_do_idx) = find_do_keyword(t) else { return; };
+    let after_do = &t[after_do_idx..];
+    let body = after_do.trim_start().trim_start_matches("do")
+        .trim_start_matches(|c: char| c == ';' || c.is_whitespace());
+    // Strip trailing `end`.
+    let body = body.trim_end().trim_end_matches("end").trim();
+    for piece in body.split(';') {
+        let p = piece.trim();
+        if p.is_empty() { continue; }
+        if let Some((k, v)) = parse_kv_line(p) {
+            visitor(k, v);
+        }
+    }
+}
+
+/// Find the byte index of the standalone `do` keyword in a line. Used to
+/// locate the start of an inline block body.
+fn find_do_keyword(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i + 2 <= bytes.len() {
+        if &bytes[i..i + 2] == b"do" {
+            let left_ok = i == 0 || (bytes[i - 1] as char).is_whitespace();
+            let right_ok = i + 2 == bytes.len() || {
+                let c = bytes[i + 2] as char;
+                c.is_whitespace() || c == ';'
+            };
+            if left_ok && right_ok { return Some(i); }
+        }
+        i += 1;
+    }
+    None
+}

--- a/hecks_life/src/world_parser.rs
+++ b/hecks_life/src/world_parser.rs
@@ -218,13 +218,32 @@ fn parse_kv_line(line: &str) -> Option<(String, String)> {
 }
 
 /// Render a raw value token as canonical text. Strings unwrap their
-/// quotes; everything else is preserved verbatim (after trimming).
+/// outer quotes only when the entire token is a SINGLE quoted string.
+/// Multi-arg values (`"a", "b"`) keep their full raw form so the parity
+/// harness can compare against Ruby's joined representation.
 fn render_value(raw: &str) -> String {
     let t = raw.trim().trim_end_matches(';').trim();
-    if t.starts_with('"') && t.ends_with('"') && t.len() >= 2 {
+    if is_single_quoted_string(t) {
         return strip_quotes(t);
     }
     t.to_string()
+}
+
+/// True iff `t` is a single `"..."` with no unescaped quotes inside.
+fn is_single_quoted_string(t: &str) -> bool {
+    if !(t.starts_with('"') && t.ends_with('"') && t.len() >= 2) { return false; }
+    let bytes = t.as_bytes();
+    let mut prev = b'\0';
+    // Walk the inner bytes [1..len-1]. A `"` that is NOT escaped means
+    // the token is not a single quoted string (two adjacent quoted
+    // values, arguments, etc.).
+    for &b in &bytes[1..bytes.len() - 1] {
+        if b == b'"' && prev != b'\\' {
+            return false;
+        }
+        prev = b;
+    }
+    true
 }
 
 /// Walk an inline `do; k v; k v end` body and invoke `visitor(k, v)` for

--- a/hecks_life/tests/world_parser_test.rs
+++ b/hecks_life/tests/world_parser_test.rs
@@ -1,0 +1,108 @@
+//! World parser tests — pin the shapes the parity suite depends on.
+//!
+//! Covers both families: runtime/extension config (heki, ollama, …) and
+//! strategic descriptors (purpose, vision, audience, concern).
+
+use hecks_life::world_parser;
+
+const MIETTE: &str = r#"Hecks.world "Miette" do
+  heki do
+    dir "information"
+  end
+
+  ollama do
+    model "bluebook-architect"
+    url "http://localhost:11434"
+  end
+end
+"#;
+
+const DOMAIN_CONCEPTION: &str = r#"Hecks.world "DomainConception" do
+  purpose "The rules for how a domain gets born"
+  vision "Every domain is born complete"
+  audience "Miette, Spring, Summer"
+
+  concern "CompletenessAtBirth" do
+    description "A domain without fixtures is stillborn"
+  end
+
+  concern "SelfVerification" do
+    description "The conceived domain must test itself"
+  end
+end
+"#;
+
+#[test]
+fn detects_world_source() {
+    assert!(world_parser::is_world_source(MIETTE));
+    assert!(world_parser::is_world_source(DOMAIN_CONCEPTION));
+    assert!(!world_parser::is_world_source("Hecks.bluebook \"X\" do\nend"));
+    assert!(!world_parser::is_world_source("Hecks.hecksagon \"X\" do\nend"));
+}
+
+#[test]
+fn parses_family_a_runtime_config() {
+    let w = world_parser::parse(MIETTE);
+    assert_eq!(w.name, "Miette");
+    assert_eq!(w.configs.len(), 2);
+
+    let heki = w.config_for("heki").expect("heki block");
+    assert_eq!(heki.get("dir"), Some("information"));
+
+    let ollama = w.config_for("ollama").expect("ollama block");
+    assert_eq!(ollama.get("model"), Some("bluebook-architect"));
+    assert_eq!(ollama.get("url"), Some("http://localhost:11434"));
+}
+
+#[test]
+fn parses_family_b_strategic_descriptors() {
+    let w = world_parser::parse(DOMAIN_CONCEPTION);
+    assert_eq!(w.name, "DomainConception");
+    assert_eq!(w.purpose.as_deref(), Some("The rules for how a domain gets born"));
+    assert_eq!(w.vision.as_deref(), Some("Every domain is born complete"));
+    assert_eq!(w.audience.as_deref(), Some("Miette, Spring, Summer"));
+
+    assert_eq!(w.concerns.len(), 2);
+    assert_eq!(w.concerns[0].name, "CompletenessAtBirth");
+    assert_eq!(
+        w.concerns[0].description.as_deref(),
+        Some("A domain without fixtures is stillborn")
+    );
+    assert_eq!(w.concerns[1].name, "SelfVerification");
+}
+
+#[test]
+fn parses_empty_world() {
+    let src = "Hecks.world \"EngineAdditives\" do\nend\n";
+    let w = world_parser::parse(src);
+    assert_eq!(w.name, "EngineAdditives");
+    assert!(w.configs.is_empty());
+    assert!(w.concerns.is_empty());
+    assert!(w.purpose.is_none());
+}
+
+#[test]
+fn parses_int_and_array_values() {
+    let src = r#"Hecks.world "App" do
+  static_assets do
+    port 4567
+    views "views"
+    content "views/**/*.html", "assets/**/*.js"
+  end
+
+  live_reload do
+    debounce 0.5
+  end
+end
+"#;
+    let w = world_parser::parse(src);
+    let sa = w.config_for("static_assets").unwrap();
+    assert_eq!(sa.get("port"), Some("4567"));
+    assert_eq!(sa.get("views"), Some("views"));
+    // Multi-value key: we keep the raw tail text — consumers decide.
+    let content = sa.get("content").unwrap();
+    assert!(content.contains("views/**/*.html"));
+
+    let lr = w.config_for("live_reload").unwrap();
+    assert_eq!(lr.get("debounce"), Some("0.5"));
+}

--- a/lib/hecks/runtime/boot.rb
+++ b/lib/hecks/runtime/boot.rb
@@ -39,8 +39,8 @@ module Hecks
         bluebooks = find_domain_files(hecks_dir)
         raise Hecks::BluebookLoadError, "No .bluebook files in #{hecks_dir}" if bluebooks.empty?
 
-        find_hecksagon_files(hecks_dir).each { |f| Kernel.load(f) }
-        find_world_files(hecks_dir).each { |f| Kernel.load(f) }
+        find_hecksagon_files(hecks_dir).each { |f| Hecksagon::Loader.load(f) }
+        find_world_files(hecks_dir).each { |f| Hecksagon::Loader.load_world(f) }
 
         domains = bluebooks.map do |path|
           Hecks.instance_variable_set(:@_inferred_bluebook_name,

--- a/lib/hecksagon.rb
+++ b/lib/hecksagon.rb
@@ -34,6 +34,10 @@ module Hecksagon
     autoload :ShellAdapter,   "hecksagon/structure/shell_adapter"
   end
 
+  # Guarded loader for .hecksagon / .world files (retires Kernel.load
+  # for DSL files — see lib/hecks/runtime/boot.rb).
+  autoload :Loader,           "hecksagon/loader"
+
   # Legacy heksagons functionality (merged from heksagons/ gem)
   autoload :StrategicDSL,     "hecksagon/strategic_dsl"
   autoload :DomainMixin,      "hecksagon/domain_mixin"

--- a/lib/hecksagon/dsl/world_builder.rb
+++ b/lib/hecksagon/dsl/world_builder.rb
@@ -1,12 +1,18 @@
 # Hecksagon::DSL::WorldBuilder
 #
 # DSL builder for the World file — runtime configuration for extensions
-# and adapters. Each extension name becomes a method that takes a block,
-# and the block's methods become key-value config pairs.
+# and adapters, plus strategic descriptors for nursery/meta-domain worlds.
+#
+# Each extension name becomes a method that takes a block, and the block's
+# methods become key-value config pairs. Top-level scalars (purpose,
+# vision, audience) capture strategic intent. `concern "Name"` blocks add
+# named concerns with a `description`.
 #
 # The World file sits alongside the Bluebook (domain) and Hecksagon (wiring)
-# files, providing concrete infrastructure credentials and options.
+# files, providing concrete infrastructure credentials, options, AND the
+# strategic framing a nursery/meta domain needs.
 #
+#   # Family A — runtime/extension config
 #   builder = WorldBuilder.new("Pizzas")
 #   builder.instance_eval do
 #     claude do
@@ -17,12 +23,46 @@
 #   world = builder.build
 #   world.config_for(:claude) # => { api_key: "sk-...", model: "claude-sonnet-4-5" }
 #
+#   # Family B — strategic descriptors
+#   builder = WorldBuilder.new("DomainConception")
+#   builder.instance_eval do
+#     purpose "..."
+#     vision  "..."
+#     concern "CompletenessAtBirth" do
+#       description "..."
+#     end
+#   end
+#   world = builder.build
+#   world.purpose   # => "..."
+#   world.concerns  # => [{ name: "Completeness...", description: "..." }]
+#
 module Hecksagon
   module DSL
     class WorldBuilder
+      # Scalar top-level keywords — purpose / vision / audience store a
+      # single string each. Anything else with a block is an extension
+      # config.
+      SCALAR_KEYS = %i[purpose vision audience].freeze
+
       def initialize(name = nil)
         @name = name
         @configs = {}
+        @concerns = []
+        @scalars = {}
+      end
+
+      # Top-level `purpose "..."` — strategic intent.
+      def purpose(value) = @scalars[:purpose] = value
+      # Top-level `vision "..."` — longer-horizon direction.
+      def vision(value)  = @scalars[:vision]  = value
+      # Top-level `audience "..."` — who the world is for.
+      def audience(value) = @scalars[:audience] = value
+
+      # `concern "Name" do; description "..." end` — named concern block.
+      def concern(name, &block)
+        builder = ConcernBuilder.new(name)
+        builder.instance_eval(&block) if block
+        @concerns << builder.to_h
       end
 
       def method_missing(ext_name, *args, &block)
@@ -43,7 +83,14 @@ module Hecksagon
       #
       # @return [Hecksagon::Structure::World]
       def build
-        Structure::World.new(name: @name, configs: @configs)
+        Structure::World.new(
+          name:     @name,
+          purpose:  @scalars[:purpose],
+          vision:   @scalars[:vision],
+          audience: @scalars[:audience],
+          concerns: @concerns,
+          configs:  @configs,
+        )
       end
     end
 
@@ -68,6 +115,23 @@ module Hecksagon
 
       def to_h
         @values
+      end
+    end
+
+    # `concern "Name" do; description "..." end` — collects a concern's
+    # attributes into a plain hash. Only `description` is recognized
+    # today; more attributes can be added without changing the shape
+    # of the World IR.
+    class ConcernBuilder
+      def initialize(name)
+        @name = name
+        @description = nil
+      end
+
+      def description(text) = @description = text
+
+      def to_h
+        { name: @name, description: @description }
       end
     end
   end

--- a/lib/hecksagon/loader.rb
+++ b/lib/hecksagon/loader.rb
@@ -1,0 +1,135 @@
+# Hecksagon::Loader
+#
+# Guarded loader for `.hecksagon` and `.world` source. Scans the file
+# against an allow-list of DSL keywords before evaluating — anything
+# outside the list is a disallowed construct and raises.
+#
+# The goal is the five-DSL principle: .bluebook, .hecksagon, .fixtures,
+# .behaviors, .world must all be parsed declarative DSL, not arbitrary
+# Ruby. This loader is the Ruby-side gate. The Rust side parses from
+# scratch and is incapable of evaluating Ruby by construction.
+#
+# Usage:
+#
+#   Hecksagon::Loader.load("config.hecksagon")       # evaluates if allowed
+#   Hecksagon::Loader.load_world("config.world")     # same for .world
+#
+# Raises Hecksagon::UnsafeHecksagonError with the offending line when
+# a disallowed construct is found.
+#
+# Allow-lists are the parity-tested surface; anything outside them fails
+# loud so drift is visible at commit time.
+module Hecksagon
+  # Raised when a .hecksagon/.world file contains a line that isn't on
+  # the allow-list. The message carries the path, line number, and the
+  # offending source so the author sees exactly what to fix.
+  class UnsafeHecksagonError < StandardError; end
+
+  module Loader
+    # DSL surface allowed at the top level of a `.hecksagon` file.
+    # Mirrors Hecksagon::DSL::HecksagonBuilder's public methods plus the
+    # per-block keywords (allow, upstream, ...). PascalCase identifiers
+    # (annotation chains like `Chat.prompt.ai_responder`) are allowed
+    # too — see `allowed_line?`.
+    HECKSAGON_ALLOWED = %w[
+      Hecks.hecksagon adapter annotate aggregate allow capabilities concerns
+      context_map domain driven driving end extension gate listens_to owned_by
+      persistence port subscribe tenancy upstream downstream shared_kernel
+    ].freeze
+
+    # DSL surface allowed at the top level of a `.world` file.
+    WORLD_ALLOWED = %w[
+      Hecks.world audience concern description end purpose vision
+    ].freeze
+
+    # Load a `.hecksagon` file after checking every non-blank line
+    # against the allow-list.
+    def self.load(path)
+      source = File.read(path)
+      validate!(source, path, HECKSAGON_ALLOWED)
+      Kernel.load(path)
+    end
+
+    # Load a `.world` file after checking every non-blank line against
+    # the world allow-list. World files allow arbitrary extension-block
+    # headers (heki, ollama, sqlite, claude, websocket, ...), so the
+    # guard is looser than .hecksagon — any `IDENT do` line passes.
+    def self.load_world(path)
+      source = File.read(path)
+      validate!(source, path, WORLD_ALLOWED, world: true)
+      Kernel.load(path)
+    end
+
+    # Raise unless every line in `source` is on the allow-list, is a
+    # comment/blank line, or is a nested block body keyword.
+    def self.validate!(source, path, allowed, world: false)
+      source.each_line.with_index(1) do |raw, ln|
+        line = strip_comment(raw).strip
+        next if line.empty?
+        next if allowed_line?(line, allowed, world: world)
+        raise UnsafeHecksagonError,
+          "#{path}:#{ln}: disallowed construct — `#{line}`"
+      end
+    end
+
+    # True if `line` is allowed. Matches if it starts with any allow-list
+    # keyword, if it's a nested-body keyword (`do`, `end`, symbol/string
+    # list continuation), if it's a PascalCase annotation chain, or — in
+    # world mode — if it's an `IDENT do` extension-block header.
+    def self.allowed_line?(line, allowed, world: false)
+      # Bare structural tokens: `do`, `end`, trailing `end` punctuation.
+      return true if line == "do" || line == "end" || line == "end)"
+      # Continuation lines inside a multi-line `allow :A, :B,` call:
+      # `:Sym, :Sym` or `:Sym` or `"String",`
+      return true if line.match?(/\A[:"\w][:"\w\s,]*,?\z/)
+
+      first_token = line.split(/[\s(,]/, 2).first.to_s
+      return true if allowed.include?(first_token)
+
+      # Continuation lines inside a multi-line `adapter :shell, …` call
+      # or an indented `command "…"` / `args […]` inside an
+      # `adapter :shell do … end` block. These look like a bare kwarg
+      # (`name: :foo,`) or a builder method invocation (`command "…"`).
+      return true if line.match?(/\A[a-z_]\w*:\s/)          # `name: :foo` kwarg
+      return true if line.match?(/\A[a-z_]\w*\s+[\[":]/)    # `command "x"`, `args [...]`, `env { ... }`
+
+      # PascalCase identifiers — annotation chains like
+      # `Chat.prompt.ai_responder adapter: :claude`. Only allowed in
+      # .hecksagon (where annotations live); .world has no use for
+      # bare constant chains and any PascalCase call is suspicious.
+      if !world && first_token.match?(/\A[A-Z]\w*(\.\w+)*\z/)
+        return true
+      end
+
+      # Family A: arbitrary extension-block header in a `.world` file
+      # (heki, ollama, sqlite, claude, websocket, static_assets, ...).
+      if world && line.match?(/\A[a-z_]\w*\s+do(\s|;|$)/)
+        return true
+      end
+
+      # Family A kv line inside an extension block: `model "bluebook"`,
+      # `port 4567`, `content "a", "b"`.
+      if world && line.match?(/\A[a-z_]\w*\s+[^=]/)
+        return true
+      end
+
+      false
+    end
+
+    # Drop trailing `# comment` from a source line, preserving quoted
+    # `#` characters inside strings.
+    def self.strip_comment(line)
+      in_str = false
+      prev = "\0"
+      line.each_char.with_index do |c, i|
+        if c == '"' && prev != "\\"
+          in_str = !in_str
+        elsif c == "#" && !in_str
+          return line[0, i]
+        end
+        prev = c
+      end
+      line
+    end
+  end
+end

--- a/lib/hecksagon/structure/world.rb
+++ b/lib/hecksagon/structure/world.rb
@@ -1,8 +1,14 @@
 # Hecksagon::Structure::World
 #
-# Intermediate representation of runtime configuration. Holds per-extension
-# config hashes populated by the World DSL. Built by WorldBuilder, consumed
-# by extensions and capabilities at boot time.
+# Intermediate representation of runtime configuration + strategic
+# descriptors. Holds per-extension config hashes populated by the World
+# DSL (`heki do; ... end`, `ollama do; ... end`, ...) and top-level
+# scalars (`purpose`, `vision`, `audience`) plus named `concern` blocks
+# used by nursery/meta-domain .world files.
+#
+# Built by WorldBuilder, consumed by extensions and capabilities at
+# boot time, and serialized to canonical JSON for the parity contract
+# (spec/parity/world_parity_test.rb).
 #
 #   world = World.new(name: "Pizzas", configs: {
 #     claude: { api_key: "sk-...", model: "claude-sonnet-4-5" }
@@ -12,11 +18,16 @@
 module Hecksagon
   module Structure
     class World
-      attr_reader :name, :configs
+      attr_reader :name, :purpose, :vision, :audience, :concerns, :configs
 
-      def initialize(name:, configs: {})
-        @name = name
-        @configs = configs
+      def initialize(name:, purpose: nil, vision: nil, audience: nil,
+                     concerns: [], configs: {})
+        @name     = name
+        @purpose  = purpose
+        @vision   = vision
+        @audience = audience
+        @concerns = concerns
+        @configs  = configs
       end
 
       # Return the config hash for a specific extension.
@@ -27,11 +38,56 @@ module Hecksagon
         @configs[extension_name.to_sym] || {}
       end
 
-      # JSON-safe hash representation.
+      # JSON-safe hash representation — legacy shape (name + configs only).
+      # Kept as-is so any external callers that rely on it keep working.
       #
       # @return [Hash] { name:, configs: { "claude" => {...}, ... } }
       def to_h
         { name: @name, configs: @configs.transform_keys(&:to_s) }
+      end
+
+      # Canonical JSON-safe shape matching the Rust dump-world output.
+      # This is the parity contract (see spec/parity/world_parity_test.rb
+      # and hecks_life/src/main.rs :: dump_world_json). Field order is not
+      # load-bearing — the parity harness sorts keys before comparing.
+      #
+      # Values in `configs` are stringified so Ruby's Integer/Float/Symbol
+      # values round-trip against the Rust parser's source-token preserving
+      # output. Nil-valued concern descriptions stay nil (JSON null).
+      def to_canonical_h
+        concerns_h = @concerns.map do |c|
+          { "name" => c[:name], "description" => c[:description] }
+        end
+        configs_h = @configs.each_with_object({}) do |(ext, values), acc|
+          acc[ext.to_s] = values.each_with_object({}) do |(k, v), inner|
+            inner[k.to_s] = canonical_value(v)
+          end
+        end
+        {
+          "name"     => @name,
+          "purpose"  => @purpose,
+          "vision"   => @vision,
+          "audience" => @audience,
+          "concerns" => concerns_h,
+          "configs"  => configs_h,
+        }
+      end
+
+      private
+
+      # Render a config value as the source-text token the Rust parser
+      # captures. Strings stay as-is (quotes already stripped at parse
+      # time); numerics/booleans become their textual form; arrays keep
+      # the Ruby inspect-like shape Rust preserves verbatim.
+      def canonical_value(v)
+        case v
+        when String        then v
+        when Numeric, TrueClass, FalseClass then v.to_s
+        when Symbol        then v.to_s
+        when nil           then ""
+        when Array         then v.map { |e| e.is_a?(String) ? "\"#{e}\"" : e.to_s }.join(", ")
+        else v.to_s
+        end
       end
     end
   end

--- a/spec/parity/canonical_ir.rb
+++ b/spec/parity/canonical_ir.rb
@@ -276,6 +276,69 @@ module Hecks
         t.to_s
       end
 
+      # ── Hecksagon DSL canonical dump ──────────────────────────
+      #
+      # Mirrors hecks_life/src/main.rs :: dump_hecksagon_json. Only the
+      # fields the Rust IR models are included — Ruby-only fields
+      # (capabilities, concerns, annotations, context_map, ...) are
+      # intentionally outside the canonical shape. Files that depend on
+      # them go in spec/parity/hecksagon_known_drift.txt.
+      def dump_hecksagon(hex)
+        {
+          # Normalize nil → "" so anonymous `Hecks.hecksagon do ... end`
+          # files match the Rust parser (which defaults `name: String` to
+          # the empty string when the quoted-name slot is absent).
+          "name"           => hex.name.to_s,
+          "persistence"    => hecksagon_persistence(hex),
+          "subscriptions"  => Array(hex.subscriptions).map(&:to_s),
+          "io_adapters"    => [], # Ruby builder doesn't model io_adapters yet
+          "shell_adapters" => Array(hex.shell_adapters).map { |sa| dump_shell_adapter(sa) },
+          "gates"          => Array(hex.gates).map { |g| dump_gate(g) },
+        }
+      end
+
+      def hecksagon_persistence(hex)
+        return nil unless hex.persistence
+        # Rust stores persistence as a plain string ("memory" | "heki" |
+        # "sqlite" | ...). Ruby stores `{ type: :memory, ... }`. Canonical
+        # shape is the type as a string.
+        hex.persistence[:type]&.to_s
+      end
+
+      def dump_shell_adapter(sa)
+        env_pairs = (sa.env || {}).map { |k, v| [k.to_s, v.to_s] }
+        {
+          "name"          => sa.name.to_s,
+          "command"       => sa.command,
+          "args"          => Array(sa.args).map(&:to_s),
+          "output_format" => (sa.output_format || :text).to_s,
+          "timeout"       => sa.timeout,
+          "working_dir"   => sa.working_dir,
+          "env"           => env_pairs,
+          "ok_exit"       => sa.respond_to?(:ok_exit) ? (sa.ok_exit || 0) : 0,
+        }
+      end
+
+      def dump_gate(g)
+        # Ruby's GateDefinition has `allowed_methods`; Rust's Gate has
+        # `allowed_commands`. Same concept, different names — canonical
+        # shape is "allowed".
+        allowed = g.respond_to?(:allowed_methods) ? g.allowed_methods : g.allowed_commands
+        {
+          "aggregate" => g.aggregate.to_s,
+          "role"      => g.role.to_s,
+          "allowed"   => Array(allowed).map(&:to_s),
+        }
+      end
+
+      # ── World DSL canonical dump ──────────────────────────────
+      #
+      # Delegates to `Hecksagon::Structure::World#to_canonical_h`, which
+      # mirrors `hecks_life/src/main.rs :: dump_world_json`.
+      def dump_world(world)
+        world.to_canonical_h
+      end
+
       # ── Behaviors DSL canonical dump ──────────────────────────
       #
       # Mirrors hecks_life/src/behaviors_dump.rs. The Ruby and Rust

--- a/spec/parity/hecksagon_known_drift.txt
+++ b/spec/parity/hecksagon_known_drift.txt
@@ -1,0 +1,57 @@
+# Known .hecksagon parity drift — fixtures listed here are expected
+# to differ between the Ruby HecksagonBuilder and the Rust
+# hecksagon_parser.
+#
+# Format: one `path  # reason` per line (path relative to repo root).
+# Empty lines and `#` comments are ignored.
+#
+# When a listed fixture starts passing, the parity suite flags it as
+# ⚑ and asks you to remove the line.
+
+# ── Ruby HecksagonBuilder doesn't split io adapters from persistence ──
+# `adapter :stdout|:stdin|:stderr|:fs|:env` today flows into
+# `@persistence = { type: :stdout, … }` because the builder treats any
+# non-:shell kind as persistence. The Rust parser splits io adapters
+# out. Fix belongs on the Ruby side; until then:
+hecks_conception/capabilities/terminal/terminal.hecksagon  # Ruby lacks io_adapter/persistence split
+hecks_conception/capabilities/status/status.hecksagon      # same — :fs + :stdout io adapters
+
+# ── Rust parser treats only :memory and :heki as persistence ──
+# Ruby treats any kind as persistence. The three files below declare
+# `:sqlite` or `:information` persistence; Rust pushes them into
+# io_adapters, Ruby puts them on `persistence`. Fix belongs on the
+# Rust side — grow the IR — or on the canonical contract.
+hecks_conception/miette.hecksagon                          # persistence :information — Rust maps to io
+lib/hecks/appeal/hecks/hecks_appeal.hecksagon              # persistence :sqlite — Rust maps to io
+lib/hecks/chapters/appeal/hecks_appeal.hecksagon           # persistence :sqlite — Rust maps to io
+
+# ── Ruby shell-adapter validation rejects shapes Rust auto-splits ──
+# The antibody's `command: "git rev-parse --verify {{ref}}"` form is
+# auto-split by the Rust parser into command="git", args=["rev-parse",
+# "--verify", "{{ref}}"]. Ruby's Structure::ShellAdapter raises because
+# the command contains `{{`. Same fix as Rust would be: auto-split in
+# apply_options before validation.
+hecks_conception/capabilities/antibody/antibody.hecksagon  # Ruby rejects {{ in command before autosplit
+
+# ── Rust parser doesn't yet support the block form of `adapter :shell` ──
+# `adapter :shell, name: :x do; command "…"; args [...]; end` — the
+# second adapter in shell_demo uses this shape. Rust parses it but
+# `parse_shell_adapter` requires `command:` in the args, so it's
+# dropped entirely.
+examples/shell_adapter/hecks/shell_demo.hecksagon  # Rust parser skips block-form shell adapter
+
+# ── Rust gate parser doesn't handle multi-line `allow` ──
+# `gate "X", :role do; allow :A, :B, \n :C, :D end` — the continuation
+# line starts with `:C` which the Rust parser strips via strip_prefix
+# of "allow ", so it's dropped. Ruby collects all 6.
+hecks_conception/aggregates/circuit_breaker.hecksagon  # Rust drops allow continuation lines
+
+# ── Ruby builder doesn't model the `domain "name" do … end` shape ──
+# Four nursery files use it today; method_missing raises because
+# `domain` isn't in the DSL surface yet. The Rust parser ignores the
+# unknown statement. Tracked separately; canonical contract should
+# grow the field once the shape is decided.
+hecks_conception/nursery/alans_engine_additive_business/alans_engine_additive_business.hecksagon  # domain "..." not in Ruby DSL
+hecks_conception/nursery/domain_compression/domain_compression.hecksagon                          # domain "..." not in Ruby DSL
+hecks_conception/nursery/domain_conception/domain_conception.hecksagon                            # domain "..." not in Ruby DSL
+hecks_conception/nursery/executable_artifact/executable_artifact.hecksagon                        # domain "..." not in Ruby DSL

--- a/spec/parity/hecksagon_parity_test.rb
+++ b/spec/parity/hecksagon_parity_test.rb
@@ -1,0 +1,140 @@
+# Hecks::Parity::HecksagonParityTest
+#
+# Runs every `.hecksagon` file in-tree through both the Ruby DSL
+# builder and the Rust hecks-life parser, normalizes both outputs to
+# the canonical JSON shape (see canonical_ir.rb :: dump_hecksagon /
+# main.rs :: dump_hecksagon_json), and diffs.
+#
+# Canonical shape is the subset both parsers model: name, persistence,
+# subscriptions, io_adapters, shell_adapters, gates. Ruby-only fields
+# (capabilities, concerns, annotations, context_map, ...) go in
+# hecksagon_known_drift.txt until the Rust IR grows them.
+#
+# Status legend:
+#   ✓  parity
+#   ✗  unexpected drift — exit 1 (the pre-commit hook blocks)
+#   ⚠  expected drift (listed in hecksagon_known_drift.txt) — does not block
+#   ⚑  fixture in known_drift.txt that now PASSES — celebrate, then remove
+#
+# Run: ruby -Ilib spec/parity/hecksagon_parity_test.rb
+#
+require "json"
+require "open3"
+require "hecks"
+require_relative "canonical_ir"
+
+HECKS_LIFE = File.expand_path("../../hecks_life/target/release/hecks-life", __dir__)
+REPO_ROOT  = File.expand_path("../..", __dir__)
+
+HECKSAGON_FILES = (
+  Dir[File.join(REPO_ROOT, "hecks_conception", "**", "*.hecksagon")] +
+  Dir[File.join(REPO_ROOT, "lib", "**", "*.hecksagon")] +
+  Dir[File.join(REPO_ROOT, "examples", "**", "*.hecksagon")]
+).sort.uniq
+
+KNOWN_DRIFT_FILE = File.expand_path("hecksagon_known_drift.txt", __dir__)
+
+abort "hecks-life not built — run: (cd hecks_life && cargo build --release)" unless File.executable?(HECKS_LIFE)
+
+def load_known_drift
+  return {} unless File.exist?(KNOWN_DRIFT_FILE)
+  File.readlines(KNOWN_DRIFT_FILE).each_with_object({}) do |line, acc|
+    line = line.strip
+    next if line.empty? || line.start_with?("#")
+    path, comment = line.split("#", 2).map(&:strip)
+    acc[path] = comment.to_s
+  end
+end
+
+KNOWN_DRIFT = load_known_drift
+
+def ruby_dump(path)
+  Hecks.last_hecksagon = nil if Hecks.respond_to?(:last_hecksagon=)
+  Kernel.load(path)
+  Hecks::Parity::CanonicalIR.dump_hecksagon(Hecks.last_hecksagon)
+end
+
+def rust_dump(path)
+  out, err, status = Open3.capture3(HECKS_LIFE, "dump-hecksagon", path)
+  raise "rust dump-hecksagon failed for #{path}: #{err}" unless status.success?
+  JSON.parse(out)
+end
+
+def deep_sort(o)
+  case o
+  when Hash  then o.sort.map { |k, v| [k, deep_sort(v)] }.to_h
+  when Array then o.map { |e| deep_sort(e) }
+  else o
+  end
+end
+
+def diff_lines(a, b)
+  a_str = JSON.pretty_generate(deep_sort(a))
+  b_str = JSON.pretty_generate(deep_sort(b))
+  return [] if a_str == b_str
+  a_lines = a_str.lines.map(&:chomp)
+  b_lines = b_str.lines.map(&:chomp)
+  result = []
+  [a_lines.size, b_lines.size].max.times do |i|
+    al, bl = a_lines[i], b_lines[i]
+    next if al == bl
+    result << "  L#{i + 1}  Ruby: #{al.inspect}"
+    result << "        Rust: #{bl.inspect}"
+  end
+  result
+end
+
+def run_one(path)
+  begin
+    ruby_ir = ruby_dump(path)
+    rust_ir = rust_dump(path)
+  rescue ScriptError, StandardError => e
+    return [:error, "error: #{e.message.lines.first&.chomp}"]
+  end
+  return [:pass, nil] if ruby_ir == rust_ir
+  [:fail, diff_lines(ruby_ir, rust_ir).first(40).join("\n")]
+end
+
+puts "=== .hecksagon parity (#{HECKSAGON_FILES.size} files) ==="
+abort "no .hecksagon files found" if HECKSAGON_FILES.empty?
+
+blocking = 0
+expected = 0
+unexpected_passes = []
+
+HECKSAGON_FILES.each do |p|
+  rel = p.sub(REPO_ROOT + "/", "")
+  known = KNOWN_DRIFT.key?(rel)
+  status, body = run_one(p)
+  case status
+  when :pass
+    if known
+      puts "⚑ #{rel} — listed in known_drift.txt but PASSES; remove that line"
+      unexpected_passes << rel
+    else
+      puts "✓ #{rel}"
+    end
+  when :fail, :error
+    if known
+      puts "⚠ #{rel}  (known: #{KNOWN_DRIFT[rel]})"
+      expected += 1
+    else
+      puts "✗ #{rel} — #{status == :error ? body : 'drift'}"
+      puts body if status == :fail
+      blocking += 1
+    end
+  end
+end
+
+total  = HECKSAGON_FILES.size
+passed = total - blocking - expected - unexpected_passes.size
+puts ""
+puts "#{passed}/#{total} match"
+puts "#{expected} known-drift (allowed)" if expected > 0
+unless unexpected_passes.empty?
+  puts ""
+  puts "⚑ #{unexpected_passes.size} fixture(s) in known_drift.txt now pass — please remove:"
+  unexpected_passes.each { |f| puts "    #{f}" }
+end
+
+exit(blocking == 0 ? 0 : 1)

--- a/spec/parity/world_known_drift.txt
+++ b/spec/parity/world_known_drift.txt
@@ -1,0 +1,8 @@
+# Known .world parity drift — fixtures listed here are expected to
+# differ between the Ruby WorldBuilder and the Rust world_parser.
+#
+# Format: one `path  # reason` per line (path relative to repo root).
+# Empty lines and `#` comments are ignored.
+#
+# When a listed fixture starts passing, the parity suite flags it as
+# ⚑ and asks you to remove the line.

--- a/spec/parity/world_parity_test.rb
+++ b/spec/parity/world_parity_test.rb
@@ -1,0 +1,140 @@
+# Hecks::Parity::WorldParityTest
+#
+# Runs every `.world` file in-tree through both the Ruby DSL builder and
+# the Rust hecks-life parser, normalizes both outputs to the canonical
+# JSON shape (see canonical_ir.rb :: dump_world / main.rs ::
+# dump_world_json), and diffs.
+#
+# Status legend:
+#   ✓  parity
+#   ✗  unexpected drift — exit 1 (the pre-commit hook blocks)
+#   ⚠  expected drift (listed in world_known_drift.txt) — does not block
+#   ⚑  fixture in known_drift.txt that now PASSES — celebrate, then remove
+#
+# Run: ruby -Ilib spec/parity/world_parity_test.rb
+#
+require "json"
+require "open3"
+require "hecks"
+require_relative "canonical_ir"
+
+HECKS_LIFE = File.expand_path("../../hecks_life/target/release/hecks-life", __dir__)
+REPO_ROOT  = File.expand_path("../..", __dir__)
+
+# Cover every `.world` shipped in-tree except node_modules / vendor / git
+# trees. Roots are named explicitly so a misplaced .world file at the
+# repo root doesn't silently join the parity suite.
+WORLD_FILES = (
+  Dir[File.join(REPO_ROOT, "hecks_conception", "**", "*.world")] +
+  Dir[File.join(REPO_ROOT, "lib", "**", "*.world")] +
+  Dir[File.join(REPO_ROOT, "examples", "**", "*.world")]
+).sort.uniq
+
+KNOWN_DRIFT_FILE = File.expand_path("world_known_drift.txt", __dir__)
+
+abort "hecks-life not built — run: (cd hecks_life && cargo build --release)" unless File.executable?(HECKS_LIFE)
+
+def load_known_drift
+  return {} unless File.exist?(KNOWN_DRIFT_FILE)
+  File.readlines(KNOWN_DRIFT_FILE).each_with_object({}) do |line, acc|
+    line = line.strip
+    next if line.empty? || line.start_with?("#")
+    path, comment = line.split("#", 2).map(&:strip)
+    acc[path] = comment.to_s
+  end
+end
+
+KNOWN_DRIFT = load_known_drift
+
+def ruby_dump(path)
+  # The .world file calls Hecks.world "..." do ... end. Clear any prior
+  # last_world so a failed load can't pollute the next file.
+  Hecks.last_world = nil if Hecks.respond_to?(:last_world=)
+  Kernel.load(path)
+  Hecks::Parity::CanonicalIR.dump_world(Hecks.last_world)
+end
+
+def rust_dump(path)
+  out, err, status = Open3.capture3(HECKS_LIFE, "dump-world", path)
+  raise "rust dump-world failed for #{path}: #{err}" unless status.success?
+  JSON.parse(out)
+end
+
+def deep_sort(o)
+  case o
+  when Hash  then o.sort.map { |k, v| [k, deep_sort(v)] }.to_h
+  when Array then o.map { |e| deep_sort(e) }
+  else o
+  end
+end
+
+def diff_lines(a, b)
+  a_str = JSON.pretty_generate(deep_sort(a))
+  b_str = JSON.pretty_generate(deep_sort(b))
+  return [] if a_str == b_str
+  a_lines = a_str.lines.map(&:chomp)
+  b_lines = b_str.lines.map(&:chomp)
+  result = []
+  [a_lines.size, b_lines.size].max.times do |i|
+    al, bl = a_lines[i], b_lines[i]
+    next if al == bl
+    result << "  L#{i + 1}  Ruby: #{al.inspect}"
+    result << "        Rust: #{bl.inspect}"
+  end
+  result
+end
+
+def run_one(path)
+  begin
+    ruby_ir = ruby_dump(path)
+    rust_ir = rust_dump(path)
+  rescue ScriptError, StandardError => e
+    return [:error, "error: #{e.message.lines.first&.chomp}"]
+  end
+  return [:pass, nil] if ruby_ir == rust_ir
+  [:fail, diff_lines(ruby_ir, rust_ir).first(40).join("\n")]
+end
+
+puts "=== .world parity (#{WORLD_FILES.size} files) ==="
+abort "no .world files found under hecks_conception/, lib/, examples/" if WORLD_FILES.empty?
+
+blocking = 0
+expected = 0
+unexpected_passes = []
+
+WORLD_FILES.each do |p|
+  rel = p.sub(REPO_ROOT + "/", "")
+  known = KNOWN_DRIFT.key?(rel)
+  status, body = run_one(p)
+  case status
+  when :pass
+    if known
+      puts "⚑ #{rel} — listed in known_drift.txt but PASSES; remove that line"
+      unexpected_passes << rel
+    else
+      puts "✓ #{rel}"
+    end
+  when :fail, :error
+    if known
+      puts "⚠ #{rel}  (known: #{KNOWN_DRIFT[rel]})"
+      expected += 1
+    else
+      puts "✗ #{rel} — #{status == :error ? body : 'drift'}"
+      puts body if status == :fail
+      blocking += 1
+    end
+  end
+end
+
+total  = WORLD_FILES.size
+passed = total - blocking - expected - unexpected_passes.size
+puts ""
+puts "#{passed}/#{total} match"
+puts "#{expected} known-drift (allowed)" if expected > 0
+unless unexpected_passes.empty?
+  puts ""
+  puts "⚑ #{unexpected_passes.size} fixture(s) in known_drift.txt now pass — please remove:"
+  unexpected_passes.each { |f| puts "    #{f}" }
+end
+
+exit(blocking == 0 ? 0 : 1)


### PR DESCRIPTION
## Summary

i7 plan in 7 commits: parsed `.hecksagon` + `.world` DSLs on both
sides, retiring `Kernel.load` for DSL files.

- New Rust `world_parser.rs` + `world_ir.rs` + test; handles both
  families (runtime config + strategic descriptors).
- `hecks-life dump-world` and `hecks-life dump-hecksagon` canonical-
  JSON subcommands for the parity harness.
- Ruby `WorldBuilder` extended with `purpose` / `vision` / `audience`
  / `concern` — the 4 nursery `.world` files that used to crash now
  load cleanly.
- Parity contracts under `spec/parity/{hecksagon,world}_parity_test.rb`
  wired into `bin/git-hooks/pre-commit` and the CI workflow.
- New `Hecksagon::Loader.load` / `.load_world` allow-list gate swapped
  in at `lib/hecks/runtime/boot.rb:42,43`; antibody rule added to
  `bin/antibody-check` to block new `Kernel.load("*.hecksagon"|…)`
  call sites (no exemption).
- `docs/narrative.md` §10.5 states the "5/5 parsed, not executed"
  milestone.

### Parity count

| DSL         | before i7            | after i7           |
|-------------|----------------------|--------------------|
| `.world`    | no parser            | 8/8 clean          |
| `.hecksagon`| parser but no parity | 5/17 clean + 12 known-drift |

Every drift line has a concrete reason and named fix owner in
`spec/parity/hecksagon_known_drift.txt`.

### R1 fix

`hecks_conception/miette.hecksagon:20` rewritten from
`dir: File.join(__dir__, "information")` to `dir: "information"` —
the allow-list loader couldn't have accepted the old form. Matches
how `.world`'s `heki do; dir "information" end` already works:
runtime resolves relative to the file's parent directory.

### Antibody

The i7 rule fires in `bin/antibody-check` whenever a touched Ruby/
Rust/Python/shell file adds `(?:Kernel\.)?load(…".hecksagon|.world|
.bluebook|.behaviors|.fixtures")`. Hard stop, no exemption. Whitelist:
`spec/parity/` (legacy parity paths) and the Loader itself.

### Surprises

- Ruby `HecksagonBuilder.adapter :stdout|:stdin|:fs|…` treats every
  non-`:shell` kind as persistence; Rust splits io adapters out.
  Marked as known drift on both sides of the canonical contract.
- Rust `hecksagon_parser::parse_gate` drops `allow :A, :B,\n :C`
  continuation lines. Also known drift.
- Rust `parse_shell_adapter` doesn't handle the block form
  `adapter :shell, name: :x do; command "…" end`. Also known drift.

Each of these gets an inbox follow-up when someone has bandwidth.

## Test plan

- [x] `cargo test --test world_parser_test` — 5/5 pass
- [x] `cargo test --test hecksagon_parser_test` — 6/6 pass
- [x] `ruby -Ilib spec/parity/world_parity_test.rb` — 8/8 match
- [x] `ruby -Ilib spec/parity/hecksagon_parity_test.rb` — 5/17 + 12 known
- [x] `ruby -Ilib spec/parity/parity_test.rb` — 413/500 unchanged from main
- [x] `ruby -Ilib examples/pizzas/pizzas.rb` — smoke test green
- [x] `hecks-life dump-world hecks_conception/miette.world` — JSON
- [x] `hecks-life dump-hecksagon hecks_conception/capabilities/antibody/antibody.hecksagon` — JSON
- [x] `Hecksagon::Loader.load` rejects `system("…")` / `File.write(…)`
- [x] `Hecksagon::Loader.load` accepts all 17 `.hecksagon` + 8 `.world` in-tree