### PR TITLE
autophagy: retire bin/specialize via RubyScript shape (i51 PC-3)

### DIFF
--- a/hecks_conception/capabilities/ruby_script_shape/fixtures/ruby_script_shape.fixtures
+++ b/hecks_conception/capabilities/ruby_script_shape/fixtures/ruby_script_shape.fixtures
@@ -1,0 +1,7 @@
+Hecks.fixtures "RubyScriptShape" do
+  # Single-line fixtures per i57 parser limitation.
+
+  aggregate "RubyScript" do
+    fixture "Specialize", name: "Specialize", shebang: "#!/usr/bin/env ruby", doc_snippet: "hecks_conception/capabilities/ruby_script_shape/snippets/specialize_doc.rb.frag", requires_block_snippet: "hecks_conception/capabilities/ruby_script_shape/snippets/specialize_requires.rb.frag", body_snippet: "hecks_conception/capabilities/ruby_script_shape/snippets/specialize_body.rb.frag", output_rb: "bin/specialize", executable: "true"
+  end
+end

--- a/hecks_conception/capabilities/ruby_script_shape/ruby_script_shape.bluebook
+++ b/hecks_conception/capabilities/ruby_script_shape/ruby_script_shape.bluebook
@@ -1,0 +1,68 @@
+Hecks.bluebook "RubyScriptShape", version: "2026.04.23.1" do
+  vision "Phase C PC-3 — shape of top-level Ruby scripts (bin/specialize, future bin/* drivers) as a bluebook. Retires the driver."
+  category "autophagy"
+
+  # ============================================================
+  # RUBY_SCRIPT META SHAPE — Phase C PC-3
+  # ============================================================
+  #
+  # PC-2 bluebook-ified Ruby *classes* inside module nesting. PC-3
+  # takes aim at Ruby *scripts* — top-level files with a shebang, a
+  # comment doc block, a require run, and an imperative body.
+  #
+  # bin/specialize (57 lines) is the pilot. The shape is designed
+  # to cover any similar driver script under bin/ (future Phase C/D
+  # work may retire more).
+  #
+  # Shape — one aggregate:
+  #
+  #   RubyScript (1+ row, one per script):
+  #     name, shebang, doc_snippet, requires_block_snippet,
+  #     body_snippet, output_rb, executable
+  #
+  # The requires block is kept as a snippet (not a structured
+  # attribute) so the shape stays honest about the verbatim nature
+  # of mixed `require` / `require_relative` / conditional requires.
+  # A richer structured form can land later if multiple scripts
+  # share machinery worth extracting.
+  #
+  # The body is likewise a verbatim snippet — the whole point of
+  # PC-3 is proving we can regenerate a script byte-identically,
+  # not structurally decomposing OptionParser dispatch. Future
+  # phases may lift parts of the body into their own sub-shapes.
+  #
+  # The meta-specializer only arranges:
+  #   1. shebang (if non-empty) + newline
+  #   2. doc_snippet verbatim (ends with `\n`)
+  #   3. blank line
+  #   4. requires_block_snippet verbatim (ends with `\n`)
+  #   5. blank line
+  #   6. body_snippet verbatim (ends with `\n`)
+  #
+  # `executable` is metadata only — the specializer prints to
+  # stdout; `--output` writes text. A future driver pass may read
+  # this to chmod +x the emitted file.
+
+  aggregate "RubyScript", "A top-level Ruby script — shebang + doc + requires + imperative body" do
+    attribute :name,                   String
+    # shebang: full shebang line WITHOUT trailing newline, e.g.
+    # "#!/usr/bin/env ruby". Empty string = emit no shebang (plain .rb).
+    attribute :shebang,                String, default: ""
+    # doc_snippet: path to a .rb.frag containing the top-of-file
+    # comment block (each line starting with `# `). Emitted verbatim.
+    attribute :doc_snippet,            String
+    # requires_block_snippet: path to a .rb.frag containing the raw
+    # require / require_relative lines, one per line. Emitted verbatim
+    # (preserves mixed require styles and any comments interleaved).
+    attribute :requires_block_snippet, String
+    # body_snippet: path to a .rb.frag containing everything after
+    # the requires block — the imperative body. Emitted verbatim.
+    attribute :body_snippet,           String
+    # output_rb: relative path to the generated script, e.g. bin/specialize.
+    attribute :output_rb,              String
+    # executable: "true" if the emitted file should be chmod +x'd.
+    # Currently metadata only — specializer emits to stdout; a future
+    # driver step may honor this when materializing to disk.
+    attribute :executable,             String, default: "false"
+  end
+end

