### PR TITLE
autophagy: Phase D pilot — hecks-life specialize validator_warnings (Ruby→Rust specializer)

### DIFF
--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -38,3 +38,4 @@ pub mod world_parser;
 pub mod run;
 pub mod run_status;
 pub mod run_stdin_loop;
+pub mod specializer;

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -171,6 +171,11 @@ fn main() {
         return;
     }
 
+    if command == "specialize" {
+        run_specialize(&args);
+        return;
+    }
+
     if command == "cascade" {
         let path = args.get(2).expect("usage: hecks-life cascade <bluebook>");
         let source = std::fs::read_to_string(path).expect("cannot read");
@@ -691,6 +696,74 @@ fn run_check_all(args: &[String]) {
         println!("FAIL — {} has issues", path);
         std::process::exit(1);
     }
+}
+
+/// `hecks-life specialize <target> [--output PATH]`
+///
+/// i51 Phase D pilot — Rust-native specializer driver. Mirrors
+/// `bin/specialize <target>` on the Ruby side; both runtimes must
+/// produce byte-identical output for every ported target until the
+/// migration completes.
+///
+/// Target name (the first positional arg) dispatches to the matching
+/// module under `hecks_life::specializer::`. Writes to `--output
+/// PATH` when provided, otherwise prints to stdout.
+fn run_specialize(args: &[String]) {
+    let target = args.get(2).map(|s| s.as_str()).unwrap_or("");
+    if target.is_empty() {
+        eprintln!("Usage: hecks-life specialize <target> [--output PATH]");
+        std::process::exit(2);
+    }
+
+    let output_path: Option<String> = args
+        .iter()
+        .position(|a| a == "--output" || a == "-o")
+        .and_then(|i| args.get(i + 1).cloned());
+
+    let repo_root = match specialize_repo_root() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("cannot locate repo root: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let rust = match hecks_life::specializer::emit(target, &repo_root) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("specialize {} failed: {}", target, e);
+            std::process::exit(1);
+        }
+    };
+
+    match output_path {
+        Some(p) => {
+            if let Err(e) = std::fs::write(&p, &rust) {
+                eprintln!("cannot write {}: {}", p, e);
+                std::process::exit(1);
+            }
+            eprintln!("wrote {} bytes to {}", rust.len(), p);
+        }
+        None => print!("{}", rust),
+    }
+}
+
+/// Locate the repository root for the `specialize` subcommand.
+///
+/// Uses `env::current_dir` — invocation convention is `hecks-life
+/// specialize …` run from the repo root (same as `bin/specialize` on
+/// the Ruby side). A sanity check verifies the expected
+/// `hecks_conception/` sibling exists.
+fn specialize_repo_root() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    if !cwd.join("hecks_conception").is_dir() {
+        return Err(format!(
+            "expected to run `specialize` from the repo root (cwd={}, no hecks_conception/ sibling)",
+            cwd.display()
+        )
+        .into());
+    }
+    Ok(cwd)
 }
 
 /// Find the source bluebook for a behaviors file.

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -1,0 +1,36 @@
+//! Rust-native specializer driver — the destination for the i51
+//! Phase D Ruby → Rust migration of `lib/hecks_specializer/`.
+//!
+//! Each module under `specializer::` owns one target's emission logic,
+//! exposing `emit(repo_root: &Path) -> Result<String, _>`. The
+//! top-level `emit(target, repo_root)` dispatcher matches a target
+//! name to its module, mirroring `Hecks::Specializer.emit(:name)` on
+//! the Ruby side.
+//!
+//! Phase D policy — both runtimes MUST produce byte-identical output
+//! for every ported target until the migration completes. Golden
+//! tests in `hecks_life/tests/specializer_golden_test.rs` enforce
+//! this for each port.
+//!
+//! Usage (from main.rs):
+//!   let rust = specializer::emit("validator_warnings", &repo_root)?;
+//!   print!("{}", rust);
+
+use std::error::Error;
+use std::path::Path;
+
+pub mod util;
+pub mod validator_warnings;
+
+/// Dispatch by target name. Phase D pilot: `validator_warnings` only.
+/// Every subsequent port adds one match arm here.
+pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    match target {
+        "validator_warnings" => validator_warnings::emit(repo_root),
+        other => Err(format!(
+            "unknown specializer target: {}. Known: validator_warnings",
+            other
+        )
+        .into()),
+    }
+}

