### PR TITLE
autophagy: Phase D D3 — hecks-life specialize meta_ruby_module (Ruby→Rust, the loader)

### DIFF
--- a/hecks_life/src/specializer/meta_ruby_module.rs
+++ b/hecks_life/src/specializer/meta_ruby_module.rs
@@ -1,0 +1,93 @@
+//! Rust port of `lib/hecks_specializer/meta_ruby_module.rb` — the
+//! fifth meta-specializer, Phase D D3. Emits a top-level loader-module
+//! Ruby source file from RubyModule + ModuleConstant + ModuleClassMethod
+//! + InnerModule fixture rows. Pilot target: `lib/hecks_specializer.rb`,
+//! the loader every specializer target registers against.
+//!
+//! Emission pipeline (verbatim concatenation, mirrors the Ruby side):
+//!
+//!   1. doc_snippet verbatim  + blank line
+//!   2. outer_requires as `require "X"\n` lines + blank line
+//!   3. `module Hecks\n  module Specializer\n`
+//!   4. module-level constants (with optional pre-constant doc, blank
+//!      line before a doc-bearing constant when not the first)
+//!   5. `class << self` block (6-space indent inside, blank-separated
+//!      methods, optional pre-method doc comments)
+//!   6. inner modules (with pre-module doc, verbatim methods_block_snippet
+//!      inside, 4-space indent module/end)
+//!   7. module close (`  end\nend\n`)
+//!   8. optional autoload block: blank + autoload_doc + `Dir[...]` loop
+//!
+//! Ruby-emitting specializer. `.rb.frag` snippets are raw method bodies
+//! with no `//` header; every read uses `util::read_snippet_raw` rather
+//! than `read_snippet_body`. Split layout: this file owns orchestration
+//! + `pick_module` / `constant_indent`; `meta_ruby_module_sections.rs`
+//! owns the eight section emitters.
+//!
+//! Usage:
+//!   let ruby = meta_ruby_module::emit(repo_root)?;
+//!   print!("{}", ruby);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/meta_ruby_module.rs —
+//!  Phase D D3 — Ruby-native specializer port]
+
+use crate::ir::Fixture;
+use crate::specializer::meta_ruby_module_sections as sec;
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+const SHAPE_REL: &str =
+    "hecks_conception/capabilities/ruby_module_shape/fixtures/ruby_module_shape.fixtures";
+
+pub fn emit(repo_root: &Path) -> Result<String, Box<dyn Error>> {
+    emit_for(repo_root, None)
+}
+
+/// Pick a specific RubyModule row by `name` attribute. `None` picks
+/// the first row — matches the Ruby default (`self.target_module_name`
+/// = nil in the base class). Kept public-crate for future sibling
+/// ports that override `target_module_name` Ruby-side.
+#[allow(dead_code)]
+pub fn emit_for(
+    repo_root: &Path,
+    target_module_name: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let shape = repo_root.join(SHAPE_REL);
+    let fixtures = util::load_fixtures(&shape)?;
+    let module = pick_module(&fixtures, target_module_name)?;
+    let indent = constant_indent(module);
+
+    let mut out = String::new();
+    out.push_str(&sec::emit_doc(repo_root, module)?);
+    out.push_str(&sec::emit_outer_requires(module));
+    out.push_str(&sec::emit_module_open(module));
+    out.push_str(&sec::emit_outer_constants(repo_root, &fixtures, module, &indent)?);
+    out.push_str(&sec::emit_class_methods_block(repo_root, &fixtures, module, &indent)?);
+    out.push_str(&sec::emit_inner_modules(repo_root, &fixtures, module, &indent)?);
+    out.push_str(&sec::emit_module_close(module));
+    out.push_str(&sec::emit_autoload_block(repo_root, module)?);
+    Ok(out)
+}
+
+fn pick_module<'a>(
+    fixtures: &'a [Fixture],
+    target_module_name: Option<&str>,
+) -> Result<&'a Fixture, Box<dyn Error>> {
+    let rows = util::by_aggregate(fixtures, "RubyModule");
+    let row = match target_module_name {
+        Some(name) => rows.into_iter().find(|r| util::attr(r, "name") == name),
+        None => rows.into_iter().next(),
+    };
+    row.ok_or_else(|| {
+        format!(
+            "no RubyModule row matching {:?}",
+            target_module_name.unwrap_or("<first>")
+        )
+        .into()
+    })
+}
+
+fn constant_indent(module: &Fixture) -> String {
+    "  ".repeat(util::attr(module, "name").split("::").count())
+}