--- a/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_body.rb.frag
@@ -1,0 +1,35 @@
+options = { output: nil, diff: false, list: false }
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/specialize <target> [options]\n\nTargets:\n  #{Hecks::Specializer.targets.join(', ')}"
+  opts.on("-o", "--output PATH", "Write to PATH instead of stdout") { |v| options[:output] = v }
+  opts.on("-d", "--diff", "Diff against the target's hand-written .rs") { options[:diff] = true }
+  opts.on("-l", "--list", "List known targets") { options[:list] = true }
+  opts.on("-h", "--help") { puts opts; exit 0 }
+end.parse!
+
+if options[:list]
+  puts Hecks::Specializer.targets
+  exit 0
+end
+
+target = ARGV.shift
+if target.nil? || target.empty?
+  warn "Missing target. Known: #{Hecks::Specializer.targets.join(', ')}"
+  exit 2
+end
+
+rust = Hecks::Specializer.emit(target)
+
+if options[:diff]
+  target_rs = Hecks::Specializer.target_module(target)::TARGET_RS
+  Tempfile.create(["specialize_#{target}_gen", ".rs"]) do |f|
+    f.write(rust)
+    f.flush
+    system "diff", "-u", target_rs.to_s, f.path
+  end
+elsif options[:output]
+  File.write(options[:output], rust)
+  warn "wrote #{rust.bytesize} bytes to #{options[:output]}"
+else
+  print rust
+end

--- a/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_doc.rb.frag
@@ -1,0 +1,16 @@
+# bin/specialize — single entry point for every i51 Futamura specializer.
+#
+# Replaces the three Phase A/B per-target scripts:
+#   bin/specialize-validator
+#   bin/specialize-validator-warnings
+#   bin/specialize-dump
+#
+# Usage:
+#   bin/specialize <target>                     # stdout
+#   bin/specialize <target> --output PATH
+#   bin/specialize <target> --diff
+#   bin/specialize --list                       # list known targets
+#
+# Target names match SpecializerTarget.name in specializer.fixtures
+# and the :specialize_<target> shell adapter names in
+# specializer.hecksagon.

--- a/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_requires.rb.frag
+++ b/hecks_conception/capabilities/ruby_script_shape/snippets/specialize_requires.rb.frag
@@ -1,0 +1,3 @@
+require "optparse"
+require "tempfile"
+require_relative "../lib/hecks_specializer"

--- a/hecks_conception/capabilities/specializer/specializer.hecksagon
+++ b/hecks_conception/capabilities/specializer/specializer.hecksagon
@@ -101,6 +101,15 @@ Hecks.hecksagon "Specializer" do
     args:    ["meta_validator_warnings", "--output", "{{output}}"],
     ok_exit: 0
 
