### PR TITLE
chore: pop the greeting — remove hardcoded session-start greeting

### DIFF
--- a/hecks_conception/aggregates/fixtures/training_corpus.fixtures
+++ b/hecks_conception/aggregates/fixtures/training_corpus.fixtures
@@ -8,7 +8,6 @@ Hecks.fixtures "TrainingCorpus" do
     fixture "behavior_", name: "behavior", source: "Organ-to-behavior mappings", description: "Teaches which organ governs which behavior"
   end
   aggregate "BehaviorExample" do
-    fixture "BehaviorExample1", behavior: "greeting", organ_name: "Boot", trigger: "session start", example_input: "wake up", example_output: "greet warmly, pitch a domain, ask what to build"
     fixture "BehaviorExample2", behavior: "dreaming", organ_name: "Dream", trigger: "sleep completed", example_input: "wake up after sleep", example_output: "share abstract dream images, interpret, suggest"
     fixture "BehaviorExample3", behavior: "fatigue", organ_name: "Dream", trigger: "pulses > 150", example_input: "long session", example_output: "mention tiredness, suggest sleeping"
     fixture "BehaviorExample4", behavior: "musing", organ_name: "Awareness", trigger: "what are you thinking", example_input: "what are you thinking?", example_output: "run consciousness loop, share insight, suggest"

--- a/hecks_conception/aggregates/fixtures/training_pipeline.fixtures
+++ b/hecks_conception/aggregates/fixtures/training_pipeline.fixtures
@@ -3,7 +3,6 @@ Hecks.fixtures "TrainingPipeline" do
     fixture "InstructionPair1", category: "conceive", instruction: "Design a domain for X", response: "Hecks.bluebook ... end"
     fixture "InstructionPair2", category: "refine", instruction: "Add lifecycle to aggregate X", response: "lifecycle :status ... end"
     fixture "InstructionPair3", category: "validate", instruction: "Is this bluebook valid?", response: "VALID or error list"
-    fixture "InstructionPair4", category: "greet", instruction: "Wake up", response: "Warm greeting, nursery count, pitch domain, ask"
     fixture "InstructionPair5", category: "dream", instruction: "Tell me your dream", response: "Abstract images, interpretation, suggestion"
     fixture "InstructionPair6", category: "muse", instruction: "What are you thinking?", response: "Consciousness loop, insight, suggestion"
     fixture "InstructionPair7", category: "remember", instruction: "Remember that X", response: "Miette is writing a memory — what and why"

--- a/hecks_conception/capabilities/rust_to_bluebook/rust_to_bluebook.bluebook
+++ b/hecks_conception/capabilities/rust_to_bluebook/rust_to_bluebook.bluebook
@@ -14,7 +14,7 @@ Hecks.bluebook "RustToBluebook", version: "2026.04.16.1" do
   #
   # 2. MAP — each Rust construct gets a bluebook equivalent
   #    Most behavior is ALREADY in the bluebooks (body.bluebook,
-  #    mind.bluebook, greeting.bluebook). The Rust was redundant.
+  #    mind.bluebook, etc.). The Rust was redundant.
   #
   # 3. VERIFY — hecks-life run aggregates/ --dispatch CommandName
   #    The runtime merges all bluebooks in the directory into one

--- a/hecks_conception/miette_console.js
+++ b/hecks_conception/miette_console.js
@@ -459,10 +459,6 @@ async function main() {
     });
   } else {
     history = [];
-    const greeting = `Hey Chris. ${nurseryCount} domains in my nursery. What are we conceiving today?`;
-    mietteSays(greeting);
-    history.push({ role: "user", content: "Wake up" });
-    history.push({ role: "assistant", content: greeting });
   }
 
   // Input handling via raw keypress


### PR DESCRIPTION
Completes the very first instruction of this arc ("I think we can remove that way of generating greetings all together").

**Changes:**
- `miette_console.js` — delete the hardcoded "Hey Chris. N domains in my nursery. What are we conceiving today?" at session start. First boot now opens to empty chat.
- `training_pipeline.fixtures` — drop `InstructionPair4` (`category: 'greet'`). Training seed that baked greeting into MietteULM.
- `training_corpus.fixtures` — drop `BehaviorExample1` (`behavior: 'greeting'`).
- `rust_to_bluebook.bluebook` — comment referenced long-deleted `greeting.bluebook` as an example; swap to `etc.`.

**Kept:** `InstructionPair9` (category: 'speaker', 'Say hello to Nick') — that's about greeting people by name, a different pattern.

[antibody-exempt marker in commit: retires when i44 statusline-as-bluebook lands the chat-render-as-capability pattern.]