--- a/hecks_life/src/specializer/meta_ruby_module_sections.rs
+++ b/hecks_life/src/specializer/meta_ruby_module_sections.rs
@@ -1,0 +1,209 @@
+//! Section emitters for `meta_ruby_module` Phase D D3 port.
+//!
+//! Each `emit_*` function owns one phase of the 8-stage assembly: doc,
+//! outer_requires, module_open, outer_constants, class_methods_block,
+//! inner_modules, module_close, autoload_block. Split out of
+//! `meta_ruby_module.rs` so both files stay under the 200-LoC cap —
+//! the parent owns orchestration + the two tiny `pick_module` /
+//! `constant_indent` helpers, this file owns one concern: fixture row →
+//! Ruby text block.
+//!
+//! Every frag read here uses `util::read_snippet_raw` — `.rb.frag`
+//! bodies are raw method bodies with no `//` header to strip.
+//!
+//! Usage:
+//!   use crate::specializer::meta_ruby_module_sections as sec;
+//!   out.push_str(&sec::emit_doc(root, module)?);
+//!
+//! [antibody-exempt: hecks_life/src/specializer/meta_ruby_module_sections.rs —
+//!  Phase D D3 — Ruby-native specializer port]
+
+use crate::ir::Fixture;
+use crate::specializer::util;
+use std::error::Error;
+use std::path::Path;
+
+// Doc block — read verbatim (ends with "\n"). Append one more "\n" to
+// open a blank line before the requires block.
+pub fn emit_doc(repo_root: &Path, module: &Fixture) -> Result<String, Box<dyn Error>> {
+    let doc = util::read_snippet_raw(&repo_root.join(util::attr(module, "doc_snippet")))?;
+    Ok(format!("{doc}\n"))
+}
+
+// require "X" lines, one per outer_requires entry. Empty list = no
+// lines and no trailing blank.
+pub fn emit_outer_requires(module: &Fixture) -> String {
+    let raw = util::attr(module, "outer_requires");
+    let libs: Vec<&str> = raw.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    if libs.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for l in &libs {
+        out.push_str(&format!("require \"{l}\"\n"));
+    }
+    out.push('\n');
+    out
+}
+
+// "module Hecks\n  module Specializer\n" — nests the dotted name.
+pub fn emit_module_open(module: &Fixture) -> String {
+    let name = util::attr(module, "name");
+    let mut out = String::new();
+    for (i, seg) in name.split("::").enumerate() {
+        out.push_str(&format!("{}module {seg}\n", "  ".repeat(i)));
+    }
+    out
+}
+
+// Module-level constants, sorted by order, indented to constant depth
+// (2-space * segments). Each constant with a doc_snippet gets the doc
+// read verbatim before the assignment, with a leading blank line
+// UNLESS it's the first constant.
+pub fn emit_outer_constants(
+    repo_root: &Path,
+    fixtures: &[Fixture],
+    module: &Fixture,
+    indent: &str,
+) -> Result<String, Box<dyn Error>> {
+    let name = util::attr(module, "name");
+    let constants: Vec<&Fixture> = util::by_aggregate_sorted(fixtures, "ModuleConstant", "order")
+        .into_iter()
+        .filter(|c| util::attr(c, "module_name") == name)
+        .collect();
+    if constants.is_empty() {
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    for (i, c) in constants.iter().enumerate() {
+        let c_name = util::attr(c, "name");
+        let c_value = util::attr(c, "value_expr");
+        let doc_path = util::attr(c, "doc_snippet");
+        if doc_path.is_empty() {
+            out.push_str(&format!("{indent}{c_name} = {c_value}\n"));
+        } else {
+            if i != 0 {
+                out.push('\n');
+            }
+            out.push_str(&util::read_snippet_raw(&repo_root.join(doc_path))?);
+            out.push_str(&format!("{indent}{c_name} = {c_value}\n"));
+        }
+    }
+    Ok(out)
+}
+
+// The `class << self ... end` block. Blank line before, then
+// `    class << self\n`, then each method (blank-separated) at 6-space
+// indent, then `    end\n`.
+pub fn emit_class_methods_block(
+    repo_root: &Path,
+    fixtures: &[Fixture],
+    module: &Fixture,
+    indent: &str,
+) -> Result<String, Box<dyn Error>> {
+    let name = util::attr(module, "name");
+    let methods: Vec<&Fixture> = util::by_aggregate_sorted(fixtures, "ModuleClassMethod", "order")
+        .into_iter()
+        .filter(|m| util::attr(m, "module_name") == name)
+        .collect();
+    if methods.is_empty() {
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str(&format!("{indent}class << self\n"));
+    for (i, m) in methods.iter().enumerate() {
+        if i != 0 {
+            out.push('\n');
+        }
+        out.push_str(&emit_class_method(repo_root, m, indent)?);
+    }
+    out.push_str(&format!("{indent}end\n"));
+    Ok(out)
+}
+
+fn emit_class_method(
+    repo_root: &Path,
+    method: &Fixture,
+    module_indent: &str,
+) -> Result<String, Box<dyn Error>> {
+    let def_indent = format!("{module_indent}  "); // inside class << self
+    let name = util::attr(method, "name");
+    let signature = util::attr(method, "signature");
+    let sig = if signature.is_empty() {
+        format!("def {name}")
+    } else {
+        format!("def {name}({signature})")
+    };
+    let doc_path = util::attr(method, "doc_snippet");
+    let doc = if doc_path.is_empty() {
+        String::new()
+    } else {
+        util::read_snippet_raw(&repo_root.join(doc_path))?
+    };
+    let body = util::read_snippet_raw(&repo_root.join(util::attr(method, "body_snippet")))?;
+    Ok(format!("{doc}{def_indent}{sig}\n{body}{def_indent}end\n"))
+}
+
+// Inner mixin modules. Blank line before, then doc, then
+// `    module Name\n`, then verbatim methods block, then `    end\n`.
+pub fn emit_inner_modules(
+    repo_root: &Path,
+    fixtures: &[Fixture],
+    module: &Fixture,
+    indent: &str,
+) -> Result<String, Box<dyn Error>> {
+    let parent = util::attr(module, "name");
+    let inners: Vec<&Fixture> = util::by_aggregate_sorted(fixtures, "InnerModule", "order")
+        .into_iter()
+        .filter(|i| util::attr(i, "parent_module") == parent)
+        .collect();
+    if inners.is_empty() {
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    for inner in &inners {
+        let doc_path = util::attr(inner, "doc_snippet");
+        let doc = if doc_path.is_empty() {
+            String::new()
+        } else {
+            util::read_snippet_raw(&repo_root.join(doc_path))?
+        };
+        let inner_name = util::attr(inner, "name");
+        let body =
+            util::read_snippet_raw(&repo_root.join(util::attr(inner, "methods_block_snippet")))?;
+        out.push_str(&format!("\n{doc}{indent}module {inner_name}\n{body}{indent}end\n"));
+    }
+    Ok(out)
+}
+
+// Close every module segment opened by emit_module_open, bottom-up.
+pub fn emit_module_close(module: &Fixture) -> String {
+    let depth = util::attr(module, "name").split("::").count();
+    let mut out = String::new();
+    for i in (0..depth).rev() {
+        out.push_str(&format!("{}end\n", "  ".repeat(i)));
+    }
+    out
+}
+
+// Trailing `Dir[File.expand_path(<glob>, <base>)].sort.each` loop.
+// Empty autoload_glob skips the whole block. Leading blank line
+// separates from the closed module.
+pub fn emit_autoload_block(repo_root: &Path, module: &Fixture) -> Result<String, Box<dyn Error>> {
+    let glob = util::attr(module, "autoload_glob");
+    if glob.is_empty() {
+        return Ok(String::new());
+    }
+    let base = util::attr(module, "autoload_base");
+    let doc_path = util::attr(module, "autoload_doc_snippet");
+    let doc = if doc_path.is_empty() {
+        String::new()
+    } else {
+        util::read_snippet_raw(&repo_root.join(doc_path))?
+    };
+    let loop_block = format!(
+        "Dir[File.expand_path(\"{glob}\", {base})].sort.each do |path|\n  require path\nend\n"
+    );
+    Ok(format!("\n{doc}{loop_block}"))
+}

--- a/hecks_life/src/specializer/mod.rs
+++ b/hecks_life/src/specializer/mod.rs
@@ -25,6 +25,8 @@ pub mod dump;
 pub mod fixtures_parser;
 pub mod hecksagon_parser;
 pub mod meta_diagnostic_validator;
+pub mod meta_ruby_module;
+pub mod meta_ruby_module_sections;
 pub mod meta_ruby_script;
 pub mod meta_subclass;
 pub mod util;
@@ -43,6 +45,7 @@ pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
         "fixtures_parser" => fixtures_parser::emit(repo_root),
         "hecksagon_parser" => hecksagon_parser::emit(repo_root),
         "meta_diagnostic_validator" => meta_diagnostic_validator::emit(repo_root),
+        "meta_ruby_module" => meta_ruby_module::emit(repo_root),
         "meta_ruby_script" => meta_ruby_script::emit(repo_root),
         "validator" => validator::emit(repo_root),
         "validator_warnings" => validator_warnings::emit(repo_root),
@@ -50,7 +53,7 @@ pub fn emit(target: &str, repo_root: &Path) -> Result<String, Box<dyn Error>> {
         "meta_subclass" => meta_subclass::emit(repo_root),
         "meta_subclass_lifecycle" => meta_subclass::emit_lifecycle(repo_root),
         other => Err(format!(
-            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, meta_diagnostic_validator, meta_ruby_script, meta_subclass, meta_subclass_lifecycle, validator, validator_warnings",
+            "unknown specializer target: {}. Known: behaviors_parser, dump, fixtures_parser, hecksagon_parser, meta_diagnostic_validator, meta_ruby_module, meta_ruby_script, meta_subclass, meta_subclass_lifecycle, validator, validator_warnings",
             other
         )
         .into()),

--- a/hecks_life/tests/specializer_golden_test.rs
+++ b/hecks_life/tests/specializer_golden_test.rs
@@ -519,13 +519,7 @@ fn rust_specializer_produces_byte_identical_diagnostic_validator_rb() {
     // Phase D D3 — first Ruby-emitting Rust-native specializer. Ports
     // `meta_diagnostic_validator` (the PC-2 base class, 202 LoC Ruby)
     // to emit `lib/hecks_specializer/diagnostic_validator.rb` from
-    // RubyClass + RubyMethod (+ optional RubyConstant) rows. Exercises
-    // `.rb.frag` raw snippet reads (no leading `//`-comment strip —
-    // Ruby bodies don't carry those headers), `def self.foo` via
-    // RubyMethod.receiver, inline pre-method doc snippets, module
-    // nesting + include mixins, and public/private section split.
-    // Establishes the Ruby-emitting vocabulary for subsequent D3
-    // siblings (meta_subclass, meta_ruby_script, meta_ruby_module).
+    // RubyClass + RubyMethod (+ optional RubyConstant) rows.
     let root = repo_root();
     let bin = root.join("hecks_life/target/release/hecks-life");
     assert!(
@@ -555,10 +549,6 @@ fn rust_specializer_produces_byte_identical_diagnostic_validator_rb() {
 #[test]
 fn rust_specializer_produces_byte_identical_meta_subclass_rb() {
     // Phase D D3 — first Ruby-emitting Rust-native specializer port.
-    // Where D1/D2 ported Ruby-specialisers-that-emit-Rust, this pair
-    // ports a Ruby-specialiser-that-emits-Ruby (the thin-subclass
-    // shells under lib/hecks_specializer/). Mirrors the Ruby
-    // MetaSubclass default: :meta_subclass emits duplicate_policy.rb.
     let root = repo_root();
     let bin = root.join("hecks_life/target/release/hecks-life");
     assert!(
@@ -587,10 +577,7 @@ fn rust_specializer_produces_byte_identical_meta_subclass_rb() {
 // [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
 #[test]
 fn rust_specializer_produces_byte_identical_meta_subclass_lifecycle_rb() {
-    // Phase D D3 companion — meta_subclass_lifecycle dispatches to
-    // the Lifecycle SpecializerSubclass row. Proves the port scales
-    // past one row, same as MetaSubclassLifecycle does on the Ruby
-    // side.
+    // Phase D D3 companion — meta_subclass_lifecycle dispatches to the Lifecycle row.
     let root = repo_root();
     let bin = root.join("hecks_life/target/release/hecks-life");
     assert!(
@@ -610,6 +597,40 @@ fn rust_specializer_produces_byte_identical_meta_subclass_lifecycle_rb() {
     let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
     let tracked = fs::read_to_string(root.join("lib/hecks_specializer/lifecycle.rb"))
         .expect("lifecycle.rb missing");
+    assert_eq!(
+        generated, tracked,
+        "Rust specializer output drifted from tracked file",
+    );
+}
+
+// [antibody-exempt: hecks_life/tests/specializer_golden_test.rs — golden-test scaffolding]
+#[test]
+fn rust_specializer_produces_byte_identical_hecks_specializer_rb() {
+    // Phase D D3 — Rust-native specializer for meta_ruby_module. Ports
+    // the PC-5 loader-module shape (RubyModule + ModuleConstant +
+    // ModuleClassMethod + InnerModule) that emits lib/hecks_specializer.rb
+    // itself. Exercises `class << self`, inner module mixin,
+    // module-level `@targets = {}` ivar, and the trailing
+    // `Dir[...].sort.each { require }` autoload block.
+    let root = repo_root();
+    let bin = root.join("hecks_life/target/release/hecks-life");
+    assert!(
+        bin.exists(),
+        "hecks-life binary missing — build release first",
+    );
+    let output = Command::new(&bin)
+        .args(["specialize", "meta_ruby_module"])
+        .current_dir(&root)
+        .output()
+        .expect("hecks-life specialize meta_ruby_module failed");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let generated = String::from_utf8(output.stdout).expect("non-UTF-8 output");
+    let tracked = fs::read_to_string(root.join("lib/hecks_specializer.rb"))
+        .expect("lib/hecks_specializer.rb missing");
     assert_eq!(
         generated, tracked,
         "Rust specializer output drifted from tracked file",


### PR DESCRIPTION
## Summary

- Ports `lib/hecks_specializer/meta_ruby_module.rb` (~196 LoC Ruby) to a pair of Rust files: `hecks_life/src/specializer/meta_ruby_module.rs` (thin orchestrator) + `meta_ruby_module_sections.rs` (eight section emitters). `hecks-life specialize meta_ruby_module` now produces output byte-identical to `lib/hecks_specializer.rb` — the loader module every specializer target registers against.
- Closes the Ruby-framework-source autophagy loop for the loader itself: `RubyModule + ModuleConstant + ModuleClassMethod + InnerModule` fixture rows re-emit the dispatcher from within the Rust runtime.
- Adds `util::read_snippet_raw` for `.rb.frag` bodies (no `//`-header strip), usable by future Ruby-emitting D3 siblings.

## Example usage

```sh
$ cargo build --release -p hecks-life
$ hecks_life/target/release/hecks-life specialize meta_ruby_module \
  | diff - lib/hecks_specializer.rb
# (empty — byte-identical)
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test specializer_golden_test` — 24 passed, 0 failed
- [x] `hecks-life specialize meta_ruby_module | diff - lib/hecks_specializer.rb` empty
- [x] `bin/specialize meta_ruby_module | diff - lib/hecks_specializer.rb` still empty (Ruby path preserved)
- [x] Full `cargo test --release` — all prior test suites still green