### PR TITLE
validator : bluebook_size_warning — large bluebook is a multi-domain signal

### DIFF
--- a/hecks_conception/capabilities/validator_warnings_shape/fixtures/validator_warnings_shape.fixtures
+++ b/hecks_conception/capabilities/validator_warnings_shape/fixtures/validator_warnings_shape.fixtures
@@ -1,8 +1,9 @@
 Hecks.fixtures "ValidatorWarningsShape" do
-  # ── 2 warnings — one fixture each, mirrors validator_warnings.rs 1:1 ──
+  # ── 3 warnings — one fixture each, mirrors validator_warnings.rs 1:1 ──
   # Single-line per i57 parser limitation (same as validator_shape).
   aggregate "WarningRule" do
     fixture "AggregateCountWarning", name: "aggregate_count_warning", rust_fn_name: "aggregate_count_warning", description: "Returns Some(msg) if the domain has more than 7 aggregates", inspects: "domain.aggregates", check_kind: "count_threshold", threshold: 7, message_template: "⚠ domain '{}' has {} aggregates; consider splitting", body_strategy: "templated", snippet_path: ""
     fixture "MixedConcernsWarning", name: "mixed_concerns_warning", rust_fn_name: "mixed_concerns_warning", description: "Returns Some(msg) if the domain has 5+ aggregates split across disconnected reference/policy clusters", inspects: "domain.aggregates+domain.policies", check_kind: "graph_components", threshold: 5, message_template: "⚠ domain '{}' has {} disconnected concern clusters: {}", body_strategy: "embedded", snippet_path: "hecks_conception/capabilities/validator_warnings_shape/snippets/mixed_concerns.rs.frag"
+    fixture "BluebookSizeWarning", name: "bluebook_size_warning", rust_fn_name: "bluebook_size_warning", description: "Returns Some(msg) if the domain's structural unit count (aggregates + attributes + commands + policies + transitions) crosses 50 — large bluebook is a signal to ask 'is this really one concern, or is it two?'", inspects: "domain.aggregates+domain.policies", check_kind: "structural_density", threshold: 50, message_template: "⚠ bluebook '{}' has {} structural units (aggregates + attributes + commands + policies + transitions) — is this really one concern, or is it two ?", body_strategy: "embedded", snippet_path: "hecks_conception/capabilities/validator_warnings_shape/snippets/bluebook_size.rs.frag"
   end
 end

--- a/hecks_conception/capabilities/validator_warnings_shape/snippets/bluebook_size.rs.frag
+++ b/hecks_conception/capabilities/validator_warnings_shape/snippets/bluebook_size.rs.frag
@@ -1,0 +1,37 @@
+// Snippet: bluebook_size body — structural-density count, threshold 50.
+// Referenced by the `BluebookSizeWarning` fixture's snippet_path. The
+// specializer interpolates this directly as the function body between
+// the opening `{` and closing `}`.
+//
+// Rationale (Chris, 2026-04-25) : a large bluebook is a signal to ask
+// 'is this really one concern, or is it two ?'. Counts structural
+// units rather than literal source lines so the metric tracks
+// maintenance load (declarations) rather than source density (which
+// can be dominated by doc comments). Each aggregate, attribute on
+// aggregate or command, command, policy, and lifecycle transition
+// counts as one unit. Threshold 50 ≈ Chris's historical 200-line
+// rule from the Ruby project, expressed in declarations.
+//
+// IR-pure : reads only what's already in `domain` — no source-file
+// access, no parser reach-around. Same style as the existing
+// validator rules.
+    let mut units = domain.aggregates.len();
+    for agg in &domain.aggregates {
+        units += agg.attributes.len();
+        units += agg.commands.len();
+        for cmd in &agg.commands {
+            units += cmd.attributes.len();
+        }
+        if let Some(lc) = &agg.lifecycle {
+            units += lc.transitions.len();
+        }
+    }
+    units += domain.policies.len();
+    if units > 50 {
+        Some(format!(
+            "⚠ bluebook '{}' has {} structural units (aggregates + attributes + commands + policies + transitions) — is this really one concern, or is it two ?",
+            domain.name, units
+        ))
+    } else {
+        None
+    }

--- a/hecks_life/src/validator_warnings.rs
+++ b/hecks_life/src/validator_warnings.rs
@@ -143,3 +143,27 @@ pub fn mixed_concerns_warning(domain: &Domain) -> Option<String> {
         rendered.join(" and ")
     ))
 }
+/// Returns Some(msg) if the domain has 50+ aggregates split across
+/// disconnected reference/policy clusters.
+pub fn bluebook_size_warning(domain: &Domain) -> Option<String> {
+    let mut units = domain.aggregates.len();
+    for agg in &domain.aggregates {
+        units += agg.attributes.len();
+        units += agg.commands.len();
+        for cmd in &agg.commands {
+            units += cmd.attributes.len();
+        }
+        if let Some(lc) = &agg.lifecycle {
+            units += lc.transitions.len();
+        }
+    }
+    units += domain.policies.len();
+    if units > 50 {
+        Some(format!(
+            "⚠ bluebook '{}' has {} structural units (aggregates + attributes + commands + policies + transitions) — is this really one concern, or is it two ?",
+            domain.name, units
+        ))
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Soft warning, threshold 50 structural units. Origin: tonight's hour where dream_review.bluebook's duplicate-Record pressure surfaced the smell. Chris's framing: 'a large file is a signal — of course it might make sense to have a big file but only if it really covers one concern.'

Files :
- new fixture row + snippet in `validator_warnings_shape`
- regenerated `hecks_life/src/validator_warnings.rs` byte-identically

Known cosmetic bug : regenerated doc-comment got templated from MixedConcerns. Function body correct ; doc cosmetic wrong. Follow-up.

NOT in this PR : wiring into `validate` output, doc-template fix, dream_review three-bluebook refactor (i74).