### PR TITLE
feat(specializer): Phase C PC-2 — meta-specializer regenerates DiagnosticValidator base class

### DIFF
--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/diagnostic_validator_meta_shape.bluebook
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/diagnostic_validator_meta_shape.bluebook
@@ -1,0 +1,67 @@
+Hecks.bluebook "DiagnosticValidatorMetaShape", version: "2026.04.23.1" do
+  vision "Phase C PC-2 — shape of lib/hecks_specializer/diagnostic_validator.rb as a bluebook. First full Ruby-class retirement (not a thin subclass)."
+  category "autophagy"
+
+  # ============================================================
+  # DIAGNOSTIC_VALIDATOR META SHAPE — Phase C PC-2
+  # ============================================================
+  #
+  # PC-1 and PC-1b bluebook-ified the thin subclass shells (15 LoC
+  # each). PC-2 tackles the base class (148 LoC of actual emission
+  # logic). Different pattern:
+  #
+  #   - 1 Ruby class with 10 methods (1 public + 9 private)
+  #   - Method bodies are mostly heredoc-template Ruby
+  #   - Dispatch methods (emit, emit_report) have case/when logic
+  #
+  # Shape — two aggregates:
+  #
+  #   RubyClass (1 row):
+  #     module_path, name, base_class (empty if none), includes,
+  #     doc_snippet, output_rb
+  #
+  #   RubyMethod (10 rows, one per top-level method):
+  #     class_name, name, visibility (public|private), signature
+  #     (parameter list; empty string if no args), body_snippet,
+  #     order (emission order inside the class body)
+  #
+  # Method bodies stay as .rb.frag snippets — same escape-hatch
+  # pattern as the Rust retirements' .rs.frag files. The meta-
+  # specializer reads them verbatim as the fn body.
+  #
+  # This shape is DESIGNED to generalize — any Ruby class that's
+  # "methods + some state" fits. Phase C PC-3 (driver) and PC-4
+  # (fixed-point, meta_subclass itself) reuse the same aggregates.
+
+  aggregate "RubyClass", "A Ruby class to emit — name, mixins, methods come from RubyMethod rows" do
+    attribute :name,         String
+    # module_path: dotted chain like "Hecks::Specializer" (empty ok)
+    attribute :module_path,  String
+    # base_class: parent class name (empty string = no parent)
+    attribute :base_class,   String
+    # includes: comma-separated mixin class names
+    # (e.g. "Target" for "include Target"). Empty allowed.
+    attribute :includes,     String
+    # doc_snippet: path to the //!-style module doc (here //-style
+    # Ruby file-top doc)
+    attribute :doc_snippet,  String
+    # output_rb: relative path to the generated .rb file
+    attribute :output_rb,    String
+  end
+
+  aggregate "RubyMethod", "One method in a RubyClass" do
+    # class_name: foreign-key-like link to RubyClass.name
+    attribute :class_name,    String
+    attribute :name,          String
+    # visibility: public | private
+    attribute :visibility,    String
+    # signature: the parameter list as written in Ruby, without
+    # the parens. E.g. "validator" or "helper, trailing_blank: false".
+    # Empty string = no-arg method.
+    attribute :signature,     String
+    # body_snippet: relative path to .rb.frag with the method body
+    attribute :body_snippet,  String
+    # order: emission order within the class
+    attribute :order,         Integer
+  end
+end

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures
@@ -1,0 +1,19 @@
+Hecks.fixtures "DiagnosticValidatorMetaShape" do
+  # Single-line fixtures per i57 parser limitation.
+
+  aggregate "RubyClass" do
+    fixture "DiagnosticValidator", name: "DiagnosticValidator", module_path: "Hecks::Specializer", base_class: "", includes: "Target", doc_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc.rb.frag", output_rb: "lib/hecks_specializer/diagnostic_validator.rb"
+  end
+
+  aggregate "RubyMethod" do
+    fixture "Emit", class_name: "DiagnosticValidator", name: "emit", visibility: "public", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_body.rb.frag", order: 1
+    fixture "EmitHeader", class_name: "DiagnosticValidator", name: "emit_header", visibility: "private", signature: "validator", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_header_body.rb.frag", order: 2
+    fixture "EmitImports", class_name: "DiagnosticValidator", name: "emit_imports", visibility: "private", signature: "validator", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_imports_body.rb.frag", order: 3
+    fixture "EmitReport", class_name: "DiagnosticValidator", name: "emit_report", visibility: "private", signature: "kind", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_body.rb.frag", order: 4
+    fixture "EmitReportFlat", class_name: "DiagnosticValidator", name: "emit_report_flat", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_body.rb.frag", order: 5
+    fixture "EmitReportFlatWithStrict", class_name: "DiagnosticValidator", name: "emit_report_flat_with_strict", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_with_strict_body.rb.frag", order: 6
+    fixture "EmitReportPartitionedWithStrict", class_name: "DiagnosticValidator", name: "emit_report_partitioned_with_strict", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_partitioned_with_strict_body.rb.frag", order: 7
+    fixture "EmitHelper", class_name: "DiagnosticValidator", name: "emit_helper", visibility: "private", signature: "helper, trailing_blank: false", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_helper_body.rb.frag", order: 8
+    fixture "EmitRule", class_name: "DiagnosticValidator", name: "emit_rule", visibility: "private", signature: "validator, leading_blank: true, trailing_blank: false", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_rule_body.rb.frag", order: 9
+  end
+end

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc.rb.frag
@@ -1,0 +1,33 @@
+# lib/hecks_specializer/diagnostic_validator.rb
+#
+# Hecks::Specializer::DiagnosticValidator — base class for the Phase B
+# diagnostic-style validator retirements (duplicate_policy, lifecycle, io).
+#
+# GENERATED FILE — do not edit.
+# Source:    hecks_conception/capabilities/diagnostic_validator_meta_shape/
+# Regenerate: bin/specialize meta_diagnostic_validator --output lib/hecks_specializer/diagnostic_validator.rb
+# Contract:  specializer.hecksagon :specialize_meta_diagnostic_validator shell adapter
+#
+# Each subclass defines:
+#   SHAPE      — path to its <target>_validator_shape.fixtures
+#   TARGET_RS  — path to the .rs file it emits
+#
+# The base class handles the emission pipeline:
+#   header → imports → Report (by report_kind) → helpers → rule
+#
+# Shape schema (identical across subclasses):
+#
+#   DiagnosticValidator (1 row):
+#     module, doc_snippet, imports, report_kind, rule_fn_name,
+#     rule_signature, check_body_snippet
+#
+#   DiagnosticHelper (N rows):
+#     validator, name, doc_comment, signature, body_snippet, order
+#
+# report_kind dispatches to canned Report templates:
+#   flat                     — findings: Vec<Finding>, errors/passes
+#   flat_with_strict         — + warnings, passes(strict)
+#   partitioned_with_strict  — static + runtime findings, strict
+#
+# Empty-body helpers (like #[allow(dead_code)] stubs) emit inline:
+# `fn x() {}` instead of `fn x() {\n}`.

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_body.rb.frag
@@ -1,0 +1,18 @@
+        validator = by_aggregate("DiagnosticValidator").first
+        helpers = by_aggregate("DiagnosticHelper")
+                    .select { |h| h["attrs"]["validator"] == validator["attrs"]["module"] }
+                    .sort_by { |h| h["attrs"]["order"].to_i }
+        helpers_first = validator["attrs"]["helpers_after_rule"] != "true"
+        parts = [emit_header(validator), emit_imports(validator), emit_report(validator["attrs"]["report_kind"])]
+        if helpers_first
+          # duplicate_policy style: Report → helpers → rule (rule last, no trailing blank)
+          parts << helpers.map { |h| emit_helper(h) }.join
+          parts << emit_rule(validator, leading_blank: true)
+        else
+          # lifecycle/io style: Report → rule → helpers (last helper no trailing blank)
+          parts << emit_rule(validator, leading_blank: false, trailing_blank: true)
+          helpers.each_with_index do |h, i|
+            parts << emit_helper(h, trailing_blank: i < helpers.size - 1)
+          end
+        end
+        parts.join

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_header_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_header_body.rb.frag
@@ -1,0 +1,2 @@
+        path = REPO_ROOT.join(validator["attrs"]["doc_snippet"])
+        File.read(path) + "\n"

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_helper_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_helper_body.rb.frag
@@ -1,0 +1,14 @@
+        a = helper["attrs"]
+        body = File.read(REPO_ROOT.join(a["body_snippet"]))
+        doc = a["doc_comment"].to_s
+        # doc_comment is the PREAMBLE — may hold /// doc, // comments,
+        # and/or #[attribute] lines. Emit verbatim if present.
+        doc_block = doc.empty? ? "" : doc + "\n"
+        core = if body.strip.empty?
+                 # Empty-body stubs (e.g. #[allow(dead_code)] placeholders)
+                 # emit inline: `fn x() {}` on one line.
+                 "#{doc_block}#{a["signature"]} {}\n"
+               else
+                 "#{doc_block}#{a["signature"]} {\n#{body}}\n"
+               end
+        trailing_blank ? core + "\n" : core

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_imports_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_imports_body.rb.frag
@@ -1,0 +1,4 @@
+        extras = validator["attrs"]["imports"].split("\n").reject(&:empty?)
+        lines = ["pub use crate::diagnostic::{Finding, Severity};"]
+        extras.each { |imp| lines << "use #{imp};" }
+        lines.join("\n") + "\n\n"

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_body.rb.frag
@@ -1,0 +1,6 @@
+        case kind
+        when "flat"                    then emit_report_flat
+        when "flat_with_strict"        then emit_report_flat_with_strict
+        when "partitioned_with_strict" then emit_report_partitioned_with_strict
+        else raise "unknown report_kind: #{kind}"
+        end

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_body.rb.frag
@@ -1,0 +1,13 @@
+        <<~RS
+          pub struct Report {
+              pub findings: Vec<Finding>,
+          }
+
+          impl Report {
+              pub fn errors(&self) -> usize {
+                  self.findings.iter().filter(|f| f.severity == Severity::Error).count()
+              }
+              pub fn passes(&self) -> bool { self.errors() == 0 }
+          }
+
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_with_strict_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_flat_with_strict_body.rb.frag
@@ -1,0 +1,20 @@
+        <<~RS
+          pub struct Report {
+              pub findings: Vec<Finding>,
+          }
+
+          impl Report {
+              pub fn errors(&self) -> usize {
+                  self.findings.iter().filter(|f| f.severity == Severity::Error).count()
+              }
+              pub fn warnings(&self) -> usize {
+                  self.findings.iter().filter(|f| f.severity == Severity::Warning).count()
+              }
+              pub fn passes(&self, strict: bool) -> bool {
+                  if self.errors() > 0 { return false; }
+                  if strict && self.warnings() > 0 { return false; }
+                  true
+              }
+          }
+
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_partitioned_with_strict_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_partitioned_with_strict_body.rb.frag
@@ -1,0 +1,1 @@
+        raise "emit_report_partitioned_with_strict not wired yet — arrives with io retirement"

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_rule_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_rule_body.rb.frag
@@ -1,0 +1,5 @@
+        a = validator["attrs"]
+        body = File.read(REPO_ROOT.join(a["check_body_snippet"]))
+        prefix = leading_blank ? "\n" : ""
+        suffix = trailing_blank ? "\n" : ""
+        "#{prefix}#{a["rule_signature"]} {\n#{body}}\n#{suffix}"

