### PR TITLE
feat(specializer): i51 Phase A commit 2 — value-objects for L1-L6 IR

### DIFF
--- a/hecks_conception/capabilities/specializer/fixtures/specializer.fixtures
+++ b/hecks_conception/capabilities/specializer/fixtures/specializer.fixtures
@@ -1,0 +1,194 @@
+Hecks.fixtures "Specializer" do
+  # ── IRLayer — the nine layers L0..L8 from plan §3 ─────────────────
+  aggregate "IRLayer" do
+    fixture "L0_Bluebook",
+      name: "bluebook", number: 0,
+      description: "Source DSL — the five .bluebook / .hecksagon / .fixtures / .behaviors / .world files",
+      reads_from: "source",
+      returns: "raw file text",
+      ship_status: "shipped"
+
+    fixture "L1_CanonicalIR",
+      name: "canonical_ir", number: 1,
+      description: "Normalized JSON IR — parsed + validated + aggregate names resolved",
+      reads_from: "bluebook",
+      returns: "Domain struct (aggregates, commands, policies, references, fixtures)",
+      ship_status: "shipped"
+
+    fixture "L2_FlowIR",
+      name: "flow_ir", number: 2,
+      description: "Command graph per aggregate: commands → events → policies → triggers",
+      reads_from: "canonical_ir",
+      returns: "Per-aggregate command/event/policy adjacency — the reactive shape",
+      ship_status: "partial"
+
+    fixture "L3_DispatchIR",
+      name: "dispatch_ir", number: 3,
+      description: "Command bus lowered: middleware chain, guards, mutations, emissions, persistence",
+      reads_from: "flow_ir",
+      returns: "Per-command dispatch tree — ready for codegen",
+      ship_status: "partial"
+
+    fixture "L4_TickIR",
+      name: "tick_ir", number: 4,
+      description: "Body-cycle shape: which commands fire on mindstream / heart / consciousness ticks",
+      reads_from: "dispatch_ir",
+      returns: "Tick → commands[] manifest",
+      ship_status: "not_started"
+
+    fixture "L5_MemoryIR",
+      name: "memory_ir", number: 5,
+      description: "Heki I/O lowered: paths, append/upsert/read, serialization contracts",
+      reads_from: "dispatch_ir",
+      returns: "Per-aggregate storage contract",
+      ship_status: "partial"
+
+    fixture "L6_RustIR",
+      name: "rust_ir", number: 6,
+      description: "Rust-specific: module structure, ownership, lifetimes, Serde derives, trait dispatch",
+      reads_from: "canonical_ir+flow_ir+dispatch_ir+memory_ir",
+      returns: "Rust module tree — structs, impls, derives, use paths",
+      ship_status: "not_started"
+
+    fixture "L7_RustSource",
+      name: "rust_source", number: 7,
+      description: "Emitted .rs files, rustfmt normalized",
+      reads_from: "rust_ir",
+      returns: "Text of .rs files written to hecks_life/src/",
+      ship_status: "not_started"
+
+    fixture "L8_RustBinary",
+      name: "rust_binary", number: 8,
+      description: "The artifact — cargo-built hecks-life binary. Terminus.",
+      reads_from: "rust_source",
+      returns: "target/release/hecks-life",
+      ship_status: "shipped"
+  end
+
+  # ── Projection — one row per L_n → L_(n+1) lowering ───────────────
+  aggregate "Projection" do
+    fixture "ParseBluebook",
+      name: "parse_bluebook",
+      from_layer: "bluebook", to_layer: "canonical_ir",
+      transform_kind: "parse",
+      description: "Read L0 source text → L1 Domain struct. Ruby + Rust parsers already parity-locked.",
+      impl_module: "hecks_life/src/parser.rs + lib/hecks/dsl/*.rb",
+      ship_status: "shipped"
+
+    fixture "GraphFlow",
+      name: "graph_flow",
+      from_layer: "canonical_ir", to_layer: "flow_ir",
+      transform_kind: "graph",
+      description: "L1 → L2 — build command/event/policy adjacency per aggregate",
+      impl_module: "hecks_life/src/ir.rs (partial: references + policies)",
+      ship_status: "partial"
+
+    fixture "LowerDispatch",
+      name: "lower_dispatch",
+      from_layer: "flow_ir", to_layer: "dispatch_ir",
+      transform_kind: "lower",
+      description: "L2 → L3 — expand flow edges into middleware/guard/mutation/emission steps",
+      impl_module: "hecks_life/src/cascade.rs + run.rs (hand-written, Phase B target)",
+      ship_status: "partial"
+
+    fixture "DeriveTick",
+      name: "derive_tick",
+      from_layer: "dispatch_ir", to_layer: "tick_ir",
+      transform_kind: "lower",
+      description: "L3 → L4 — which commands fire on each body tick",
+      impl_module: "hecks_conception/*.sh (currently shell; Phase B target)",
+      ship_status: "partial"
+
+    fixture "LowerMemory",
+      name: "lower_memory",
+      from_layer: "dispatch_ir", to_layer: "memory_ir",
+      transform_kind: "lower",
+      description: "L3 → L5 — map aggregate state to heki paths and append/upsert contracts",
+      impl_module: "hecks_life/src/heki.rs + heki_query.rs (hand-written)",
+      ship_status: "partial"
+
+    fixture "SpecializeRust",
+      name: "specialize_rust",
+      from_layer: "canonical_ir", to_layer: "rust_ir",
+      transform_kind: "lower",
+      description: "L1 → L6 — the heart of the specializer. Applies per-target templates from the L0 shape bluebook",
+      impl_module: "hecks_life/src/specializer/ (Phase A commit 3+, not yet written)",
+      ship_status: "phase_a"
+
+    fixture "EmitRust",
+      name: "emit_rust",
+      from_layer: "rust_ir", to_layer: "rust_source",
+      transform_kind: "emit",
+      description: "L6 → L7 — render Rust module tree as .rs text, rustfmt-normalized",
+      impl_module: "hecks_life/src/specializer/emit.rs (Phase A commit 4, not yet written)",
+      ship_status: "phase_a"
+
+    fixture "CompileBinary",
+      name: "compile_binary",
+      from_layer: "rust_source", to_layer: "rust_binary",
+      transform_kind: "compile",
+      description: "L7 → L8 — hand off to cargo build. External dependency per C3.",
+      impl_module: "cargo (external)",
+      ship_status: "shipped"
+  end
+
+  # ── SpecializerTarget — what's being specialized, in what phase ───
+  aggregate "SpecializerTarget" do
+    fixture "Validator",
+      name: "validator",
+      source_bluebook: "hecks_conception/capabilities/validator_shape/validator_shape.bluebook",
+      output_rs: "hecks_life/src/validator.rs",
+      phase: "a",
+      ship_status: "in_progress",
+      description: "Phase A proof — 6 rules + word-classifier. 400 LoC target. Byte-identity gate."
+
+    # Phase B queue — plan §7. Filed now so the manifest shows the arc.
+    fixture "ValidatorWarnings",
+      name: "validator_warnings",
+      source_bluebook: "hecks_conception/capabilities/validator_warnings_shape/validator_warnings_shape.bluebook",
+      output_rs: "hecks_life/src/validator_warnings.rs",
+      phase: "b",
+      ship_status: "not_started",
+      description: "Sibling of validator — same shape, different rules. First Phase B module."
+
+    fixture "FixturesParser",
+      name: "fixtures_parser",
+      source_bluebook: "hecks_conception/capabilities/fixtures_parser_shape/fixtures_parser_shape.bluebook",
+      output_rs: "hecks_life/src/fixtures_parser.rs",
+      phase: "b",
+      ship_status: "not_started",
+      description: "Per plan §7 step 2 — parsers next after validators"
+
+    fixture "BehaviorsParser",
+      name: "behaviors_parser",
+      source_bluebook: "hecks_conception/capabilities/behaviors_parser_shape/behaviors_parser_shape.bluebook",
+      output_rs: "hecks_life/src/behaviors_parser.rs",
+      phase: "b",
+      ship_status: "not_started",
+      description: "Per plan §7 step 2"
+
+    fixture "HecksagonParser",
+      name: "hecksagon_parser",
+      source_bluebook: "hecks_conception/capabilities/hecksagon_parser_shape/hecksagon_parser_shape.bluebook",
+      output_rs: "hecks_life/src/hecksagon_parser.rs",
+      phase: "b",
+      ship_status: "not_started",
+      description: "Per plan §7 step 2"
+
+    fixture "Dump",
+      name: "dump",
+      source_bluebook: "hecks_conception/capabilities/dump_shape/dump_shape.bluebook",
+      output_rs: "hecks_life/src/dump.rs",
+      phase: "b",
+      ship_status: "not_started",
+      description: "Canonical-IR serializer — almost declarative, easy Phase B target"
+
+    fixture "Specializer",
+      name: "specializer",
+      source_bluebook: "hecks_conception/capabilities/specializer/specializer.bluebook",
+      output_rs: "hecks_life/src/specializer/",
+      phase: "c",
+      ship_status: "not_started",
+      description: "The self-referential one — Phase C, 2nd Futamura. Specializer lifted from its own bluebook."
+  end
+end

