### PR TITLE
feat(autophagy): tracker bluebook — retirement state as queryable data

### DIFF
--- a/hecks_conception/capabilities/autophagy_tracker_shape/autophagy_tracker_shape.bluebook
+++ b/hecks_conception/capabilities/autophagy_tracker_shape/autophagy_tracker_shape.bluebook
@@ -1,0 +1,70 @@
+Hecks.bluebook "AutophagyTrackerShape", version: "2026.04.23.1" do
+  vision "Autophagy retirement state as queryable data — every candidate file, its phase, its bluebook, its ship-status, one row each"
+  category "autophagy"
+
+  # ============================================================
+  # AUTOPHAGY TRACKER SHAPE — i51 retirement arc, as data
+  # ============================================================
+  #
+  # The compiler eats itself in phases. Each phase retires one or
+  # more files from hand-written into bluebook-described: the
+  # specializer reads a shape (.bluebook + .fixtures) and emits the
+  # target file byte-identical.
+  #
+  # This shape lets Miette answer questions like "how many files
+  # left?", "which phase is PC-3 in?", "what's the gap LoC?" without
+  # rerunning shell scripts. Measurements go in the fixtures file;
+  # queries come from the runtime.
+  #
+  # One row per candidate file. Phases match the i51 plan:
+  #   phase a — first Futamura proof (validator.rs)
+  #   phase b — more Rust targets + diagnostic-validator retirements
+  #   phase c — meta-specializer (ruby subclass shells, then full
+  #             ruby classes); PC-1, PC-2, PC-3 driver, PC-4 fixed
+  #             point
+  #   phase d — parsers + specializer itself (not yet started)
+
+  # ---- RetirementTarget --------------------------------------------
+  #
+  # One row per file in the autophagy scope. source_path is relative
+  # to repo root. kind is "rust" for hecks_life/src/*.rs, "ruby" for
+  # lib/hecks_specializer/*.rb, "script" reserved for future shell /
+  # python candidates. ship_status mirrors the SpecializerTarget
+  # vocabulary: byte_identical means the specializer reproduces it
+  # exactly; in_flight means agent work is happening; not_started
+  # means hand-written, no shape yet.
+
+  aggregate "RetirementTarget", "One candidate file in the autophagy arc — name, path, kind, LoC, ship status, owning shape capability, phase" do
+    attribute :name,                      String
+    attribute :source_path,               String
+    # kind: rust | ruby | script
+    attribute :kind,                      String
+    attribute :loc,                       Integer
+    # ship_status: byte_identical | in_flight | not_started
+    attribute :ship_status,               String
+    # source_shape_capability: the hecks_conception/capabilities/<dir>
+    # that owns this file's shape. Empty string when no shape exists.
+    attribute :source_shape_capability,   String
+    # phase: a | b | c | d
+    attribute :phase,                     String
+  end
+
+  # ---- RetirementSummary -------------------------------------------
+  #
+  # One row per phase — rolled-up narrative. files_count and loc_total
+  # are the totals across RetirementTargets in that phase; byte_*
+  # fields are the subset already shape-driven. gap_loc is
+  # loc_total - byte_identical_loc and represents hand-written
+  # remaining. description is a one-line summary of what the phase
+  # achieved (or aims to achieve).
+
+  aggregate "RetirementSummary", "One row per retirement phase — rolled-up counts, LoC totals, and a narrative description" do
+    attribute :phase,                String
+    attribute :files_count,          Integer
+    attribute :loc_total,            Integer
+    attribute :byte_identical_count, Integer
+    attribute :byte_identical_loc,   Integer
+    attribute :gap_loc,              Integer
+    attribute :description,          String
+  end
+end

