### PR TITLE
chore: track .herb.yml — Herb linter/formatter config for ERB

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,86 @@
+# This file configures Herb for your project and team.
+# Settings here take precedence over individual editor preferences.
+#
+# Herb is a suite of tools for HTML+ERB templates including:
+# - Linter: Validates templates and enforces best practices
+# - Formatter: Auto-formats templates with intelligent indentation
+# - Language Server: Provides IDE support (VS Code, Zed, Neovim, etc.)
+#
+# Website: https://herb-tools.dev
+# Configuration: https://herb-tools.dev/configuration
+# GitHub Repo: https://github.com/marcoroth/herb
+#
+
+version: 0.9.7
+
+# files:
+#   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
+#   include:
+#     - '**/*.xml.erb'
+#     - 'custom/**/*.html'
+#
+#   # Patterns to exclude (can exclude defaults too)
+#   exclude:
+#     - 'public/**/*'
+#     - 'tmp/**/*'
+
+# engine:
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
+
+linter:
+  enabled: true
+  # # Exit with error code when diagnostics of this severity or higher are present
+  # # Valid values: error (default), warning, info, hint
+  # failLevel: warning
+
+  # # Additional patterns beyond the defaults for linting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from linting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # rules:
+  #   erb-no-extra-newline:
+  #     enabled: false
+  #
+  #   # Rules can have 'include', 'only', and 'exclude' patterns
+  #   some-rule:
+  #     # Additional patterns to check (additive, ignored when 'only' is present)
+  #     include:
+  #       - 'app/components/**/*'
+  #     # Don't apply this rule to files matching these patterns
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+  #
+  #   another-rule:
+  #     # Only apply this rule to files matching these patterns (overrides all 'include')
+  #     only:
+  #       - 'app/views/**/*'
+  #     # Exclude still applies even with 'only'
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+
+formatter:
+  enabled: true
+  indentWidth: 2
+  maxLineLength: 80
+  # # Additional patterns beyond the defaults for formatting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from formatting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # # Rewriters modify templates during formatting
+  # rewriter:
+  #   # Pre-format rewriters (modify AST before formatting)
+  #   pre:
+  #     - tailwind-class-sorter
+  #   # Post-format rewriters (modify formatted output string)
+  #   post: []


### PR DESCRIPTION
## Summary

Adds `.herb.yml` at repo root to pin Herb (herb-tools.dev) configuration for the team. Herb is a linter + formatter + language server for HTML+ERB templates; the repo has ERB under `lib/hecks/extensions/*/views`, `lib/hecks/workshop/web_runner/views`, and the `pizzas_rails` example.

- Linter: enabled
- Formatter: enabled, indent 2, max line length 80
- All rule overrides left commented out (defaults)

Tracking this means editors (VS Code, Zed, Neovim via the Herb LSP) and any future CI step pick up the same version and rules.

## Test plan

- [ ] Open an `.erb` file with the Herb extension installed and confirm it picks up formatter defaults
- [ ] Confirm no existing templates are broken by default rules (run Herb locally on `lib/hecks/extensions/**/views`)

## Example usage

```sh
# with herb installed
herb format lib/hecks/extensions/web_explorer/views/index.erb
herb lint lib/hecks/extensions/web_explorer/views/index.erb
```