### PR TITLE
phase F-6: BehaviorsRunner bluebook — test runner as domain (completes top six)

### DIFF
--- a/hecks_conception/capabilities/behaviors_runner/behaviors_runner.bluebook
+++ b/hecks_conception/capabilities/behaviors_runner/behaviors_runner.bluebook
@@ -1,0 +1,297 @@
+Hecks.bluebook "BehaviorsRunner", version: "2026.04.24.1" do
+  vision "The test runner as a domain — one BehaviorsRun per invocation, one TestExecution per test, pure-memory by design"
+  category "runtime"
+
+  # ============================================================
+  # BEHAVIORSRUNNER — Phase F-6 — test runner as domain
+  # ============================================================
+  #
+  # Sixth file of the Phase F arc (docs/phase-f-0-survey.md),
+  # completing the survey's top six targets. The test runner lives in
+  # one Rust file :
+  #
+  #   hecks_life/src/behaviors_runner.rs  (401 LOC)
+  #
+  # Two aggregates :
+  #   BehaviorsRun    — one invocation of the runner on a whole suite
+  #   TestExecution   — one test inside a suite
+  #
+  # The runner is pure-memory by design : each test gets a fresh
+  # Runtime::boot with no data_dir, no hecksagon, no adapters. If a
+  # test triggers IO, the source bluebook is doing something it
+  # should not — the fix is the bluebook, not the runner. This
+  # invariant is declared in the behavior of the commands below, and
+  # the hecksagon declares only :memory + :fs (reading source) with
+  # no outbound IO port.
+  #
+  # Implementation details the bluebook does NOT try to model :
+  # reference injection from in_scope → command kwargs, snake_case
+  # self-ref detection for bootstrap-less aggregates, the parse_value
+  # coercion of source-token strings into typed Values. Those are
+  # kernel-level helpers in the Rust file — Phase F discipline is to
+  # declare what the subsystem does at the command / event / phase
+  # level, not every internal helper.
+
+  # ============================================================
+  # BEHAVIORSRUN — one invocation of the runner
+  # ============================================================
+
+  aggregate "BehaviorsRun", "One `hecks-life behaviors <suite.bluebook>` invocation. Loads the source bluebook and the companion behaviors file, optionally loads sibling fixtures, runs every test, collects pass/fail/error totals" do
+    # source_path : the .bluebook the tests target (derived by
+    # stripping the _behavioral_tests suffix from suite_path).
+    attribute :source_path, String
+    # suite_path : the *_behavioral_tests.bluebook argv passed in.
+    attribute :suite_path, String
+    # tests_total : number of Test records in the parsed TestSuite.
+    attribute :tests_total, Integer
+    # passed / failed / errored : tallies updated as TestExecution
+    # records finish.
+    attribute :passed, Integer
+    attribute :failed, Integer
+    attribute :errored, Integer
+    # all_passed : true when failed + errored both zero. Redundant
+    # with the tallies but kept as an attribute so the lifecycle
+    # guard can read it directly.
+    attribute :all_passed, String
+    # phase : pending | loading | executing | done | failed.
+    attribute :phase, String
+
+    command "LoadSource" do
+      role "System"
+      description "Read the source bluebook text from source_path. The runner re-parses this text per test so no state leaks across tests (fresh Runtime::boot per TestExecution)."
+      attribute :source_path, String
+      then_set :source_path, to: :source_path
+      then_set :phase, to: "loading"
+      emits "SourceLoaded"
+    end
+
+    command "LoadSuite" do
+      role "System"
+      description "Parse the *_behavioral_tests.bluebook at suite_path into a TestSuite IR and count the tests."
+      attribute :suite_path, String
+      attribute :tests_total, Integer
+      then_set :suite_path, to: :suite_path
+      then_set :tests_total, to: :tests_total
+      emits "SuiteLoaded"
+    end
+
+    command "LoadFixtures" do
+      role "System"
+      description "Look for a sibling .fixtures file (i4 gap 8). Each fresh runtime is seeded with those records BEFORE setup commands replay, so tests that assume pre-existing state can lean on fixtures rather than redundant setups."
+      emits "FixturesLoaded"
+    end
+
+    command "ExecuteSuite" do
+      role "System"
+      description "Walk the TestSuite in source order. For each Test, create a TestExecution record and let it walk its phase lifecycle. Tally each outcome into passed / failed / errored."
+      then_set :phase, to: "executing"
+      then_set :passed, to: 0
+      then_set :failed, to: 0
+      then_set :errored, to: 0
+      emits "SuiteStarted"
+    end
+
+    command "RecordPass" do
+      role "System"
+      description "One TestExecution finished in the pass state. Increment passed."
+      then_set :passed, increment: 1
+      emits "PassRecorded"
+    end
+
+    command "RecordFail" do
+      role "System"
+      description "One TestExecution finished in the fail state (assertion mismatch). Increment failed."
+      then_set :failed, increment: 1
+      emits "FailRecorded"
+    end
+
+    command "RecordError" do
+      role "System"
+      description "One TestExecution errored out (setup failed or dispatch threw). Increment errored."
+      then_set :errored, increment: 1
+      emits "ErrorRecorded"
+    end
+
+    command "CompleteRun" do
+      role "System"
+      description "Every test finished. Compute all_passed (true only when failed + errored are both zero) and move to the done phase."
+      given("must be executing") { phase == "executing" }
+      then_set :phase, to: "done"
+      emits "RunCompleted"
+    end
+
+    command "FailRun" do
+      role "System"
+      description "Source bluebook could not be parsed, suite file missing, or other pre-execution error. Phase goes to failed ; no individual TestExecution records exist."
+      attribute :reason, String
+      then_set :phase, to: "failed"
+      emits "RunFailed"
+    end
+
+    lifecycle :phase, default: "pending" do
+      transition "LoadSource"    => "loading",   from: "pending"
+      transition "ExecuteSuite"  => "executing", from: "loading"
+      transition "CompleteRun"   => "done",      from: "executing"
+      transition "FailRun"       => "failed",    from: ["pending", "loading", "executing"]
+    end
+  end
+
+  # ============================================================
+  # TESTEXECUTION — one test inside a suite
+  # ============================================================
+
+  aggregate "TestExecution", "One Test record from a TestSuite, executed against a fresh Runtime::boot. Walks boot → fixtures → pre-seed singletons → setups → dispatch → assert, landing in pass / fail / error" do
+    # description : the behavioral test's description string, used
+    # for reporting.
+    attribute :description, String
+    # kind : command | cascade | query. Drives dispatch mode — cascade
+    # tests dispatch through the policy chain (so `expect emits: [...]`
+    # asserts the cascade) ; command + query tests dispatch isolated.
+    attribute :kind, String
+    # on_aggregate : the aggregate the expect map asserts against.
+    # Resolves to the dispatch result's aggregate_type when the test's
+    # named aggregate has no post-dispatch record.
+    attribute :on_aggregate, String
+    # tests_command : the command or query name under test.
+    attribute :tests_command, String
+    # status : pass | fail | error. Final outcome.
+    attribute :status, String
+    # message : populated on fail / error with the diagnostic string.
+    attribute :message, String
+    # phase : pending | booted | seeded | setup_done | dispatched |
+    #         asserted | completed.
+    attribute :phase, String
+
+    # ---- TestOutcome -----------------------------------------------
+    #
+    # The reporting value the runner returns per test. Mirrors the
+    # Rust TestRun struct.
+
+    value_object "TestOutcome" do
+      attribute :description, String
+      attribute :status, String
+      attribute :message, String
+    end
+
+    command "BootRuntime" do
+      role "System"
+      description "Parse the source bluebook fresh and boot an in-memory Runtime. No data_dir, no hecksagon, no adapters. If a test cascades into IO, that is a bluebook bug, not a runner bug."
+      then_set :phase, to: "booted"
+      emits "RuntimeBooted"
+    end
+
+    command "SeedFixtures" do
+      role "System"
+      description "Apply the loaded .fixtures records into the fresh runtime, if any, populating the in_scope map so reference-injection has something to point at."
+      then_set :phase, to: "seeded"
+      emits "FixturesSeeded"
+    end
+
+    command "PreSeedSingletons" do
+      role "System"
+      description "Find aggregates whose every command self-refs (no bootstrap command) and save an empty AggregateState at id 1 for each. Lifecycle defaults are deliberately NOT applied so gaps surface as clear failures on the next dispatch."
+      emits "SingletonsPreSeeded"
+    end
+
+    command "ReplaySetup" do
+      role "System"
+      description "Dispatch the test's setup commands in order with cascade OFF. Each successful setup updates in_scope with the resulting aggregate_type → aggregate_id mapping. A setup failure moves the test to error with a `setup failed: <msg>` message."
+      then_set :phase, to: "setup_done"
+      emits "SetupReplayed"
+    end
+
+    command "DispatchInput" do
+      role "System"
+      description "Dispatch the test's input command. kind=cascade uses the cascading dispatch so the policy chain fires (and `expect emits` can assert on it) ; kind=command uses dispatch_isolated so asserted state reflects the command's direct mutations. kind=query uses resolve_query and goes straight to AssertCount."
+      then_set :phase, to: "dispatched"
+      emits "InputDispatched"
+    end
+
+    command "AssertFinalState" do
+      role "System"
+      description "Walk every key in the test's expect map. Special keys : refused (match a GivenFailed error message), emits (list of event names published by this dispatch), <field>_size (list length, only when <field> is a Value::List), ok (sentinel meaning dispatch succeeded and no field assertion is needed). Otherwise compare stringified field values."
+      then_set :phase, to: "asserted"
+      emits "FinalStateAsserted"
+    end
+
+    command "Pass" do
+      role "System"
+      description "Every assertion matched. status → pass, message empty."
+      then_set :status, to: "pass"
+      then_set :phase, to: "completed"
+      emits "TestPassed"
+    end
+
+    command "MarkFail" do
+      role "System"
+      description "An assertion in the expect map did not match. status → fail, message records the mismatch (expected vs got)."
+      attribute :failure_message, String
+      then_set :status, to: "fail"
+      then_set :message, to: :failure_message
+      then_set :phase, to: "completed"
+      emits "TestFailed"
+    end
+
+    command "MarkError" do
+      role "System"
+      description "A setup command failed or the dispatch itself threw a runtime error. status → error, message records the underlying exception."
+      attribute :error_message, String
+      then_set :status, to: "error"
+      then_set :message, to: :error_message
+      then_set :phase, to: "completed"
+      emits "TestErrored"
+    end
+
+    lifecycle :phase, default: "pending" do
+      transition "BootRuntime"        => "booted",      from: "pending"
+      transition "SeedFixtures"       => "seeded",      from: "booted"
+      transition "ReplaySetup"        => "setup_done",  from: ["seeded", "booted"]
+      transition "DispatchInput"      => "dispatched",  from: "setup_done"
+      transition "AssertFinalState"   => "asserted",    from: "dispatched"
+      transition "Pass"               => "completed",   from: "asserted"
+      transition "MarkFail"           => "completed",   from: ["asserted", "dispatched"]
+      transition "MarkError"          => "completed",   from: ["pending", "booted", "seeded", "setup_done", "dispatched"]
+    end
+  end
+
+  # ============================================================
+  # POLICIES — runner orchestration
+  # ============================================================
+  #
+  # Source load → suite load → fixture discovery → execution. The
+  # per-test pipeline (Boot → Seed → Setup → Dispatch → Assert) is
+  # tracked inside TestExecution's lifecycle ; the runner-level
+  # policies just chain the suite-scoped phases.
+
+  policy "LoadSuiteAfterSource" do
+    on "SourceLoaded"
+    trigger "LoadSuite"
+  end
+
+  policy "LoadFixturesAfterSuite" do
+    on "SuiteLoaded"
+    trigger "LoadFixtures"
+  end
+
+  policy "ExecuteAfterFixtures" do
+    on "FixturesLoaded"
+    trigger "ExecuteSuite"
+  end
+
+  # Per-test outcomes roll up into the BehaviorsRun tallies.
+
+  policy "RecordPassOnTestPassed" do
+    on "TestPassed"
+    trigger "RecordPass"
+  end
+
+  policy "RecordFailOnTestFailed" do
+    on "TestFailed"
+    trigger "RecordFail"
+  end
+
+  policy "RecordErrorOnTestErrored" do
+    on "TestErrored"
+    trigger "RecordError"
+  end
+end