--- a/hecks_conception/capabilities/autophagy_tracker_shape/fixtures/autophagy_tracker_shape.fixtures
+++ b/hecks_conception/capabilities/autophagy_tracker_shape/fixtures/autophagy_tracker_shape.fixtures
@@ -1,0 +1,43 @@
+Hecks.fixtures "AutophagyTrackerShape" do
+  # Note: single-line fixtures — the Rust fixtures_parser only reads one
+  # line per `fixture` directive today (i57 tracks multi-line support).
+  #
+  # Measurements taken at HEAD = b0400791 (miette/i51-phase-c-meta-validator-warnings-v2,
+  # the PC-2 extension commit). See autophagy_tracker_shape.bluebook for
+  # field semantics.
+
+  # ── RetirementTarget — one row per candidate file ──────────────────
+  #
+  # Ruby rows: every file under lib/hecks_specializer/*.rb.
+  # Rust rows: every SpecializerTarget row in specializer.fixtures.
+
+  aggregate "RetirementTarget" do
+    # ---- Ruby specializer files (phase c) ----------------------------
+    fixture "RubyDiagnosticValidator",       name: "diagnostic_validator",       source_path: "lib/hecks_specializer/diagnostic_validator.rb",       kind: "ruby", loc: 153, ship_status: "byte_identical", source_shape_capability: "diagnostic_validator_meta_shape", phase: "c"
+    fixture "RubyDump",                      name: "dump",                       source_path: "lib/hecks_specializer/dump.rb",                      kind: "ruby", loc: 203, ship_status: "not_started",    source_shape_capability: "",                                phase: "c"
+    fixture "RubyDuplicatePolicy",           name: "duplicate_policy",           source_path: "lib/hecks_specializer/duplicate_policy.rb",           kind: "ruby", loc: 20,  ship_status: "byte_identical", source_shape_capability: "specializer",                     phase: "c"
+    fixture "RubyLifecycle",                 name: "lifecycle",                  source_path: "lib/hecks_specializer/lifecycle.rb",                  kind: "ruby", loc: 20,  ship_status: "byte_identical", source_shape_capability: "specializer",                     phase: "c"
+    fixture "RubyMetaDiagnosticValidator",   name: "meta_diagnostic_validator",  source_path: "lib/hecks_specializer/meta_diagnostic_validator.rb",  kind: "ruby", loc: 192, ship_status: "not_started",    source_shape_capability: "",                                phase: "c"
+    fixture "RubyMetaSubclass",              name: "meta_subclass",              source_path: "lib/hecks_specializer/meta_subclass.rb",              kind: "ruby", loc: 97,  ship_status: "not_started",    source_shape_capability: "",                                phase: "c"
+    fixture "RubyValidator",                 name: "validator",                  source_path: "lib/hecks_specializer/validator.rb",                  kind: "ruby", loc: 393, ship_status: "not_started",    source_shape_capability: "",                                phase: "c"
+    fixture "RubyValidatorWarnings",         name: "validator_warnings",         source_path: "lib/hecks_specializer/validator_warnings.rb",         kind: "ruby", loc: 113, ship_status: "byte_identical", source_shape_capability: "diagnostic_validator_meta_shape", phase: "c"
+
+    # ---- Rust SpecializerTarget rows ---------------------------------
+    fixture "RustValidator",                 name: "validator",                  source_path: "hecks_life/src/validator.rs",                         kind: "rust", loc: 248, ship_status: "byte_identical", source_shape_capability: "validator_shape",                 phase: "a"
+    fixture "RustValidatorWarnings",         name: "validator_warnings",         source_path: "hecks_life/src/validator_warnings.rs",                kind: "rust", loc: 145, ship_status: "byte_identical", source_shape_capability: "validator_warnings_shape",        phase: "b"
+    fixture "RustFixturesParser",            name: "fixtures_parser",            source_path: "hecks_life/src/fixtures_parser.rs",                   kind: "rust", loc: 440, ship_status: "not_started",    source_shape_capability: "fixtures_parser_shape",           phase: "b"
+    fixture "RustBehaviorsParser",           name: "behaviors_parser",           source_path: "hecks_life/src/behaviors_parser.rs",                  kind: "rust", loc: 372, ship_status: "not_started",    source_shape_capability: "behaviors_parser_shape",          phase: "b"
+    fixture "RustHecksagonParser",           name: "hecksagon_parser",           source_path: "hecks_life/src/hecksagon_parser.rs",                  kind: "rust", loc: 189, ship_status: "not_started",    source_shape_capability: "hecksagon_parser_shape",          phase: "b"
+    fixture "RustDump",                      name: "dump",                       source_path: "hecks_life/src/dump.rs",                              kind: "rust", loc: 185, ship_status: "byte_identical", source_shape_capability: "dump_shape",                      phase: "b"
+    fixture "RustDuplicatePolicy",           name: "duplicate_policy",           source_path: "hecks_life/src/duplicate_policy_validator.rs",        kind: "rust", loc: 86,  ship_status: "byte_identical", source_shape_capability: "duplicate_policy_validator_shape", phase: "b"
+    fixture "RustLifecycle",                 name: "lifecycle",                  source_path: "hecks_life/src/lifecycle_validator.rs",               kind: "rust", loc: 288, ship_status: "byte_identical", source_shape_capability: "lifecycle_validator_shape",       phase: "b"
+    fixture "RustSpecializer",               name: "specializer",                source_path: "hecks_life/src/specializer/",                         kind: "rust", loc: 0,   ship_status: "not_started",    source_shape_capability: "specializer",                     phase: "d"
+  end
+
+  # ── RetirementSummary — one row per phase, rolled-up narrative ─────
+  aggregate "RetirementSummary" do
+    fixture "PhaseA", phase: "a", files_count: 1, loc_total: 248,  byte_identical_count: 1, byte_identical_loc: 248, gap_loc: 0,    description: "First Futamura proof — validator.rs regenerated byte-identical from validator_shape."
+    fixture "PhaseB", phase: "b", files_count: 7, loc_total: 1705, byte_identical_count: 4, byte_identical_loc: 704, gap_loc: 1001, description: "More Rust targets + diagnostic-validator retirements — validator_warnings, dump, duplicate_policy, lifecycle shipped byte-identical. Parsers (fixtures, behaviors, hecksagon) still hand-written."
+    fixture "PhaseC", phase: "c", files_count: 8, loc_total: 1191, byte_identical_count: 4, byte_identical_loc: 306, gap_loc: 885,  description: "Meta-specializer — PC-1 pilot retired duplicate_policy.rb + lifecycle.rb shells; PC-2 retired diagnostic_validator.rb + validator_warnings.rb full classes. PC-3 driver + PC-4 fixed point still open."
+  end
+end