--- a/hecks_life/src/specializer/util.rs
+++ b/hecks_life/src/specializer/util.rs
@@ -1,0 +1,92 @@
+//! Shared helpers for every Rust-native specializer target.
+//!
+//! Mirrors the Ruby `Hecks::Specializer::Target` mixin +
+//! `Hecks::Specializer` module-level helpers. Each ported target
+//! reuses these three entry points — load the shape fixtures, filter
+//! by aggregate name, read a snippet-body file with its leading
+//! `//`-comment header stripped.
+//!
+//! Usage:
+//!   use crate::specializer::util;
+//!   let fixtures = util::load_fixtures(shape_path)?;
+//!   let rules = util::by_aggregate(&fixtures, "WarningRule");
+//!   let body = util::read_snippet_body(&snippet_path)?;
+
+use crate::fixtures_parser;
+use crate::ir::Fixture;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+/// Parse a `.fixtures` file and return its flat `Fixture` list.
+///
+/// Ruby path shells out to `hecks-life dump-fixtures` + `JSON.parse`;
+/// in Rust we skip the JSON round-trip and call `fixtures_parser::parse`
+/// directly — same parser the `dump-fixtures` subcommand already uses.
+pub fn load_fixtures(shape_path: &Path) -> Result<Vec<Fixture>, Box<dyn Error>> {
+    let source = fs::read_to_string(shape_path)
+        .map_err(|e| format!("cannot read shape {}: {}", shape_path.display(), e))?;
+    Ok(fixtures_parser::parse(&source).fixtures)
+}
+
+/// Return every fixture whose `aggregate_name` matches `name`, in
+/// source order. Mirrors Ruby `@fixtures.select { |f| f["aggregate"] == name }`.
+pub fn by_aggregate<'a>(fixtures: &'a [Fixture], name: &str) -> Vec<&'a Fixture> {
+    fixtures.iter().filter(|f| f.aggregate_name == name).collect()
+}
+
+/// Look up a fixture attribute by key. Panics-free: returns an empty
+/// string for missing keys, matching the Ruby side's `a["key"]` which
+/// yields `nil` then gets interpolated as `""`. Specializers that need
+/// to distinguish missing-vs-empty call `attr_opt` instead.
+pub fn attr<'a>(fixture: &'a Fixture, key: &str) -> &'a str {
+    fixture
+        .attributes
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("")
+}
+
+/// Look up a fixture attribute by key, returning `None` when absent.
+#[allow(dead_code)]
+pub fn attr_opt<'a>(fixture: &'a Fixture, key: &str) -> Option<&'a str> {
+    fixture
+        .attributes
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.as_str())
+}
+
+/// Read a `.rs.frag` snippet file, stripping the leading `//`-comment
+/// header and leading blank lines. Everything from the first
+/// non-comment, non-empty line onward is returned verbatim — the Ruby
+/// side does exactly this and downstream specializers interpolate the
+/// result as a function body.
+pub fn read_snippet_body(path: &Path) -> Result<String, Box<dyn Error>> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("snippet missing {}: {}", path.display(), e))?;
+
+    // Split keeping line terminators so we can reassemble byte-exact.
+    let mut lines: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    for c in raw.chars() {
+        buf.push(c);
+        if c == '\n' {
+            lines.push(std::mem::take(&mut buf));
+        }
+    }
+    if !buf.is_empty() {
+        lines.push(buf);
+    }
+
+    let start = lines.iter().position(|l| {
+        let t = l.trim();
+        !t.is_empty() && !t.starts_with("//")
+    });
+
+    Ok(match start {
+        Some(i) => lines[i..].concat(),
+        None => String::new(),
+    })
+}

