### PR TITLE
autophagy: Phase D D2 — hecks-life specialize dump (Ruby→Rust)

### DIFF
--- a/hecks_life/src/specializer/dump.rs
+++ b/hecks_life/src/specializer/dump.rs
@@ -1,0 +1,202 @@
+//! Rust port of `lib/hecks_specializer/dump.rb`.
+//!
+//! Emits `hecks_life/src/dump.rs` byte-identical to the Ruby
+//! specializer's output. Reads the `Serializer`, `JsonField`, and
+//! `EnumCase` rows from the dump_shape fixture, sorts by `order`, and
+//! dispatches each Serializer row by `body_kind`:
+//!
+//!   - `json_object`     — `json!({...})` body; if any field uses
+//!                         `mapping_kind: fixture_pairs` the function
+//!                         gains an order-preserving preamble first
+//!   - `embedded_helper` — raw `.rs.frag` body interpolated between `{` `}`
+//!   - `enum_match`      — hand-aligned `match` arms with padding
+//!                         calculated from the widest variant
+//!
+//! Phase D D2 — second Rust-native specializer. Extends the D1 pilot
+//! (`validator_warnings.rs`) with multi-aggregate dispatch, order
+//! sorting, and the padded enum_match emitter. Every subsequent
+//! Rust-emitting specializer reuses this vocabulary.
+//!
+//! Usage:
+//!   let rust = dump::emit(repo_root)?;
+//!   print!("{}", rust);
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/dump_shape/fixtures/dump_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+    let serializers = util::by_aggregate_sorted(&fixtures, "Serializer", "order");
+
+    let mut out = String::new();
+    out.push_str(HEADER);
+    out.push_str(IMPORTS);
+    for ser in &serializers {
+        out.push_str(&emit_serializer(repo_root, &fixtures, ser)?);
+    }
+    Ok(out)
+}
+
+const HEADER: &str = r#"//! Canonical IR dump — JSON shape that both Ruby and Rust must agree on.
+//!
+//! GENERATED FILE — do not edit.
+//! Source:    hecks_conception/capabilities/dump_shape/
+//! Regenerate: bin/specialize dump --output hecks_life/src/dump.rs
+//! Contract:  specializer.hecksagon :specialize_dump shell adapter
+//!
+//! This is the parity contract. Hand-written so the JSON shape is chosen
+//! explicitly, not accidentally derived from Rust struct field names or
+//! serde defaults. When the Ruby BluebookModel serializer (canonical_ir.rb)
+//! produces the same shape, both parsers can be diffed deterministically.
+//!
+//! Shape:
+//!   { name, category, vision, aggregates[], policies[], fixtures[], vows[] }
+//!
+//! Each Aggregate, Command, Attribute, etc. has a fixed key order and
+//! omits no fields (uses null where absent). Stable field naming —
+//! `attributes[*].type` (not Rust's internal `attr_type`),
+//! `references[*].target`, etc. — so the contract reads naturally.
+//!
+//! Usage:
+//!   hecks-life dump path/to/foo.bluebook
+//!   # → JSON to stdout, exit 0
+
+"#;
+
+const IMPORTS: &str = "use crate::ir::{
+    Aggregate, Attribute, Command, Domain, Fixture, Given, Lifecycle, Mutation,
+    MutationOp, Policy, Query, Reference, Transition, ValueObject,
+};
+use serde_json::{json, Value};
+
+";
+
+const NORMALIZE_DOC: &str = "\
+// Strip whitespace adjacent to brackets/braces/parens. Source representations
+// differ (\"[ a, b ]\" vs \"[a, b]\") even when semantically identical; both
+// runtimes normalize so the canonical output agrees.
+";
+
+/// Common `fn NAME(BINDING: &TARGET) -> RET` signature prefix used by
+/// every serializer body_kind. `is_entry=true` on the Dump row emits a
+/// leading `pub `.
+fn signature(ser: &Fixture) -> String {
+    let pub_prefix = if util::attr(ser, "is_entry") == "true" { "pub " } else { "" };
+    format!(
+        "{}fn {}({}: &{}) -> {}",
+        pub_prefix,
+        util::attr(ser, "name"),
+        util::attr(ser, "input_binding"),
+        util::attr(ser, "target_type"),
+        util::attr(ser, "return_type"),
+    )
+}
+
+fn emit_serializer(
+    repo_root: &Path,
+    fixtures: &[Fixture],
+    ser: &Fixture,
+) -> Result<String, Box<dyn Error>> {
+    match util::attr(ser, "body_kind") {
+        "json_object" => Ok(emit_json_object(fixtures, ser)),
+        "embedded_helper" => emit_embedded_helper(repo_root, ser),
+        "enum_match" => Ok(emit_enum_match(fixtures, ser)),
+        other => Err(format!("unknown body_kind: {}", other).into()),
+    }
+}
+
+/// Render a single JSON-field line. Returns `None` when the field's
+/// `mapping_kind` is `fixture_pairs` — caller replaces it with a
+/// `"<key>": pairs,` reference after emitting the preamble.
+fn emit_field(f: &Fixture, binding: &str) -> Option<String> {
+    let key = util::attr(f, "key");
+    let src = util::attr(f, "source");
+    let helper = util::attr(f, "helper_fn");
+    let line = match util::attr(f, "mapping_kind") {
+        "direct" => format!("\"{}\": {}.{},", key, binding, src),
+        "recurse_list" => format!(
+            "\"{}\": {}.{}.iter().map({}).collect::<Vec<_>>(),",
+            key, binding, src, helper
+        ),
+        "recurse_optional" => format!("\"{}\": {}.{}.as_ref().map({}),", key, binding, src, helper),
+        "helper_call" => format!("\"{}\": {}(&{}.{}),", key, helper, binding, src),
+        "normalize" => format!("\"{}\": normalize_value(&{}.{}),", key, binding, src),
+        "fixture_pairs" => return None,
+        other => panic!("unknown mapping_kind: {}", other),
+    };
+    Some(format!("        {}", line))
+}
+
+fn emit_json_object(fixtures: &[Fixture], ser: &Fixture) -> String {
+    let binding = util::attr(ser, "input_binding");
+    let fields: Vec<&Fixture> = util::by_aggregate_sorted(fixtures, "JsonField", "order")
+        .into_iter()
+        .filter(|f| util::attr(f, "serializer") == util::attr(ser, "name"))
+        .collect();
+    let pair_field = fields
+        .iter()
+        .find(|f| util::attr(f, "mapping_kind") == "fixture_pairs")
+        .copied();
+
+    let mut out = format!("{} {{\n", signature(ser));
+    if let Some(pf) = pair_field {
+        out.push_str(
+            "    // Use array of [key, value] pairs to preserve order — same shape Ruby will emit.\n",
+        );
+        out.push_str(&format!(
+            "    let pairs: Vec<Value> = {}.{}.iter()\n",
+            binding,
+            util::attr(pf, "source"),
+        ));
+        out.push_str("        .map(|(k, v)| json!([k, normalize_value(v)]))\n");
+        out.push_str("        .collect();\n");
+    }
+    out.push_str("    json!({\n");
+    let pair_key = pair_field.map(|pf| util::attr(pf, "key")).unwrap_or("");
+    let lines: Vec<String> = fields
+        .iter()
+        .map(|f| {
+            emit_field(f, binding)
+                .unwrap_or_else(|| format!("        \"{}\": pairs,", pair_key))
+        })
+        .collect();
+    out.push_str(&lines.join("\n"));
+    out.push_str("\n    })\n}\n\n");
+    out
+}
+
+fn emit_embedded_helper(repo_root: &Path, ser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let snippet_path = repo_root.join(util::attr(ser, "snippet_path"));
+    let body = util::read_snippet_body(&snippet_path)?;
+    let doc = if util::attr(ser, "name") == "normalize_value" { NORMALIZE_DOC } else { "" };
+    Ok(format!("{}{} {{\n{}}}\n\n", doc, signature(ser), body))
+}
+
+fn emit_enum_match(fixtures: &[Fixture], ser: &Fixture) -> String {
+    let serializer_name = util::attr(ser, "name");
+    let cases: Vec<&Fixture> = util::by_aggregate_sorted(fixtures, "EnumCase", "order")
+        .into_iter()
+        .filter(|c| util::attr(c, "serializer") == serializer_name)
+        .collect();
+    let widest = cases.iter().map(|c| util::attr(c, "variant").len()).max().unwrap_or(0);
+    let arms: Vec<String> = cases
+        .iter()
+        .map(|c| {
+            let variant = util::attr(c, "variant");
+            let pad = " ".repeat(widest - variant.len());
+            format!("        {}{} => \"{}\",", variant, pad, util::attr(c, "emits"))
+        })
+        .collect();
+
+    let mut out = format!("{} {{\n", signature(ser));
+    out.push_str(&format!("    match {} {{\n", util::attr(ser, "input_binding")));
+    out.push_str(&arms.join("\n"));
+    out.push_str("\n    }\n}\n\n");
+    out
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -19,16 +19,19 @@
 use std::error::Error;
 use std::path::Path;
 
+pub mod dump;
 pub mod util;
 pub mod validator_warnings;
 
-/// Dispatch by target name. Phase D pilot: `validator_warnings` only.
-/// Every subsequent port adds one match arm here.
+/// Dispatch by target name. Phase D ports are additive — each new
+/// Rust-native specializer adds one match arm here and one module
+/// under `specializer::`.
 pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
     match target {
         "validator_warnings" => validator_warnings::emit(repo_root),
+        "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: validator_warnings",
+            "unknown specializer target: {}. Known: validator_warnings, dump",
             other
         )
         .into()),

