### PR TITLE
autophagy: Phase D — hecks-life specialize validator (Ruby→Rust, the biggest)

### DIFF
--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -25,6 +25,10 @@ pub mod dump;
 pub mod fixtures_parser;
 pub mod hecksagon_parser;
 pub mod util;
+pub mod validator;
+pub mod validator_checks;
+pub mod validator_checks_graph;
+pub mod validator_morphology;
 pub mod validator_warnings;
 
 /// Dispatch by target name. Phase D ports are additive — each new
@@ -35,10 +39,11 @@ pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
         "behaviors_parser" => behaviors_parser::emit(repo_root),
         "fixtures_parser" => fixtures_parser::emit(repo_root),
         "hecksagon_parser" => hecksagon_parser::emit(repo_root),
+        "validator" => validator::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, validator, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/src/specializer/validator.rs
+++ b/hecks_life/src/specializer/validator.rs
@@ -1,0 +1,138 @@
+//! Rust port of `lib/hecks_specializer/validator.rb`.
+//!
+//! Emits `hecks_life/src/validator.rs` byte-identical to the Ruby
+//! specializer's output. Reads `ValidatorEntryPoint`, `ValidationRule`,
+//! `SuffixTable`, and `ExceptionWord` rows from validator_shape and
+//! assembles: header → imports → entry point → rule → rule →
+//! command_naming_support → remaining rules. All emission is inline —
+//! no `.rs.frag` snippets (per the Phase D plan, validator is the
+//! "all-inline Ruby" specializer).
+//!
+//! Per-concern split (to stay under the 200-LoC cap):
+//!   this file                       — orchestration, header / imports /
+//!                                      entry-point
+//!   validator_checks.rs             — four local check_kind emitters
+//!                                      (unique, non_empty,
+//!                                      first_word_verb, unique_across)
+//!   validator_checks_graph.rs       — three graph-walking check_kind
+//!                                      emitters (reference_valid,
+//!                                      trigger_valid, distinct_aliases)
+//!   validator_morphology.rs         — command_naming_support + the
+//!                                      suffix / verb-exception /
+//!                                      verb-suffix formatters
+//!                                      (hand-aligned columns)
+//!
+//! Usage:
+//!   let rust = validator::emit(repo_root)?;
+//!   print!("{}", rust);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/validator.rs —
+//!  Phase D — Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use crate::specializer::validator_checks;
+use crate::specializer::validator_morphology;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/validator_shape/fixtures/validator_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+
+    let mut out = String::new();
+    out.push_str(HEADER);
+    out.push_str(IMPORTS);
+    out.push_str(&emit_entry_point(&fixtures)?);
+    out.push_str(&validator_checks::emit_rule(
+        &fixtures,
+        find_rule(&fixtures, "unique_aggregate_names")?,
+    ));
+    out.push_str(&validator_checks::emit_rule(
+        &fixtures,
+        find_rule(&fixtures, "aggregates_have_commands")?,
+    ));
+    out.push_str(&validator_morphology::emit_command_naming_support(&fixtures));
+    for rust_fn_name in [
+        "command_naming",
+        "valid_references",
+        "valid_policy_triggers",
+        "no_duplicate_commands",
+        "distinct_reference_aliases",
+    ] {
+        out.push_str(&validator_checks::emit_rule(
+            &fixtures,
+            find_rule(&fixtures, rust_fn_name)?,
+        ));
+    }
+    Ok(out)
+}
+
+fn find_rule<'a>(
+    fixtures: &'a [Fixture],
+    rust_fn_name: &str,
+) -> Result<&'a Fixture, Box<dyn Error>> {
+    util::by_aggregate(fixtures, "ValidationRule")
+        .into_iter()
+        .find(|r| util::attr(r, "rust_fn_name") == rust_fn_name)
+        .ok_or_else(|| {
+            format!("no ValidationRule fixture with rust_fn_name={}", rust_fn_name).into()
+        })
+}
+
+fn emit_entry_point(fixtures: &[Fixture]) -> Result<String, Box<dyn Error>> {
+    let entry = util::by_aggregate(fixtures, "ValidatorEntryPoint")
+        .into_iter()
+        .next()
+        .ok_or("no ValidatorEntryPoint fixture")?;
+    let fn_name = util::attr(entry, "fn_name");
+    let returns = util::attr(entry, "returns");
+    let collects_into = util::attr(entry, "collects_into");
+    let rules: Vec<String> = util::attr(entry, "rule_order")
+        .split(',')
+        .map(|r| format!("    errors.extend({}(domain));", r.trim()))
+        .collect();
+
+    Ok(format!(
+        "\
+/// Run all validation rules and return collected errors.
+pub fn {fn_name}(domain: &Domain) -> {returns} {{
+    let mut {collects_into} = vec![];
+{rules_block}
+    {collects_into}
+}}
+
+",
+        fn_name = fn_name,
+        returns = returns,
+        collects_into = collects_into,
+        rules_block = rules.join("\n"),
+    ))
+}
+
+const HEADER: &str = "\
+//! Domain validator — checks a parsed domain for DDD consistency
+//!
+//! GENERATED FILE — do not edit.
+//! Source:    hecks_conception/capabilities/validator_shape/
+//! Regenerate: bin/specialize validator --output hecks_life/src/validator.rs
+//! Contract:  specializer.hecksagon :specialize_validator shell adapter
+//! Tests:     hecks_life/tests/validator_rules_test.rs (moved out for i51 Phase A commit 4)
+//!
+//! Ports the Ruby Hecks::Validator rules to Rust. Each rule inspects
+//! the Domain IR and returns error strings. An empty vec means valid.
+//!
+//! Usage:
+//!   let errors = validator::validate(&domain);
+//!   if errors.is_empty() { println!(\"VALID\"); }
+
+";
+
+const IMPORTS: &str = "\
+use crate::ir::Domain;
+use std::collections::HashSet;
+
+";

