### PR TITLE
fix: stale bin/specialize comments in generated Rust files

### DIFF
--- a/hecks_conception/capabilities/behaviors_parser_shape/snippets/doc.rs.frag
+++ b/hecks_conception/capabilities/behaviors_parser_shape/snippets/doc.rs.frag
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/behaviors_parser_shape/
-//! Regenerate: bin/specialize behaviors_parser --output hecks_life/src/behaviors_parser.rs
-//! Contract:  specializer.hecksagon :specialize_behaviors_parser shell adapter
+//! Regenerate: hecks-life specialize behaviors_parser --output hecks_life/src/behaviors_parser.rs
+//! Contract:  hecks_life/src/specializer/behaviors_parser.rs (Rust-native)
 //! Tests:     in-file #[cfg(test)] mod tests
 //!
 //! Fourth parser retirement after validator.rs, dump.rs, and

--- a/hecks_conception/capabilities/duplicate_policy_validator_shape/snippets/doc.rs.frag
+++ b/hecks_conception/capabilities/duplicate_policy_validator_shape/snippets/doc.rs.frag
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/duplicate_policy_validator_shape/
-//! Regenerate: bin/specialize duplicate_policy --output hecks_life/src/duplicate_policy_validator.rs
-//! Contract:  specializer.hecksagon :specialize_duplicate_policy shell adapter
+//! Regenerate: hecks-life specialize duplicate_policy --output hecks_life/src/duplicate_policy_validator.rs
+//! Contract:  hecks_life/src/specializer/duplicate_policy_validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/duplicate_policy_validator_test.rs
 //!
 //! Catches bluebooks that declare two or more policies wired to the

--- a/hecks_conception/capabilities/hecksagon_parser_shape/snippets/doc.rs.frag
+++ b/hecks_conception/capabilities/hecksagon_parser_shape/snippets/doc.rs.frag
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/hecksagon_parser_shape/
-//! Regenerate: bin/specialize hecksagon_parser --output hecks_life/src/hecksagon_parser.rs
-//! Contract:  specializer.hecksagon :specialize_hecksagon_parser shell adapter
+//! Regenerate: hecks-life specialize hecksagon_parser --output hecks_life/src/hecksagon_parser.rs
+//! Contract:  hecks_life/src/specializer/hecksagon_parser.rs (Rust-native)
 //! Tests:     hecks_life/tests/hecksagon_parser_test.rs
 //!
 //! Line-oriented, pattern-match style just like the bluebook parser. Not

--- a/hecks_conception/capabilities/lifecycle_validator_shape/snippets/doc.rs.frag
+++ b/hecks_conception/capabilities/lifecycle_validator_shape/snippets/doc.rs.frag
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/lifecycle_validator_shape/
-//! Regenerate: bin/specialize lifecycle --output hecks_life/src/lifecycle_validator.rs
-//! Contract:  specializer.hecksagon :specialize_lifecycle shell adapter
+//! Regenerate: hecks-life specialize lifecycle --output hecks_life/src/lifecycle_validator.rs
+//! Contract:  hecks_life/src/specializer/lifecycle_validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/lifecycle_validator_test.rs
 //!
 //! Catches contradictions in lifecycle declarations — patterns where

--- a/hecks_life/src/behaviors_parser.rs
+++ b/hecks_life/src/behaviors_parser.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/behaviors_parser_shape/
-//! Regenerate: bin/specialize behaviors_parser --output hecks_life/src/behaviors_parser.rs
-//! Contract:  specializer.hecksagon :specialize_behaviors_parser shell adapter
+//! Regenerate: hecks-life specialize behaviors_parser --output hecks_life/src/behaviors_parser.rs
+//! Contract:  hecks_life/src/specializer/behaviors_parser.rs (Rust-native)
 //! Tests:     in-file #[cfg(test)] mod tests
 //!
 //! Fourth parser retirement after validator.rs, dump.rs, and

--- a/hecks_life/src/dump.rs
+++ b/hecks_life/src/dump.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/dump_shape/
-//! Regenerate: bin/specialize dump --output hecks_life/src/dump.rs
-//! Contract:  specializer.hecksagon :specialize_dump shell adapter
+//! Regenerate: hecks-life specialize dump --output hecks_life/src/dump.rs
+//! Contract:  hecks_life/src/specializer/dump.rs (Rust-native)
 //!
 //! This is the parity contract. Hand-written so the JSON shape is chosen
 //! explicitly, not accidentally derived from Rust struct field names or

--- a/hecks_life/src/duplicate_policy_validator.rs
+++ b/hecks_life/src/duplicate_policy_validator.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/duplicate_policy_validator_shape/
-//! Regenerate: bin/specialize duplicate_policy --output hecks_life/src/duplicate_policy_validator.rs
-//! Contract:  specializer.hecksagon :specialize_duplicate_policy shell adapter
+//! Regenerate: hecks-life specialize duplicate_policy --output hecks_life/src/duplicate_policy_validator.rs
+//! Contract:  hecks_life/src/specializer/duplicate_policy_validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/duplicate_policy_validator_test.rs
 //!
 //! Catches bluebooks that declare two or more policies wired to the