--- a/hecks_life/src/specializer/validator_warnings.rs
+++ b/hecks_life/src/specializer/validator_warnings.rs
@@ -1,0 +1,122 @@
+//! Rust port of `lib/hecks_specializer/validator_warnings.rb`.
+//!
+//! Emits `hecks_life/src/validator_warnings.rs` byte-identical to the
+//! Ruby specializer's output. Reads the `WarningRule` fixture rows
+//! from the validator_warnings shape, dispatches each row by
+//! `body_strategy` (templated | embedded) and `check_kind`
+//! (count_threshold for templated; embedded reads a `.rs.frag`
+//! snippet whose leading `//`-comment header is stripped).
+//!
+//! Usage:
+//!   let rust = validator_warnings::emit(repo_root)?;
+//!   print!("{}", rust);
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/validator_warnings_shape/fixtures/validator_warnings_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+    let rules = util::by_aggregate(&fixtures, "WarningRule");
+
+    let mut out = String::new();
+    out.push_str(&emit_header());
+    out.push_str(&emit_imports());
+    for rule in rules {
+        out.push_str(&emit_rule(repo_root, rule)?);
+    }
+    Ok(out)
+}
+
+fn emit_header() -> String {
+    r#"//! Soft warnings for domain quality — non-failing bounded-context checks
+//!
+//! GENERATED FILE — do not edit.
+//! Source:    hecks_conception/capabilities/validator_warnings_shape/
+//! Regenerate: bin/specialize validator_warnings --output hecks_life/src/validator_warnings.rs
+//! Contract:  specializer.hecksagon :specialize_validator_warnings shell adapter
+//! Tests:     hecks_life/tests/validator_warnings_test.rs
+//!
+//! These rules emit advisory warnings but never cause validation to fail.
+//! They help domain modelers spot bounded-context smell early.
+//!
+//! Usage:
+//!   if let Some(msg) = validator_warnings::aggregate_count_warning(&domain) {
+//!       println!("  {}", msg);
+//!   }
+//!   if let Some(msg) = validator_warnings::mixed_concerns_warning(&domain) {
+//!       println!("  {}", msg);
+//!   }
+
+"#
+    .to_string()
+}
+
+fn emit_imports() -> String {
+    "use crate::ir::Domain;\nuse std::collections::{HashMap, HashSet, VecDeque};\n\n"
+        .to_string()
+}
+
+fn emit_rule(repo_root: &Path, rule: &Fixture) -> Result<String, Box<dyn Error>> {
+    match util::attr(rule, "body_strategy") {
+        "templated" => emit_templated(rule),
+        "embedded" => emit_embedded(repo_root, rule),
+        other => Err(format!("unknown body_strategy: {}", other).into()),
+    }
+}
+
+fn emit_templated(rule: &Fixture) -> Result<String, Box<dyn Error>> {
+    match util::attr(rule, "check_kind") {
+        "count_threshold" => Ok(emit_count_threshold(rule)),
+        other => Err(format!("unknown templated check_kind: {}", other).into()),
+    }
+}
+
+fn emit_count_threshold(rule: &Fixture) -> String {
+    let threshold: i64 = util::attr(rule, "threshold").parse().unwrap_or(0);
+    let rust_fn_name = util::attr(rule, "rust_fn_name");
+    let message_template = util::attr(rule, "message_template");
+    format!(
+        "\
+/// Returns Some(msg) if the domain has more than {threshold} aggregates.
+pub fn {rust_fn_name}(domain: &Domain) -> Option<String> {{
+    if domain.aggregates.len() > {threshold} {{
+        Some(format!(
+            \"{message_template}\",
+            domain.name,
+            domain.aggregates.len()
+        ))
+    }} else {{
+        None
+    }}
+}}
+
+",
+        threshold = threshold,
+        rust_fn_name = rust_fn_name,
+        message_template = message_template,
+    )
+}
+
+fn emit_embedded(repo_root: &Path, rule: &Fixture) -> Result<String, Box<dyn Error>> {
+    let snippet_path = repo_root.join(util::attr(rule, "snippet_path"));
+    let body = util::read_snippet_body(&snippet_path)?;
+    let threshold: i64 = util::attr(rule, "threshold").parse().unwrap_or(0);
+    let rust_fn_name = util::attr(rule, "rust_fn_name");
+    Ok(format!(
+        "\
+/// Returns Some(msg) if the domain has {threshold}+ aggregates split across
+/// disconnected reference/policy clusters.
+pub fn {rust_fn_name}(domain: &Domain) -> Option<String> {{
+{body}}}
+",
+        threshold = threshold,
+        rust_fn_name = rust_fn_name,
+        body = body,
+    ))
+}

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -248,6 +248,38 @@ fn meta_specializer_produces_byte_identical_meta_validator_warnings_rb() {
     );
 }
 
