### PR TITLE
autophagy: Phase D D3 — hecks-life specialize meta_ruby_script (Ruby→Rust)

### DIFF
--- a/hecks_life/src/specializer/meta_ruby_script.rs
+++ b/hecks_life/src/specializer/meta_ruby_script.rs
@@ -1,0 +1,108 @@
+//! Rust port of `lib/hecks_specializer/meta_ruby_script.rb` (Phase D D3).
+//!
+//! Regenerates a top-level Ruby script from a single `RubyScript`
+//! fixture row. First Ruby-emitting specializer to land in Rust. The
+//! emission is a straight four-section concatenation of verbatim
+//! snippets — no templating, no interpolation — so the port stays
+//! small and mirrors the Ruby side line-for-line.
+//!
+//! Emission pipeline (verbatim concatenation, matching the Ruby):
+//!
+//!   1. shebang line + "\n" — skipped entirely if shebang is empty
+//!   2. doc_snippet — read raw (already ends with "\n")
+//!   3. "\n" — blank line separator
+//!   4. requires_block_snippet — read raw (already ends with "\n")
+//!   5. "\n" — blank line separator
+//!   6. body_snippet — read raw (already ends with "\n")
+//!
+//! Snippets are `.rb.frag` files with no `//`-comment header, so we
+//! use `util::read_snippet_raw` rather than `util::read_snippet_body`.
+//! A leading `//`-strip would silently corrupt Ruby source whose lines
+//! happen to start with `//` inside string literals.
+//!
+//! Usage:
+//!   let ruby = meta_ruby_script::emit(repo_root)?;
+//!   print!("{}", ruby);
+//
+// [antibody-exempt: hecks_life/src/specializer/meta_ruby_script.rs — Phase D D3 — Ruby-native specializer port]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/ruby_script_shape/fixtures/ruby_script_shape.fixtures";
+
+/// Which `RubyScript` fixture row to emit for. `None` picks the first
+/// row — kept simple for the PC-3 pilot, which ships with a single row
+/// (Specialize). A future subclass-style port would thread this value
+/// through the top-level `emit` match arm in `specializer::mod`.
+fn target_row_name() -> Option<&'static str> {
+    None
+}
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+    let rows = util::by_aggregate(&fixtures, "RubyScript");
+    let row = pick_row(&rows, target_row_name())?;
+
+    let mut out = String::new();
+    out.push_str(&emit_shebang(row));
+    out.push_str(&emit_doc(repo_root, row)?);
+    out.push_str(&emit_requires(repo_root, row)?);
+    out.push_str(&emit_body(repo_root, row)?);
+    Ok(out)
+}
+
+fn pick_row<'a>(
+    rows: &'a [&'a Fixture],
+    name: Option<&str>,
+) -> Result<&'a Fixture, Box<dyn Error>> {
+    let row = match name {
+        Some(n) => rows.iter().find(|r| util::attr(r, "name") == n).copied(),
+        None => rows.first().copied(),
+    };
+    row.ok_or_else(|| {
+        format!(
+            "no RubyScript row matching {:?}",
+            name.unwrap_or("<first>")
+        )
+        .into()
+    })
+}
+
+/// Shebang line followed by "\n". Empty string (no shebang) skips the
+/// whole line — used for plain `.rb` outputs with no shebang.
+fn emit_shebang(row: &Fixture) -> String {
+    let shebang = util::attr(row, "shebang");
+    if shebang.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", shebang)
+    }
+}
+
+/// Doc block — read verbatim. Snippet already ends with "\n".
+/// Append one more "\n" to insert the blank line that separates doc
+/// from requires.
+fn emit_doc(repo_root: &Path, row: &Fixture) -> Result<String, Box<dyn Error>> {
+    let path = repo_root.join(util::attr(row, "doc_snippet"));
+    Ok(format!("{}\n", util::read_snippet_raw(&path)?))
+}
+
+/// Requires block — read verbatim. Snippet already ends with "\n".
+/// Append one more "\n" to insert the blank line that separates
+/// requires from body.
+fn emit_requires(repo_root: &Path, row: &Fixture) -> Result<String, Box<dyn Error>> {
+    let path = repo_root.join(util::attr(row, "requires_block_snippet"));
+    Ok(format!("{}\n", util::read_snippet_raw(&path)?))
+}
+
+/// Imperative body — read verbatim. Final section; snippet's own
+/// trailing "\n" is the file's trailing newline.
+fn emit_body(repo_root: &Path, row: &Fixture) -> Result<String, Box<dyn Error>> {
+    let path = repo_root.join(util::attr(row, "body_snippet"));
+    util::read_snippet_raw(&path)
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -24,6 +24,7 @@ pub mod behaviors_parser_dispatch;
 pub mod dump;
 pub mod fixtures_parser;
 pub mod hecksagon_parser;
+pub mod meta_ruby_script;
 pub mod util;
 pub mod validator;
 pub mod validator_checks;
@@ -39,11 +40,12 @@ pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
         "behaviors_parser" => behaviors_parser::emit(repo_root),
         "fixtures_parser" => fixtures_parser::emit(repo_root),
         "hecksagon_parser" => hecksagon_parser::emit(repo_root),
+        "meta_ruby_script" => meta_ruby_script::emit(repo_root),
         "validator" => validator::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, validator, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, meta_ruby_script, validator, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/src/specializer/util.rs
+++ b/hecks_life/src/specializer/util.rs
@@ -72,6 +72,18 @@ pub fn attr_opt<'a>(fixture: &'a Fixture, key: &str) -> Option<&'a str> {
         .map(|(_, v)| v.as_str())
 }
 