+  # Phase C PC-3 — meta-specializer for top-level Ruby scripts. Emits
+  # bin/specialize itself from a RubyScript fixture row (shebang + doc
+  # block + requires + body snippets). First retirement of a bin/ driver.
+  adapter :shell,
+    name:    :specialize_meta_ruby_script,
+    command: "bin/specialize",
+    args:    ["meta_ruby_script", "--output", "{{output}}"],
+    ok_exit: 0
+
   # Phase C PC-4 — THE FUTAMURA FIXED POINT. The meta-specializer
   # regenerates its own source (meta_diagnostic_validator.rb + the
   # thin subclass meta_validator_warnings.rb) from the same

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -90,6 +90,7 @@ fn specializer_hecksagon_wiring_is_present() {
         "specialize_meta_subclass_lifecycle",
         "specialize_meta_diagnostic_validator",
         "specialize_meta_validator_warnings",
+        "specialize_meta_ruby_script",
         "specialize_meta_meta_diagnostic_validator",
         "specialize_meta_meta_validator_warnings",
     ] {
@@ -186,6 +187,18 @@ fn meta_specializer_produces_byte_identical_validator_warnings_rb() {
         "meta_validator_warnings",
         "lib/hecks_specializer/validator_warnings.rb",
     );
+}
+
+#[test]
+fn meta_specializer_produces_byte_identical_bin_specialize() {
+    // Phase C PC-3 — first retirement of a top-level Ruby script
+    // under bin/. Emits bin/specialize itself from a RubyScript row:
+    // shebang + doc_snippet + requires_block_snippet + body_snippet.
+    //
+    // This is the driver that runs every other specializer target —
+    // including the one being exercised here. Byte-identity means
+    // the driver can regenerate itself and the build stays idempotent.
+    assert_byte_identical("meta_ruby_script", "bin/specialize");
 }
 
 #[test]

--- a/lib/hecks_specializer/meta_ruby_script.rb
+++ b/lib/hecks_specializer/meta_ruby_script.rb
@@ -1,0 +1,96 @@
+# lib/hecks_specializer/meta_ruby_script.rb
+#
+# Hecks::Specializer::MetaRubyScript — Phase C PC-3.
+#
+# Third meta-specializer. Regenerates a top-level Ruby script from a
+# single RubyScript fixture row. Covers the driver script itself
+# (bin/specialize) — first retirement under bin/.
+#
+# Emission pipeline (verbatim concatenation):
+#
+#   1. shebang line + "\n" — skipped entirely if shebang is empty
+#   2. doc_snippet — read raw (already ends with "\n")
+#   3. "\n" — blank line separator
+#   4. requires_block_snippet — read raw (already ends with "\n")
+#   5. "\n" — blank line separator
+#   6. body_snippet — read raw (already ends with "\n")
+#
+# Everything other than the shebang is snippet-driven, so the shape
+# stays honest about script bodies being author-verbatim. What the
+# meta-specializer contributes is the skeleton (shebang + inter-
+# section blank lines) and a data-driven choice of which row to emit.
+#
+# Subclasses override `self.target_row_name` to pick which RubyScript
+# row to emit for. Default (nil) picks the first row — kept simple
+# for the PC-3 pilot, which ships with a single row (Specialize).
+#
+# `executable` is currently metadata only — the CLI prints to stdout
+# and `--output` writes text. A future driver pass may chmod +x on
+# write. The specializer's own output stays deterministic text.
+
+module Hecks
+  module Specializer
+    class MetaRubyScript
+      include Target
+
+      SHAPE = REPO_ROOT.join("hecks_conception/capabilities/ruby_script_shape/fixtures/ruby_script_shape.fixtures")
+      TARGET_RS = REPO_ROOT.join("bin/specialize")
+
+      # Which RubyScript fixture row to emit for. Subclasses override
+      # to pick a different row. Default (nil) picks the first row.
+      def self.target_row_name
+        nil
+      end
+
+      def emit
+        row = pick_row
+        [
+          emit_shebang(row),
+          emit_doc(row),
+          emit_requires(row),
+          emit_body(row),
+        ].join
+      end
+
+      private
+
+      def pick_row
+        rows = by_aggregate("RubyScript")
+        name = self.class.target_row_name
+        row = name ? rows.find { |r| r["attrs"]["name"] == name } : rows.first
+        raise "no RubyScript row matching #{name.inspect}" unless row
+        row
+      end
+
+      # Shebang line followed by "\n". Empty string (no shebang) skips
+      # the whole line — used for plain `.rb` outputs with no shebang.
+      def emit_shebang(row)
+        shebang = row["attrs"]["shebang"]
+        return "" if shebang.nil? || shebang.empty?
+        "#{shebang}\n"
+      end
+
+      # Doc block — read verbatim. Snippet already ends with "\n".
+      # Append one more "\n" to insert the blank line that separates
+      # doc from requires.
+      def emit_doc(row)
+        File.read(REPO_ROOT.join(row["attrs"]["doc_snippet"])) + "\n"
+      end
+
+      # Requires block — read verbatim. Snippet already ends with "\n".
+      # Append one more "\n" to insert the blank line that separates
+      # requires from body.
+      def emit_requires(row)
+        File.read(REPO_ROOT.join(row["attrs"]["requires_block_snippet"])) + "\n"
+      end
+
+      # Imperative body — read verbatim. Final section; snippet's own
+      # trailing "\n" is the file's trailing newline.
+      def emit_body(row)
+        File.read(REPO_ROOT.join(row["attrs"]["body_snippet"]))
+      end
+    end
+
+    register :meta_ruby_script, MetaRubyScript
+  end
+end