--- a/hecks_conception/capabilities/behaviors_runner/behaviors_runner.hecksagon
+++ b/hecks_conception/capabilities/behaviors_runner/behaviors_runner.hecksagon
@@ -1,0 +1,41 @@
+Hecks.hecksagon "BehaviorsRunner" do
+  # ============================================================
+  # BEHAVIORSRUNNER — hexagonal wiring for Phase F-6
+  # ============================================================
+  #
+  # The sibling bluebook declares BehaviorsRun + TestExecution. The
+  # runner is pure-memory by design : every test gets a fresh
+  # Runtime::boot with NO data_dir, NO hecksagon, NO adapters. If a
+  # test triggers IO, that is a bluebook bug — not a runner bug.
+  # The hecksagon's adapter list enforces that invariant at the
+  # declaration layer.
+  #
+  # Adapters :
+  #
+  #   :fs     — ONLY for reading source input. BehaviorsRun.LoadSource,
+  #             LoadSuite, LoadFixtures use this port to open the
+  #             three input files. No .heki writes, no stdout, no
+  #             network — just three reads at run start.
+  #
+  #   :memory — the only persistence for BehaviorsRun and every
+  #             TestExecution. Fresh Runtime per test means no
+  #             cross-test state, ever.
+  #
+  # Not declared (by design) :
+  #
+  #   :stdout / :stderr — the Rust does eprintln! for pass/fail
+  #   summary, but that's a reporting concern the user CLI owns
+  #   rather than something the runner dispatches through a declared
+  #   port. Keeping it out of the hecksagon is honest : a future
+  #   self-interpreting runtime that reads this declaration would
+  #   NOT automatically gain terminal output, which is the correct
+  #   behaviour for a library-ish test runner.
+  #
+  #   :runtime_dispatch — the runner DOES dispatch commands against
+  #   the per-test runtime (setup commands, the input command), but
+  #   those dispatches are in-process against a Runtime instance the
+  #   runner owns. Not an outbound port to an external runtime.
+
+  adapter :memory
+  adapter :fs, root: "."
+end


