### PR TITLE
feat(dsl): enforce distinct as: aliases on duplicate reference_to targets

### DIFF
--- a/examples/banking/hecks/banking.bluebook
+++ b/examples/banking/hecks/banking.bluebook
@@ -60,8 +60,8 @@ Hecks.bluebook "Banking" do
   end
 
   aggregate "Transfer" do
-    reference_to Account
-    reference_to Account
+    reference_to Account, as: :source
+    reference_to Account, as: :destination
     attribute :amount, Float
     attribute :status, String, default: "pending"
     attribute :memo, String

--- a/examples/spaghetti_western/hecks/spaghetti_western.bluebook
+++ b/examples/spaghetti_western/hecks/spaghetti_western.bluebook
@@ -25,10 +25,10 @@ Hecks.bluebook "SpaghettiWestern" do
   end
 
   aggregate "Duel" do
-    reference_to Gunslinger
-    reference_to Gunslinger
+    reference_to Gunslinger, as: :challenger
+    reference_to Gunslinger, as: :opponent
     reference_to Town
-    reference_to Gunslinger
+    reference_to Gunslinger, as: :referee
     attribute :status, String
     attribute :narration, String
     attribute :dramatic_pause_seconds, Float
@@ -67,8 +67,8 @@ Hecks.bluebook "SpaghettiWestern" do
 
   aggregate "Bounty" do
     attribute :bounty_type, String
-    reference_to Gunslinger
-    reference_to Gunslinger
+    reference_to Gunslinger, as: :target
+    reference_to Gunslinger, as: :bounty_hunter
     attribute :amount, Integer
     attribute :status, String, enum: ["active", "claimed", "expired", "cancelled"]
     attribute :description, String

--- a/hecks_conception/capabilities/validator_shape/fixtures/validator_shape.fixtures
+++ b/hecks_conception/capabilities/validator_shape/fixtures/validator_shape.fixtures
@@ -3,7 +3,7 @@ Hecks.fixtures "ValidatorShape" do
   # Note: single-line fixtures — the Rust fixtures_parser only reads one
   # line per `fixture` directive today (i57 tracks multi-line support).
   aggregate "ValidatorEntryPoint" do
-    fixture "Validate", fn_name: "validate", returns: "Vec<String>", rule_order: "unique_aggregate_names,aggregates_have_commands,command_naming,valid_references,valid_policy_triggers,no_duplicate_commands", collects_into: "errors"
+    fixture "Validate", fn_name: "validate", returns: "Vec<String>", rule_order: "unique_aggregate_names,aggregates_have_commands,command_naming,valid_references,valid_policy_triggers,no_duplicate_commands,distinct_reference_aliases", collects_into: "errors"
   end
 
   # ── The 6 rules — one fixture each, mirrors validator.rs 1:1 ────
@@ -14,6 +14,7 @@ Hecks.fixtures "ValidatorShape" do
     fixture "ValidReferences", name: "valid_references", rust_fn_name: "valid_references", description: "reference_to(X) must target a declared aggregate in the same domain", inspects: "domain.aggregates[].references+domain.aggregates[].commands[].references", check_kind: "reference_valid", error_template: "{parent} references unknown aggregate: {target}", applied_to: "aggregate_or_command"
     fixture "ValidPolicyTriggers", name: "valid_policy_triggers", rust_fn_name: "valid_policy_triggers", description: "Policy triggers must name a command declared in the same domain", inspects: "domain.policies", check_kind: "trigger_valid", error_template: "Policy {name} triggers unknown command: {trigger}", applied_to: "policy"
     fixture "NoDuplicateCommands", name: "no_duplicate_commands", rust_fn_name: "no_duplicate_commands", description: "No two commands across all aggregates may share the same name", inspects: "domain.aggregates[].commands", check_kind: "unique_across", error_template: "Duplicate command name: {name} (in {parent})", applied_to: "command"
+    fixture "DistinctReferenceAliases", name: "distinct_reference_aliases", rust_fn_name: "distinct_reference_aliases", description: "When an aggregate has multiple reference_to the same target, each must carry a distinct as: alias — otherwise downstream consumers (event payloads, generated form fields, Ruby/Rust routing) can't tell the references apart", inspects: "domain.aggregates[].references", check_kind: "distinct_aliases", error_template: "{parent} has {count} references to {target} with duplicate alias {name:?} — add `as: :<alias>` to each so they have distinct names", applied_to: "aggregate"
   end
 
   # ── Suffix tables (NOUN_SUFFIXES, ADJ_SUFFIXES, verb_suffixes) ───

