### PR TITLE
autophagy: retire validator_warnings.rb via meta-specializer (i51 PC-2)

### DIFF
--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/diagnostic_validator_meta_shape.bluebook
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/diagnostic_validator_meta_shape.bluebook
@@ -1,5 +1,5 @@
-Hecks.bluebook "DiagnosticValidatorMetaShape", version: "2026.04.23.1" do
-  vision "Phase C PC-2 — shape of lib/hecks_specializer/diagnostic_validator.rb as a bluebook. First full Ruby-class retirement (not a thin subclass)."
+Hecks.bluebook "DiagnosticValidatorMetaShape", version: "2026.04.23.2" do
+  vision "Phase C PC-2 — shape of Ruby specializer classes (diagnostic_validator.rb, validator_warnings.rb) as a bluebook. First full Ruby-class retirements."
   category "autophagy"
 
   # ============================================================
@@ -47,6 +47,27 @@ Hecks.bluebook "DiagnosticValidatorMetaShape", version: "2026.04.23.1" do
     attribute :doc_snippet,  String
     # output_rb: relative path to the generated .rb file
     attribute :output_rb,    String
+    # register_target_name: if non-empty, emit
+    #   register :<register_target_name>, <ClassName>
+    # inside the inner module scope (after the class close) — the
+    # specializer-target self-registration pattern used by every
+    # lib/hecks_specializer/*.rb module. Empty for classes that are
+    # not registered (base classes like DiagnosticValidator itself).
+    attribute :register_target_name, String, default: ""
+  end
+
+  aggregate "RubyConstant", "A class-level constant assignment in a RubyClass" do
+    # class_name: foreign-key-like link to RubyClass.name
+    attribute :class_name,  String
+    # name: the constant name (e.g. "SHAPE" or "TARGET_RS")
+    attribute :name,        String
+    # value_expr: the RHS of the assignment, written verbatim.
+    # E.g. `REPO_ROOT.join("hecks_conception/...")`
+    attribute :value_expr,  String
+    # order: emission order among constants inside the class body.
+    # Constants are emitted after the `include` lines and before
+    # any method definition.
+    attribute :order,       Integer
   end
 
   aggregate "RubyMethod", "One method in a RubyClass" do

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures
@@ -3,6 +3,12 @@ Hecks.fixtures "DiagnosticValidatorMetaShape" do
 
   aggregate "RubyClass" do
     fixture "DiagnosticValidator", name: "DiagnosticValidator", module_path: "Hecks::Specializer", base_class: "", includes: "Target", doc_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc.rb.frag", output_rb: "lib/hecks_specializer/diagnostic_validator.rb"
+    fixture "ValidatorWarnings", name: "ValidatorWarnings", module_path: "Hecks::Specializer", base_class: "", includes: "Target", doc_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc_validator_warnings.rb.frag", output_rb: "lib/hecks_specializer/validator_warnings.rb", register_target_name: "validator_warnings"
+  end
+
+  aggregate "RubyConstant" do
+    fixture "VwShape", class_name: "ValidatorWarnings", name: "SHAPE", value_expr: "REPO_ROOT.join(\"hecks_conception/capabilities/validator_warnings_shape/fixtures/validator_warnings_shape.fixtures\")", order: 1
+    fixture "VwTargetRs", class_name: "ValidatorWarnings", name: "TARGET_RS", value_expr: "REPO_ROOT.join(\"hecks_life/src/validator_warnings.rs\")", order: 2
   end
 
   aggregate "RubyMethod" do
@@ -15,5 +21,12 @@ Hecks.fixtures "DiagnosticValidatorMetaShape" do
     fixture "EmitReportPartitionedWithStrict", class_name: "DiagnosticValidator", name: "emit_report_partitioned_with_strict", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_report_partitioned_with_strict_body.rb.frag", order: 7
     fixture "EmitHelper", class_name: "DiagnosticValidator", name: "emit_helper", visibility: "private", signature: "helper, trailing_blank: false", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_helper_body.rb.frag", order: 8
     fixture "EmitRule", class_name: "DiagnosticValidator", name: "emit_rule", visibility: "private", signature: "validator, leading_blank: true, trailing_blank: false", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/emit_rule_body.rb.frag", order: 9