--- a/hecks_life/src/specializer/validator_checks.rs
+++ b/hecks_life/src/specializer/validator_checks.rs
@@ -1,0 +1,130 @@
+//! Local check-kind emitters for the `validator` Phase D port.
+//!
+//! Owns the four single-aggregate emitters and dispatches to the
+//! graph-traversal trio living in `validator_checks_graph.rs`:
+//!
+//!   this file                     — unique | non_empty |
+//!                                    first_word_verb | unique_across
+//!   validator_checks_graph.rs     — reference_valid | trigger_valid |
+//!                                    distinct_aliases
+//!   validator_morphology.rs       — command_naming_support + suffix
+//!                                    / verb-exception / verb-suffix
+//!                                    formatters
+//!
+//! Byte-identity policy — every `format!` block here reproduces the
+//! Ruby `Hecks::Specializer::Validator` heredoc output character for
+//! character.
+//!
+//! Usage:
+//!   let text = emit_rule(&fixtures, rule);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/validator_checks.rs —
+//!  Phase D — Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use crate::specializer::validator_checks_graph as graph;
+
+/// Dispatch a single `ValidationRule` fixture row to its emitter.
+pub fn emit_rule(_fixtures: &[Fixture], rule: &Fixture) -> String {
+    match util::attr(rule, "check_kind") {
+        "unique" => emit_unique(rule),
+        "non_empty" => emit_non_empty(rule),
+        "first_word_verb" => emit_first_word_verb(rule),
+        "unique_across" => emit_unique_across(rule),
+        "reference_valid" => graph::emit_reference_valid(rule),
+        "trigger_valid" => graph::emit_trigger_valid(rule),
+        "distinct_aliases" => graph::emit_distinct_aliases(rule),
+        other => panic!("unknown check_kind: {}", other),
+    }
+}
+
+fn emit_unique(rule: &Fixture) -> String {
+    let description = util::attr(rule, "description");
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// {description}.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let mut seen = HashSet::new();
+    let mut errors = vec![];
+    for agg in &domain.aggregates {{
+        if !seen.insert(&agg.name) {{
+            errors.push(format!(\"Duplicate aggregate name: {{}}\", agg.name));
+        }}
+    }}
+    errors
+}}
+
+"
+    )
+}
+
+fn emit_non_empty(rule: &Fixture) -> String {
+    let description = util::attr(rule, "description");
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// {description}.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    domain
+        .aggregates
+        .iter()
+        .filter(|a| a.commands.is_empty())
+        .map(|a| format!(\"{{}} has no commands\", a.name))
+        .collect()
+}}
+
+"
+    )
+}
+
+fn emit_first_word_verb(rule: &Fixture) -> String {
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let mut errors = vec![];
+    for agg in &domain.aggregates {{
+        for cmd in &agg.commands {{
+            let word = first_word(&cmd.name);
+            if is_not_verb(&word) {{
+                errors.push(format!(
+                    \"Command {{}} in {{}} starts with '{{}}' which looks like a {{}} — commands should start with a verb\",
+                    cmd.name, agg.name, word,
+                    if NOUN_SUFFIXES.iter().any(|s| word.to_lowercase().ends_with(s)) {{ \"noun\" }} else {{ \"adjective\" }}
+                ));
+            }}
+        }}
+    }}
+    errors
+}}
+
+"
+    )
+}
+
+fn emit_unique_across(rule: &Fixture) -> String {
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// No two commands across all aggregates should share the same name.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let mut seen = HashSet::new();
+    let mut errors = vec![];
+    for agg in &domain.aggregates {{
+        for cmd in &agg.commands {{
+            if !seen.insert(&cmd.name) {{
+                errors.push(format!(
+                    \"Duplicate command name: {{}} (in {{}})\",
+                    cmd.name, agg.name
+                ));
+            }}
+        }}
+    }}
+    errors
+}}
+
+"
+    )
+}