### PR DESCRIPTION
## Summary

New capability `autophagy_tracker_shape` captures the i51 autophagy arc as data. Two aggregates:

- **RetirementTarget** — one row per candidate file (ruby + rust) with `loc`, `ship_status`, `source_shape_capability`, and `phase`.
- **RetirementSummary** — one row per phase (a/b/c/d) with rolled-up counts, LoC totals, and a one-line narrative.

Fixtures populated with real measurements taken at HEAD = `b0400791` (the PC-2 extension commit):

- 8 ruby rows for `lib/hecks_specializer/*.rb` (1191 LoC; 306 shape-driven, 885 gap).
- 9 rust rows mirroring every `SpecializerTarget` in `specializer.fixtures` (1953 LoC across phases; 952 byte-identical so far).
- 3 summary rows: Phase A (1/1 file, 248 LoC, 100% shipped); Phase B (4/7, 704/1705 LoC, 41% byte-identical); Phase C (4/8, 306/1191 LoC, 26% byte-identical).

Headline ratio: **1258 / 3144 LoC = 40% autophagy completeness** across the in-scope files (`lib/hecks_specializer/` + all Rust specializer targets).

Bluebook is 70 lines (22 non-comment LoC), fixtures is 43 lines. Version stamp: `2026.04.23.1`. Category: `autophagy`. No antibody exemptions needed — both files are bluebook vocabulary.

## Example usage

Once hecks-life reloads the capability, Miette can answer retirement questions from the .heki:

```ruby
# "which files are still not_started in Phase C?"
RetirementTarget.where(phase: "c", ship_status: "not_started")
# → dump.rb, meta_diagnostic_validator.rb, meta_subclass.rb, validator.rb

# "how much gap remains in Phase B?"
RetirementSummary.find(phase: "b").gap_loc
# → 1001
```

No more shell math for status questions — the tracker shape IS the truth.

## Test plan

- [ ] `ruby -Ilib -e 'require "hecks"; load "hecks_conception/capabilities/autophagy_tracker_shape/autophagy_tracker_shape.bluebook"'` parses without error (verified).
- [ ] Fixtures file parses the same way (verified).
- [ ] Pre-commit antibody gate passes — both files are bluebook vocabulary (verified: `antibody: no non-bluebook files touched`).
- [ ] When hecks-life rebuilds, `hecks-life check-lifecycle` passes on the new bluebook (no lifecycle — attribute-only aggregates).