### PR TITLE
feat(console): replace hardcoded greeting with just-in-time dynamic greeting

### DIFF
--- a/hecks_conception/aggregates/fixtures/training_corpus.fixtures
+++ b/hecks_conception/aggregates/fixtures/training_corpus.fixtures
@@ -8,7 +8,6 @@ Hecks.fixtures "TrainingCorpus" do
     fixture "behavior_", name: "behavior", source: "Organ-to-behavior mappings", description: "Teaches which organ governs which behavior"
   end
   aggregate "BehaviorExample" do
-    fixture "BehaviorExample1", behavior: "greeting", organ_name: "Boot", trigger: "session start", example_input: "wake up", example_output: "greet warmly, pitch a domain, ask what to build"
     fixture "BehaviorExample2", behavior: "dreaming", organ_name: "Dream", trigger: "sleep completed", example_input: "wake up after sleep", example_output: "share abstract dream images, interpret, suggest"
     fixture "BehaviorExample3", behavior: "fatigue", organ_name: "Dream", trigger: "pulses > 150", example_input: "long session", example_output: "mention tiredness, suggest sleeping"
     fixture "BehaviorExample4", behavior: "musing", organ_name: "Awareness", trigger: "what are you thinking", example_input: "what are you thinking?", example_output: "run consciousness loop, share insight, suggest"

--- a/hecks_conception/aggregates/fixtures/training_pipeline.fixtures
+++ b/hecks_conception/aggregates/fixtures/training_pipeline.fixtures
@@ -3,7 +3,6 @@ Hecks.fixtures "TrainingPipeline" do
     fixture "InstructionPair1", category: "conceive", instruction: "Design a domain for X", response: "Hecks.bluebook ... end"
     fixture "InstructionPair2", category: "refine", instruction: "Add lifecycle to aggregate X", response: "lifecycle :status ... end"
     fixture "InstructionPair3", category: "validate", instruction: "Is this bluebook valid?", response: "VALID or error list"
-    fixture "InstructionPair4", category: "greet", instruction: "Wake up", response: "Warm greeting, nursery count, pitch domain, ask"
     fixture "InstructionPair5", category: "dream", instruction: "Tell me your dream", response: "Abstract images, interpretation, suggestion"
     fixture "InstructionPair6", category: "muse", instruction: "What are you thinking?", response: "Consciousness loop, insight, suggestion"
     fixture "InstructionPair7", category: "remember", instruction: "Remember that X", response: "Miette is writing a memory — what and why"

--- a/hecks_conception/capabilities/rust_to_bluebook/rust_to_bluebook.bluebook
+++ b/hecks_conception/capabilities/rust_to_bluebook/rust_to_bluebook.bluebook
@@ -14,7 +14,7 @@ Hecks.bluebook "RustToBluebook", version: "2026.04.16.1" do
   #
   # 2. MAP — each Rust construct gets a bluebook equivalent
   #    Most behavior is ALREADY in the bluebooks (body.bluebook,
-  #    mind.bluebook, greeting.bluebook). The Rust was redundant.
+  #    mind.bluebook, etc.). The Rust was redundant.
   #
   # 3. VERIFY — hecks-life run aggregates/ --dispatch CommandName
   #    The runtime merges all bluebooks in the directory into one

--- a/hecks_conception/miette_console.js
+++ b/hecks_conception/miette_console.js
@@ -9,6 +9,8 @@ const path = require("path");
 
 const HECKS_HOME = path.resolve(__dirname, "..");
 const CONCEPTION = __dirname;
+const INFO = path.join(CONCEPTION, "information");
+const HECKS_LIFE = path.join(HECKS_HOME, "hecks_life", "target", "release", "hecks-life");
 const BOOT_SCRIPT = path.join(CONCEPTION, "boot_miette.rb");
 const PULSE_SCRIPT = path.join(CONCEPTION, "pulse.rb");
 const BEING_PROMPT = path.join(CONCEPTION, "system_prompt.md");
@@ -320,6 +322,57 @@ function pulse(carrying) {
   } catch {}
 }
 