--- a/hecks_life/src/specializer/validator_checks_graph.rs
+++ b/hecks_life/src/specializer/validator_checks_graph.rs
@@ -1,0 +1,138 @@
+//! Graph-traversal check emitters for the `validator` Phase D port.
+//!
+//! The three `check_kind`s in this file each walk the cross-aggregate
+//! graph to detect constraint violations:
+//!
+//!   reference_valid   — every `reference_to(X)` must resolve to a
+//!                        declared aggregate in the same domain
+//!   trigger_valid     — every policy's `trigger_command` must match
+//!                        a command declared in the same domain
+//!   distinct_aliases  — multiple references to the same target must
+//!                        carry distinct `as:` aliases
+//!
+//! Split out from `validator_checks.rs` so neither file crosses the
+//! 200-LoC cap. The parent `validator_checks::emit_rule` dispatches
+//! in; each emitter here is pub(super) so only sibling modules in
+//! `specializer::` can call them.
+//!
+//! Byte-identity policy — identical to sibling emitters: every
+//! `format!` body reproduces the Ruby heredoc text character for
+//! character.
+//!
+//! Usage:
+//!   let text = emit_reference_valid(rule);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/validator_checks_graph.rs —
+//!  Phase D — Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+
+pub(super) fn emit_reference_valid(rule: &Fixture) -> String {
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// References must target existing aggregate roots.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let agg_names: HashSet<&str> = domain
+        .aggregates
+        .iter()
+        .map(|a| a.name.as_str())
+        .collect();
+
+    let mut errors = vec![];
+    for agg in &domain.aggregates {{
+        for reference in &agg.references {{
+            if reference.domain.is_some() {{
+                continue; // cross-domain refs validated elsewhere
+            }}
+            if !agg_names.contains(reference.target.as_str()) {{
+                errors.push(format!(
+                    \"{{}} references unknown aggregate: {{}}\",
+                    agg.name, reference.target
+                ));
+            }}
+        }}
+        for cmd in &agg.commands {{
+            for reference in &cmd.references {{
+                if reference.domain.is_some() {{
+                    continue;
+                }}
+                if !agg_names.contains(reference.target.as_str()) {{
+                    errors.push(format!(
+                        \"Command {{}} references unknown aggregate: {{}}\",
+                        cmd.name, reference.target
+                    ));
+                }}
+            }}
+        }}
+    }}
+    errors
+}}
+
+"
+    )
+}
+
+pub(super) fn emit_trigger_valid(rule: &Fixture) -> String {
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// Policy triggers must name existing commands.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let all_commands: HashSet<&str> = domain
+        .aggregates
+        .iter()
+        .flat_map(|a| a.commands.iter().map(|c| c.name.as_str()))
+        .collect();
+
+    domain
+        .policies
+        .iter()
+        .filter(|p| p.target_domain.is_none()) // skip cross-domain
+        .filter(|p| !all_commands.contains(p.trigger_command.as_str()))
+        .map(|p| {{
+            format!(
+                \"Policy {{}} triggers unknown command: {{}}\",
+                p.name, p.trigger_command
+            )
+        }})
+        .collect()
+}}
+
+"
+    )
+}
+
+pub(super) fn emit_distinct_aliases(rule: &Fixture) -> String {
+    let name = util::attr(rule, "rust_fn_name");
+    format!(
+        "\
+/// When an aggregate has multiple reference_to the same target,
+/// each must carry a distinct `as:` alias — otherwise the references
+/// share the same `name` and downstream consumers (event payloads,
+/// generated form fields, dispatch routing) can't tell them apart.
+fn {name}(domain: &Domain) -> Vec<String> {{
+    let mut errors = vec![];
+    for agg in &domain.aggregates {{
+        // Group references by (target, name). Any group with size > 1
+        // is a collision: multiple references share the same alias.
+        let mut groups: std::collections::BTreeMap<(&str, &str), usize> =
+            std::collections::BTreeMap::new();
+        for r in &agg.references {{
+            *groups.entry((r.target.as_str(), r.name.as_str())).or_insert(0) += 1;
+        }}
+        for ((target, name), count) in &groups {{
+            if *count > 1 {{
+                errors.push(format!(
+                    \"{{}} has {{}} references to {{}} with duplicate alias {{:?}} — add `as: :<alias>` to each so they have distinct names\",
+                    agg.name, count, target, name
+                ));
+            }}
+        }}
+    }}
+    errors
+}}
+"
+    )
+}