+    fixture "VwEmit", class_name: "ValidatorWarnings", name: "emit", visibility: "public", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_body.rb.frag", order: 1
+    fixture "VwEmitHeader", class_name: "ValidatorWarnings", name: "emit_header", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_header_body.rb.frag", order: 2
+    fixture "VwEmitImports", class_name: "ValidatorWarnings", name: "emit_imports", visibility: "private", signature: "", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_imports_body.rb.frag", order: 3
+    fixture "VwEmitRule", class_name: "ValidatorWarnings", name: "emit_rule", visibility: "private", signature: "rule", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_rule_body.rb.frag", order: 4
+    fixture "VwEmitTemplated", class_name: "ValidatorWarnings", name: "emit_templated", visibility: "private", signature: "rule", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_templated_body.rb.frag", order: 5
+    fixture "VwEmitCountThreshold", class_name: "ValidatorWarnings", name: "emit_count_threshold", visibility: "private", signature: "rule", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_count_threshold_body.rb.frag", order: 6
+    fixture "VwEmitEmbedded", class_name: "ValidatorWarnings", name: "emit_embedded", visibility: "private", signature: "rule", body_snippet: "hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_embedded_body.rb.frag", order: 7
   end
 end

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc_validator_warnings.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/doc_validator_warnings.rb.frag
@@ -1,0 +1,4 @@
+# lib/hecks_specializer/validator_warnings.rb
+#
+# Hecks::Specializer::ValidatorWarnings — emits validator_warnings.rs.
+# Moved from bin/specialize-validator-warnings.

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_body.rb.frag
@@ -1,0 +1,6 @@
+        rules = by_aggregate("WarningRule")
+        [
+          emit_header,
+          emit_imports,
+          rules.map { |r| emit_rule(r) }.join,
+        ].join

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_count_threshold_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_count_threshold_body.rb.frag
@@ -1,0 +1,18 @@
+        a = rule["attrs"]
+        threshold = a["threshold"].to_i
+        doc = "Returns Some(msg) if the domain has more than #{threshold} aggregates."
+        <<~RS
+          /// #{doc}
+          pub fn #{a["rust_fn_name"]}(domain: &Domain) -> Option<String> {
+              if domain.aggregates.len() > #{threshold} {
+                  Some(format!(
+                      "#{a["message_template"]}",
+                      domain.name,
+                      domain.aggregates.len()
+                  ))
+              } else {
+                  None
+              }
+          }
+
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_embedded_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_embedded_body.rb.frag
@@ -1,0 +1,14 @@
+        a = rule["attrs"]
+        path = REPO_ROOT.join(a["snippet_path"])
+        body = read_snippet_body(path)
+        threshold = a["threshold"].to_i
+        doc = [
+          "Returns Some(msg) if the domain has #{threshold}+ aggregates split across",
+          "disconnected reference/policy clusters.",
+        ]
+        <<~RS
+          /// #{doc[0]}
+          /// #{doc[1]}
+          pub fn #{a["rust_fn_name"]}(domain: &Domain) -> Option<String> {
+          #{body}}
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_header_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_header_body.rb.frag
@@ -1,0 +1,21 @@
+        <<~RS
+          //! Soft warnings for domain quality — non-failing bounded-context checks
+          //!
+          //! GENERATED FILE — do not edit.
+          //! Source:    hecks_conception/capabilities/validator_warnings_shape/
+          //! Regenerate: bin/specialize validator_warnings --output hecks_life/src/validator_warnings.rs
+          //! Contract:  specializer.hecksagon :specialize_validator_warnings shell adapter
+          //! Tests:     hecks_life/tests/validator_warnings_test.rs
+          //!
+          //! These rules emit advisory warnings but never cause validation to fail.
+          //! They help domain modelers spot bounded-context smell early.
+          //!
+          //! Usage:
+          //!   if let Some(msg) = validator_warnings::aggregate_count_warning(&domain) {
+          //!       println!("  {}", msg);
+          //!   }
+          //!   if let Some(msg) = validator_warnings::mixed_concerns_warning(&domain) {
+          //!       println!("  {}", msg);
+          //!   }
+
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_imports_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_imports_body.rb.frag
@@ -1,0 +1,5 @@
+        <<~RS
+          use crate::ir::Domain;
+          use std::collections::{HashMap, HashSet, VecDeque};
+
+        RS

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_rule_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_rule_body.rb.frag
@@ -1,0 +1,5 @@
+        case rule["attrs"]["body_strategy"]
+        when "templated" then emit_templated(rule)
+        when "embedded"  then emit_embedded(rule)
+        else raise "unknown body_strategy: #{rule["attrs"]["body_strategy"]}"
+        end