--- a/hecks_life/src/specializer/util.rs
+++ b/hecks_life/src/specializer/util.rs
@@ -35,6 +35,20 @@ pub fn by_aggregate<'a>(fixtures: &'a [Fixture], name: &str) -> Vec<&'a Fixture>
     fixtures.iter().filter(|f| f.aggregate_name == name).collect()
 }
 
+/// Same as `by_aggregate`, but sorted by the named attribute parsed as
+/// `i64` (missing/non-numeric sorts as 0). Mirrors the Ruby
+/// `sort_by { |r| r["attrs"]["order"].to_i }` idiom repeated in every
+/// multi-aggregate specializer (dump, validator, parser-shape targets).
+pub fn by_aggregate_sorted<'a>(
+    fixtures: &'a [Fixture],
+    name: &str,
+    order_key: &str,
+) -> Vec<&'a Fixture> {
+    let mut rows = by_aggregate(fixtures, name);
+    rows.sort_by_key(|f| attr(f, order_key).parse::<i64>().unwrap_or(0));
+    rows
+}
+
 /// Look up a fixture attribute by key. Panics-free: returns an empty
 /// string for missing keys, matching the Ruby side's `a["key"]` which
 /// yields `nil` then gets interpolated as `""`. Specializers that need

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -312,6 +312,37 @@ fn rust_specializer_produces_byte_identical_validator_warnings_rs() {
     );
 }
 