--- a/hecks_life/src/parser.rs
+++ b/hecks_life/src/parser.rs
@@ -177,15 +177,27 @@ fn parse_aggregate(lines: &[&str]) -> (Aggregate, usize) {
                 agg.description = extract_string(line);
             } else if line.starts_with("reference_to") {
                 // Two forms: `reference_to Pizza` (spaced) and `reference_to(Pizza)` /
-                // `reference_to(Pizza, role: :foo)` (paren). Delegate the paren form
-                // to parse_shorthand_reference so we honor `role:` and `.as()`.
+                // `reference_to(Pizza, as: :foo)` (paren). Both honor `as:` / `role:`
+                // kwargs; the spaced form picks them up from the trailing tail
+                // after the target identifier.
                 if line.starts_with("reference_to(") {
                     if let Some(r) = parse_shorthand_reference(line) {
                         agg.references.push(r);
                     }
                 } else if let Some(target) = extract_word_after(line, "reference_to") {
-                    let snake = to_snake_case(&target);
-                    agg.references.push(Reference { name: snake, target, domain: None });
+                    // `reference_to X, as: :foo` and `, role: :foo` — spaced-form
+                    // trailing kwarg. Mirrors parse_shorthand_reference's kwarg
+                    // resolution so Ruby/Rust parity holds for both syntaxes.
+                    let name = if let Some(pos) = line.find(", as:") {
+                        let after = &line[pos + ", as:".len()..];
+                        extract_symbol(after).unwrap_or_else(|| to_snake_case(&target))
+                    } else if let Some(pos) = line.find(", role:") {
+                        let after = &line[pos + ", role:".len()..];
+                        extract_symbol(after).unwrap_or_else(|| to_snake_case(&target))
+                    } else {
+                        to_snake_case(&target)
+                    };
+                    agg.references.push(Reference { name, target, domain: None });
                 }
             } else if line.starts_with("lifecycle") {
                 let (lc, consumed) = parse_lifecycle(&lines[i..]);

--- a/hecks_life/src/validator.rs
+++ b/hecks_life/src/validator.rs
@@ -25,6 +25,7 @@ pub fn validate(domain: &Domain) -> Vec<String> {
     errors.extend(valid_references(domain));
     errors.extend(valid_policy_triggers(domain));
     errors.extend(no_duplicate_commands(domain));
+    errors.extend(distinct_reference_aliases(domain));
     errors
 }
 
@@ -213,6 +214,32 @@ fn no_duplicate_commands(domain: &Domain) -> Vec<String> {
                 errors.push(format!(
                     "Duplicate command name: {} (in {})",
                     cmd.name, agg.name
+                ));
+            }
+        }
+    }
+    errors
+}
+
+/// When an aggregate has multiple reference_to the same target,
+/// each must carry a distinct `as:` alias — otherwise the references
+/// share the same `name` and downstream consumers (event payloads,
+/// generated form fields, dispatch routing) can't tell them apart.
+fn distinct_reference_aliases(domain: &Domain) -> Vec<String> {
+    let mut errors = vec![];
+    for agg in &domain.aggregates {
+        // Group references by (target, name). Any group with size > 1
+        // is a collision: multiple references share the same alias.
+        let mut groups: std::collections::BTreeMap<(&str, &str), usize> =
+            std::collections::BTreeMap::new();
+        for r in &agg.references {
+            *groups.entry((r.target.as_str(), r.name.as_str())).or_insert(0) += 1;
+        }
+        for ((target, name), count) in &groups {
+            if *count > 1 {
+                errors.push(format!(
+                    "{} has {} references to {} with duplicate alias {:?} — add `as: :<alias>` to each so they have distinct names",
+                    agg.name, count, target, name
                 ));
             }
         }

--- a/hecks_life/tests/validator_rules_test.rs
+++ b/hecks_life/tests/validator_rules_test.rs
@@ -160,6 +160,54 @@ end"#);
 }
 
 #[test]
+fn duplicate_reference_aliases_errors() {
+    // Two reference_to pointing at the same target with the same alias
+    // should fail the distinct_reference_aliases rule. With `as:` aliases
+    // giving each a distinct name, the check passes.
+    let duped = parser::parse(r#"Hecks.bluebook "T" do
+  aggregate "Account" do
+    command "Create" do
+      role "Owner"
+    end
+  end
+  aggregate "Transfer" do
+    reference_to Account
+    reference_to Account
+    command "Initiate" do
+      role "Customer"
+    end
+  end
+end"#);
+    let errors = validate(&duped);
+    assert!(
+        errors.iter().any(|e| e.contains("duplicate alias")),
+        "expected duplicate-alias error, got: {:?}",
+        errors
+    );
+
+    let aliased = parser::parse(r#"Hecks.bluebook "T" do
+  aggregate "Account" do
+    command "Create" do
+      role "Owner"
+    end
+  end
+  aggregate "Transfer" do
+    reference_to Account, as: :source
+    reference_to Account, as: :destination
+    command "Initiate" do
+      role "Customer"
+    end
+  end
+end"#);
+    let errors = validate(&aliased);
+    assert!(
+        !errors.iter().any(|e| e.contains("duplicate alias")),
+        "with distinct aliases should pass; got: {:?}",
+        errors
+    );
+}
+
+#[test]
 fn unknown_policy_trigger() {
     let domain = Domain {
         name: "T".into(),

--- a/lib/hecks_specializer/validator.rb
+++ b/lib/hecks_specializer/validator.rb
@@ -27,6 +27,7 @@ module Hecks
           emit_rule(find_rule("valid_references")),
           emit_rule(find_rule("valid_policy_triggers")),
           emit_rule(find_rule("no_duplicate_commands")),
+          emit_rule(find_rule("distinct_reference_aliases")),
         ].join
       end
 
@@ -83,12 +84,13 @@ module Hecks
 
       def emit_rule(rule)
         case rule["attrs"]["check_kind"]
-        when "unique"          then emit_unique(rule)
-        when "non_empty"       then emit_non_empty(rule)
-        when "first_word_verb" then emit_first_word_verb(rule)
-        when "reference_valid" then emit_reference_valid(rule)
-        when "trigger_valid"   then emit_trigger_valid(rule)
-        when "unique_across"   then emit_unique_across(rule)
+        when "unique"           then emit_unique(rule)
+        when "non_empty"        then emit_non_empty(rule)
+        when "first_word_verb"  then emit_first_word_verb(rule)
+        when "reference_valid"  then emit_reference_valid(rule)
+        when "trigger_valid"    then emit_trigger_valid(rule)
+        when "unique_across"    then emit_unique_across(rule)
+        when "distinct_aliases" then emit_distinct_aliases(rule)
         else raise "unknown check_kind: #{rule["attrs"]["check_kind"]}"
         end
       end
@@ -344,6 +346,38 @@ module Hecks
                           errors.push(format!(
                               "Duplicate command name: {} (in {})",
                               cmd.name, agg.name
+                          ));
+                      }
+                  }
+              }
+              errors
+          }
+
+        RS
+      end
+
+      def emit_distinct_aliases(rule)
+        a = rule["attrs"]
+        <<~RS
+          /// When an aggregate has multiple reference_to the same target,
+          /// each must carry a distinct `as:` alias — otherwise the references
+          /// share the same `name` and downstream consumers (event payloads,
+          /// generated form fields, dispatch routing) can't tell them apart.
+          fn #{a["rust_fn_name"]}(domain: &Domain) -> Vec<String> {
+              let mut errors = vec![];
+              for agg in &domain.aggregates {
+                  // Group references by (target, name). Any group with size > 1
+                  // is a collision: multiple references share the same alias.
+                  let mut groups: std::collections::BTreeMap<(&str, &str), usize> =
+                      std::collections::BTreeMap::new();
+                  for r in &agg.references {
+                      *groups.entry((r.target.as_str(), r.name.as_str())).or_insert(0) += 1;
+                  }
+                  for ((target, name), count) in &groups {
+                      if *count > 1 {
+                          errors.push(format!(
+                              "{} has {} references to {} with duplicate alias {:?} — add `as: :<alias>` to each so they have distinct names",
+                              agg.name, count, target, name
                           ));
                       }
                   }


### PR DESCRIPTION
## Summary

Two fixes landing together:

### 1. Rust parser parity fix

The spaced form `reference_to Account, as: :source` was silently dropping the `as:` kwarg — only the paren form `reference_to(Account, as: :source)` honored it. Ruby handled both; Rust did not. Now both forms produce the same Reference IR.

### 2. New validator rule — `distinct_reference_aliases`

Enforced via the shape-driven specializer (`validator_shape.fixtures` + `bin/specialize validator`). Rejects duplicate-target references without distinct aliases:

```
Transfer has 2 references to Account with duplicate alias "account" — 
add `as: :<alias>` to each so they have distinct names
```

Corpus scan across **514 bluebooks**: 2 violations caught, 2 fixed, 0 remaining.

## Corpus changes

- `examples/banking/hecks/banking.bluebook` — Transfer now `as: :source` / `as: :destination`. Flipped from "honest ambiguity" to enforced feature.
- `examples/spaghetti_western/hecks/spaghetti_western.bluebook` — Duel (challenger/opponent/referee), Bounty (target/bounty_hunter).

## Tests

- `validator_rules_test`: **7/7** pass (+ new `duplicate_reference_aliases_errors`)
- `specializer_golden_test`: **9/9** pass (byte-identity gate on regenerated validator.rs still green)
- Corpus: all 514 bluebooks validate clean

## Why the new rule matters

Before: `reference_to Account` twice left downstream consumers (event payloads, form fields, dispatch routing) with no way to disambiguate. Paper called it "honest ambiguity in the example rather than a demonstrated feature."

After: the DSL requires explicit `as: :source` / `as: :destination`. The "two references to the same aggregate" pattern is now a demonstrated, enforced, mechanically-checked feature rather than a workaround.

## Test plan
- [x] `hecks-life validate examples/banking/hecks/banking.bluebook` → VALID
- [x] `hecks-life validate examples/spaghetti_western/hecks/spaghetti_western.bluebook` → VALID
- [x] `cargo test --release --test validator_rules_test` — 7/7
- [x] `cargo test --release --test specializer_golden_test` — 9/9
- [x] Parity: 502/509 unchanged
- [x] Full corpus scan: 514 bluebooks, 0 duplicate-alias violations