--- a/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_templated_body.rb.frag
+++ b/hecks_conception/capabilities/diagnostic_validator_meta_shape/snippets/vw_emit_templated_body.rb.frag
@@ -1,0 +1,4 @@
+        case rule["attrs"]["check_kind"]
+        when "count_threshold" then emit_count_threshold(rule)
+        else raise "unknown templated check_kind: #{rule["attrs"]["check_kind"]}"
+        end

--- a/hecks_conception/capabilities/specializer/specializer.hecksagon
+++ b/hecks_conception/capabilities/specializer/specializer.hecksagon
@@ -92,6 +92,15 @@ Hecks.hecksagon "Specializer" do
     args:    ["meta_diagnostic_validator", "--output", "{{output}}"],
     ok_exit: 0
 
+  # Phase C PC-2 extension — second full Ruby class retirement.
+  # Emits lib/hecks_specializer/validator_warnings.rb using the same
+  # meta-shape. Adds RubyConstant + register_target_name features.
+  adapter :shell,
+    name:    :specialize_meta_validator_warnings,
+    command: "bin/specialize",
+    args:    ["meta_validator_warnings", "--output", "{{output}}"],
+    ok_exit: 0
+
   # ---- Gate ----------------------------------------------------
   #
   # :autophagy — the gate for all i51 work. Specialize commands run

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -89,6 +89,7 @@ fn specializer_hecksagon_wiring_is_present() {
         "specialize_meta_subclass",
         "specialize_meta_subclass_lifecycle",
         "specialize_meta_diagnostic_validator",
+        "specialize_meta_validator_warnings",
     ] {
         assert!(
             hex.shell_adapters.iter().any(|a| a.name == expected),
@@ -167,5 +168,20 @@ fn meta_specializer_produces_byte_identical_diagnostic_validator_rb() {
     assert_byte_identical(
         "meta_diagnostic_validator",
         "lib/hecks_specializer/diagnostic_validator.rb",
+    );
+}
+
+#[test]
+fn meta_specializer_produces_byte_identical_validator_warnings_rb() {
+    // Phase C PC-2 extension — second full Ruby class retirement
+    // using the same meta-shape. Adds RubyConstant rows (SHAPE +
+    // TARGET_RS emit at class-body top) and register_target_name
+    // (the `register :validator_warnings, ValidatorWarnings` line
+    // inside module Specializer after the class close). Proves the
+    // shape generalizes — one shape now covers both the base class
+    // AND a self-registering specializer target.
+    assert_byte_identical(
+        "meta_validator_warnings",
+        "lib/hecks_specializer/validator_warnings.rb",
     );
 }

--- a/lib/hecks_specializer/meta_diagnostic_validator.rb
+++ b/lib/hecks_specializer/meta_diagnostic_validator.rb
@@ -3,26 +3,36 @@
 # Hecks::Specializer::MetaDiagnosticValidator — Phase C PC-2.
 #
 # First meta-specializer that regenerates a FULL Ruby class (not just
-# a thin subclass shell). Reads RubyClass + RubyMethod fixture rows
-# from diagnostic_validator_meta_shape.fixtures and emits
-# lib/hecks_specializer/diagnostic_validator.rb byte-identical.
+# a thin subclass shell). Reads RubyClass + RubyMethod (+ optional
+# RubyConstant) fixture rows from diagnostic_validator_meta_shape.fixtures
+# and emits lib/hecks_specializer/<target>.rb byte-identical.
 #
 # Emission pipeline:
 #   1. doc block (from RubyClass.doc_snippet, verbatim)
 #   2. module nesting open (from RubyClass.module_path)
 #   3. class declaration + include lines
-#   4. blank line
-#   5. public methods (RubyMethod rows with visibility=public) in order
-#   6. blank line + "private" + blank line
-#   7. private methods in order
-#   8. module nesting close (ends + ends)
+#   4. constants (if any RubyConstant rows match class_name), sorted
+#      by order, each preceded/separated by a blank line
+#   5. blank line
+#   6. public methods (RubyMethod rows with visibility=public) in order
+#   7. blank line + "private" + blank line
+#   8. private methods in order
+#   9. class close
+#  10. IF register_target_name non-empty: blank line + register call
+#      at class-close depth (inside the innermost module)
+#  11. module nesting close (ends)
 #
 # Method bodies come from .rb.frag snippets, read raw. The specializer
 # only arranges the skeleton; bodies are the author's Ruby.
 #
-# Scope: the base class diagnostic_validator.rb (148 LoC). Design
-# generalizes — PC-3 (driver) and PC-4 (fixed-point of meta_subclass
-# itself) should reuse this pattern with different RubyClass rows.
+# Subclasses override `self.target_class_name` to pick which RubyClass
+# row to emit for. Default picks the first row — kept for the pilot
+# (DiagnosticValidator) which was the sole row when PC-2 landed.
+#
+# Scope: the base class diagnostic_validator.rb (148 LoC) and
+# validator_warnings.rb (113 LoC). Design generalizes — PC-3 (driver)
+# and PC-4 (fixed-point of meta_subclass itself) should reuse this
+# pattern with different RubyClass rows.
 
 module Hecks
   module Specializer
@@ -32,8 +42,14 @@ module Hecks
       SHAPE = REPO_ROOT.join("hecks_conception/capabilities/diagnostic_validator_meta_shape/fixtures/diagnostic_validator_meta_shape.fixtures")
       TARGET_RS = REPO_ROOT.join("lib/hecks_specializer/diagnostic_validator.rb")
 
+      # Which RubyClass fixture row to emit for. Subclasses override
+      # to pick a different row. Default (nil) picks the first row.
+      def self.target_class_name
+        nil
+      end
+
       def emit
-        klass = by_aggregate("RubyClass").first or raise "no RubyClass row"
+        klass = pick_class
         methods = by_aggregate("RubyMethod")
                     .select { |m| m["attrs"]["class_name"] == klass["attrs"]["name"] }
                     .sort_by { |m| m["attrs"]["order"].to_i }
@@ -44,6 +60,7 @@ module Hecks
           emit_doc(klass),
           emit_module_open(klass),
           emit_class_header(klass),
+          emit_constants(klass),
           emit_methods(public_methods, blank_before_first: true),
           emit_private_section(private_methods),
           emit_module_close(klass),
@@ -51,6 +68,14 @@ module Hecks
       end
 
       private
+
+      def pick_class
+        rows = by_aggregate("RubyClass")
+        name = self.class.target_class_name
+        row = name ? rows.find { |r| r["attrs"]["name"] == name } : rows.first
+        raise "no RubyClass row matching #{name.inspect}" unless row
+        row
+      end
 
       def emit_doc(klass)
         # Doc snippet ends with `\n`; add one more for blank-line separator
@@ -73,8 +98,19 @@ module Hecks
         path = klass["attrs"]["module_path"]
         depth = path.empty? ? 0 : path.split("::").length
         class_end = "  " * depth + "end\n"
+        register = emit_register_line(klass, depth)
         module_ends = (0...depth).to_a.reverse.map { |i| "  " * i + "end\n" }.join
-        class_end + module_ends
+        class_end + register + module_ends
+      end
+
+      # If the class registers itself as a specializer target (non-empty
+      # register_target_name), emit the register call inside the innermost
+      # module scope, separated by a blank line from the class close.
+      def emit_register_line(klass, depth)
+        name = klass["attrs"]["register_target_name"]
+        return "" if name.nil? || name.empty?
+        indent = "  " * depth
+        "\n#{indent}register :#{name}, #{klass["attrs"]["name"]}\n"
       end
 
       # Emit the class line + include lines. Indented to match nested
@@ -89,6 +125,25 @@ module Hecks
         mixins = a["includes"].split(",").map(&:strip).reject(&:empty?)
         mixin_lines = mixins.map { |m| "#{indent}  include #{m}\n" }.join
         class_line + mixin_lines
+      end
+
+      # Emit RubyConstant rows matching this class, sorted by order.
+      # Each constant line is indented one step deeper than the class,
+      # preceded by a blank line (separating from include block).
+      # Empty if no constants — whole block collapses.
+      def emit_constants(klass)
+        constants = by_aggregate("RubyConstant")
+                      .select { |c| c["attrs"]["class_name"] == klass["attrs"]["name"] }
+                      .sort_by { |c| c["attrs"]["order"].to_i }
+        return "" if constants.empty?
+        depth = klass["attrs"]["module_path"].empty? \
+                  ? 0 : klass["attrs"]["module_path"].split("::").length
+        indent = "  " * (depth + 1)
+        lines = constants.map do |c|
+          a = c["attrs"]
+          "#{indent}#{a["name"]} = #{a["value_expr"]}\n"
+        end.join
+        "\n#{lines}"
       end
 
       # Emit a run of methods with correct spacing. Each method preceded
@@ -118,5 +173,20 @@ module Hecks
     end
 
     register :meta_diagnostic_validator, MetaDiagnosticValidator
+
+    # Phase C PC-2 extension — second full Ruby class retirement.
+    # Emits lib/hecks_specializer/validator_warnings.rb from the
+    # ValidatorWarnings RubyClass row in the same shape. Adds two
+    # features the base exercised for the first time:
+    #   - RubyConstant rows (SHAPE, TARGET_RS at class-body top)
+    #   - register_target_name ("validator_warnings")
+    class MetaValidatorWarnings < MetaDiagnosticValidator
+      TARGET_RS = REPO_ROOT.join("lib/hecks_specializer/validator_warnings.rb")
+      def self.target_class_name
+        "ValidatorWarnings"
+      end
+    end
+
+    register :meta_validator_warnings, MetaValidatorWarnings
   end
 end


### PR DESCRIPTION
## Summary

- Second full Ruby-class autophagy retirement using the existing `diagnostic_validator_meta_shape`. `lib/hecks_specializer/validator_warnings.rb` (113 LoC) is now regenerated byte-identical from fixture rows + 8 `.rb.frag` snippets.
- Extends the meta-shape with two features it didn't previously need: `RubyConstant` aggregate (class-level constants like `SHAPE`/`TARGET_RS`) and `register_target_name` on `RubyClass` (the `register :<name>, <Class>` line inside module scope after the class close).
- One meta-specializer (`MetaDiagnosticValidator`) now drives two retired files via a `target_class_name` hook — proving the shape generalizes to "any Ruby class that's methods + some state."

## Example usage

```bash
$ bin/specialize meta_validator_warnings > /tmp/vw.rb
$ diff /tmp/vw.rb lib/hecks_specializer/validator_warnings.rb   # (empty — byte-identical)

$ bin/specialize --list
dump
duplicate_policy
lifecycle
meta_diagnostic_validator
meta_subclass
meta_subclass_lifecycle
meta_validator_warnings       ← new
validator
validator_warnings
```

## Test plan

- [x] `cargo test --release --test specializer_golden_test` — 10/10 pass (new test: `meta_specializer_produces_byte_identical_validator_warnings_rb`)
- [x] Existing `meta_diagnostic_validator` golden test still passes — confirms the refactor (class filter, constants emitter, register-line handling) didn't break the original base-class retirement
- [x] `bin/specialize --list` shows `meta_validator_warnings`
- [x] specializer.hecksagon wiring test catches `specialize_meta_validator_warnings` adapter