### PR DESCRIPTION
## Summary

Sixth file of the Phase F arc — **completes the F-0 survey's top six natural-fit targets**. One Rust file, two aggregates :

| Rust file | LOC | aggregates |
|---|---|---|
| `hecks_life/src/behaviors_runner.rs` | 401 | `BehaviorsRun` + `TestExecution` |

The test runner is pure-memory by design — every test gets a fresh `Runtime::boot` with no `data_dir`, no hecksagon, no adapters. If a test triggers IO, that's a *bluebook* bug, not a runner bug. **The hecksagon's adapter list declaratively enforces that invariant** : only `:fs` (for reading the three input files at run start) and `:memory`. Absent : `:stdout`, `:runtime_dispatch`, any network port.

## What reads now

**`BehaviorsRun`** (9 commands) — one `hecks-life behaviors <suite>` invocation.
- `LoadSource`, `LoadSuite`, `LoadFixtures`, `ExecuteSuite`, `RecordPass`, `RecordFail`, `RecordError`, `CompleteRun`, `FailRun`.
- Lifecycle on `:phase` : `pending → loading → executing → done | failed`.

**`TestExecution`** (9 commands + 1 value object) — one test inside a suite.
- `BootRuntime`, `SeedFixtures`, `PreSeedSingletons`, `ReplaySetup`, `DispatchInput`, `AssertFinalState`, `Pass`, `MarkFail`, `MarkError`.
- `TestOutcome` value object (description, status, message).
- Lifecycle on `:phase` : `pending → booted → seeded → setup_done → dispatched → asserted → completed`.

