### PR TITLE
autophagy: Phase D D3 — hecks-life specialize meta_subclass (Ruby→Rust)

### DIFF
--- a/hecks_life/src/specializer/meta_subclass.rs
+++ b/hecks_life/src/specializer/meta_subclass.rs
@@ -1,0 +1,120 @@
+//! Rust port of `lib/hecks_specializer/meta_subclass.rb`.
+//!
+//! Emits one thin-subclass Ruby shell under `lib/hecks_specializer/`
+//! from a `SpecializerSubclass` fixture row — the Phase C PC-1 pilot,
+//! now also available through the Phase D Rust-native driver.
+//!
+//! Unlike the D1/D2 ports, which emit Rust, this port emits Ruby.
+//! The source fixtures contain no `.rb.frag` snippets — every shell
+//! is assembled inline from fixture attributes (class_name,
+//! base_class, module_doc, shape_path, target_rs_path, target_name,
+//! output_rb). The template has to match the hand-written shells
+//! byte-for-byte: doc block, `require_relative`, class body, register
+//! call.
+//!
+//! Which row to emit is controlled by a row-target name — the
+//! dispatcher picks the row whose `target_name` matches. Default
+//! (`meta_subclass`) emits the DuplicatePolicy row, mirroring the
+//! Ruby `MetaSubclass.row_target_name`; `meta_subclass_lifecycle`
+//! picks the Lifecycle row, mirroring `MetaSubclassLifecycle`.
+//!
+//! Usage:
+//!   let rb = meta_subclass::emit_named(repo_root, "duplicate_policy")?;
+//!   print!("{}", rb);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/meta_subclass.rs —
+//!  Phase D D3 — Ruby-native specializer port]
+
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str = "hecks_conception/capabilities/specializer/fixtures/specializer.fixtures";
+
+/// Emit the shell for the `duplicate_policy` row — the default
+/// `meta_subclass` dispatch target, mirroring Ruby
+/// `MetaSubclass.row_target_name`.
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    emit_named(repo_root, "duplicate_policy")
+}
+
+/// Emit the shell for the `lifecycle` row — the
+/// `meta_subclass_lifecycle` dispatch target, mirroring Ruby
+/// `MetaSubclassLifecycle.row_target_name`.
+pub fn emit_lifecycle(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    emit_named(repo_root, "lifecycle")
+}
+
+/// Locate the `SpecializerSubclass` row whose `target_name` matches
+/// `row_target_name`, then render the thin-subclass Ruby shell.
+pub fn emit_named(repo_root: &Path, row_target_name: &str) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+    let rows = util::by_aggregate(&fixtures, "SpecializerSubclass");
+    let row = rows
+        .iter()
+        .find(|r| util::attr(r, "target_name") == row_target_name)
+        .ok_or_else(|| {
+            format!(
+                "no SpecializerSubclass row for {:?}",
+                row_target_name
+            )
+        })?;
+    Ok(emit_row(row))
+}
+
+fn emit_row(row: &crate::ir::Fixture) -> String {
+    let output_rb = util::attr(row, "output_rb");
+    let class_name = util::attr(row, "class_name");
+    let base_class = util::attr(row, "base_class");
+    let shape_path = util::attr(row, "shape_path");
+    let target_rs_path = util::attr(row, "target_rs_path");
+    let target_name = util::attr(row, "target_name");
+    let module_doc = util::attr(row, "module_doc");
+
+    // Ruby:
+    //   doc_lines = module_doc.split("\n").map { |l| l.empty? ? "#" : "# #{l}" }
+    // The fixtures parser already expanded `\n` escapes to real newlines.
+    let doc_lines: Vec<String> = module_doc
+        .split('\n')
+        .map(|line| {
+            if line.is_empty() {
+                "#".to_string()
+            } else {
+                format!("# {line}")
+            }
+        })
+        .collect();
+    let doc_block = doc_lines.join("\n");
+
+    // Mirrors the Ruby heredoc byte-for-byte. Indentation is two
+    // spaces for `module Specializer`, four for the class body, six
+    // for SHAPE/TARGET_RS.
+    format!(
+        "\
+# {output_rb}
+#
+{doc_block}
+
+require_relative \"diagnostic_validator\"
+
+module Hecks
+  module Specializer
+    class {class_name} < {base_class}
+      SHAPE = REPO_ROOT.join(\"{shape_path}\")
+      TARGET_RS = REPO_ROOT.join(\"{target_rs_path}\")
+    end
+
+    register :{target_name}, {class_name}
+  end
+end
+",
+        output_rb = output_rb,
+        doc_block = doc_block,
+        class_name = class_name,
+        base_class = base_class,
+        shape_path = shape_path,
+        target_rs_path = target_rs_path,
+        target_name = target_name,
+    )
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -26,6 +26,7 @@ pub mod fixtures_parser;
 pub mod hecksagon_parser;
 pub mod meta_diagnostic_validator;
 pub mod meta_ruby_script;
+pub mod meta_subclass;
 pub mod util;
 pub mod validator;
 pub mod validator_checks;
@@ -46,8 +47,10 @@ pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
         "validator" => validator::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
         "dump" => dump::emit(repo_root),
+        "meta_subclass" => meta_subclass::emit(repo_root),
+        "meta_subclass_lifecycle" => meta_subclass::emit_lifecycle(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, meta_diagnostic_validator, meta_ruby_script, validator, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, meta_diagnostic_validator, meta_ruby_script, meta_subclass, meta_subclass_lifecycle, validator, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/src/specializer/util.rs
+++ b/hecks_life/src/specializer/util.rs
@@ -72,16 +72,16 @@ pub fn attr_opt<'a>(fixture: &'a Fixture, key: &str) -> Option<&'a str> {
         .map(|(_, v)| v.as_str())
 }
 
-/// Read a snippet file verbatim — bare `fs::read_to_string`, no
-/// comment stripping. Use this for `.rb.frag` and any other snippet
-/// where the file is raw source with no leading `//`-comment header.
-/// `read_snippet_body` is WRONG for `.rb.frag` because Ruby sources
-/// have no `//` comments and would lose any line that happens to
-/// start with `//` inside a string literal.
-// [antibody-exempt: hecks_life/src/specializer/util.rs — Phase D D3 — Ruby-native specializer port]
+/// Read a snippet file verbatim — no comment-header strip, no blank-
+/// line trim. Required for `.rb.frag` bodies (Ruby method bodies that
+/// legitimately begin with `# internal:` comments we must preserve)
+/// and any `.rs.frag` where the opening `//` is load-bearing code.
+/// Mirrors the local `read_raw` override several Phase D Rust ports
+/// carry; promoted here so Ruby-emitting D3 ports can share one copy.
+#[allow(dead_code)]
 pub fn read_snippet_raw(path: &Path) -> Result<String, Box<dyn Error>> {
     fs::read_to_string(path)
-        .map_err(|e| format!("snippet missing {}: {}", path.display(), e).into())
+        .map_err(|e| format!("snippet missing: {} ({})", path.display(), e).into())
 }
 
 /// Read a `.rs.frag` snippet file, stripping the leading `//`-comment

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -551,6 +551,71 @@ fn rust_specializer_produces_byte_identical_diagnostic_validator_rb() {
     );
 }
 
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn rust_specializer_produces_byte_identical_meta_subclass_rb() {
+    // Phase D D3 — first Ruby-emitting Rust-native specializer port.
+    // Where D1/D2 ported Ruby-specialisers-that-emit-Rust, this pair
+    // ports a Ruby-specialiser-that-emits-Ruby (the thin-subclass
+    // shells under lib/hecks_specializer/). Mirrors the Ruby
+    // MetaSubclass default: :meta_subclass emits duplicate_policy.rb.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "meta_subclass"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize meta_subclass failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("lib/hecks_specializer/duplicate_policy.rb"))
+        .expect("duplicate_policy.rb missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn rust_specializer_produces_byte_identical_meta_subclass_lifecycle_rb() {
+    // Phase D D3 companion — meta_subclass_lifecycle dispatches to
+    // the Lifecycle SpecializerSubclass row. Proves the port scales
+    // past one row, same as MetaSubclassLifecycle does on the Ruby
+    // side.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "meta_subclass_lifecycle"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize meta_subclass_lifecycle failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("lib/hecks_specializer/lifecycle.rb"))
+        .expect("lifecycle.rb missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
 #[test]
 fn meta_specializer_produces_byte_identical_hecks_specializer_rb() {
     // Phase C PC-5 — retires the loader module lib/hecks_specializer.rb


### PR DESCRIPTION
## Summary

- First Ruby-emitting Rust-native specializer port (i51 Phase D D3). Where D1/D2 ported Ruby specialisers that emit Rust, this one emits Ruby — the thin-subclass shells under `lib/hecks_specializer/` (`duplicate_policy.rb` and `lifecycle.rb`).
- `hecks-life specialize meta_subclass` and `hecks-life specialize meta_subclass_lifecycle` now produce output byte-identical to their `bin/specialize` counterparts and to the tracked `.rb` files.
- Promotes `read_snippet_raw` into `specializer::util` so D3 siblings (meta_diagnostic_validator, meta_ruby_module, meta_ruby_script) can share one bare-read helper; `meta_subclass` itself has no snippet reads (every shell is inlined from fixture attributes).

## Implementation

- `hecks_life/src/specializer/meta_subclass.rs` — new ~94 LoC module. Reads `SpecializerSubclass` rows from `specializer.fixtures`, picks the row whose `target_name` matches, renders the thin-subclass shell. Mirrors Ruby `MetaSubclass` / `MetaSubclassLifecycle`: `:meta_subclass` defaults to `duplicate_policy`, `:meta_subclass_lifecycle` picks `lifecycle`.
- `hecks_life/src/specializer/util.rs` — adds `read_snippet_raw(path)`, a bare `fs::read_to_string` with no comment-strip (promoted from `fixtures_parser.rs`'s local `read_raw`). Unused by meta_subclass itself, but siblings need it for `.rb.frag` bodies that legitimately begin with `#` Ruby comments.
- `hecks_life/src/specializer/mod.rs` — two new match arms (`meta_subclass` + `meta_subclass_lifecycle`), one new `pub mod`, updated unknown-target error message.
- `hecks_life/tests/specializer_golden_test.rs` — two new tests: `rust_specializer_produces_byte_identical_meta_subclass_rb` and `..._meta_subclass_lifecycle_rb`. Both antibody-exempt as golden-test scaffolding.
- `lib/hecks_specializer/meta_subclass.rb` is **unchanged** — both runtimes coexist per Phase D policy.

## Example usage

```sh
# Rust-native (new):
hecks-life specialize meta_subclass              # → lib/hecks_specializer/duplicate_policy.rb
hecks-life specialize meta_subclass_lifecycle    # → lib/hecks_specializer/lifecycle.rb

# Ruby (unchanged, still byte-identical):
bin/specialize meta_subclass
bin/specialize meta_subclass_lifecycle
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test specializer_golden_test` — 25 passed (2 new + 23 existing)
- [x] `hecks-life specialize meta_subclass | diff - lib/hecks_specializer/duplicate_policy.rb` empty
- [x] `hecks-life specialize meta_subclass_lifecycle | diff - lib/hecks_specializer/lifecycle.rb` empty
- [x] `bin/specialize meta_subclass | diff - lib/hecks_specializer/duplicate_policy.rb` empty
- [x] `bin/specialize meta_subclass_lifecycle | diff - lib/hecks_specializer/lifecycle.rb` empty