--- a/hecks_conception/capabilities/specializer/specializer.bluebook
+++ b/hecks_conception/capabilities/specializer/specializer.bluebook
@@ -1,0 +1,108 @@
+Hecks.bluebook "Specializer", version: "2026.04.23.1" do
+  vision "The Futamura specializer — value-object shape for the L1-L6 interpreter IR layers + the projections that lower between them. First-Futamura target: given any bluebook, produce Rust byte-equivalent to hand-written source."
+  category "autophagy"
+
+  # ============================================================
+  # SPECIALIZER — i51 Phase A commit 2 (value objects for L1-L6)
+  # ============================================================
+  #
+  # This is §9 commit 1 in docs/plans/i51_futamura_projections.md:
+  # "value-objects for L1-L6 IR" — the declarative scaffold the later
+  # projection logic will consume. No logic here yet; just the shape
+  # of each IR layer and the projections that connect them.
+  #
+  # Per §3 of the plan, the hecks_life interpreter already has these
+  # internal stages. Naming them as shape-only aggregates lets us
+  # partial-evaluate one layer at a time rather than all at once.
+  #
+  #   L0 bluebook      — source DSL (the five .bluebook / .hecksagon /
+  #                      .fixtures / .behaviors / .world files)
+  #   L1 canonical_ir  — normalized JSON IR (already shipped as dump.rs
+  #                      + spec/parity/canonical_ir.rb)
+  #   L2 flow_ir       — command graph per aggregate: commands → events
+  #                      → policies → triggers
+  #   L3 dispatch_ir   — command bus lowered: middleware, guards,
+  #                      mutations, emissions, persistence
+  #   L4 tick_ir       — body-cycle shape: which commands fire on
+  #                      mindstream/heart/consciousness ticks
+  #   L5 memory_ir     — heki I/O lowered: paths, append/upsert,
+  #                      serialization contracts
+  #   L6 rust_ir       — Rust-specific: module structure, ownership,
+  #                      lifetimes, Serde derives, trait dispatch
+  #   L7 rust_source   — emitted .rs files, rustfmt'd, cargo-built
+  #   L8 rust_binary   — the artifact. Terminus.
+  #
+  # For validator.rs (Phase A target) the useful projections are
+  # L0 → L1 → L6 → L7. Most modules will skip L2-L5 — they only apply
+  # where runtime dispatch is involved. The layer taxonomy is general
+  # so Phase B can extend it module by module without reshaping the
+  # specializer.
+  #
+  # Shape-only aggregates per the transitional pattern from PR #267
+  # and documented in validator_shape.bluebook. When i42 (catalog-
+  # dialect) lands, these move to sibling .fixtures catalog tables.
+
+  # ---- IRLayer ------------------------------------------------------
+  #
+  # One row per layer L0..L8 in the interpreter factoring. `number` is
+  # the numeric index so projections can reference "the layer below me"
+  # uniformly. `reads_from` / `returns` describe the pure-function
+  # contract — each layer is a function of the one above.
+
+  aggregate "IRLayer", "One layer in the L0..L8 interpreter factoring" do
+    attribute :name,        String
+    # number: L0..L8 — 0..8
+    attribute :number,      Integer
+    attribute :description, String
+    # reads_from: the layer this one is a pure function of (or 'source'
+    # for L0, which reads raw file text)
+    attribute :reads_from,  String
+    # returns: short description of the data shape this layer produces
+    attribute :returns,     String
+    # ship_status: shipped | partial | not_started — tracks which
+    # layers already exist in hecks_life vs which are Phase B+ work
+    attribute :ship_status, String
+  end
+
+  # ---- Projection ---------------------------------------------------
+  #
+  # One row per L_n → L_(n+1) lowering. transform_kind describes the
+  # algorithmic shape the specializer uses (parse / normalize / graph
+  # / lower / emit). from_layer / to_layer name the source + target
+  # layers by their IRLayer.name so the projection chain composes.
+
+  aggregate "Projection", "One L_n → L_(n+1) lowering step — the specializer's unit of work" do
+    attribute :name,           String
+    attribute :from_layer,     String
+    attribute :to_layer,       String
+    # transform_kind: parse | normalize | graph | lower | emit | compile
+    attribute :transform_kind, String
+    attribute :description,    String
+    # impl_module: the Rust module (or Ruby file) that holds the logic
+    # for this projection once it's written. Points at hand-written
+    # source during Phase A; points at generated source at Phase B end.
+    attribute :impl_module,    String
+    # ship_status: shipped | partial | not_started | phase_a | phase_b
+    attribute :ship_status,    String
+  end
+
+  # ---- SpecializerTarget --------------------------------------------
+  #
+  # One row per module the specializer is being applied to. Phase A
+  # has a single row (validator). Phase B will add rows for every
+  # module listed in plan §7. Gives us a queryable manifest of the
+  # autophagy arc's progress.
+
+  aggregate "SpecializerTarget", "One module being specialized — source bluebook, output Rust path, current phase" do
+    attribute :name,               String
+    # source_bluebook: relative path to the L0 shape bluebook
+    attribute :source_bluebook,    String
+    # output_rs: relative path the emitted .rs lands at
+    attribute :output_rs,          String
+    # phase: a | b | c — which Futamura phase this target ships in
+    attribute :phase,              String
+    # ship_status: not_started | in_progress | byte_identical | retired
+    attribute :ship_status,        String
+    attribute :description,        String
+  end
+end


