### PR TITLE
hecksagon: memory is default — strip declarations, keep None out of the IR

### DIFF
--- a/hecks_conception/capabilities/antibody/antibody.hecksagon
+++ b/hecks_conception/capabilities/antibody/antibody.hecksagon
@@ -3,7 +3,6 @@ Hecks.hecksagon "Antibody" do
   # evaluation. The memory adapter holds the CommitCheck / BranchScan /
   # StagedCheck aggregates for the lifetime of a single CLI invocation
   # or git-hook dispatch and then goes away.
-  adapter :memory
 
   # ---- Git shell adapters ----------------------------------------
   #

--- a/hecks_conception/capabilities/behaviors_runner/behaviors_runner.hecksagon
+++ b/hecks_conception/capabilities/behaviors_runner/behaviors_runner.hecksagon
@@ -36,6 +36,5 @@ Hecks.hecksagon "BehaviorsRunner" do
   #   those dispatches are in-process against a Runtime instance the
   #   runner owns. Not an outbound port to an external runtime.
 
-  adapter :memory
   adapter :fs, root: "."
 end

--- a/hecks_conception/capabilities/conception/conception.hecksagon
+++ b/hecks_conception/capabilities/conception/conception.hecksagon
@@ -41,7 +41,6 @@ Hecks.hecksagon "Conception" do
   #   templates don't fit aggregate/command shape without extending
   #   the DSL, and the Phase F discipline refuses to do so.
 
-  adapter :memory
   adapter :fs, root: "."
   adapter :stdout
 end

--- a/hecks_conception/capabilities/dispatch/dispatch.hecksagon
+++ b/hecks_conception/capabilities/dispatch/dispatch.hecksagon
@@ -35,5 +35,4 @@ Hecks.hecksagon "Dispatch" do
   #                          or the terminal. Those are the business
   #                          of the user's bluebook and its hecksagon.
 
-  adapter :memory
 end

--- a/hecks_conception/capabilities/query/query.hecksagon
+++ b/hecks_conception/capabilities/query/query.hecksagon
@@ -30,5 +30,4 @@ Hecks.hecksagon "Query" do
   # a `function` or `transform` DSL keyword the Phase F discipline
   # refuses to add.
 
-  adapter :memory
 end

--- a/hecks_conception/capabilities/rem_dream/rem_dream.hecksagon
+++ b/hecks_conception/capabilities/rem_dream/rem_dream.hecksagon
@@ -48,7 +48,6 @@ Hecks.hecksagon "RemDream" do
   # Rust remains while the bluebook is the source-of-truth
   # declaration).
 
-  adapter :memory
 
   adapter :llm,
     backend: :claude

--- a/hecks_conception/capabilities/runner/runner.hecksagon
+++ b/hecks_conception/capabilities/runner/runner.hecksagon
@@ -28,7 +28,6 @@ Hecks.hecksagon "Runner" do
   # status_report, one_shot). That inspection is in-memory against
   # the IR — pure computation, no adapter.
 
-  adapter :memory
   adapter :fs, root: "."
   adapter :runtime_dispatch
   adapter :stdin

--- a/hecks_conception/capabilities/seed_loader/seed_loader.hecksagon
+++ b/hecks_conception/capabilities/seed_loader/seed_loader.hecksagon
@@ -24,7 +24,6 @@ Hecks.hecksagon "SeedLoader" do
   #                        dispatched command is chosen per-line, not
   #                        statically.
 
-  adapter :memory
   adapter :fs, root: "."
   adapter :runtime_dispatch
 end

--- a/hecks_conception/capabilities/server/server.hecksagon
+++ b/hecks_conception/capabilities/server/server.hecksagon
@@ -41,7 +41,6 @@ Hecks.hecksagon "Server" do
   #   — templates would want a `template` DSL keyword this arc
   #   refuses to add.
 
-  adapter :memory
   adapter :fs, root: "."
   adapter :runtime_dispatch
 end

--- a/hecks_conception/capabilities/specializer/specializer.hecksagon
+++ b/hecks_conception/capabilities/specializer/specializer.hecksagon
@@ -15,7 +15,6 @@ Hecks.hecksagon "Specializer" do
   #   :fs       — reads shape bluebooks + fixtures under hecks_conception/
   #               and writes emitted .rs under hecks_life/src/
 