**Six policies** chain the pipeline and roll per-test outcomes into BehaviorsRun tallies.

## What the bluebook deliberately does NOT model

Reference injection from `in_scope` → command kwargs. Snake_case self-ref detection for bootstrap-less aggregates. `parse_value` coercion of source-token strings into typed `Value`s. Those are kernel-level helpers in the Rust — Phase F declares command / event / phase, not every internal helper. That's the discipline : if the DSL doesn't naturally express a thing, the thing stays in Rust and the declaration is honest about what's declared and what isn't.

## Series complete on the F-0 top six

| PR | Target | LOC | Aggregates |
|---|---|---|---|
| #406 | SeedLoader | 57 | 1 |
| #407 | Status pipeline | 510 | 1 (enriched) |
| #409 | Storage core | 343 | 3 |
| #410 | Runner surface | 297 | 2 |
| #411 | Server skeleton | 382 | 3 |
| **#412** | **BehaviorsRunner** | **401** | **2** |

**Total F-n scope shipped so far** : 1,990 LOC of Rust declared as 12 aggregates across 6 domains, with 23 lifecycle phases and 22 policies chaining their pipelines. The expected residue from F-0 (HTML templates, pure transforms, kernel primitives, CLI glue — ~4,500–5,500 LOC) remains hand-written by design.

## Test plan

- [x] `hecks-life dump capabilities/behaviors_runner/behaviors_runner.bluebook` — 2 aggregates, 18 commands, 6 policies
- [x] `hecks-life dump-hecksagon capabilities/behaviors_runner/behaviors_runner.hecksagon` — :memory + :fs only, invariant enforced declaratively
- [x] Ruby ↔ Rust parity passes
- [ ] Chris reads the bluebook and confirms the phase lifecycle matches how `behaviors_runner.rs` actually walks each test

## Minor — parser bug worth filing

Fourth occurrence in this arc of the Rust parser choking on escaped quotes inside description strings. Consistently worked around by rephrasing. Worth filing as its own issue if not already tracked.

## Series

- #403 paper catch-up
- #405 Phase F-0 survey
- #406 Phase F-1 SeedLoader
- #407 Phase F-2 Status pipeline
- #408 §16 Acknowledgments + §9.11 Phase F (paper)
- #409 Phase F-3 Storage core
- #410 Phase F-4 Runner surface
- #411 Phase F-5 Server skeleton
- **this — Phase F-6 BehaviorsRunner (completes top six)**
- Open question : where does the arc go next? Remaining natural-fit files are smaller individual targets (runtime/repository, event_bus, middleware — already covered by F-3). The big remaining decision is whether to tackle partials (main.rs dispatch table, conceiver/commands) or declare the arc done and shift focus.