--- a/hecks_life/src/specializer/validator_morphology.rs
+++ b/hecks_life/src/specializer/validator_morphology.rs
@@ -1,0 +1,181 @@
+//! Morphology support for the `validator` Phase D port.
+//!
+//! Owns the block of const tables + `first_word` + `is_not_verb` that
+//! sits between the `aggregates_have_commands` and `command_naming`
+//! rules in the generated validator.rs. Split out from
+//! `validator_checks.rs` so neither file crosses the 200-LoC cap:
+//!
+//!   validator_checks.rs      — the seven `check_kind` emitters
+//!   validator_morphology.rs  — `emit_command_naming_support`, the
+//!                              `format_suffix_list` / `format_verb_*`
+//!                              helpers and their hand-formatted column
+//!                              widths
+//!
+//! Byte-identity policy — column widths in `format_verb_exceptions`
+//! and `format_verb_suffixes` are hardcoded to match the Ruby spec.
+//! The hand-formatted output IS the contract; do not try to infer
+//! widths dynamically.
+//!
+//! Usage:
+//!   let block = emit_command_naming_support(&fixtures);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/validator_morphology.rs —
+//!  Phase D — Rust-native specializer implementation]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+
+/// Emit the const tables + `first_word` + `is_not_verb` support block
+/// that sits between the `aggregates_have_commands` and `command_naming`
+/// rules in the generated validator.rs.
+pub fn emit_command_naming_support(fixtures: &[Fixture]) -> String {
+    let suffixes = util::by_aggregate(fixtures, "SuffixTable");
+    let nouns: Vec<&str> = suffixes
+        .iter()
+        .filter(|s| util::attr(s, "table") == "noun")
+        .map(|s| util::attr(s, "suffix"))
+        .collect();
+    let adjs: Vec<&str> = suffixes
+        .iter()
+        .filter(|s| util::attr(s, "table") == "adj")
+        .map(|s| util::attr(s, "suffix"))
+        .collect();
+
+    let exceptions = util::by_aggregate(fixtures, "ExceptionWord");
+    let false_pos: Vec<&str> = exceptions
+        .iter()
+        .filter(|e| util::attr(e, "category") == "false_positive")
+        .map(|e| util::attr(e, "word"))
+        .collect();
+
+    format!(
+        "\
+/// Command names must start with a verb — detected by morphological patterns.
+/// Flipped logic: a command is imperative by definition. We only reject if
+/// the first word is provably NOT a verb (noun/adjective suffixes).
+/// Everything else passes — commands are verbs until proven otherwise.
+
+/// Suffixes that prove a word is a noun — not a verb.
+const NOUN_SUFFIXES: &[&str] = &[
+{nouns_block}
+];
+
+/// Suffixes that prove a word is an adjective — not a verb.
+const ADJ_SUFFIXES: &[&str] = &[
+{adjs_block}
+];
+
+/// Words that look like they could be verbs but are actually nouns
+/// when used as command first-words. Very short list — only add
+/// proven false positives.
+const FALSE_POSITIVES: &[&str] = &[
+{false_pos_block}
+];
+
+/// Extract the first word from a PascalCase name.
+fn first_word(name: &str) -> String {{
+    let mut word = String::new();
+    for (i, c) in name.chars().enumerate() {{
+        if i > 0 && c.is_uppercase() {{ break; }}
+        word.push(c);
+    }}
+    word
+}}
+
+/// A command first-word is NOT a verb if it matches noun/adjective patterns.
+/// Everything else is assumed to be a verb — commands are imperative.
+fn is_not_verb(word: &str) -> bool {{
+    let lower = word.to_lowercase();
+
+    // Too short to classify — single char is fine (commands like \"X\" are weird but not invalid)
+    if lower.len() < 2 {{ return false; }}
+
+    // Known false positives — articles, possessives, adjectives used as names
+    if FALSE_POSITIVES.iter().any(|fp| *fp == word) {{ return true; }}
+
+    // Words ending in noun suffixes that are actually verbs
+    let verb_exceptions = {verb_exceptions};
+    if verb_exceptions.iter().any(|v| lower == *v) {{ return false; }}
+
+    // Verb suffixes — if these match, the word is a verb even if it
+    // also matches a noun/adjective suffix (verb wins)
+    let verb_suffixes = {verb_suffixes};
+    let has_verb_suffix = verb_suffixes.iter().any(|s| lower.ends_with(s));
+
+    // Noun suffixes — if it ends like a noun AND doesn't have a verb suffix, reject
+    for suffix in NOUN_SUFFIXES {{
+        if lower.ends_with(suffix) && lower.len() > suffix.len() + 1 && !has_verb_suffix {{
+            return true;
+        }}
+    }}
+
+    // Adjective suffixes — same logic
+    for suffix in ADJ_SUFFIXES {{
+        if lower.ends_with(suffix) && lower.len() > suffix.len() + 1 && !has_verb_suffix {{
+            return true;
+        }}
+    }}
+
+    // Everything else is a verb. Commands are imperative by definition.
+    false
+}}
+
+",
+        nouns_block = format_suffix_list(&nouns, 7),
+        adjs_block = format_suffix_list(&adjs, 8),
+        false_pos_block = format_suffix_list(&false_pos, 7),
+        verb_exceptions = format_verb_exceptions(fixtures),
+        verb_suffixes = format_verb_suffixes(fixtures),
+    )
+}
+
+/// Chunk `items` into lines of at most `per_line` strings, each line
+/// indented four spaces and terminated with a trailing comma. Matches
+/// Ruby `items.each_slice(per_line).map { ... }.join("\n")`.
+fn format_suffix_list(items: &[&str], per_line: usize) -> String {
+    items
+        .chunks(per_line)
+        .map(|chunk| {
+            let quoted: Vec<String> = chunk.iter().map(|s| format!("\"{}\"", s)).collect();
+            format!("    {},", quoted.join(", "))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Hand-formatted verb-exception list with hardcoded column widths
+/// matching the Ruby spec. 24 words split 3+1 / 6 / 5 / 5 / 4.
+fn format_verb_exceptions(fixtures: &[Fixture]) -> String {
+    let words: Vec<&str> = util::by_aggregate(fixtures, "ExceptionWord")
+        .into_iter()
+        .filter(|e| util::attr(e, "category") == "verb_exception")
+        .map(|e| util::attr(e, "word"))
+        .collect();
+    let lines = vec![
+        format!("[\"{}\", \"{}\",", words[0..3].join("\", \""), words[3]),
+        format!("        \"{}\",", words[4..10].join("\", \"")),
+        format!("        \"{}\",", words[10..15].join("\", \"")),
+        format!("        \"{}\",", words[15..20].join("\", \"")),
+        format!("        \"{}\"]", words[20..24].join("\", \"")),
+    ];
+    lines.join("\n")
+}
+
+/// Hand-formatted verb-suffix list: first 7 inline, remainder on a
+/// continuation line indented 8 spaces. Matches the Ruby emitter.
+fn format_verb_suffixes(fixtures: &[Fixture]) -> String {
+    let suffixes: Vec<&str> = util::by_aggregate(fixtures, "SuffixTable")
+        .into_iter()
+        .filter(|s| util::attr(s, "table") == "verb")
+        .map(|s| util::attr(s, "suffix"))
+        .collect();
+    let head: Vec<String> = suffixes[0..7]
+        .iter()
+        .map(|s| format!("\"{}\"", s))
+        .collect();
+    let tail: Vec<String> = suffixes[7..]
+        .iter()
+        .map(|s| format!("\"{}\"", s))
+        .collect();
+    format!("[{},\n        {}]", head.join(", "), tail.join(", "))
+}

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -377,6 +377,41 @@ fn rust_specializer_produces_byte_identical_hecksagon_parser_rs() {
     );
 }
 
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn rust_specializer_produces_byte_identical_validator_rs() {
+    // Phase D — Rust-native specializer for validator.rs. Largest
+    // standalone specializer in the codebase (393 LoC Ruby). Seven
+    // check_kind emitters (unique, non_empty, first_word_verb,
+    // reference_valid, trigger_valid, unique_across, distinct_aliases)
+    // plus the command_naming_support block with hand-formatted suffix
+    // tables, verb-exception list, and verb-suffix list. No .rs.frag
+    // snippets — all emission is inline Rust format! strings.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "validator"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize validator failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("hecks_life/src/validator.rs"))
+        .expect("validator.rs missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
 #[test]
 fn rust_specializer_produces_byte_identical_behaviors_parser_rs() {
     // Phase D — Rust-native specializer for behaviors_parser. Ports


### PR DESCRIPTION
## Summary

- Ports the biggest standalone Ruby specializer — `lib/hecks_specializer/validator.rb` (393 LoC) — to Rust. `hecks-life specialize validator` now produces byte-identical output to `hecks_life/src/validator.rs`, matching the Ruby `bin/specialize validator` path exactly.
- Four-file split to stay under the 200-LoC cap per file:
  - `hecks_life/src/specializer/validator.rs` (138) — orchestration (header, imports, entry point, rule dispatch).
  - `hecks_life/src/specializer/validator_checks.rs` (130) — four local `check_kind` emitters (unique, non_empty, first_word_verb, unique_across).
  - `hecks_life/src/specializer/validator_checks_graph.rs` (138) — three graph-walking emitters (reference_valid, trigger_valid, distinct_aliases).
  - `hecks_life/src/specializer/validator_morphology.rs` (181) — `emit_command_naming_support` plus the hand-aligned suffix / verb-exception / verb-suffix column formatters.
- Verb-morphology padding is hardcoded to match the Ruby spec (3+1 / 6 / 5 / 5 / 4 for verb-exceptions; 7 / 7+9 for verb-suffixes). No `.rs.frag` snippets — validator is the "all inline" specializer per the Phase D plan.
- Phase D is now 4 of ~10 ports complete (validator_warnings, dump, behaviors_parser, validator). validator.rs was the biggest standalone specializer in the codebase.

## Example usage

```
$ hecks_life/target/release/hecks-life specialize validator | diff - hecks_life/src/validator.rs
$ bin/specialize validator | diff - hecks_life/src/validator.rs
# both: empty diff
```

## Test plan

- [x] `cargo build --release` — clean.
- [x] `cargo test --release --test specializer_golden_test` — 21 passed, 0 failed (new `rust_specializer_produces_byte_identical_validator_rs` plus the 20 pre-existing golden tests).
- [x] Full `cargo test --release` — 224 tests pass across 26 binaries, no failures.
- [x] `hecks_life/target/release/hecks-life specialize validator | diff - hecks_life/src/validator.rs` — empty.
- [x] `bin/specialize validator | diff - hecks_life/src/validator.rs` — empty (Ruby path still works).