--- a/hecks_life/src/hecksagon_parser.rs
+++ b/hecks_life/src/hecksagon_parser.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/hecksagon_parser_shape/
-//! Regenerate: bin/specialize hecksagon_parser --output hecks_life/src/hecksagon_parser.rs
-//! Contract:  specializer.hecksagon :specialize_hecksagon_parser shell adapter
+//! Regenerate: hecks-life specialize hecksagon_parser --output hecks_life/src/hecksagon_parser.rs
+//! Contract:  hecks_life/src/specializer/hecksagon_parser.rs (Rust-native)
 //! Tests:     hecks_life/tests/hecksagon_parser_test.rs
 //!
 //! Line-oriented, pattern-match style just like the bluebook parser. Not

--- a/hecks_life/src/lifecycle_validator.rs
+++ b/hecks_life/src/lifecycle_validator.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/lifecycle_validator_shape/
-//! Regenerate: bin/specialize lifecycle --output hecks_life/src/lifecycle_validator.rs
-//! Contract:  specializer.hecksagon :specialize_lifecycle shell adapter
+//! Regenerate: hecks-life specialize lifecycle --output hecks_life/src/lifecycle_validator.rs
+//! Contract:  hecks_life/src/specializer/lifecycle_validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/lifecycle_validator_test.rs
 //!
 //! Catches contradictions in lifecycle declarations — patterns where

--- a/hecks_life/src/specializer/dump.rs
+++ b/hecks_life/src/specializer/dump.rs
@@ -47,8 +47,8 @@ const HEADER: &str = r#"//! Canonical IR dump — JSON shape that both Ruby and 
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/dump_shape/
-//! Regenerate: bin/specialize dump --output hecks_life/src/dump.rs
-//! Contract:  specializer.hecksagon :specialize_dump shell adapter
+//! Regenerate: hecks-life specialize dump --output hecks_life/src/dump.rs
+//! Contract:  hecks_life/src/specializer/dump.rs (Rust-native)
 //!
 //! This is the parity contract. Hand-written so the JSON shape is chosen
 //! explicitly, not accidentally derived from Rust struct field names or

--- a/hecks_life/src/specializer/validator.rs
+++ b/hecks_life/src/specializer/validator.rs
@@ -118,8 +118,8 @@ const HEADER: &str = "\
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/validator_shape/
-//! Regenerate: bin/specialize validator --output hecks_life/src/validator.rs
-//! Contract:  specializer.hecksagon :specialize_validator shell adapter
+//! Regenerate: hecks-life specialize validator --output hecks_life/src/validator.rs
+//! Contract:  hecks_life/src/specializer/validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/validator_rules_test.rs (moved out for i51 Phase A commit 4)
 //!
 //! Ports the Ruby Hecks::Validator rules to Rust. Each rule inspects

--- a/hecks_life/src/specializer/validator_warnings.rs
+++ b/hecks_life/src/specializer/validator_warnings.rs
@@ -38,8 +38,8 @@ fn emit_header() -> String {
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/validator_warnings_shape/
-//! Regenerate: bin/specialize validator_warnings --output hecks_life/src/validator_warnings.rs
-//! Contract:  specializer.hecksagon :specialize_validator_warnings shell adapter
+//! Regenerate: hecks-life specialize validator_warnings --output hecks_life/src/validator_warnings.rs
+//! Contract:  hecks_life/src/specializer/validator_warnings.rs (Rust-native)
 //! Tests:     hecks_life/tests/validator_warnings_test.rs
 //!
 //! These rules emit advisory warnings but never cause validation to fail.

--- a/hecks_life/src/validator.rs
+++ b/hecks_life/src/validator.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/validator_shape/
-//! Regenerate: bin/specialize validator --output hecks_life/src/validator.rs
-//! Contract:  specializer.hecksagon :specialize_validator shell adapter
+//! Regenerate: hecks-life specialize validator --output hecks_life/src/validator.rs
+//! Contract:  hecks_life/src/specializer/validator.rs (Rust-native)
 //! Tests:     hecks_life/tests/validator_rules_test.rs (moved out for i51 Phase A commit 4)
 //!
 //! Ports the Ruby Hecks::Validator rules to Rust. Each rule inspects

--- a/hecks_life/src/validator_warnings.rs
+++ b/hecks_life/src/validator_warnings.rs
@@ -2,8 +2,8 @@
 //!
 //! GENERATED FILE — do not edit.
 //! Source:    hecks_conception/capabilities/validator_warnings_shape/
-//! Regenerate: bin/specialize validator_warnings --output hecks_life/src/validator_warnings.rs
-//! Contract:  specializer.hecksagon :specialize_validator_warnings shell adapter
+//! Regenerate: hecks-life specialize validator_warnings --output hecks_life/src/validator_warnings.rs
+//! Contract:  hecks_life/src/specializer/validator_warnings.rs (Rust-native)
 //! Tests:     hecks_life/tests/validator_warnings_test.rs
 //!
 //! These rules emit advisory warnings but never cause validation to fail.


### PR DESCRIPTION
After Phase E deleted bin/specialize, every generated .rs file still had `//! Regenerate: bin/specialize X` + `//! Contract: specializer.hecksagon :specialize_X shell adapter` in its doc header. Both refs point at deleted artifacts.

- Updated 4 doc.rs.frag snippets (behaviors_parser, duplicate_policy_validator, hecksagon_parser, lifecycle_validator)
- Updated 3 Rust specializer sources (validator, validator_warnings, dump — had headers baked in as raw strings)
- Regenerated 6 .rs files via `hecks-life specialize <target> --output <path>`
- Hand-edited 2 orphaned .rs files (duplicate_policy_validator, lifecycle_validator — no Rust specializer yet; flagged as future work)

7/7 golden tests pass; full cargo test suite green.