-  adapter :memory
 
   # Read the shape (L0 bluebook + L0 fixtures) and write the
   # generated Rust (L7) into hecks_life/src/. `root:` anchors the

--- a/hecks_conception/capabilities/status/status.hecksagon
+++ b/hecks_conception/capabilities/status/status.hecksagon
@@ -20,7 +20,6 @@ Hecks.hecksagon "Status" do
 
   # Ephemeral report — no persistence. Values are read from the heki
   # stores owned by other capabilities; this one only prints a snapshot.
-  adapter :memory
 
   # ---- I/O wiring --------------------------------------------------
   #

--- a/hecks_conception/capabilities/storage/storage.hecksagon
+++ b/hecks_conception/capabilities/storage/storage.hecksagon
@@ -27,6 +27,5 @@ Hecks.hecksagon "Storage" do
   # hecksagon ; it is an accurate description of the subsystem, which
   # is by design volatile across runtime restarts.
 
-  adapter :memory
   adapter :fs, root: "information"
 end

--- a/hecks_conception/capabilities/terminal/terminal.hecksagon
+++ b/hecks_conception/capabilities/terminal/terminal.hecksagon
@@ -2,7 +2,6 @@ Hecks.hecksagon "Terminal" do
   # Memory-only — the terminal session is ephemeral. Persistence of
   # conversations lives elsewhere (Conversation aggregate in the
   # consciousness capability, written by a separate policy).
-  adapter :memory
 
   # ---- I/O wiring --------------------------------------------------
   #

--- a/hecks_life/src/hecksagon_parser.rs
+++ b/hecks_life/src/hecksagon_parser.rs
@@ -78,6 +78,18 @@ pub fn parse(source: &str) -> Hecksagon {
         i += 1;
     }
 
+    // Default persistence to "memory" when no persistence adapter was
+    // declared. The IR consumers have always treated None as "memory"
+    // by convention ; normalising here removes the None possibility
+    // from downstream code paths so the field is always a concrete
+    // value. Keeps hecksagons that don't declare `adapter :memory`
+    // (the default) equivalent to ones that do — eliminates the
+    // redundant-declaration noise without introducing a None
+    // representation.
+    if hex.persistence.is_none() {
+        hex.persistence = Some("memory".to_string());
+    }
+
     hex
 }
 

--- a/hecks_life/src/specializer/hecksagon_parser.rs
+++ b/hecks_life/src/specializer/hecksagon_parser.rs
@@ -126,6 +126,18 @@ fn emit_parse(parser: &Fixture, dispatches: &[&Fixture]) -> String {
         i += 1;
     }}
 
+    // Default persistence to \"memory\" when no persistence adapter was
+    // declared. The IR consumers have always treated None as \"memory\"
+    // by convention ; normalising here removes the None possibility
+    // from downstream code paths so the field is always a concrete
+    // value. Keeps hecksagons that don't declare `adapter :memory`
+    // (the default) equivalent to ones that do — eliminates the
+    // redundant-declaration noise without introducing a None
+    // representation.
+    if hex.persistence.is_none() {{
+        hex.persistence = Some(\"memory\".to_string());
+    }}
+
     hex
 }}
 


### PR DESCRIPTION
Closes the `hecksagon-default-memory-noise` inbox item (filed with F-10). Thirteen Phase F hecksagons were declaring `adapter :memory`, which is the runtime default when nothing is declared. Removing them naively leaks None into the IR's persistence field ; this PR does both : strips the redundant declarations AND defaults `persistence` to `Some("memory")` at parse time so the IR always reports a concrete value.

**What ships :**
- 13 hecksagons with `adapter :memory` removed
- `hecksagon_parser.rs` adds a post-parse default block
- `specializer/hecksagon_parser.rs` template mirrors the default so byte-identity tests still pass

**Parity + tests clean.** Two antibody exemptions (named in the commit), both scoped : one for the parser change, one for keeping the specializer template in sync.

Follow-up work queued in the inbox :
- `fixtures-overmodeling-audit` — walk every .fixtures file
- (new) delete-dead-rust — audit Phase F Rust for deletion candidates now that bluebooks exist