+/// Read a snippet file verbatim — bare `fs::read_to_string`, no
+/// comment stripping. Use this for `.rb.frag` and any other snippet
+/// where the file is raw source with no leading `//`-comment header.
+/// `read_snippet_body` is WRONG for `.rb.frag` because Ruby sources
+/// have no `//` comments and would lose any line that happens to
+/// start with `//` inside a string literal.
+// [antibody-exempt: hecks_life/src/specializer/util.rs — Phase D D3 — Ruby-native specializer port]
+pub fn read_snippet_raw(path: &Path) -> Result<String, Box<dyn Error>> {
+    fs::read_to_string(path)
+        .map_err(|e| format!("snippet missing {}: {}", path.display(), e).into())
+}
+
 /// Read a `.rs.frag` snippet file, stripping the leading `//`-comment
 /// header and leading blank lines. Everything from the first
 /// non-comment, non-empty line onward is returned verbatim — the Ruby

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -479,6 +479,40 @@ fn rust_specializer_produces_byte_identical_fixtures_parser_rs() {
     );
 }
 
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn rust_specializer_produces_byte_identical_bin_specialize() {
+    // Phase D D3 — Rust-native port of meta_ruby_script. Emits the
+    // bin/specialize driver itself from a single RubyScript fixture
+    // row (shebang + doc_snippet + requires_block_snippet +
+    // body_snippet). First Ruby-emitting specializer in Rust; exercises
+    // the new util::read_snippet_raw helper (bare fs::read_to_string,
+    // no `//` strip — `.rb.frag` has no comment header).
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "meta_ruby_script"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize meta_ruby_script failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("bin/specialize"))
+        .expect("bin/specialize missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked bin/specialize",
+    );
+}
+
 #[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {
     // Phase C PC-5 — retires the loader module lib/hecks_specializer.rb


### PR DESCRIPTION
## Summary

Phase D D3 port of `lib/hecks_specializer/meta_ruby_script.rb` (~96 LoC Ruby) to `hecks_life/src/specializer/meta_ruby_script.rs` (~108 LoC Rust; well under the 200-LoC cap).

First **Ruby-emitting** specializer in Rust. Four-section verbatim concatenation:

1. shebang + `\n`
2. `doc_snippet` (raw `.rb.frag`) + `\n`
3. `requires_block_snippet` (raw `.rb.frag`) + `\n`
4. `body_snippet` (raw `.rb.frag`)

## New shared helper

- `util::read_snippet_raw(path) -> Result<String>` — bare `fs::read_to_string`, no `//`-comment strip. `.rb.frag` has no comment header, so the existing `read_snippet_body` was wrong for Ruby-emitting specializers.

## Example usage

```console
$ hecks-life specialize meta_ruby_script | diff - bin/specialize
$ bin/specialize meta_ruby_script | diff - bin/specialize
$ # both empty — byte-identical from Rust path and idempotent from Ruby path
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test specializer_golden_test` — 24/24 pass (new: `rust_specializer_produces_byte_identical_bin_specialize`)
- [x] `hecks-life specialize meta_ruby_script | diff - bin/specialize` — empty
- [x] `bin/specialize meta_ruby_script | diff - bin/specialize` — empty (script regenerates itself)
- [x] Ruby `meta_ruby_script.rb` intact (Phase D ports are additive until migration completes)