### PR TITLE
autophagy: Phase D — hecks-life specialize fixtures_parser (Ruby→Rust)

### DIFF
--- a/hecks_life/src/specializer/fixtures_parser.rs
+++ b/hecks_life/src/specializer/fixtures_parser.rs
@@ -1,0 +1,144 @@
+//! Rust port of `lib/hecks_specializer/fixtures_parser.rb`.
+//!
+//! Emits `hecks_life/src/fixtures_parser.rs` byte-identical to the
+//! Ruby specializer's output. Reads the fixtures_parser_shape fixtures
+//! (LineParser singleton + ParserHelper rows — LineDispatch rows are
+//! documentation-only; `parse_body_snippet` is authoritative) and
+//! assembles header + imports + before_root helpers + parse() +
+//! after_root helpers + test block in the same order the Ruby side
+//! emits them.
+//!
+//! Notable wrinkle carried over from the Ruby specializer: several
+//! helper bodies here legitimately start with `//` comments (e.g.,
+//! `extract_schema_kwarg_body.rs.frag` opens with `// Find the first
+//! top-level comma …`), which the generic `util::read_snippet_body`
+//! would strip as a leading-comment header. We use a local `read_raw`
+//! helper instead — bare `fs::read_to_string`, no comment strip. If a
+//! future port needs the same override, promote `read_raw` to
+//! `util.rs`.
+//!
+//! Usage:
+//!   let rust = fixtures_parser::emit(repo_root)?;
+//!   print!("{}", rust);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/fixtures_parser.rs —
+//!  Phase D Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/fixtures_parser_shape/fixtures/fixtures_parser_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+
+    let parser = util::by_aggregate(&fixtures, "LineParser")
+        .into_iter()
+        .next()
+        .ok_or("no LineParser fixture")?;
+    let module = util::attr(parser, "module");
+
+    let mut helpers: Vec<&Fixture> = util::by_aggregate(&fixtures, "ParserHelper")
+        .into_iter()
+        .filter(|f| util::attr(f, "parser") == module)
+        .collect();
+
+    let before = filter_position(&helpers, "before_root");
+    let after = filter_position(&helpers, "after_root");
+    // Drain so `helpers` is only used for partitioning above.
+    helpers.clear();
+
+    let mut out = String::new();
+    out.push_str(&emit_header(repo_root, parser)?);
+    out.push_str(&emit_imports(parser));
+    for h in &before {
+        out.push_str(&emit_helper(repo_root, h)?);
+    }
+    out.push_str(&emit_parse(repo_root, parser)?);
+    for h in &after {
+        out.push_str(&emit_helper(repo_root, h)?);
+    }
+    out.push_str(&emit_test_block(repo_root, parser)?);
+    Ok(out)
+}
+
+fn filter_position<'a>(helpers: &[&'a Fixture], position: &str) -> Vec<&'a Fixture> {
+    let mut v: Vec<&Fixture> = helpers
+        .iter()
+        .copied()
+        .filter(|h| {
+            let p = util::attr(h, "position");
+            let effective = if p.is_empty() { "after_root" } else { p };
+            effective == position
+        })
+        .collect();
+    v.sort_by_key(|h| util::attr(h, "order").parse::<i64>().unwrap_or(0));
+    v
+}
+
+fn emit_header(repo_root: &Path, parser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let raw = read_raw(&repo_root.join(util::attr(parser, "doc_snippet")))?;
+    Ok(format!("{raw}\n"))
+}
+
+fn emit_imports(parser: &Fixture) -> String {
+    let lines: Vec<String> = util::attr(parser, "imports")
+        .split('\n')
+        .filter(|s| !s.is_empty())
+        .map(|imp| format!("use {imp};"))
+        .collect();
+    // Ruby: lines.join("\n") + "\n\n". Same byte shape.
+    let mut out = lines.join("\n");
+    out.push_str("\n\n");
+    out
+}
+
+fn emit_parse(repo_root: &Path, parser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let sig = util::attr(parser, "root_signature");
+    let body = read_raw(&repo_root.join(util::attr(parser, "parse_body_snippet")))?;
+    Ok(format!("{sig} {{\n{body}}}\n\n"))
+}
+
+fn emit_helper(repo_root: &Path, helper: &Fixture) -> Result<String, Box<dyn Error>> {
+    let doc = helper_doc(repo_root, helper)?;
+    let sig = util::attr(helper, "signature");
+    let body = read_raw(&repo_root.join(util::attr(helper, "body_snippet")))?;
+    Ok(format!("{doc}{sig} {{\n{body}}}\n\n"))
+}
+
+fn helper_doc(repo_root: &Path, helper: &Fixture) -> Result<String, Box<dyn Error>> {
+    let snippet = util::attr(helper, "doc_snippet");
+    if !snippet.is_empty() {
+        return read_raw(&repo_root.join(snippet));
+    }
+    let inline = util::attr(helper, "doc_comment");
+    if inline.is_empty() {
+        return Ok(String::new());
+    }
+    Ok(format!("{inline}\n"))
+}
+
+fn emit_test_block(repo_root: &Path, parser: &Fixture) -> Result<String, Box<dyn Error>> {
+    let snippet = util::attr(parser, "test_block_snippet");
+    if snippet.is_empty() {
+        return Ok(String::new());
+    }
+    // Snippet ends with its own closing `}\n`; no trailing blank line —
+    // file ends right after.
+    read_raw(&repo_root.join(snippet))
+}
+
+/// Bare file read — no leading-comment-header strip. Mirrors the
+/// `read_raw` override in the Ruby specializer. Several fixtures_parser
+/// snippet bodies open with `//` comments that are part of the emitted
+/// source (not a header to strip), so the generic `util::read_snippet_body`
+/// is wrong for this target.
+fn read_raw(path: &Path) -> Result<String, Box<dyn Error>> {
+    fs::read_to_string(path)
+        .map_err(|e| format!("snippet missing: {} ({})", path.display(), e).into())
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 pub mod behaviors_parser;
 pub mod behaviors_parser_dispatch;
 pub mod dump;
+pub mod fixtures_parser;
 pub mod hecksagon_parser;
 pub mod util;
 pub mod validator_warnings;
@@ -32,11 +33,12 @@ pub mod validator_warnings;
 pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
     match target {
         "behaviors_parser" => behaviors_parser::emit(repo_root),
+        "fixtures_parser" => fixtures_parser::emit(repo_root),
         "hecksagon_parser" => hecksagon_parser::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, hecksagon_parser, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -410,6 +410,41 @@ fn rust_specializer_produces_byte_identical_behaviors_parser_rs() {
 }
 
 #[test]
+fn rust_specializer_produces_byte_identical_fixtures_parser_rs() {
+    // Phase D — Rust-native specializer for fixtures_parser. Ports the
+    // smallest Rust-emitter Ruby specializer (~112 LoC) reusing the
+    // LineParser + ParserHelper 2-aggregate shape (LineDispatch rows
+    // are documentation-only; parse_body_snippet is authoritative).
+    // Notable override: several helper bodies legitimately start with
+    // `//` comments (e.g., extract_schema_kwarg's `// Find the first
+    // top-level comma …`), so the port uses a bare file read instead
+    // of util::read_snippet_body's leading-comment strip.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "fixtures_parser"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize fixtures_parser failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/fixtures_parser.rs"))
+        .expect("fixtures_parser.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
+#[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {
     // Phase C PC-5 — retires the loader module lib/hecks_specializer.rb
     // (108 LoC) via the new RubyModule shape. This is the first shape


### PR DESCRIPTION
## Summary

- Ports `lib/hecks_specializer/fixtures_parser.rb` (~112 LoC Ruby) to `hecks_life/src/specializer/fixtures_parser.rs` (118 LoC code).
- `hecks-life specialize fixtures_parser` now emits output **byte-identical** to the tracked `hecks_life/src/fixtures_parser.rs`; the Ruby `bin/specialize fixtures_parser` path continues to produce the same bytes.
- Closes all three parser ports for Phase D (hecksagon + behaviors + fixtures) and brings Phase D to 5+ of the ~10 target files (validator_warnings, dump, hecksagon_parser, behaviors_parser, fixtures_parser).

## Notable wrinkle: `read_raw` vs `util::read_snippet_body`

The Ruby `fixtures_parser.rb` overrides the shared `read_snippet_body` with a bare `File.read` variant called `read_raw` because several helper bodies here legitimately start with `//` comments (e.g., `extract_schema_kwarg_body.rs.frag` opens with `// Find the first top-level comma …`) — the generic leading-comment strip would eat them. The Rust port mirrors that override as a local `fn read_raw(path)`. If a future port needs the same behavior, promote it to `util.rs`; today the need is fixtures-parser-specific.

## Example usage

```sh
# Rust path (new)
$ ./hecks_life/target/release/hecks-life specialize fixtures_parser | diff - hecks_life/src/fixtures_parser.rs
# (empty diff)

# Ruby path (still works)
$ bin/specialize fixtures_parser | diff - hecks_life/src/fixtures_parser.rs
# (empty diff)
```

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release --test specializer_golden_test` — 21/21 pass (includes new `rust_specializer_produces_byte_identical_fixtures_parser_rs`)
- [x] `hecks-life specialize fixtures_parser | diff - hecks_life/src/fixtures_parser.rs` — empty
- [x] `bin/specialize fixtures_parser | diff - hecks_life/src/fixtures_parser.rs` — empty