### PR TITLE
fix(antibody): catalog-dialect migration — i42

### DIFF
--- a/hecks_conception/capabilities/antibody/antibody.bluebook
+++ b/hecks_conception/capabilities/antibody/antibody.bluebook
@@ -204,42 +204,13 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
   # CONFIG CATALOGS
   # ============================================================
   #
-  # The four aggregates below are pure config tables — no commands,
-  # no lifecycle, no behavior. They declare the shape of the rows
-  # seeded by fixtures/antibody.fixtures so the fixture references
-  # resolve against a declared aggregate (PR #258 orphan inventory).
+  # The four shape-only aggregates (FlaggedExtension, ShebangMapping,
+  # ExemptionPattern, TestCase) that used to live here were moved to
+  # self-declaring form in `fixtures/antibody.fixtures` via the
+  # `aggregate "Name", schema: { k: T, ... } do` DSL extension — they
+  # no longer need a bluebook-side declaration. Closes inbox i42.
   #
-  #   FlaggedExtension  — the CODE_EXTS list antibody inspects
-  #   ShebangMapping    — shebang→extension recovery for extensionless files
-  #   ExemptionPattern  — the canonical exemption-marker regex
-  #   TestCase          — self-contained scenarios replayed by antibody.behaviors
-
-  # ---- FlaggedExtension ------------------------------------------
-
-  aggregate "FlaggedExtension", "One code extension antibody inspects — adding or removing a row here is the only way to change what antibody flags" do
-    attribute :ext, String
-  end
-
-  # ---- ShebangMapping --------------------------------------------
-
-  aggregate "ShebangMapping", "Maps a shebang interpreter name to the synthetic extension antibody should treat an extensionless file as" do
-    attribute :match, String
-    attribute :ext, String
-  end
-
-  # ---- ExemptionPattern ------------------------------------------
-
-  aggregate "ExemptionPattern", "The regex antibody uses to detect an exemption marker in a commit message — anchored at line start to prevent false matches in commit body prose" do
-    attribute :pattern, String
-    attribute :flags, String
-    attribute :anchor, String
-  end
-
-  # ---- TestCase --------------------------------------------------
-
-  aggregate "TestCase", "A self-contained antibody scenario — touched files, commit message, expected verdict; antibody.behaviors replays each one" do
-    attribute :touched_files, list_of(String)
-    attribute :message, String
-    attribute :expected, String
-  end
+  # To see their current schemas and row sets, read
+  # `fixtures/antibody.fixtures` — the `schema:` kwarg on each
+  # `aggregate` line carries what used to be `attribute :...` in here.
 end

--- a/hecks_conception/capabilities/antibody/fixtures/antibody.fixtures
+++ b/hecks_conception/capabilities/antibody/fixtures/antibody.fixtures
@@ -6,7 +6,7 @@ Hecks.fixtures "Antibody" do
   # .heki stores, the four DSL extensions, etc. Adding or removing
   # a row here is the only way to change what antibody flags.
 
-  aggregate "FlaggedExtension" do
+  aggregate "FlaggedExtension", schema: { ext: String } do
     fixture "Ruby",       ext: "rb"
     fixture "Rust",       ext: "rs"
     fixture "Python",     ext: "py"
@@ -28,7 +28,7 @@ Hecks.fixtures "Antibody" do
   # Only the shebangs listed here recover; anything else (awk, perl,
   # raku) is ignored and the file is treated as non-code.
 
-  aggregate "ShebangMapping" do
+  aggregate "ShebangMapping", schema: { match: String, ext: String } do
     fixture "Ruby",   match: "ruby",   ext: "rb"
     fixture "Python", match: "python", ext: "py"
     fixture "Bash",   match: "bash",   ext: "sh"
@@ -44,7 +44,7 @@ Hecks.fixtures "Antibody" do
   # does NOT exempt. Leading whitespace before the marker is allowed
   # (\s* in the pattern). Case-insensitive (flags: "i").
 
-  aggregate "ExemptionPattern" do
+  aggregate "ExemptionPattern", schema: { pattern: String, flags: String, anchor: String } do
     fixture "Canonical", pattern: "^\s*\[antibody-exempt:\s*([^\]]+)\]", flags: "i", anchor: "line_start"
   end
 
@@ -55,7 +55,7 @@ Hecks.fixtures "Antibody" do
   # the seeds that anchor `antibody.behaviors` — the runtime replays
   # each one and asserts the verdict matches.
 
-  aggregate "TestCase" do
+  aggregate "TestCase", schema: { touched_files: list_of(String), message: String, expected: String } do
     fixture "OnlyBluebook", touched: ["information/arc.heki", "hecks_conception/capabilities/antibody/antibody.bluebook"], message: "antibody: draft bluebook", expected: "pass"
     fixture "UntriagedRuby", touched: ["lib/hecks/shell_adapter.rb"], message: "wire the shell adapter", expected: "rejected"
     fixture "LineAnchoredExemption", touched: ["lib/hecks/shell_adapter.rb"], message: "wire the shell adapter\n\n[antibody-exempt: bootstrap rust shim not ready]", expected: "exempted"


### PR DESCRIPTION
PR #267 added 4 shape-only aggregates to antibody.bluebook (FlaggedExtension, ShebangMapping, ExemptionPattern, TestCase) as a transitional orphan fix. The real solution — `aggregate "X", schema: { ... } do` in the fixtures file — is shipped. This PR completes the migration.

- antibody.fixtures: 4 `aggregate` declarations gain `schema:` kwargs with the field types
- antibody.bluebook: 4 shape-only aggregates removed (~40 LoC)
- hecks verify: 0 errors (unchanged)
- dump-fixtures: all 4 catalogs correctly carry their schemas

Closes inbox `i42`.