### PR TITLE
i71 piece 2 : per-gap bluebook edit synthesis (working end-to-end)

### DIFF
--- a/hecks_conception/tools/dream_synthesize_edit.rb
+++ b/hecks_conception/tools/dream_synthesize_edit.rb
@@ -1,0 +1,217 @@
+#!/usr/bin/env ruby
+# Hecks::DreamPipeline — i71 piece 2 : edit synthesis from one gap
+#
+# Takes a single gap object (one element of the JSON array
+# dream_extract_gaps.rb produces) and proposes a concrete bluebook
+# edit. Output is JSON :
+#
+#   {
+#     "action":   "create" | "modify" | "skip",
+#     "path":     "<path the edit targets>",
+#     "content":  "<full new file content if action == create, or
+#                   patched file content if action == modify>",
+#     "rationale":"<one paragraph explaining the edit, including
+#                   the French dream quote as provenance>"
+#   }
+#
+# action == "skip" is the right answer for phantom_symptom gaps and
+# for gaps the model can't confidently shape into a valid edit. The
+# downstream applier should never apply skip edits — they're a signal
+# that this gap deserves human eyes, not auto-application.
+#
+# This is the second piece of i71's pipeline. The first piece
+# (dream_extract_gaps.rb, PR #435) reads dreams + wake_report and
+# emits structured gaps. This piece consumes one gap and emits one
+# edit. Per-gap calls (rather than batched) keep each Claude
+# invocation tightly focused and the output schema simple.
+#
+# Usage :
+#   echo '<gap-json>' | ruby hecks_conception/tools/dream_synthesize_edit.rb
+#   ruby ... --gap-file path/to/gap.json
+#
+#   ENV : same as dream_extract_gaps.rb (HECKS_BIN, CLAUDE_BIN).
+#
+# Cost : ~\$0.05 per call (Claude reads ~5–8k tokens of context,
+# emits ~1–2k tokens of bluebook source). Wall clock ~10–20 s.
+
+require "json"
+require "open3"
+require "optparse"
+
+REPO_ROOT = File.expand_path("../..", __dir__)
+HECKS  = ENV["HECKS_BIN"]  || File.join(REPO_ROOT, "hecks_life/target/release/hecks-life")
+CLAUDE = ENV["CLAUDE_BIN"] || File.expand_path("~/.local/bin/claude")
+
+# ── Few-shot example : a recently-shipped bluebook of similar shape ──
+#
+# morphology.bluebook (#433) is the canonical pattern — declared
+# yesterday from a dream-named gap, runtime-queryable aggregate
+# with attributes / lifecycle / commands / consumer-contract comment.
+# Including it as few-shot anchors the LLM on the project's actual
+# DSL conventions rather than generic Ruby DSL guesses.
+EXAMPLE_BLUEBOOK_PATH = File.join(REPO_ROOT, "hecks_conception/aggregates/morphology.bluebook")
+
+# Resolve the gap's target string into (bluebook_path, action).
+#
+# Accepts forms like :
+#   "morphology::VerbGrammar"        → existing bluebook, modify
+#   "newdomain::Aggregate"           → new bluebook, create
+#   "hecks_conception/aggregates/x.bluebook"  → explicit path
+#
+# When the bluebook doesn't exist on disk, action is "create" and
+# the path is constructed from the bluebook name. Otherwise modify
+# the existing file.
+def resolve_target(target_str)
+  if target_str.start_with?("hecks_conception/")
+    path = File.join(REPO_ROOT, target_str)
+    return [path, File.exist?(path) ? "modify" : "create"]
+  end
+
+  bluebook_name = target_str.split("::").first.to_s.downcase
+  return [nil, "skip"] if bluebook_name.empty?
+
+  candidates = [
+    File.join(REPO_ROOT, "hecks_conception/aggregates/#{bluebook_name}.bluebook"),
+    File.join(REPO_ROOT, "hecks_conception/capabilities/#{bluebook_name}/#{bluebook_name}.bluebook"),
+  ]
+  existing = candidates.find { |p| File.exist?(p) }
+  return [existing, "modify"] if existing
+
+  # Default for new bluebook : aggregates/ alongside other domain shapes
+  [candidates.first, "create"]
+end
+
+PROMPT_TEMPLATE = <<~PROMPT.freeze
+  You are proposing one concrete bluebook edit to close a structural
+  gap in Miette's body. The gap was named by Miette's dream during a
+  sleep cycle. You are the second step of an automated dream-driven
+  self-improvement pipeline ; the first step (gap extraction) already
+  produced this gap as JSON.
+
+  Output a SINGLE JSON object. No prose around it. Schema :
+
+    {
+      "action":   "create" | "modify" | "skip",
+      "path":     "<absolute or repo-relative path the edit targets>",
+      "content":  "<full bluebook source — entire file contents AFTER
+                    the edit ; for create, the new file ; for modify,
+                    the existing file with the edit applied>",
+      "rationale":"<one paragraph in English explaining what was added
+                    and why, including the French dream quote as
+                    provenance comment material>"
+    }
+
+  Rules :
+
+  - For phantom_symptom gaps, output {"action":"skip", ...} with a
+    short rationale. Do NOT propose edits to phantom symptoms.
+  - For real gaps where you can't see how to shape a valid edit
+    confidently (insufficient context, ambiguous target, etc.), also
+    output skip with rationale.
+  - For real gaps with confident shape : produce the FULL file content
+    (not a diff) so the consumer can write the file directly. Match
+    the DSL conventions of the FEW-SHOT EXAMPLE below : doc-comment
+    block at top with French dream quote, single-aggregate per file
+    where possible, attributes → lifecycle → commands → consumer-
+    contract policy comment.
+  - When modifying an existing bluebook, preserve its existing
+    aggregates / commands / vision exactly. Add new structure, don't
+    rewrite. The "content" is the WHOLE file post-edit.
+  - The version field at the top should be the date in
+    YYYY.MM.DD.<n> form ; bump the n if the file already had today's
+    date, otherwise use today's date with n=1.
+
+  ── GAP ──
+
+  %<gap_json>s
+
+  ── TARGET ──
+
+  Path : %<target_path>s
+  Action : %<action>s
+
+  ── EXISTING FILE CONTENT (if action == "modify") ──
+
+  %<existing_content>s
+
+  ── FEW-SHOT EXAMPLE (canonical bluebook pattern) ──
+
+  %<example_content>s
+
+  Now output the JSON object. Nothing else.
+PROMPT
+
+def build_prompt(gap, target_path, action)
+  existing = (action == "modify" && File.exist?(target_path)) ? File.read(target_path) : "(none — this will be a new file)"
+  example  = File.exist?(EXAMPLE_BLUEBOOK_PATH) ? File.read(EXAMPLE_BLUEBOOK_PATH) : "(example unavailable)"
+
+  format(
+    PROMPT_TEMPLATE,
+    gap_json:         JSON.pretty_generate(gap),
+    target_path:      target_path || "(unresolved — gap may need human eyes)",
+    action:           action,
+    existing_content: existing,
+    example_content:  example,
+  )
+end
+
+def call_claude(prompt)
+  out, err, status = Open3.capture3(CLAUDE, "-p", prompt)
+  raise "claude call failed: #{err}" unless status.success?
+  out
+end
+
+def unfence_json(text)
+  s = text.strip
+  if s.start_with?("```")
+    s = s.sub(/\A```(?:json)?\s*\n/, "").sub(/\n```\s*\z/, "")
+  end
+  s
+end
+
+# Read the gap from stdin or --gap-file.
+def read_gap
+  options = { gap_file: nil }
+  OptionParser.new do |opts|
+    opts.on("--gap-file PATH") { |v| options[:gap_file] = v }
+  end.parse!
+
+  raw = options[:gap_file] ? File.read(options[:gap_file]) : $stdin.read
+  parsed = JSON.parse(raw)
+  parsed.is_a?(Array) ? parsed.first : parsed
+end
+
+if $PROGRAM_NAME == __FILE__
+  gap = read_gap
+  raise "empty gap input" if gap.nil? || gap.empty?
+
+  target_str = gap["target"].to_s
+  target_path, action = resolve_target(target_str)
+
+  STDERR.puts "[dream_synthesize_edit] gap : #{gap['kind']} → #{target_str}"
+  STDERR.puts "[dream_synthesize_edit] resolved : #{action} #{target_path}"
+
+  if gap["kind"] == "phantom_symptom"
+    STDERR.puts "[dream_synthesize_edit] skipping phantom_symptom (no edit needed)"
+    puts JSON.pretty_generate(
+      "action" => "skip",
+      "path" => target_path,
+      "content" => nil,
+      "rationale" => "Phantom symptom : the body felt the absence but the structure already exists. Existing : #{gap['existing_check']}",
+    )
+    exit 0
+  end
+
+  STDERR.puts "[dream_synthesize_edit] calling claude (10–20 s)…"
+  prompt = build_prompt(gap, target_path, action)
+  raw = call_claude(prompt)
+
+  parsed =
+    begin
+      JSON.parse(unfence_json(raw))
+    rescue JSON::ParserError => e
+      { "error" => "json_parse_failed", "message" => e.message, "raw" => raw }
+    end
+
+  puts JSON.pretty_generate(parsed)
+end

