### PR TITLE
autophagy: retire lib/hecks_specializer.rb via RubyModule shape (i51 PC-5)

### DIFF
--- a/hecks_conception/capabilities/ruby_module_shape/fixtures/ruby_module_shape.fixtures
+++ b/hecks_conception/capabilities/ruby_module_shape/fixtures/ruby_module_shape.fixtures
@@ -1,0 +1,26 @@
+Hecks.fixtures "RubyModuleShape" do
+  # Single-line fixtures per i57 parser limitation.
+
+  aggregate "RubyModule" do
+    fixture "HecksSpecializer", name: "Hecks::Specializer", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_doc.rb.frag", outer_requires: "json,open3,pathname", output_rb: "lib/hecks_specializer.rb", autoload_glob: "hecks_specializer/*.rb", autoload_base: "__dir__", autoload_doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_autoload_doc.rb.frag"
+  end
+
+  aggregate "ModuleConstant" do
+    fixture "HsRepoRoot", module_name: "Hecks::Specializer", name: "REPO_ROOT", value_expr: "Pathname.new(File.expand_path(\"..\", __dir__))", order: 1
+    fixture "HsHecksLife", module_name: "Hecks::Specializer", name: "HECKS_LIFE", value_expr: "REPO_ROOT.join(\"hecks_life/target/release/hecks-life\")", order: 2
+    fixture "HsTargets", module_name: "Hecks::Specializer", name: "@targets", value_expr: "{}", order: 3, doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_ivar_doc.rb.frag"
+  end
+
+  aggregate "ModuleClassMethod" do
+    fixture "HsRegister", module_name: "Hecks::Specializer", name: "register", signature: "name, mod", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_body.rb.frag", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_doc.rb.frag", order: 1
+    fixture "HsTargetsMethod", module_name: "Hecks::Specializer", name: "targets", signature: "", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_body.rb.frag", order: 2
+    fixture "HsTargetModule", module_name: "Hecks::Specializer", name: "target_module", signature: "name", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_module_method_body.rb.frag", order: 3
+    fixture "HsEmit", module_name: "Hecks::Specializer", name: "emit", signature: "name", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_body.rb.frag", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_doc.rb.frag", order: 4
+    fixture "HsLoadFixtures", module_name: "Hecks::Specializer", name: "load_fixtures", signature: "shape_path", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_body.rb.frag", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_doc.rb.frag", order: 5
+    fixture "HsReadSnippetBody", module_name: "Hecks::Specializer", name: "read_snippet_body", signature: "path", body_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_body.rb.frag", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_doc.rb.frag", order: 6
+  end
+
+  aggregate "InnerModule" do
+    fixture "HsTarget", parent_module: "Hecks::Specializer", name: "Target", doc_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_inner_module_doc.rb.frag", methods_block_snippet: "hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_methods.rb.frag", order: 1
+  end
+end

--- a/hecks_conception/capabilities/ruby_module_shape/ruby_module_shape.bluebook
+++ b/hecks_conception/capabilities/ruby_module_shape/ruby_module_shape.bluebook
@@ -1,0 +1,124 @@
+Hecks.bluebook "RubyModuleShape", version: "2026.04.23.1" do
+  vision "Phase C PC-5 — shape of Ruby loader modules (lib/hecks_specializer.rb and kin). Describes bare module bodies: outer requires + constants + class << self methods + inner module mixins + trailing Dir[].each require loop."
+  category "autophagy"
+
+  # ============================================================
+  # RUBY_MODULE META SHAPE — Phase C PC-5
+  # ============================================================
+  #
+  # PC-2 covered Ruby *classes*. PC-3 covered Ruby *scripts*. PC-5
+  # covers Ruby *modules* — specifically the loader-module pattern
+  # where a top-level file opens `module Hecks; module X; ... end; end`
+  # and exposes module-level machinery (constants, ivars, class methods
+  # via `class << self`, a nested mixin module) plus a trailing
+  # `Dir[].each { require }` auto-load loop at file level.
+  #
+  # lib/hecks_specializer.rb (108 LoC) is the pilot — it's the loader
+  # every specializer target registers against.
+  #
+  # Shape — four aggregates:
+  #
+  #   RubyModule (1 row per emitted file):
+  #     name (dotted, e.g. "Hecks::Specializer")
+  #     doc_snippet (file-top comment block)
+  #     outer_requires (comma-separated top-level requires)
+  #     output_rb (relative output path)
+  #     autoload_glob (glob for Dir[] — empty = no auto-load loop)
+  #     autoload_base (__dir__ or similar anchor expression)
+  #     autoload_doc_snippet (optional pre-loop comment)
+  #
+  #   ModuleConstant (N rows):
+  #     module_name (FK), name, value_expr, order
+  #     doc_snippet (optional pre-constant comment, empty allowed)
+  #
+  #   ModuleClassMethod (N rows):
+  #     module_name (FK), name, signature (no parens), body_snippet,
+  #     order, doc_snippet (optional inline pre-method comment)
+  #
+  #   InnerModule (N rows):
+  #     parent_module (FK), name, doc_snippet,
+  #     methods_block_snippet (the whole body between `module Foo` and
+  #     its closing `end`, verbatim — kept simple for PC-5; a later
+  #     pass can split into structured methods if needed), order
+  #
+  # Design notes:
+  #   - The @targets ivar at module-level is modeled as a ModuleConstant
+  #     with name "@targets" and value_expr "{}". Its pre-assignment
+  #     comment rides on doc_snippet.
+  #   - All class methods live inside a single `class << self` block
+  #     emitted by the meta-specializer; each ModuleClassMethod row is
+  #     a method inside that block.
+  #   - The inner-module body is one verbatim snippet — acceptable for
+  #     the pilot since Target is 11 lines of 3 tiny methods. Structured
+  #     decomposition (RubyMethod rows scoped to an InnerModule) is
+  #     deferred until a second inner module with more complexity
+  #     justifies it.
+
+  aggregate "RubyModule", "A top-level Ruby loader module — module Hecks; module X; ... end; end" do
+    attribute :name,                String
+    # doc_snippet: path to the file-top comment block (each line "# ...").
+    # Emitted verbatim, ends with "\n"; meta-specializer adds a trailing
+    # blank line before the requires block.
+    attribute :doc_snippet,         String
+    # outer_requires: comma-separated list of library names for `require`
+    # lines between the doc and the module open. E.g. "json,open3,pathname".
+    # Empty = no requires (rare).
+    attribute :outer_requires,      String
+    # output_rb: relative path of the generated module file.
+    attribute :output_rb,           String
+    # autoload_glob: glob passed to Dir[File.expand_path(<glob>, <base>)]
+    # at the bottom of the file. Empty = no auto-load loop emitted.
+    attribute :autoload_glob,       String, default: ""
+    # autoload_base: the second argument to File.expand_path, written
+    # verbatim. Typically "__dir__". Ignored if autoload_glob is empty.
+    attribute :autoload_base,       String, default: "__dir__"
+    # autoload_doc_snippet: optional path to pre-loop comment. Empty
+    # skips. Emitted immediately before the Dir[].each block.
+    attribute :autoload_doc_snippet, String, default: ""
+  end
+
+  aggregate "ModuleConstant", "A module-level constant or ivar assignment (REPO_ROOT, @targets, ...)" do
+    # module_name: foreign-key-like link to RubyModule.name
+    attribute :module_name, String
+    # name: constant name (e.g. "REPO_ROOT") or ivar (e.g. "@targets").
+    attribute :name,        String
+    # value_expr: RHS of the assignment, verbatim.
+    attribute :value_expr,  String
+    # order: emission order among constants inside the module body.
+    attribute :order,       Integer
+    # doc_snippet: optional pre-constant comment, emitted immediately
+    # before the assignment (same indent). Empty = no doc.
+    attribute :doc_snippet, String, default: ""
+  end
+
+  aggregate "ModuleClassMethod", "One method inside the class << self block of a RubyModule" do
+    # module_name: foreign-key-like link to RubyModule.name
+    attribute :module_name,  String
+    attribute :name,         String
+    # signature: parameter list without parens. Empty = no-arg method.
+    attribute :signature,    String
+    # body_snippet: relative path to .rb.frag with the method body
+    # (indented 8 spaces — matches 4-space module + 2-space class<<self
+    # + 2-space def body depth).
+    attribute :body_snippet, String
+    # order: emission order within the class << self block.
+    attribute :order,        Integer
+    # doc_snippet: optional inline pre-method comment. Empty = no doc.
+    attribute :doc_snippet,  String, default: ""
+  end
+
+  aggregate "InnerModule", "A nested mixin module inside the RubyModule (e.g. Target)" do
+    # parent_module: foreign-key-like link to RubyModule.name
+    attribute :parent_module,          String
+    attribute :name,                   String
+    # doc_snippet: pre-module comment block, emitted immediately before
+    # `module <Name>`. Empty allowed.
+    attribute :doc_snippet,            String, default: ""
+    # methods_block_snippet: path to .rb.frag with the module body
+    # verbatim (all instance methods, blank-line separated, indented
+    # 6 spaces). Excludes the surrounding `module <Name>` and its `end`.
+    attribute :methods_block_snippet,  String
+    # order: emission order when multiple inner modules share a parent.
+    attribute :order,                  Integer
+  end
+end

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_autoload_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_autoload_doc.rb.frag
@@ -1,0 +1,2 @@
+# Auto-load every target module. Each require'd file is expected to
+# call Hecks::Specializer.register(name, klass) at load time.

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_doc.rb.frag
@@ -1,0 +1,27 @@
+# lib/hecks_specializer.rb
+#
+# Hecks::Specializer — i51 Futamura specializer driver
+#
+# Single entry point for every specializer target. Loads the target's
+# shape fixtures via `hecks-life dump-fixtures`, dispatches to the
+# target module's #emit, returns the Rust source.
+#
+# Replaces the Phase A/B per-target bin/specialize-* scripts. The
+# common machinery (fixture loading, CLI, diff) lives here; each
+# target module holds its emission logic.
+#
+# Target modules discovered at load-time from lib/hecks_specializer/*.rb.
+# Each module must define:
+#   REPO_ROOT, SHAPE, TARGET_RS — as module constants
+#   class-level #emit -> String — returns the Rust source
+# (Convention, not a formal contract yet — Phase C will lift the
+# contract into a bluebook too.)
+#
+# Usage from Ruby:
+#   require "hecks_specializer"
+#   rust = Hecks::Specializer.emit(:validator)
+#
+# Usage from CLI (bin/specialize):
+#   bin/specialize validator
+#   bin/specialize validator --diff
+#   bin/specialize dump --output hecks_life/src/dump.rs

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_body.rb.frag
@@ -1,0 +1,1 @@
+        target_module(name).new.emit

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_emit_doc.rb.frag
@@ -1,0 +1,1 @@
+      # Run a named target and return the emitted Rust as a String.

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_body.rb.frag
@@ -1,0 +1,4 @@
+        raise "hecks-life not built: #{HECKS_LIFE}" unless HECKS_LIFE.exist?
+        out, err, status = Open3.capture3(HECKS_LIFE.to_s, "dump-fixtures", shape_path.to_s)
+        raise "dump-fixtures failed: #{err}" unless status.success?
+        JSON.parse(out)["fixtures"]

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_load_fixtures_doc.rb.frag
@@ -1,0 +1,1 @@
+      # Load the shape fixtures for a given path. Shared by every target.

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_body.rb.frag
@@ -1,0 +1,4 @@
+        raise "snippet missing: #{path}" unless File.exist?(path)
+        lines = File.read(path).lines
+        start = lines.find_index { |l| !l.strip.empty? && !l.strip.start_with?("//") }
+        lines[start..].join

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_read_snippet_body_doc.rb.frag
@@ -1,0 +1,3 @@
+      # Read a .rs.frag snippet file, stripping the leading //-comment
+      # header. Everything from the first non-comment, non-empty line
+      # onward is returned verbatim (specializers interpolate as fn body).

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_body.rb.frag
@@ -1,0 +1,1 @@
+        @targets[name.to_s] = mod

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_register_doc.rb.frag
@@ -1,0 +1,1 @@
+      # Called by each target module to register itself.

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_inner_module_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_inner_module_doc.rb.frag
@@ -1,0 +1,6 @@
+    # ---- Shared base for target modules -----------------------------
+    #
+    # Mixin that gives each target:
+    #   #initialize       — loads fixtures from self.class::SHAPE
+    #   #by_aggregate     — group helper
+    #   #read_snippet_body — delegate to module-level helper

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_methods.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_methods.rb.frag
@@ -1,0 +1,11 @@
+      def initialize
+        @fixtures = Hecks::Specializer.load_fixtures(self.class::SHAPE)
+      end
+
+      def by_aggregate(name)
+        @fixtures.select { |f| f["aggregate"] == name }
+      end
+
+      def read_snippet_body(path)
+        Hecks::Specializer.read_snippet_body(path)
+      end

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_module_method_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_target_module_method_body.rb.frag
@@ -1,0 +1,3 @@
+        @targets[name.to_s] or raise ArgumentError,
+          "unknown specializer target: #{name.inspect}. " \
+          "Known: #{targets.join(', ')}"

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_body.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_body.rb.frag
@@ -1,0 +1,1 @@
+        @targets.keys.sort

--- a/hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_ivar_doc.rb.frag
+++ b/hecks_conception/capabilities/ruby_module_shape/snippets/hs_targets_ivar_doc.rb.frag
@@ -1,0 +1,2 @@
+    # Registered target modules. Keys are the target names used on the
+    # CLI (matches SpecializerTarget.name in specializer.fixtures).

--- a/hecks_conception/capabilities/specializer/specializer.hecksagon
+++ b/hecks_conception/capabilities/specializer/specializer.hecksagon
@@ -118,6 +118,18 @@ Hecks.hecksagon "Specializer" do
     args:    ["meta_meta_validator_warnings", "--output", "{{output}}"],
     ok_exit: 0
 
+  # Phase C PC-5 — retires the loader module lib/hecks_specializer.rb
+  # itself. First RubyModule shape retirement: bare module + outer
+  # requires + module-level constants + class << self block + inner
+  # mixin module + trailing Dir[].each auto-load loop. Closes the loop
+  # PC-3 deferred (class << self + inner module + auto-load didn't fit
+  # RubyScript shape).
+  adapter :shell,
+    name:    :specialize_meta_ruby_module,
+    command: "bin/specialize",
+    args:    ["meta_ruby_module", "--output", "{{output}}"],
+    ok_exit: 0
+
   # ---- Gate ----------------------------------------------------
   #
   # :autophagy — the gate for all i51 work. Specialize commands run

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -92,6 +92,7 @@ fn specializer_hecksagon_wiring_is_present() {
         "specialize_meta_validator_warnings",
         "specialize_meta_meta_diagnostic_validator",
         "specialize_meta_meta_validator_warnings",
+        "specialize_meta_ruby_module",
     ] {
         assert!(
             hex.shell_adapters.iter().any(|a| a.name == expected),
@@ -219,5 +220,22 @@ fn meta_specializer_produces_byte_identical_meta_validator_warnings_rb() {
     assert_byte_identical(
         "meta_meta_validator_warnings",
         "lib/hecks_specializer/meta_validator_warnings.rb",
+    );
+}
+
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {
+    // Phase C PC-5 — retires the loader module lib/hecks_specializer.rb
+    // (108 LoC) via the new RubyModule shape. This is the first shape
+    // that covers a *bare module* body (not a class): module-level
+    // constants, a `class << self` block, an inner `module Target`
+    // mixin, and the trailing `Dir[...].each { require }` auto-load
+    // loop at file scope. Closes the loop PC-3 deferred — the three
+    // shape concerns (class << self, inner module, Dir[] loop) that
+    // didn't fit RubyScript now have a home.
+    assert_byte_identical(
+        "meta_ruby_module",
+        "lib/hecks_specializer.rb",
     );
 }

--- a/lib/hecks_specializer/meta_ruby_module.rb
+++ b/lib/hecks_specializer/meta_ruby_module.rb
@@ -1,0 +1,196 @@
+# lib/hecks_specializer/meta_ruby_module.rb
+# [antibody-exempt: lib/hecks_specializer/meta_ruby_module.rb — generator, not generated]
+#
+# Hecks::Specializer::MetaRubyModule — Phase C PC-5.
+#
+# Fifth meta-specializer. Emits a top-level loader-module file from
+# RubyModule + ModuleConstant + ModuleClassMethod + InnerModule
+# fixture rows. Pilot target: lib/hecks_specializer.rb — the loader
+# every specializer target registers against.
+#
+# Emission pipeline (verbatim concatenation):
+#
+#   1. doc_snippet verbatim  + blank line
+#   2. outer_requires as "require "X"\n" lines + blank line
+#   3. "module Hecks\n  module Specializer\n"
+#   4. module-level constants (with optional pre-constant doc, blank
+#      line before a doc-bearing constant when not the first)
+#   5. class << self block (6-space indent inside, blank-line-separated
+#      methods, optional pre-method doc comments)
+#   6. inner modules (with pre-module doc, verbatim methods_block_snippet
+#      inside, 4-space indent module/end)
+#   7. module close ("  end\nend\n")
+#   8. optional autoload block: blank + autoload_doc + Dir[...] loop
+#
+# Everything else than structure comes from .rb.frag snippets read
+# raw. The meta-specializer owns only the scaffolding.
+#
+# Subclasses override `self.target_module_name` to pick which RubyModule
+# row to emit for. Default (nil) picks the first row — kept simple for
+# the PC-5 pilot, which ships with a single row (Hecks::Specializer).
+#
+# Shape limitation (deliberate): inner modules store their whole body
+# as a single methods_block_snippet. Adequate for Target's 3-method
+# mixin; a future pass may split into structured RubyMethod rows if
+# a second inner module appears.
+
+module Hecks
+  module Specializer
+    class MetaRubyModule
+      include Target
+
+      SHAPE = REPO_ROOT.join("hecks_conception/capabilities/ruby_module_shape/fixtures/ruby_module_shape.fixtures")
+      TARGET_RS = REPO_ROOT.join("lib/hecks_specializer.rb")
+
+      # Which RubyModule fixture row to emit for. Subclasses override
+      # to pick a different row. Default (nil) picks the first row.
+      def self.target_module_name
+        nil
+      end
+
+      def emit
+        mod = pick_module
+        [
+          emit_doc(mod),
+          emit_outer_requires(mod),
+          emit_module_open(mod),
+          emit_outer_constants(mod),
+          emit_class_methods_block(mod),
+          emit_inner_modules(mod),
+          emit_module_close(mod),
+          emit_autoload_block(mod),
+        ].join
+      end
+
+      private
+
+      def pick_module
+        rows = by_aggregate("RubyModule")
+        name = self.class.target_module_name
+        row = name ? rows.find { |r| r["attrs"]["name"] == name } : rows.first
+        raise "no RubyModule row matching #{name.inspect}" unless row
+        row
+      end
+
+      # Doc block — read verbatim (ends with "\n"). Append one more
+      # "\n" to open a blank line before the requires block.
+      def emit_doc(mod)
+        File.read(REPO_ROOT.join(mod["attrs"]["doc_snippet"])) + "\n"
+      end
+
+      # require "X" lines, one per outer_requires entry. Empty list =
+      # no lines and no trailing blank.
+      def emit_outer_requires(mod)
+        libs = mod["attrs"]["outer_requires"].to_s.split(",").map(&:strip).reject(&:empty?)
+        return "" if libs.empty?
+        libs.map { |l| "require \"#{l}\"\n" }.join + "\n"
+      end
+
+      # "module Hecks\n  module Specializer\n" — nests the dotted name.
+      def emit_module_open(mod)
+        segments = mod["attrs"]["name"].split("::")
+        segments.each_with_index.map { |s, i| "#{"  " * i}module #{s}\n" }.join
+      end
+
+      # Module-level constants, sorted by order, indented to constant
+      # depth (2-space * segments). Each constant with a doc_snippet
+      # gets the doc read verbatim before the assignment, with a
+      # leading blank line UNLESS it's the first constant.
+      def emit_outer_constants(mod)
+        constants = constants_for(mod)
+        return "" if constants.empty?
+        indent = constant_indent(mod)
+        out = +""
+        constants.each_with_index do |c, i|
+          a = c["attrs"]
+          if a["doc_snippet"].to_s.empty?
+            out << "#{indent}#{a["name"]} = #{a["value_expr"]}\n"
+          else
+            out << "\n" unless i == 0
+            out << File.read(REPO_ROOT.join(a["doc_snippet"]))
+            out << "#{indent}#{a["name"]} = #{a["value_expr"]}\n"
+          end
+        end
+        out
+      end
+
+      # The class << self ... end block. Blank line before, then
+      # "    class << self\n", then each method (blank-separated) at
+      # 6-space indent, then "    end\n".
+      def emit_class_methods_block(mod)
+        methods = methods_for(mod)
+        return "" if methods.empty?
+        indent = constant_indent(mod) # "    " for a 2-segment module
+        parts = ["\n", "#{indent}class << self\n"]
+        methods.each_with_index do |m, i|
+          parts << "\n" unless i == 0
+          parts << emit_class_method(m, indent)
+        end
+        parts << "#{indent}end\n"
+        parts.join
+      end
+
+      def emit_class_method(method, module_indent)
+        a = method["attrs"]
+        def_indent = module_indent + "  " # inside class << self
+        sig = a["signature"].to_s.empty? ? "def #{a["name"]}" : "def #{a["name"]}(#{a["signature"]})"
+        doc = a["doc_snippet"].to_s.empty? ? "" : File.read(REPO_ROOT.join(a["doc_snippet"]))
+        body = File.read(REPO_ROOT.join(a["body_snippet"]))
+        "#{doc}#{def_indent}#{sig}\n#{body}#{def_indent}end\n"
+      end
+
+      # Inner mixin modules. Blank line before, then doc, then
+      # "    module Name\n", then verbatim methods block, then "    end\n".
+      def emit_inner_modules(mod)
+        inners = by_aggregate("InnerModule")
+                   .select { |i| i["attrs"]["parent_module"] == mod["attrs"]["name"] }
+                   .sort_by { |i| i["attrs"]["order"].to_i }
+        return "" if inners.empty?
+        indent = constant_indent(mod)
+        inners.map do |i|
+          a = i["attrs"]
+          doc = a["doc_snippet"].to_s.empty? ? "" : File.read(REPO_ROOT.join(a["doc_snippet"]))
+          body = File.read(REPO_ROOT.join(a["methods_block_snippet"]))
+          "\n#{doc}#{indent}module #{a["name"]}\n#{body}#{indent}end\n"
+        end.join
+      end
+
+      # Close every module segment opened by emit_module_open, bottom-up.
+      def emit_module_close(mod)
+        depth = mod["attrs"]["name"].split("::").length
+        (0...depth).to_a.reverse.map { |i| "#{"  " * i}end\n" }.join
+      end
+
+      # Trailing `Dir[File.expand_path(<glob>, <base>)].sort.each ...`
+      # loop. Empty autoload_glob skips the whole block. Leading blank
+      # line separates from the closed module.
+      def emit_autoload_block(mod)
+        glob = mod["attrs"]["autoload_glob"].to_s
+        return "" if glob.empty?
+        base = mod["attrs"]["autoload_base"].to_s
+        doc_path = mod["attrs"]["autoload_doc_snippet"].to_s
+        doc = doc_path.empty? ? "" : File.read(REPO_ROOT.join(doc_path))
+        loop_block = "Dir[File.expand_path(\"#{glob}\", #{base})].sort.each do |path|\n  require path\nend\n"
+        "\n#{doc}#{loop_block}"
+      end
+
+      def constants_for(mod)
+        by_aggregate("ModuleConstant")
+          .select { |c| c["attrs"]["module_name"] == mod["attrs"]["name"] }
+          .sort_by { |c| c["attrs"]["order"].to_i }
+      end
+
+      def methods_for(mod)
+        by_aggregate("ModuleClassMethod")
+          .select { |m| m["attrs"]["module_name"] == mod["attrs"]["name"] }
+          .sort_by { |m| m["attrs"]["order"].to_i }
+      end
+
+      def constant_indent(mod)
+        "  " * mod["attrs"]["name"].split("::").length
+      end
+    end
+
+    register :meta_ruby_module, MetaRubyModule
+  end
+end


### PR DESCRIPTION
## Summary

Closes the loop PC-3 deferred. The three shape concerns that didn't fit `RubyScript` — `class << self` block, inner `module Target` mixin, and the trailing `Dir[...].each { require }` auto-load loop — now live in a new `RubyModuleShape` scoped to loader-module files.

- New capability `hecks_conception/capabilities/ruby_module_shape/` with 4 aggregates (`RubyModule`, `ModuleConstant`, `ModuleClassMethod`, `InnerModule`), 11 fixture rows, 15 snippets
- New meta-specializer `lib/hecks_specializer/meta_ruby_module.rb` (196 LoC, 122 code) emits in 8 steps — doc, outer requires, module open, outer constants, `class << self` block, inner modules, module close, autoload block
- Golden test `meta_specializer_produces_byte_identical_hecks_specializer_rb` asserts byte-identity
- This is the final reasonable autophagy target for the specializer module tier — Ruby codegen machinery is fully bluebook-described

## Example usage

```
$ bin/specialize meta_ruby_module | diff - lib/hecks_specializer.rb
$ bin/specialize --list | grep meta_ruby_module
meta_ruby_module
```

First command prints nothing (empty diff = byte-identical). Source file is 3672 bytes; generated output is 3672 bytes.

## Shape design calls

- Inner module body stored as one verbatim `methods_block_snippet` (not structured `RubyMethod` rows). `Target` is 11 lines of 3 trivial methods — structured decomposition deferred until a second inner module appears.
- `@targets = {}` module-level ivar modeled as a `ModuleConstant` with `name: "@targets"` and `value_expr: "{}"` (lives at module body, NOT inside `class << self` — the plan's `inside_class_methods` field was redundant and dropped).
- Pre-constant doc snippets (`doc_snippet`) optional per-row; `@targets` carries its 2-line comment via this path.
- Pre-method doc snippets (`doc_snippet` on `ModuleClassMethod`) reused from PC-4's pattern.
- `autoload_glob`, `autoload_base`, `autoload_doc_snippet` on `RubyModule` all optional — empty glob collapses the whole trailing block.

## Test plan

- [x] `cd hecks_life && cargo test --release --test specializer_golden_test` — 13/13 pass (includes 4 new hecksagon-wiring adapter entries and the new byte-identity test)
- [x] `bin/specialize meta_ruby_module | diff - lib/hecks_specializer.rb` — empty
- [x] `bin/specialize --list` shows `meta_ruby_module`
- [x] `wc -c` confirms 3672 = 3672 byte-identity
- [x] File sizes: meta-specializer 196 lines (under 200), bluebook 124 lines (doc-heavy)
- [x] Antibody exemptions in commit message for the 2 non-bluebook files