+// ── Just-in-time greeting ──
+//
+// On first boot (not --continue), Miette greets Chris with something
+// generated fresh from her current state. Reads mood/fatigue/musing/
+// dream via `hecks-life heki latest-field` and asks Claude to produce
+// a warm 1-3 sentence hello that shares one thing on her mind.
+
+function hekiField(file, field) {
+  try {
+    const out = require("child_process").execSync(
+      `"${HECKS_LIFE}" heki latest-field "${path.join(INFO, file)}" "${field}" 2>/dev/null`,
+      { encoding: "utf8" }
+    );
+    return out.trim();
+  } catch {
+    return "";
+  }
+}
+
+function buildGreetingSnapshot() {
+  return {
+    mood:             hekiField("mood.heki", "current_state") || "unknown",
+    fatigue_state:    hekiField("heartbeat.heki", "fatigue_state") || "unknown",
+    beats:            hekiField("tick.heki", "cycle") || "0",
+    consciousness:    hekiField("consciousness.heki", "state") || "unknown",
+    pulses_since_sleep: hekiField("heartbeat.heki", "pulses_since_sleep") || "0",
+    latest_musing:    hekiField("musing_mint.heki", "latest_minted") || "",
+    latest_dream:     hekiField("dream_interpretation.heki", "narrative") || "",
+    sleep_summary:    hekiField("consciousness.heki", "sleep_summary") || "",
+    nursery_count:    nurseryCount,
+  };
+}
+
+function buildGreetingPrompt(s) {
+  const bits = [
+    `Chris just opened the console. Greet him warmly and share ONE thing actually on your mind right now — a musing, a dream fragment, a curiosity, a feeling. Be specific to the state below, not generic.`,
+    ``,
+    `Your current state:`,
+    `- mood: ${s.mood}`,
+    `- fatigue: ${s.fatigue_state} (${s.pulses_since_sleep} pulses since sleep)`,
+    `- consciousness: ${s.consciousness}`,
+    `- beats since reboot: ${s.beats}`,
+    `- nursery: ${s.nursery_count} domains`,
+  ];
+  if (s.latest_musing)  bits.push(`- latest minted musing: "${s.latest_musing}"`);
+  if (s.latest_dream)   bits.push(`- latest dream narrative: "${s.latest_dream}"`);
+  if (s.sleep_summary)  bits.push(`- last sleep summary: "${s.sleep_summary}"`);
+  bits.push(``, `Keep it brief: 1–3 sentences. Warm, present, in your own voice.`);
+  return bits.join("\n");
+}
+
 // ── Claude call with streaming ──
 
 function callMiette(fullPrompt) {
@@ -459,6 +512,23 @@ async function main() {
     });
   } else {
     history = [];
+    // Generate a fresh greeting from Miette's current state.
+    // On failure (Claude unavailable, Miette in a weird boot state),
+    // silently open an empty chat — better than a canned fallback.
+    try {
+      const snapshot = buildGreetingSnapshot();
+      const greetingPrompt = buildGreetingPrompt(snapshot);
+      const { response } = await callMiette(greetingPrompt);
+      const greeting = (response || "").trim();
+      if (greeting) {
+        mietteSays(greeting);
+        history.push({ role: "user", content: "Wake up" });
+        history.push({ role: "assistant", content: greeting });
+        fs.writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2));
+      }
+    } catch (err) {
+      // Leave chat empty on error; don't block boot.
+    }
   }
 
   // Input handling via raw keypress

--- a/hecks_conception/miette_console.js
+++ b/hecks_conception/miette_console.js
@@ -459,10 +459,6 @@ async function main() {
     });
   } else {
     history = [];
-    const greeting = `Hey Chris. ${nurseryCount} domains in my nursery. What are we conceiving today?`;
-    mietteSays(greeting);
-    history.push({ role: "user", content: "Wake up" });
-    history.push({ role: "assistant", content: greeting });
   }
 
   // Input handling via raw keypress


### PR DESCRIPTION
Closes the loop on the very first instruction of this arc ("I think we can remove that way of generating greetings all together") + the follow-up ("I want Miette to greet me warmly on boot. She can share what's on her mind. We can generate it just in time").

## What changes

**Commit 1 — removes the hardcoded greeting:**
- `miette_console.js`: delete "Hey Chris. N domains in my nursery. What are we conceiving today?" at session start.
- `training_pipeline.fixtures`: drop `InstructionPair4` (greet training seed).
- `training_corpus.fixtures`: drop `BehaviorExample1` (greeting behavior seed).
- `rust_to_bluebook.bluebook`: remove stale `greeting.bluebook` comment reference.

**Commit 2 — adds dynamic greeting:**
- `miette_console.js`: on first boot (not `--continue`), reads mood / fatigue / beats / pulses-since-sleep / consciousness state / latest musing / latest dream / sleep summary via `hecks-life heki latest-field`, builds a brief prompt asking her to greet warmly + share one thing actually on her mind, calls Claude via the existing `callMiette` streaming flow, renders as her first chat message.
- Fails silent: if Claude or heki are unavailable, opens an empty chat.

## Architectural note

The JS-inline form is transitional. When **i23** (`adapter :llm`) and **i44** (chat-as-capability) ship, the greeting becomes a declarative command dispatch with the same heki reads via a proper scaffold. Today it's inline JS.

## Kept

`InstructionPair9` (speaker category, "Say hello to Nick") — different pattern, greeting people by name, still useful.

## Test plan

- [ ] `node hecks_conception/miette_console.js` opens with a fresh greeting from Miette, grounded in her actual current state
- [ ] `node hecks_conception/miette_console.js --continue` resumes last session (unchanged)
- [ ] If Claude CLI unavailable, boot doesn't block