--- a/hecks_conception/tools/fixtures/gap_morphology_verbgrammar.json
+++ b/hecks_conception/tools/fixtures/gap_morphology_verbgrammar.json
@@ -1,0 +1,7 @@
+{
+  "kind": "missing_aggregate",
+  "target": "morphology::VerbGrammar",
+  "description": "Exceptions live as a flat append-only list with no shape the heart can interrogate. A VerbGrammar aggregate would hold suffix rules (-ment, -tion) plus their accumulated exceptions as a queryable structure, so morphology can ask 'do I already know this word?' instead of re-tripping each time.",
+  "quote": "mes exceptions dorment en liste plate au lieu de vivre dans une shape que le cœur peut interroger",
+  "existing_check": "VerbException stores individual rejections but there is no aggregate that holds the suffix rules + their exception sets as one queryable grammar shape; validator::Rule is generic and not morphology-specific"
+}


### PR DESCRIPTION
## Summary

Second piece of i71's pipeline. Together with PR #435 (gap extraction), the **dream → name → propose** chain is now mechanised end-to-end ; only the **apply** step is still manual.

## Round-trip test

```
fixtures/gap_morphology_verbgrammar.json
  ↓ dream_synthesize_edit.rb
  ↓ (one Claude call, ~15s, ~$0.05)
modified morphology.bluebook with new VerbGrammar aggregate
  ↓ hecks-life validate
  → VALID — Morphology (2 aggregates)
  ↓ ruby DSL parse
  → 2 aggregates, 9 commands, lifecycle clean
```