### PR DESCRIPTION
## Summary
- First retirement of a top-level Ruby script under `bin/`. PC-1/PC-2 covered Ruby classes (subclass shells, base + self-registering class); PC-3 tackles a different shape: shebang + doc block + requires + imperative body.
- New capability `ruby_script_shape/` with one aggregate (`RubyScript`) and one fixture row (`Specialize`). Snippets carry verbatim byte content for the doc block, requires block, and imperative body.
- New meta-specializer `Hecks::Specializer::MetaRubyScript` (96 LoC) — shape-driven concatenation of shebang, snippets, and inter-section blank lines. The snippets are authoritative; the meta-specializer only arranges skeleton.
- Golden test `meta_specializer_produces_byte_identical_bin_specialize` added. Wiring test extended to expect `specialize_meta_ruby_script` adapter.

## Shape decisions
- **Requires kept as a verbatim snippet** (`requires_block_snippet`) rather than parallel `requires` / `require_relatives` String lists. Keeps the shape honest about mixed `require` / `require_relative` styles, conditional requires, and interleaved comments a future script may carry. If N scripts later prove the structured form pulls weight, lifting it in is cheap.
- **`executable` attribute is metadata only** for now — the specializer prints to stdout; `--output` writes text. A future driver pass (when we regenerate *to disk* as part of a build step) can read this and chmod +x without shape churn.
- **Default `target_row_name` is nil** (picks first row); subclasses override for additional scripts. Pattern mirrors `MetaDiagnosticValidator`'s `target_class_name`.

## Deferred
- `lib/hecks_specializer.rb` retirement — its shape is materially different from `RubyScript`. It has `class << self` on a module (module-level state + class methods), an inner `module Target` (nested module, not a class), and a `Dir[...].each { require }` auto-load loop at the bottom. Each construct needs its own shape concept; bundling them into PC-3 would have blown scope. A follow-up story should extend the shape (add `RubyModule` or similar) rather than torturing `RubyScript` to fit.

## Example usage
```sh
$ bin/specialize meta_ruby_script > /tmp/out && diff /tmp/out bin/specialize
$ echo $?
0
$ # empty diff — byte-identical regeneration proven
```

## Test plan
- [x] `cd hecks_life && cargo test --release --test specializer_golden_test` — 11/11 pass (10 prior + 1 new)
- [x] `bin/specialize meta_ruby_script | diff - bin/specialize` — empty output
- [x] `bin/specialize --list` — includes `meta_ruby_script`
- [x] File-line cap: meta_ruby_script.rb is 96 LoC, well under 200
- [x] Antibody hook green (meta-specializer + golden test file marked `[antibody-exempt]`)
- [x] No unrelated files staged