### PR DESCRIPTION
## Summary

Next commit in the i51 Futamura arc. This is §9 commit 1 from [the plan](docs/plans/i51_futamura_projections.md) — the declarative scaffold for the specializer itself. No logic yet; just the shape.

**Three aggregates, 24 fixtures:**

| Aggregate | Rows | What it names |
|---|---|---|
| `IRLayer` | 9 (L0..L8) | The interpreter factoring from plan §3. Each row: `name`, `number`, `reads_from`, `returns`, `ship_status` |
| `Projection` | 8 | One row per L_n → L_(n+1) lowering step. `transform_kind` ∈ {parse, graph, lower, emit, compile}. `impl_module` points at current Rust |
| `SpecializerTarget` | 7 | Manifest of modules being specialized. Phase A: `validator` (in_progress). Phase B queue: validator_warnings, parsers, dump. Phase C: the specializer itself (2nd Futamura) |

**Ship-status at a glance:**
- L0 shipped, L1 shipped, L2-L5 partial, L6-L7 not_started, L8 shipped
- 3 projections shipped (parse_bluebook, compile_binary), 4 partial, 2 phase_a targets (specialize_rust, emit_rust)

**Why commit this shape first:**
It's queryable. Once we wire `hecks-life dump-fixtures` through a small Ruby/Rust tool, the arc's progress becomes a live report — no spreadsheets, no tracking docs. The specializer literally reads from its own manifest.

**Next commits** (§9 steps 2-5):
3. `feat(specializer): L1 → L2 projection for validator.rs` — ~200 LoC
4. `feat(specializer): L2 → L3 dispatch lowering` — ~200 LoC  
5. `feat(specializer): L6 → L7 Rust emission for validator shape` — ~300 LoC
6. `test(specializer): byte-identity vs hand-written validator.rs` — golden

## Test plan
- [x] `hecks-life parse specializer.bluebook` — 3 aggregates
- [x] `hecks-life dump-fixtures specializer.fixtures` — 24 rows, parses clean
- [x] Parity: 497/504 match (+1 capability), 7 accepted nursery soft drift