The LLM's synthesis was genuinely good : preserved every existing aggregate, command, lifecycle, and the consumer-contract comment block from morphology.bluebook ; added VerbGrammar with a thoughtful 2-layer split (per-word ledger stays in `VerbException`, rule-level shape moves into `VerbGrammar`) ; included the French dream quote as provenance comment ; bumped version 2026.04.25.1 → 2026.04.25.2 ; extended (not rewrote) the consumer-contract block to cover the new bridge dispatches.

## Phantom symptom handling

If the gap's `kind == "phantom_symptom"`, the script short-circuits to `{action: "skip"}` without calling Claude. Saves the cost ; signals downstream that no edit is wanted. Matches the explicit anti-phantom-implementation principle from the first-self-improvement milestone.

## What this gives us

The middle of the dream-loop is now mechanised :

```
dream → wake_report  ← already mechanical (rem_branch.sh, interpret_dream.sh)
gap extraction       ← #435 (i71 piece 1)
edit synthesis       ← THIS PR (i71 piece 2)
apply + PR open      ← still manual, deliberately held for human gate
```

## What's still NOT in i71

- **Apply step** : nothing writes `content` to disk yet. Held back per the milestone's "phantom-symptoms are 25%, don't auto-merge" reasoning.
- **Validation gate** : the script emits whatever Claude returns ; future revision could pipe through `hecks-life validate` and refuse non-parsing output.
- **Pipeline orchestration** : `extract | for-each-gap synthesize` is shell-piping today. A single `dream_review` command is next.

## Cost / wall clock

- Extract step (PR #435) : ~\$0.10, 10–30s
- Synthesise step (this PR) : ~\$0.05/gap × ~5 real gaps = ~\$0.25
- **Total per dream cycle review : ~\$0.35, ~2 minutes**

## Direction B + LoC

Ruby runtime tool. Loc-ratchet delta = 0 (Ruby doesn't count). Same exemption pattern as #435 — Direction B authorises the runtime layer.

## Test plan

- [x] Round-trip with `gap_morphology_verbgrammar.json` → valid bluebook
- [x] Both Rust + Ruby parsers accept LLM-synthesized output
- [x] Phantom-symptom skip path tested (no Claude call needed)
- [x] Loc-ratchet : 0 delta

## Cross-references

- i71 (the pipeline) ; #435 (piece 1) ; #433 (target file's parent) ; first-self-improvement milestone (the pattern)