+#[test]
+fn rust_specializer_produces_byte_identical_validator_warnings_rs() {
+    // Phase D pilot — hecks-life specialize (Rust-native) produces
+    // output byte-identical to the Ruby bin/specialize output for the
+    // same target. First proof that the specializer itself can migrate
+    // from Ruby to Rust while keeping byte-identity. Every subsequent
+    // Phase D port adds another test with the same shape.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "validator_warnings"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/validator_warnings.rs"))
+        .expect("validator_warnings.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
 // [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
 #[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {


### PR DESCRIPTION
## Summary

- **Phase D starts.** First port of a Ruby specializer (`lib/hecks_specializer/validator_warnings.rb`) to Rust. `hecks-life specialize validator_warnings` now produces output byte-identical to both `bin/specialize validator_warnings` and the tracked `hecks_life/src/validator_warnings.rs`.
- **New module tree** under `hecks_life/src/specializer/`: `mod.rs` (dispatcher), `util.rs` (shared helpers — `load_fixtures`, `by_aggregate`, `attr`, `read_snippet_body`), `validator_warnings.rs` (the ported emitter). The util module is one-time infrastructure — every subsequent Phase D port plugs in beside `validator_warnings` and reuses the same helpers.
- **Both runtimes stay in sync.** `lib/hecks_specializer/validator_warnings.rb` is untouched; per Phase D policy both paths must produce identical output until every specializer is ported. Deletion of the Ruby side comes after the last port.
- **What's next.** Every remaining Ruby specializer follows the same template: one module under `specializer::`, one match arm in `emit()`, one golden test. Once all are ported, `lib/hecks_specializer/` and `bin/specialize` can be deleted and the two-runtimes framing dissolves.

## Example usage

```
$ hecks_life/target/release/hecks-life specialize validator_warnings | diff - hecks_life/src/validator_warnings.rs
$ bin/specialize validator_warnings | diff - hecks_life/src/validator_warnings.rs
```

Both produce empty output — byte-identical on both runtimes.

```
$ hecks-life specialize validator_warnings --output hecks_life/src/validator_warnings.rs
wrote 5153 bytes to hecks_life/src/validator_warnings.rs
```

## Test plan

- [x] `cargo build --release` (clean build; pre-existing dead-code warnings only)
- [x] `cargo test --release --test specializer_golden_test` — 16/16 pass, including the new `rust_specializer_produces_byte_identical_validator_warnings_rs`
- [x] `cargo test --release` — full suite green
- [x] `hecks-life specialize validator_warnings | diff - hecks_life/src/validator_warnings.rs` — empty
- [x] `bin/specialize validator_warnings | diff - hecks_life/src/validator_warnings.rs` — empty (Ruby path unchanged)

## Phase D context

This is step 1 of the Ruby→Rust specializer migration. Each future port adds one `pub mod <target>` under `src/specializer/`, one match arm in `specializer::emit`, and one golden test matching this shape. The `util.rs` module (`load_fixtures` / `by_aggregate` / `read_snippet_body` / `attr`) is the one-time infrastructure cost — subsequent ports are ~100-200 LoC of mechanical translation on top.