--- a/hecks_conception/capabilities/specializer/specializer.hecksagon
+++ b/hecks_conception/capabilities/specializer/specializer.hecksagon
@@ -82,6 +82,16 @@ Hecks.hecksagon "Specializer" do
     args:    ["meta_subclass_lifecycle", "--output", "{{output}}"],
     ok_exit: 0
 
+  # Phase C PC-2 — first full-Ruby-class meta-specializer. Emits
+  # lib/hecks_specializer/diagnostic_validator.rb (the base class) from
+  # RubyClass + RubyMethod fixture rows. Handles module nesting,
+  # include mixins, public/private sections, multi-method emission.
+  adapter :shell,
+    name:    :specialize_meta_diagnostic_validator,
+    command: "bin/specialize",
+    args:    ["meta_diagnostic_validator", "--output", "{{output}}"],
+    ok_exit: 0
+
   # ---- Gate ----------------------------------------------------
   #
   # :autophagy — the gate for all i51 work. Specialize commands run

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -88,6 +88,7 @@ fn specializer_hecksagon_wiring_is_present() {
         "specialize_lifecycle",
         "specialize_meta_subclass",
         "specialize_meta_subclass_lifecycle",
+        "specialize_meta_diagnostic_validator",
     ] {
         assert!(
             hex.shell_adapters.iter().any(|a| a.name == expected),
@@ -149,5 +150,22 @@ fn meta_specializer_produces_byte_identical_lifecycle_rb() {
     assert_byte_identical(
         "meta_subclass_lifecycle",
         "lib/hecks_specializer/lifecycle.rb",
+    );
+}
+
+#[test]
+fn meta_specializer_produces_byte_identical_diagnostic_validator_rb() {
+    // Phase C PC-2 — the first full Ruby class retirement (not a thin
+    // subclass). Emits lib/hecks_specializer/diagnostic_validator.rb
+    // from RubyClass + RubyMethod fixture rows. Exercises module
+    // nesting, include mixins, public/private sections, 9 methods
+    // with per-method body snippets.
+    //
+    // This is also the *base class that emits all the diagnostic
+    // retirements* — meaning its byte-identity is doubly important:
+    // hand-edit drift here breaks every diagnostic retirement.
+    assert_byte_identical(
+        "meta_diagnostic_validator",
+        "lib/hecks_specializer/diagnostic_validator.rb",
     );
 }

--- a/lib/hecks_specializer/diagnostic_validator.rb
+++ b/lib/hecks_specializer/diagnostic_validator.rb
@@ -3,6 +3,11 @@
 # Hecks::Specializer::DiagnosticValidator — base class for the Phase B
 # diagnostic-style validator retirements (duplicate_policy, lifecycle, io).
 #
+# GENERATED FILE — do not edit.
+# Source:    hecks_conception/capabilities/diagnostic_validator_meta_shape/
+# Regenerate: bin/specialize meta_diagnostic_validator --output lib/hecks_specializer/diagnostic_validator.rb
+# Contract:  specializer.hecksagon :specialize_meta_diagnostic_validator shell adapter
+#
 # Each subclass defines:
 #   SHAPE      — path to its <target>_validator_shape.fixtures
 #   TARGET_RS  — path to the .rs file it emits

--- a/lib/hecks_specializer/meta_diagnostic_validator.rb
+++ b/lib/hecks_specializer/meta_diagnostic_validator.rb
@@ -1,0 +1,122 @@
+# lib/hecks_specializer/meta_diagnostic_validator.rb
+#
+# Hecks::Specializer::MetaDiagnosticValidator — Phase C PC-2.
+#
+# First meta-specializer that regenerates a FULL Ruby class (not just
+# a thin subclass shell). Reads RubyClass + RubyMethod fixture rows
+# from diagnostic_validator_meta_shape.fixtures and emits
+# lib/hecks_specializer/diagnostic_validator.rb byte-identical.
+#
+# Emission pipeline:
+#   1. doc block (from RubyClass.doc_snippet, verbatim)
+#   2. module nesting open (from RubyClass.module_path)
+#   3. class declaration + include lines
+#   4. blank line
+#   5. public methods (RubyMethod rows with visibility=public) in order
+#   6. blank line + "private" + blank line
+#   7. private methods in order
+#   8. module nesting close (ends + ends)
+#
+# Method bodies come from .rb.frag snippets, read raw. The specializer
+# only arranges the skeleton; bodies are the author's Ruby.
+#
+# Scope: the base class diagnostic_validator.rb (148 LoC). Design
+# generalizes — PC-3 (driver) and PC-4 (fixed-point of meta_subclass
+# itself) should reuse this pattern with different RubyClass rows.
+
+module Hecks
+  module Specializer
+    class MetaDiagnosticValidator
+      include Target
+
+      SHAPE = REPO_ROOT.join("hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures")
+      TARGET_RS = REPO_ROOT.join("lib/hecks_specializer/diagnostic_validator.rb")
+
+      def emit
+        klass = by_aggregate("RubyClass").first or raise "no RubyClass row"
+        methods = by_aggregate("RubyMethod")
+                    .select { |m| m["attrs"]["class_name"] == klass["attrs"]["name"] }
+                    .sort_by { |m| m["attrs"]["order"].to_i }
+        public_methods = methods.select { |m| m["attrs"]["visibility"] == "public" }
+        private_methods = methods.select { |m| m["attrs"]["visibility"] == "private" }
+
+        [
+          emit_doc(klass),
+          emit_module_open(klass),
+          emit_class_header(klass),
+          emit_methods(public_methods, blank_before_first: true),
+          emit_private_section(private_methods),
+          emit_module_close(klass),
+        ].join
+      end
+
+      private
+
+      def emit_doc(klass)
+        # Doc snippet ends with `\n`; add one more for blank-line separator
+        # before the module nesting begins.
+        File.read(REPO_ROOT.join(klass["attrs"]["doc_snippet"])) + "\n"
+      end
+
+      # Emit "module A\n  module B\n  ..." for each segment of module_path.
+      # Empty module_path = no module nesting.
+      def emit_module_open(klass)
+        path = klass["attrs"]["module_path"]
+        return "" if path.empty?
+        segments = path.split("::")
+        segments.each_with_index.map do |seg, i|
+          "  " * i + "module #{seg}\n"
+        end.join
+      end
+
+      def emit_module_close(klass)
+        path = klass["attrs"]["module_path"]
+        depth = path.empty? ? 0 : path.split("::").length
+        class_end = "  " * depth + "end\n"
+        module_ends = (0...depth).to_a.reverse.map { |i| "  " * i + "end\n" }.join
+        class_end + module_ends
+      end
+
+      # Emit the class line + include lines. Indented to match nested
+      # module depth.
+      def emit_class_header(klass)
+        a = klass["attrs"]
+        depth = a["module_path"].empty? ? 0 : a["module_path"].split("::").length
+        indent = "  " * depth
+        class_line = a["base_class"].empty? \
+                       ? "#{indent}class #{a["name"]}\n"
+                       : "#{indent}class #{a["name"]} < #{a["base_class"]}\n"
+        mixins = a["includes"].split(",").map(&:strip).reject(&:empty?)
+        mixin_lines = mixins.map { |m| "#{indent}  include #{m}\n" }.join
+        class_line + mixin_lines
+      end
+
+      # Emit a run of methods with correct spacing. Each method preceded
+      # by a blank line (except maybe the first — controlled by flag).
+      def emit_methods(methods, blank_before_first:)
+        methods.each_with_index.map do |m, i|
+          lead = (i == 0 && !blank_before_first) ? "" : "\n"
+          lead + emit_method(m)
+        end.join
+      end
+
+      def emit_private_section(private_methods)
+        return "" if private_methods.empty?
+        # Blank line, "private" (indented to method depth), blank line,
+        # then each private method preceded by blank.
+        indent = "      " # 3 levels of 2-space = 6 spaces (Hecks::Specializer::Class)
+        "\n#{indent}private\n" + emit_methods(private_methods, blank_before_first: true)
+      end
+
+      def emit_method(method)
+        a = method["attrs"]
+        indent = "      " # 6 spaces: module → module → class
+        sig = a["signature"].empty? ? "def #{a["name"]}" : "def #{a["name"]}(#{a["signature"]})"
+        body = File.read(REPO_ROOT.join(a["body_snippet"]))
+        "#{indent}#{sig}\n#{body}#{indent}end\n"
+      end
+    end
+
+    register :meta_diagnostic_validator, MetaDiagnosticValidator
+  end
+end


### PR DESCRIPTION
## Summary

**Phase C PC-2.** The DiagnosticValidator base class (148 LoC, 9 methods) is now regenerated from shape. First **full Ruby class retirement** — beyond PC-1's thin subclass shells.

Structurally important: DiagnosticValidator is what emits **every diagnostic retirement**. Golden test now gates hand-edits to the base class the same way it gates hand-edits to the .rs files it produces.

## Proof

```
$ bin/specialize meta_diagnostic_validator --diff
$ echo $?
0
$ cargo test --release --test specializer_golden_test
running 9 tests
...
test meta_specializer_produces_byte_identical_diagnostic_validator_rb ... ok
test result: ok. 9 passed; 0 failed
```

And the downstream is still clean — the regenerated DiagnosticValidator produces the same Rust that the hand-written one did:

```
$ bin/specialize duplicate_policy | diff -q - hecks_life/src/duplicate_policy_validator.rs
# clean
$ bin/specialize lifecycle | diff -q - hecks_life/src/lifecycle_validator.rs
# clean
```

## New capability

`diagnostic_validator_meta_shape` — 2 aggregates, 10 fixtures, 11 snippets.

- **RubyClass** (1 row): `name`, `module_path`, `base_class`, `includes`, `doc_snippet`, `output_rb`
- **RubyMethod** (9 rows, one per method): `class_name`, `name`, `visibility`, `signature`, `body_snippet`, `order`

Method bodies travel as `.rb.frag` snippets — same escape-hatch pattern as `.rs.frag`.

## What the meta-specializer handles

- Doc block (raw, with GENERATED marker)
- Module nesting open/close (`module Hecks; module Specializer; ... end; end`)
- Class header + `include Target` lines
- Public method section
- `private` keyword + blank-line separators
- Private method section
- Correct indentation throughout (2-space per nest level, 6-space for method bodies)

Method bodies include heredocs (`<<~RS ... RS`) — they travel through the fixture pipeline unchanged because they're just literal string content.

## Golden-test coverage

| Gate | Target | Type |
|---|---|---|
| validator_rs | Rust | Phase A |
| validator_warnings_rs | Rust | Phase B |
| dump_rs | Rust | Phase B |
| duplicate_policy_validator_rs | Rust | Phase B (post-i59) |
| lifecycle_validator_rs | Rust | Phase B (post-i59) |
| duplicate_policy_rb | Ruby (thin subclass) | Phase C PC-1 |
| lifecycle_rb | Ruby (thin subclass) | Phase C PC-1b |
| **diagnostic_validator_rb** | **Ruby (base class)** | **Phase C PC-2** |
| hecksagon wiring | — | infrastructure |

**9/9 byte-identity gates green.**

## Phase C status

- ✅ **PC-1** — bluebook-ify one thin subclass (#357)
- ✅ **PC-1b** — extend to second subclass (#358)
- ✅ **PC-2** — bluebook-ify the base class **← this PR**
- ⏸ PC-3 — bluebook-ify the driver (`bin/specialize` + `lib/hecks_specializer.rb`)
- ⏸ PC-4 — fixed point: meta-specializer regenerates its own source

## What's still hand-written (Ruby side)

- `lib/hecks_specializer/{validator,validator_warnings,dump}.rb` — not thin subclasses; each has its own `emit()` body. Could use the RubyClass/RubyMethod shape in a future PR.
- `lib/hecks_specializer/{meta_subclass,meta_diagnostic_validator}.rb` — the meta-specializers themselves. PC-4.
- `lib/hecks_specializer.rb` + `bin/specialize` — the driver. PC-3.

## Antibody

Two exemptions, both same class as prior Phase C specializers (already exempted).

## Test plan
- [x] `bin/specialize meta_diagnostic_validator --diff` — no output
- [x] `cargo test --release --test specializer_golden_test` — 9/9
- [x] Downstream specializers (Rust retirements) still byte-identical
- [x] Parity: 502/509, capabilities 40/40, fixtures 357/367