### PR TITLE
autophagy: Phase D — hecks-life specialize behaviors_parser (Ruby→Rust)

### DIFF
--- a/hecks_life/src/specializer/behaviors_parser.rs
+++ b/hecks_life/src/specializer/behaviors_parser.rs
@@ -1,0 +1,157 @@
+//! Rust port of `lib/hecks_specializer/behaviors_parser.rb`.
+//!
+//! Emits `hecks_life/src/behaviors_parser.rs` byte-identical to the
+//! Ruby specializer's output. Reads the behaviors_parser_shape fixtures
+//! (LineParser singleton + LineDispatch rows + ParserHelper rows),
+//! assembles header + imports + parse() body + helpers + detector +
+//! tests-snippet in the same order the Ruby side emits them.
+//!
+//! Per-concern split (to stay under the 200-LoC cap):
+//!   this file                      — orchestration + emitters for
+//!                                     header/imports/parse/helper/detector
+//!   behaviors_parser_dispatch.rs   — the if/else-if chain + per-handler
+//!                                     body-line generator
+//!
+//! Usage:
+//!   let rust = behaviors_parser::emit(repo_root)?;
+//!   print!("{}", rust);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/behaviors_parser.rs —
+//!  Phase D Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::behaviors_parser_dispatch;
+use crate::specializer::util;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/behaviors_parser_shape/fixtures/behaviors_parser_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+
+    let parser = util::by_aggregate(&fixtures, "LineParser")
+        .into_iter()
+        .next()
+        .ok_or("no LineParser fixture")?;
+    let module = util::attr(parser, "module");
+    let dispatches = filtered_sorted(&fixtures, "LineDispatch", module);
+    let helpers = filtered_sorted(&fixtures, "ParserHelper", module);
+
+    let mut out = String::new();
+    out.push_str(&emit_header(repo_root, parser)?);
+    out.push_str(&emit_imports(parser));
+    out.push_str(&emit_parse(repo_root, parser, &dispatches)?);
+    for h in &helpers {
+        out.push('\n');
+        out.push_str(&emit_helper(repo_root, h)?);
+    }
+    out.push('\n');
+    out.push_str(&emit_detector(parser));
+    let tests = util::attr(parser, "tests_snippet");
+    if !tests.is_empty() {
+        out.push('\n');
+        out.push_str(&util::read_snippet_body(&repo_root.join(tests))?);
+    }
+    Ok(out)
+}
+
+fn filtered_sorted<'a>(
+    fixtures: &'a [Fixture],
+    aggregate: &str,
+    parser_module: &str,
+) -> Vec<&'a Fixture> {
+    let mut v: Vec<&Fixture> = util::by_aggregate(fixtures, aggregate)
+        .into_iter()
+        .filter(|f| util::attr(f, "parser") == parser_module)
+        .collect();
+    v.sort_by_key(|f| util::attr(f, "order").parse::<i64>().unwrap_or(0));
+    v
+}
+
+fn emit_header(repo_root: &Path, parser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let path = repo_root.join(util::attr(parser, "doc_snippet"));
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read doc snippet {}: {}", path.display(), e))?;
+    Ok(format!("{raw}\n"))
+}
+
+fn emit_imports(parser: &Fixture) -> String {
+    let mut out = String::new();
+    for imp in util::attr(parser, "imports").split('\n').filter(|s| !s.is_empty()) {
+        out.push_str("use ");
+        out.push_str(imp);
+        out.push_str(";\n");
+    }
+    // Ruby joins with "\n" then appends "\n\n"; we emit "use X;\n" per
+    // line above, then one more "\n" to produce the blank separator.
+    out.push('\n');
+    out
+}
+
+fn emit_parse(
+    repo_root: &Path,
+    parser: &Fixture,
+    dispatches: &[&Fixture],
+) -> Result<String, Box<dyn Error>> {
+    let init = util::read_snippet_body(&repo_root.join(util::attr(parser, "state_init_snippet")))?;
+    let lv = util::attr(parser, "loop_var_name");
+    let sv = util::attr(parser, "state_var");
+    let sig = util::attr(parser, "root_signature");
+    let dispatch_block = behaviors_parser_dispatch::emit_chain(dispatches, sv, lv);
+
+    // Explicit line-by-line assembly mirrors the Ruby side — avoids
+    // heredoc dedent traps when interpolating pre-indented fragments.
+    let lines: Vec<String> = vec![
+        format!("{sig} {{"),
+        chomp(&init).to_string(),
+        String::new(),
+        format!("    while i < {lv}.len() {{"),
+        format!("        let line = {lv}[i].trim();"),
+        String::new(),
+        chomp(&dispatch_block).to_string(),
+        "        i += 1;".to_string(),
+        "    }".to_string(),
+        String::new(),
+        format!("    {sv}"),
+        "}".to_string(),
+    ];
+    let mut out = lines.join("\n");
+    out.push('\n');
+    Ok(out)
+}
+
+fn emit_helper(repo_root: &Path, helper: &Fixture) -> Result<String, Box<dyn Error>> {
+    let body = util::read_snippet_body(&repo_root.join(util::attr(helper, "body_snippet")))?;
+    let doc = util::attr(helper, "doc_comment");
+    let doc_block = if doc.is_empty() { String::new() } else { format!("{doc}\n") };
+    let sig = util::attr(helper, "signature");
+    Ok(format!("{doc_block}{sig} {{\n{body}}}\n"))
+}
+
+fn emit_detector(parser: &Fixture) -> String {
+    let kw = util::attr(parser, "detector_keyword");
+    let fn_name = util::attr(parser, "detector_fn_name");
+    format!(
+        "\
+/// Returns true if the source's first non-blank, non-comment line is the
+/// `{kw}` keyword. Used by callers to dispatch to this parser
+/// instead of the regular bluebook parser.
+pub fn {fn_name}(source: &str) -> bool {{
+    for line in source.lines() {{
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {{ continue; }}
+        return t.starts_with(\"{kw}\");
+    }}
+    false
+}}
+"
+    )
+}
+
+fn chomp(s: &str) -> &str {
+    s.strip_suffix('\n').unwrap_or(s)
+}

--- a/hecks_life/src/specializer/behaviors_parser_dispatch.rs
+++ b/hecks_life/src/specializer/behaviors_parser_dispatch.rs
@@ -1,0 +1,105 @@
+//! Dispatch-chain emission for `behaviors_parser` Phase D port.
+//!
+//! Translates a run of LineDispatch fixtures into the Rust text that
+//! goes inside the `parse()` loop: the outer `if ... } else if ... }`
+//! chain, each branch's condition (match_mode), and each branch's body
+//! (handler_kind). Split out from `behaviors_parser.rs` so both files
+//! stay under the 200-LoC cap — the parent file handles orchestration,
+//! this file handles one concern: fixture-row → Rust-lines.
+//!
+//! Usage:
+//!   let block = emit_chain(&dispatches, "suite", "lines");
+//!   // → "        if line.starts_with(...) {\n            ...\n        }\n"
+//!
+//! [antibody-exempt: hecks_life/src/specializer/behaviors_parser_dispatch.rs —
+//!  Phase D Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+
+/// Emit the `if / else if` chain body for the parse() loop. Each
+/// dispatch fixture becomes one arm; bodies are indented 12 spaces
+/// (matching the Ruby side's explicit-line assembly). Output always
+/// ends with a trailing newline.
+pub fn emit_chain(dispatches: &[&Fixture], sv: &str, lv: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let last = dispatches.len().saturating_sub(1);
+    for (idx, d) in dispatches.iter().enumerate() {
+        let kw_form = if idx == 0 { "if " } else { "} else if " };
+        lines.push(format!("        {kw_form}{} {{", condition(d)));
+        for l in body_lines(d, sv, lv) {
+            lines.push(format!("            {l}"));
+        }
+        if idx == last {
+            lines.push("        }".to_string());
+        }
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+fn condition(d: &Fixture) -> String {
+    let mode = match util::attr(d, "match_mode") { "" => "prefix", m => m };
+    let kw = util::attr(d, "match_keyword");
+    match mode {
+        "prefix" => kw.split(',')
+            .map(|p| format!("line.starts_with(\"{p}\")"))
+            .collect::<Vec<_>>()
+            .join(" || "),
+        "word" => format!("line.starts_with(\"{kw} \") || line.starts_with(\"{kw}\\t\")"),
+        "word_or_equal" => format!(
+            "line.starts_with(\"{kw} \") || line.starts_with(\"{kw}\\t\") || line == \"{kw}\""
+        ),
+        other => panic!("unknown match_mode: {:?}", other),
+    }
+}
+
+fn body_lines(d: &Fixture, sv: &str, lv: &str) -> Vec<String> {
+    let qfn = util::attr(d, "quote_fn");
+    let vfn = util::attr(d, "variadic_fn");
+    let field = util::attr(d, "target_field");
+    let helper = util::attr(d, "helper_fn");
+    let cvar = match util::attr(d, "capture_var") { "" => "n", s => s };
+    let kind = util::attr(d, "handler_kind");
+
+    let mut lines: Vec<String> = Vec::new();
+    let comment = util::attr(d, "body_comment");
+    if !comment.is_empty() {
+        for c in comment.split('\n') {
+            lines.push(format!("// {c}"));
+        }
+    }
+
+    match kind {
+        "capture_quoted_into" => lines.push(format!(
+            "if let Some({cvar}) = {qfn}(line) {{ {sv}.{field} = {cvar}; }}"
+        )),
+        "capture_quoted_into_option" => lines.push(format!(
+            "if let Some({cvar}) = {qfn}(line) {{ {sv}.{field} = Some({cvar}); }}"
+        )),
+        "push_quoted_onto" => lines.push(format!(
+            "if let Some({cvar}) = {qfn}(line) {{ {sv}.{field}.push({cvar}); }}"
+        )),
+        "push_all_quoted_onto" => {
+            lines.push(format!("for name in {vfn}(line) {{"));
+            lines.push(format!("    {sv}.{field}.push(name);"));
+            lines.push("}".to_string());
+        }
+        "multiline_block_direct" => {
+            lines.push(format!("let (test, consumed) = {helper}(&{lv}[i..]);"));
+            lines.push(format!("{sv}.{field}.push(test);"));
+            lines.push("i += consumed;".to_string());
+            lines.push("continue;".to_string());
+        }
+        "multiline_block" => {
+            lines.push(format!("let (gate, consumed) = {helper}(&{lv}[i..]);"));
+            lines.push(format!("if let Some(g) = gate {{ {sv}.{field}.push(g); }}"));
+            lines.push("i += consumed;".to_string());
+            lines.push("continue;".to_string());
+        }
+        other => panic!("unknown handler_kind: {:?}", other),
+    }
+
+    lines
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -19,6 +19,8 @@
 use std::error::Error;
 use std::path::Path;
 
+pub mod behaviors_parser;
+pub mod behaviors_parser_dispatch;
 pub mod dump;
 pub mod util;
 pub mod validator_warnings;
@@ -28,10 +30,11 @@ pub mod validator_warnings;
 /// under `specializer::`.
 pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
     match target {
+        "behaviors_parser" => behaviors_parser::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: validator_warnings, dump",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -345,6 +345,38 @@ fn rust_specializer_produces_byte_identical_dump_rs() {
 
 // [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
 #[test]
+fn rust_specializer_produces_byte_identical_behaviors_parser_rs() {
+    // Phase D — Rust-native specializer for behaviors_parser. Ports
+    // the LineParser + LineDispatch + ParserHelper 3-aggregate shape
+    // including the else_if loop style, tests_snippet, and the new
+    // capture_quoted_into_option / push_all_quoted_onto /
+    // multiline_block_direct handler kinds.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "behaviors_parser"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize behaviors_parser failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/behaviors_parser.rs"))
+        .expect("behaviors_parser.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
+#[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {
     // Phase C PC-5 — retires the loader module lib/hecks_specializer.rb
     // (108 LoC) via the new RubyModule shape. This is the first shape


### PR DESCRIPTION
## Summary

- Ports `lib/hecks_specializer/behaviors_parser.rb` (~167 LoC Ruby) to a native Rust specializer module under `hecks_life/src/specializer/`. `hecks-life specialize behaviors_parser` now produces output byte-identical to `hecks_life/src/behaviors_parser.rs`, matching the existing `bin/specialize` path.
- Split into two files to respect the 200-LoC cap: `behaviors_parser.rs` (157 LoC) handles orchestration (header / imports / parse / helper / detector); `behaviors_parser_dispatch.rs` (105 LoC) handles the if/else-if chain and per-handler body-line generator.
- Encodes the six `handler_kind` variants and the three `match_mode` variants as string `match` arms — fixture strings stay the single source of truth. No enum intermediary; adding a new kind means one more match arm.

The Ruby specializer stays in place — both runtimes must produce identical output through all of Phase D until every target is ported. Runs concurrently with the dump port on `miette/i51-phase-d-d2-dump`; together they establish the shared vocabulary (multi-aggregate dispatch, order-sorted rows, position-aware helpers, handler-kind match) that validator.rb will reuse.

## Example usage

```bash
# Both paths produce identical output:
hecks-life specialize behaviors_parser | diff - hecks_life/src/behaviors_parser.rs
# (empty diff)

bin/specialize behaviors_parser | diff - hecks_life/src/behaviors_parser.rs
# (empty diff)
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test specializer_golden_test` — 19/19 pass (new: `rust_specializer_produces_byte_identical_behaviors_parser_rs`)
- [x] `cargo test --release` — all 26 suites pass
- [x] `hecks-life specialize behaviors_parser | diff - hecks_life/src/behaviors_parser.rs` — empty
- [x] `bin/specialize behaviors_parser | diff - hecks_life/src/behaviors_parser.rs` — empty (Ruby path still works)

## Notes

- The only shared files with the parallel dump port are `specializer/mod.rs` (dispatcher — append-only) and the golden test file (append-only). Rebase should be clean on whichever lands first.
- Antibody exemptions: 4 Rust files (new implementation + mod dispatcher + test) marked at commit with concrete per-change reasons.