### PR TITLE
wake_report: strip lifecycle guard — each dispatch stands alone

### DIFF
--- a/hecks_conception/aggregates/wake_report.bluebook
+++ b/hecks_conception/aggregates/wake_report.bluebook
@@ -112,13 +112,23 @@ Hecks.bluebook "WakeReport", version: "2026.04.24.1" do
       emits "ReportFiled"
     end
 
-    lifecycle :phase, default: "pending" do
-      transition "StartReport"         => "gathering",   from: "pending"
-      transition "SurfaceDreams"       => "interpreted", from: "gathering"
-      transition "CountWitnessFirings" => "interpreted", from: "interpreted"
-      transition "ReflectOnBody"       => "reflected",   from: "interpreted"
-      transition "FileReport"          => "filed",       from: "reflected"
-    end
+    # ---- No lifecycle guard -------------------------------------
+    #
+    # Earlier versions of this bluebook carried a lifecycle on :phase
+    # with ordered transitions. That turned out to be the wrong shape
+    # for the adapter pattern : the shell re-runs wake_report.sh on
+    # every wake, which means the aggregate needs to accept StartReport
+    # from ANY phase (filed, consumed, etc.) — not just pending. A
+    # lifecycle guard that requires phase=pending makes the second
+    # run fail, and the heki upsert "reset" trick doesn't actually
+    # replace the runtime's singleton record (it appends a record
+    # with a generated Store key, which the load_persisted iteration
+    # collapses to the old value on deterministic order). Stripping
+    # the lifecycle removes the guard ; the shell orchestrates the
+    # sequence explicitly, and the :phase attribute is now pure
+    # observable state (reading "filed" means the last run completed,
+    # "pending" means the current run is between StartReport and
+    # SurfaceDreams, etc.).
   end
 
   # ============================================================

--- a/hecks_conception/capabilities/wake_report/wake_report.sh
+++ b/hecks_conception/capabilities/wake_report/wake_report.sh
@@ -46,16 +46,14 @@ woke_at=$("$HECKS" heki latest-field "$INFO/consciousness.heki" last_wake_at 2>/
 sleep_entered_at=$(date -u -v-30M -j -f "%Y-%m-%dT%H:%M:%SZ" "$woke_at" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
   || date -u -d "$woke_at - 30 minutes" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
 
-# ── Reset the singleton WakeReport to pending ------------------
-# The lifecycle guards the ordered walk ; we need phase=pending at
-# StartReport time. Each wake overwrites the previous run's record.
-# The runtime boots WakeReport's state from wake_report.heki ; we
-# reset that store to phase=pending before the dispatch chain so
-# the lifecycle walks cleanly.
-"$HECKS" heki upsert "$INFO/wake_report.heki" \
-  id="1" phase="pending" >/dev/null 2>&1
-
-# ── Dispatch StartReport ----------------------------------------
+# ── Dispatch the chain ------------------------------------------
+# The WakeReport bluebook carries no lifecycle guard — each command
+# stands alone and can fire regardless of the previous run's phase.
+# This was changed after the 2026-04-24 post-merge run surfaced that
+# `heki upsert id=1 phase=pending` does not actually replace the
+# runtime's singleton record (it appends with a generated Store key),
+# so the "reset" trick was a silent-no-op. The simpler shape : no
+# lifecycle, no reset, every dispatch runs.
 
 "$HECKS" "$AGG" WakeReport.StartReport \
   sleep_entered_at="$sleep_entered_at" \


### PR DESCRIPTION
Fixes the broken lifecycle-reset pattern surfaced by the first post-merge wake-report auto-fire attempt (2026-04-24). `heki upsert id=1 phase=pending` does NOT replace the runtime's singleton record ; it appends a new Store entry with a generated key, and load_persisted's iteration keeps the older phase=filed record. Every re-run of `wake_report.sh` failed on `StartReport: LifecycleViolation { current: 'filed', allowed: ['pending'] }`.

Removing the lifecycle block from WakeReport lets each dispatch stand alone. The :phase attribute persists as observable state ; the shell orchestrates the sequence.

## Test
- `hecks-life check-lifecycle aggregates/wake_report.bluebook` — clean
- `./capabilities/wake_report/wake_report.sh` — files `wake_report: filed` end-to-end on a store that already has a filed record

## Antibody
Exemption on the .sh edit is named in commit message — reuses the existing in-file wake_report.sh exemption scope.