### PR TITLE
autophagy: Phase D — hecks-life specialize hecksagon_parser (Ruby to Rust)

### DIFF
--- a/hecks_life/src/specializer/hecksagon_parser.rs
+++ b/hecks_life/src/specializer/hecksagon_parser.rs
@@ -1,0 +1,198 @@
+//! Rust port of `lib/hecks_specializer/hecksagon_parser.rb`.
+//!
+//! Emits `hecks_life/src/hecksagon_parser.rs` byte-identical to the
+//! Ruby specializer's output. Reads the hecksagon_parser_shape fixtures
+//! (LineParser singleton + LineDispatch rows + ParserHelper rows),
+//! assembles header + imports + detector + parse() body + helpers in
+//! the same order the Ruby side emits them.
+//!
+//! Single-file port — hecksagon_parser.rb is simpler than
+//! behaviors_parser.rb (4 LineDispatch handler kinds, no match_mode
+//! variants, no tests_snippet, no state_init_snippet). The emission
+//! fits under the 200-LoC cap without a dispatch-split sibling file.
+//!
+//! Usage:
+//!   let rust = hecksagon_parser::emit(repo_root)?;
+//!   print!("{}", rust);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/hecksagon_parser.rs —
+//!  Phase D Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/hecksagon_parser_shape/fixtures/hecksagon_parser_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+
+    let parser = util::by_aggregate(&fixtures, "LineParser")
+        .into_iter()
+        .next()
+        .ok_or("no LineParser fixture")?;
+    let module = util::attr(parser, "module");
+    let dispatches = filtered_sorted(&fixtures, "LineDispatch", module);
+    let helpers = filtered_sorted(&fixtures, "ParserHelper", module);
+
+    let mut out = String::new();
+    out.push_str(&emit_header(repo_root, parser)?);
+    out.push_str(&emit_imports(parser));
+    out.push_str(&emit_detector(parser));
+    out.push_str(&emit_parse(parser, &dispatches));
+    let last = helpers.len().saturating_sub(1);
+    for (i, h) in helpers.iter().enumerate() {
+        out.push_str(&emit_helper(repo_root, h, i < last)?);
+    }
+    Ok(out)
+}
+
+fn filtered_sorted<'a>(
+    fixtures: &'a [Fixture],
+    aggregate: &str,
+    parser_module: &str,
+) -> Vec<&'a Fixture> {
+    let mut v: Vec<&Fixture> = util::by_aggregate(fixtures, aggregate)
+        .into_iter()
+        .filter(|f| util::attr(f, "parser") == parser_module)
+        .collect();
+    v.sort_by_key(|f| util::attr(f, "order").parse::<i64>().unwrap_or(0));
+    v
+}
+
+fn emit_header(repo_root: &Path, parser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let path = repo_root.join(util::attr(parser, "doc_snippet"));
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read doc snippet {}: {}", path.display(), e))?;
+    Ok(format!("{raw}\n"))
+}
+
+fn emit_imports(parser: &Fixture) -> String {
+    let mut out = String::new();
+    for imp in util::attr(parser, "imports").split('\n').filter(|s| !s.is_empty()) {
+        out.push_str("use ");
+        out.push_str(imp);
+        out.push_str(";\n");
+    }
+    out.push('\n');
+    out
+}
+
+fn emit_detector(parser: &Fixture) -> String {
+    let kw = util::attr(parser, "detector_keyword");
+    let fn_name = util::attr(parser, "detector_fn_name");
+    format!(
+        "\
+/// Lowest-cost source detection. Skips leading blanks and `#` comments
+/// and checks the first non-empty line.
+pub fn {fn_name}(source: &str) -> bool {{
+    for line in source.lines() {{
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {{ continue; }}
+        return t.starts_with(\"{kw}\");
+    }}
+    false
+}}
+
+"
+    )
+}
+
+fn emit_parse(parser: &Fixture, dispatches: &[&Fixture]) -> String {
+    let sig = util::attr(parser, "root_signature");
+    // One blank line between dispatch blocks; blocks are indented 8
+    // spaces (inside the `while` loop).
+    let blocks = dispatches
+        .iter()
+        .map(|d| emit_dispatch_block(d))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "\
+{sig} {{
+    let mut hex = Hecksagon::default();
+    let source = crate::parser::strip_shebang(source);
+    let raw: Vec<&str> = source.lines().collect();
+
+    let mut i = 0;
+    while i < raw.len() {{
+        let line = raw[i].trim();
+
+{blocks}
+        i += 1;
+    }}
+
+    hex
+}}
+
+"
+    )
+}
+
+fn emit_dispatch_block(dispatch: &Fixture) -> String {
+    let starts_with = util::attr(dispatch, "starts_with");
+    let condition = dispatch_condition(starts_with);
+    let body = dispatch_body_lines(dispatch);
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format!("        if {condition} {{"));
+    for l in body {
+        lines.push(format!("            {l}"));
+    }
+    lines.push("            continue;".to_string());
+    lines.push("        }".to_string());
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+fn dispatch_condition(starts_with: &str) -> String {
+    starts_with
+        .split(',')
+        .map(|p| format!("line.starts_with(\"{p}\")"))
+        .collect::<Vec<_>>()
+        .join(" || ")
+}
+
+fn dispatch_body_lines(dispatch: &Fixture) -> Vec<String> {
+    let kind = util::attr(dispatch, "handler_kind");
+    let field = util::attr(dispatch, "target_field");
+    let helper = util::attr(dispatch, "helper_fn");
+    match kind {
+        "capture_quoted_into" => vec![
+            format!("if let Some(n) = between_quotes(line) {{ hex.{field} = n; }}"),
+            "i += 1;".to_string(),
+        ],
+        "push_quoted_onto" => vec![
+            format!("if let Some(n) = between_quotes(line) {{ hex.{field}.push(n); }}"),
+            "i += 1;".to_string(),
+        ],
+        "multiline_block" => vec![
+            format!("let (gate, consumed) = {helper}(&raw[i..]);"),
+            format!("if let Some(g) = gate {{ hex.{field}.push(g); }}"),
+            "i += consumed;".to_string(),
+        ],
+        "multiline_adapter" => vec![
+            "let (joined, consumed) = join_adapter_lines(&raw[i..]);".to_string(),
+            format!("{helper}(&joined, &mut hex);"),
+            "i += consumed;".to_string(),
+        ],
+        other => panic!("unknown handler_kind: {:?}", other),
+    }
+}
+
+fn emit_helper(
+    repo_root: &Path,
+    helper: &Fixture,
+    trailing_blank: bool,
+) -> Result<String, Box<dyn Error>> {
+    let body = util::read_snippet_body(&repo_root.join(util::attr(helper, "body_snippet")))?;
+    let doc = util::attr(helper, "doc_comment");
+    let doc_block = if doc.is_empty() { String::new() } else { format!("{doc}\n") };
+    let sig = util::attr(helper, "signature");
+    let core = format!("{doc_block}{sig} {{\n{body}}}\n");
+    Ok(if trailing_blank { format!("{core}\n") } else { core })
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 pub mod behaviors_parser;
 pub mod behaviors_parser_dispatch;
 pub mod dump;
+pub mod hecksagon_parser;
 pub mod util;
 pub mod validator_warnings;
 
@@ -31,10 +32,11 @@ pub mod validator_warnings;
 pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
     match target {
         "behaviors_parser" => behaviors_parser::emit(repo_root),
+        "hecksagon_parser" => hecksagon_parser::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, hecksagon_parser, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -345,6 +345,39 @@ fn rust_specializer_produces_byte_identical_dump_rs() {
 
 // [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
 #[test]
+fn rust_specializer_produces_byte_identical_hecksagon_parser_rs() {
+    // Phase D — Rust-native specializer for hecksagon_parser. Third
+    // parser port in the Phase D LineParser/LineDispatch/ParserHelper
+    // arc (validator, behaviors_parser, fixtures_parser). The 4-row
+    // dispatch exercises capture_quoted_into, push_quoted_onto,
+    // multiline_block, and multiline_adapter handler kinds against the
+    // simplest single-parse-loop shape.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "hecksagon_parser"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize hecksagon_parser failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/hecksagon_parser.rs"))
+        .expect("hecksagon_parser.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
+#[test]
 fn rust_specializer_produces_byte_identical_behaviors_parser_rs() {
     // Phase D — Rust-native specializer for behaviors_parser. Ports
     // the LineParser + LineDispatch + ParserHelper 3-aggregate shape


### PR DESCRIPTION
## Summary

Ports `lib/hecks_specializer/hecksagon_parser.rb` (170 LoC Ruby) to `hecks_life/src/specializer/hecksagon_parser.rs` (Rust). Both Ruby and Rust paths now emit `hecks_life/src/hecksagon_parser.rs` byte-identical — `hecks-life specialize hecksagon_parser` and `bin/specialize hecksagon_parser` produce the exact same output.

Reuses the `behaviors_parser.rs` template: same `util` helpers (`load_fixtures`, `by_aggregate`, `attr`, `read_snippet_body`), same `LineParser` singleton + `LineDispatch` rows + `ParserHelper` rows 3-aggregate shape. Simpler than behaviors_parser — only 4 handler kinds (`capture_quoted_into`, `push_quoted_onto`, `multiline_block`, `multiline_adapter`), no `match_mode` variants, no `tests_snippet`, no `state_init_snippet`. Fits in a single file under the 200-LoC cap (no `_dispatch.rs` sibling needed).

## Example usage

```
$ ./hecks_life/target/release/hecks-life specialize hecksagon_parser | diff - hecks_life/src/hecksagon_parser.rs
$ bin/specialize hecksagon_parser | diff - hecks_life/src/hecksagon_parser.rs
```

Both return empty — Rust and Ruby paths agree byte-for-byte with the tracked artifact.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test specializer_golden_test` — 21 passed
- [x] `cargo test --release` — all suites green
- [x] `hecks-life specialize hecksagon_parser | diff - hecks_life/src/hecksagon_parser.rs` empty
- [x] `bin/specialize hecksagon_parser | diff - hecks_life/src/hecksagon_parser.rs` empty (Ruby path still works)
- [x] New golden: `rust_specializer_produces_byte_identical_hecksagon_parser_rs`

## Arc note

Three parser ports landing in succession — **hecksagon_parser + behaviors_parser + fixtures_parser** — proves the `LineParser`/`LineDispatch`/`ParserHelper` pattern covers the full parser family. hecksagon (simplest, 4 handlers, no state prelude) and behaviors (medium, 6 handlers with match_mode + tests_snippet) share enough that ~85% of behaviors_parser.rs was directly adaptable — only the `emit_detector` placement (before parse here, after parse in behaviors), the single-handler dispatch style (if-continue rather than if/else-if chain), and the reduced handler vocabulary needed adaptation.