+#[test]
+fn rust_specializer_produces_byte_identical_dump_rs() {
+    // Phase D D2 — second Rust-native specializer. Stretches the
+    // D1 pilot to multi-aggregate dispatch, order sorting, and the
+    // padded enum_match emitter. Every subsequent Rust-emitting
+    // specializer (validator, the parsers) reuses this vocabulary.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "dump"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize dump failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/dump.rs"))
+        .expect("dump.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
 // [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
 #[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {


### PR DESCRIPTION
## Summary

- Ports `lib/hecks_specializer/dump.rb` (203 LoC Ruby) to `hecks_life/src/specializer/dump.rs` (152 LoC Rust code + doc header). Second Rust-native specializer after the D1 `validator_warnings` pilot.
- Adds Phase D vocabulary the next ports reuse: **multi-aggregate dispatch** (Serializer + JsonField + EnumCase), **order sorting** (factored into `util::by_aggregate_sorted`), and the **padded enum_match** emitter with width calculated from the widest variant.
- `hecks-life specialize dump` and `bin/specialize dump` now both produce output byte-identical to the tracked `hecks_life/src/dump.rs`. Per Phase D policy the Ruby source stays intact — deletion belongs to Phase E.

## Example usage

```sh
# Rust path — empty diff.
$ hecks_life/target/release/hecks-life specialize dump | diff - hecks_life/src/dump.rs
$ echo $?
0

# Ruby path still works, also empty diff.
$ bin/specialize dump | diff - hecks_life/src/dump.rs
$ echo $?
0
```

## Test plan

- [x] `cargo build --release --manifest-path hecks_life/Cargo.toml` — clean build
- [x] `cargo test --release --manifest-path hecks_life/Cargo.toml --test specializer_golden_test` — 19/19 pass (18 before + 1 new)
- [x] `cargo test --release --manifest-path hecks_life/Cargo.toml --lib` — 44/44 pass
- [x] `hecks-life specialize dump | diff - hecks_life/src/dump.rs` — empty diff
- [x] `bin/specialize dump | diff - hecks_life/src/dump.rs` — empty diff (Ruby path still live)

## Context

D2 is now 2 of ~11 Phase D ports complete. This commit established the multi-aggregate + padded enum_match vocabulary that `validator.rb` (393 LoC) and the parser-shape targets will reuse — `util::by_aggregate_sorted` is the first shared helper that pays out across ports. Every subsequent Rust-emitting specializer now has a template to follow.

## Antibody markers

Commit carries per-file exemptions for the four Rust files touched:
- `hecks_life/src/specializer/dump.rs` — Phase D Rust-native specializer implementation
- `hecks_life/src/specializer/mod.rs` — dispatcher match arm
- `hecks_life/src/specializer/util.rs` — shared helper extraction
- `hecks_life/tests/specializer_golden_test.rs` — golden-test scaffolding