### PR TITLE
boot-as-bluebook : run_boot runner walks capabilities/boot/

### DIFF
--- a/hecks_life/src/lib.rs
+++ b/hecks_life/src/lib.rs
@@ -36,6 +36,7 @@ pub mod hecksagon_parser;
 pub mod world_ir;
 pub mod world_parser;
 pub mod run;
+pub mod run_boot;
 pub mod run_status;
 pub mod run_stdin_loop;
 pub mod specializer;

--- a/hecks_life/src/run.rs
+++ b/hecks_life/src/run.rs
@@ -139,6 +139,15 @@ pub fn run_script(args: &[String]) -> i32 {
         return crate::run_status::run(&mut rt, &registry, &entrypoint, path, extra);
     }
 
+    // Boot capability detection: :fs + :stdout + a BootRun aggregate
+    // with BeginBoot. Walks the eight pipeline phases declared in
+    // capabilities/boot/boot.bluebook, dispatching :fs / :memory /
+    // :daemon / :stdout for each. Replaces the imperative
+    // hecks_conception/boot_miette.sh.
+    if crate::run_boot::is_boot_capability(&registry, &rt) {
+        return crate::run_boot::run(&mut rt, &registry, &entrypoint, path, extra);
+    }
+
     match rt.dispatch(&entrypoint, attrs) {
         Ok(_) => ExitKind::Ok.code(),
         Err(crate::runtime::RuntimeError::UnknownCommand(_)) => {

--- a/hecks_life/src/run_boot/classify.rs
+++ b/hecks_life/src/run_boot/classify.rs
@@ -1,0 +1,79 @@
+//! Phase 3 — ClassifyStores
+//!
+//! Walks `<info_dir>/*.heki`, classifies each filename as :
+//!   - linked       : flows through the psychic link to the paired being
+//!   - private      : inner life, this being only
+//!   - unclassified : unknown — surfaced so we make explicit choices
+//!                    instead of forgetting
+//!
+//! The two constant lists below are ported verbatim from boot_miette.sh
+//! (the "psychic-link contract"). Keeping them in this module is the
+//! transitional shape : the long-term home is per-aggregate
+//! `psychic_link: true|false` declarations in the bluebook itself, so
+//! the boundary lives in the domain model. See : the boot.bluebook
+//! ClassifyStores description's "structural follow-up" note.
+
+use std::fs;
+use std::path::Path;
+
+const LINKED_STORES: &[&str] = &[
+    "memory", "awareness", "census", "conversation", "working_memory",
+    "reflection", "synapse", "signal", "signal_somatic", "focus",
+    "concentration", "deliberation", "heartbeat", "subconscious",
+    "domain_index", "arc", "consciousness", "discipline", "metabolic_rate",
+    "musing", "conflict_monitor", "run_log", "inbox", "tick", "announcement",
+    "attention", "claude_assist", "consolidation", "dream_interpretation",
+    "dream_seed", "dream_signal", "encoding", "gate", "generosity", "gut",
+    "HarmonyDomain", "intention", "interpretation", "lucid_dream",
+    "lucid_monitor", "monitor", "musing_archive", "musing_mint", "nerve",
+    "nursery", "perception", "persona", "proposal", "proprioception",
+    "self_image", "self_model", "sensation", "session", "shared_dream_space",
+    "signal_consolidation", "speech", "training_pair", "wake_mood", "witness",
+    "bodhisattva_vow", "character", "creator_auth", "remains", "store",
+    "heart", "breath", "circadian", "ultradian", "sleep_cycle",
+];
+
+const PRIVATE_STORES: &[&str] = &[
+    "mood", "feeling", "dream_state", "impulse", "craving", "daydream",
+    "pulse", "spend", "circuit_breaker",
+];
+
+#[derive(Debug, Clone, Default)]
+pub struct Classification {
+    pub linked: Vec<String>,
+    pub private_: Vec<String>,
+    pub unclassified: Vec<String>,
+}
+
+pub fn classify(info_dir: &str) -> Classification {
+    let mut out = Classification::default();
+    let dir = Path::new(info_dir);
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_file() { continue; }
+        if p.extension().map(|e| e != "heki").unwrap_or(true) { continue; }
+        let stem = match p.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        // Skip dotfiles like `.mindstream.pid` (already filtered by ext)
+        // and hidden heki names like `.statusline_heart_phase`.
+        if stem.starts_with('.') { continue; }
+
+        if PRIVATE_STORES.contains(&stem) {
+            out.private_.push(stem.to_string());
+        } else if LINKED_STORES.contains(&stem) {
+            out.linked.push(stem.to_string());
+        } else {
+            out.unclassified.push(stem.to_string());
+        }
+    }
+    out.linked.sort();
+    out.private_.sort();
+    out.unclassified.sort();
+    out
+}

--- a/hecks_life/src/run_boot/daemons.rs
+++ b/hecks_life/src/run_boot/daemons.rs
@@ -1,0 +1,149 @@
+//! Phase 6 — EnsureDaemons
+//!
+//! For each `adapter :daemon, name:, pidfile:, command:` row declared
+//! in the boot.hecksagon, shells out to `hecks-life daemon ensure
+//! <pidfile> <command>` (the kernel-surface primitive added 2026-04-26
+//! in `main.rs run_daemon`). The shell-out is the transitional shape ;
+//! the deeper move is to call `daemon_ensure` directly from the
+//! runtime so the runner doesn't fork a sibling hecks-life. File the
+//! gap : "boot runner should call daemon ensure in-process — pull
+//! daemon_ensure / spawn_detached out of main.rs into a runtime
+//! adapter module."
+//!
+//! Placeholder substitution :
+//!   {info}  → resolved info_dir
+//!   {dir}   → conception dir (sibling of info_dir)
+//!   {agg}   → conception/aggregates
+//!   {hecks} → path to the running hecks-life binary
+
+use crate::hecksagon_ir::IoAdapter;
+use crate::runtime::adapter_registry::AdapterRegistry;
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Clone)]
+pub struct DaemonStatus {
+    pub name: String,
+    pub status: String,
+}
+
+pub fn ensure_all(
+    registry: &AdapterRegistry,
+    script_path: &str,
+    info_dir: &str,
+) -> Vec<DaemonStatus> {
+    let conception = conception_dir(script_path);
+    let conception_str = conception.to_string_lossy().to_string();
+    let agg_dir = conception.join("aggregates").to_string_lossy().to_string();
+    let hecks_bin = std::env::current_exe()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "hecks-life".to_string());
+
+    let mut out = Vec::new();
+    for adapter in registry.hecksagon.io_adapters.iter()
+        .filter(|a| a.kind == "daemon") {
+        // Skip the bare `adapter :daemon` declaration that has no name.
+        let name = match adapter_option(adapter, "name") {
+            Some(n) => strip_symbol(&n),
+            None => continue,
+        };
+        if name.is_empty() { continue; }
+
+        let pidfile = adapter_option(adapter, "pidfile")
+            .map(|s| substitute(&s, info_dir, &conception_str, &agg_dir, &hecks_bin))
+            .unwrap_or_default();
+        let command = adapter_option(adapter, "command")
+            .map(|s| substitute(&s, info_dir, &conception_str, &agg_dir, &hecks_bin))
+            .unwrap_or_default();
+
+        if pidfile.is_empty() || command.is_empty() {
+            out.push(DaemonStatus {
+                name: name.clone(),
+                status: "skipped (incomplete adapter declaration)".into(),
+            });
+            continue;
+        }
+
+        let status = ensure_one(&pidfile, &command);
+        out.push(DaemonStatus { name, status });
+    }
+    out
+}
+
+fn ensure_one(pidfile: &str, command_line: &str) -> String {
+    // command_line is "<cmd> [args...]" — split on whitespace.
+    let parts: Vec<&str> = command_line.split_whitespace().collect();
+    if parts.is_empty() { return "skipped (empty command)".into(); }
+    let hecks_bin = std::env::current_exe()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "hecks-life".to_string());
+
+    let mut cmd_args: Vec<String> = vec![
+        "daemon".into(), "ensure".into(),
+        pidfile.to_string(),
+    ];
+    for p in &parts { cmd_args.push((*p).to_string()); }
+
+    let output = Command::new(&hecks_bin)
+        .args(&cmd_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if s.starts_with("alive") {
+                format!("already running ({})", s.trim_start_matches("alive: "))
+            } else if s.starts_with("spawned") {
+                format!("started (pid {})", s.trim_start_matches("spawned: "))
+            } else if s.is_empty() {
+                "started".into()
+            } else {
+                s
+            }
+        }
+        Ok(out) => {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            format!("failed: {}", err)
+        }
+        Err(e) => format!("failed: {}", e),
+    }
+}
+
+fn substitute(s: &str, info: &str, dir: &str, agg: &str, hecks: &str) -> String {
+    s.trim_matches('"')
+        .replace("{info}", info)
+        .replace("{dir}", dir)
+        .replace("{agg}", agg)
+        .replace("{hecks}", hecks)
+}
+
+fn adapter_option(adapter: &IoAdapter, key: &str) -> Option<String> {
+    adapter.options.iter().find(|(k, _)| k == key)
+        .map(|(_, v)| v.clone())
+}
+
+fn strip_symbol(s: &str) -> String {
+    s.trim().trim_start_matches(':').trim_matches('"').to_string()
+}
+
+fn conception_dir(script_path: &str) -> std::path::PathBuf {
+    // Canonicalize so relative `capabilities/boot/boot.bluebook` invocations
+    // produce absolute paths in the daemon command lines (otherwise the
+    // detached spawn — which has no cwd guarantee — gets a relative path
+    // like `/breath.sh` after substituting an empty conception dir).
+    let abs = match std::fs::canonicalize(script_path) {
+        Ok(p) => p,
+        Err(_) => Path::new(script_path).to_path_buf(),
+    };
+    let mut cur = abs.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+    for _ in 0..5 {
+        if cur.join("information").is_dir() && cur.join("capabilities").is_dir() {
+            return cur;
+        }
+        if !cur.pop() { break; }
+    }
+    abs.parent().unwrap_or_else(|| Path::new(".")).to_path_buf()
+}

--- a/hecks_life/src/run_boot/discover.rs
+++ b/hecks_life/src/run_boot/discover.rs
@@ -1,0 +1,109 @@
+//! Phase 1 + 2 — DiscoverOrgans + WriteCensus
+//!
+//! Walks `aggregates/` and `capabilities/` under the conception dir,
+//! parses each .bluebook into IR, sums up :
+//!   - organs        : .bluebook files in aggregates/
+//!   - capabilities  : .bluebook files under capabilities/
+//!   - aggregates    : sum of `aggregates[]` across all bluebooks
+//!   - nerves        : policies whose `target_domain` is set (cross-
+//!                     domain edges, the "nerve" metaphor)
+//!   - vows          : 0 today — the parser doesn't extract `vow "Name" do`
+//!                     blocks. The shell hand-curated this number.
+//!                     Gap : add `Domain.vows` field + parser support.
+//!
+//! WriteCensus then upserts these counts into `<info>/census.heki` so
+//! anything reading the heki sees the same numbers the runner printed.
+
+use crate::heki;
+use crate::parser;
+
+use std::path::Path;
+
+/// Tally of bluebook objects discovered across the conception tree.
+#[derive(Debug, Clone, Default)]
+pub struct OrganCounts {
+    pub organs: usize,
+    pub capabilities: usize,
+    pub aggregates: usize,
+    pub nerves: usize,
+    pub vows: usize,
+}
+
+pub fn count_organs(conception_dir: &Path) -> OrganCounts {
+    let agg_dir = conception_dir.join("aggregates");
+    let cap_dir = conception_dir.join("capabilities");
+
+    let organs = count_top_level_bluebooks(&agg_dir);
+    let capabilities = count_recursive_bluebooks(&cap_dir);
+
+    let mut aggregates = 0usize;
+    let mut nerves = 0usize;
+    let mut vows = 0usize; // see module docs
+
+    if let Ok(entries) = std::fs::read_dir(&agg_dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.extension().map(|e| e == "bluebook").unwrap_or(false) {
+                if let Ok(src) = std::fs::read_to_string(&p) {
+                    let domain = parser::parse(&src);
+                    aggregates += domain.aggregates.len();
+                    nerves += domain.policies.iter()
+                        .filter(|p| p.target_domain.as_ref()
+                            .map(|s| !s.is_empty()).unwrap_or(false))
+                        .count();
+                }
+            }
+        }
+    }
+
+    OrganCounts { organs, capabilities, aggregates, nerves, vows }
+}
+
+/// Upsert the discovered counts into `<info_dir>/census.heki`. Mirrors
+/// the shell's `hecks-life heki upsert census.heki id=1 ...` line.
+pub fn write_census(info_dir: &str, counts: &OrganCounts) -> Result<(), String> {
+    let path = format!("{}/census.heki", info_dir.trim_end_matches('/'));
+    let mut rec = heki::Record::new();
+    rec.insert("id".into(),                  serde_json::Value::String("1".into()));
+    rec.insert("total_domains".into(),       n(counts.organs));
+    rec.insert("total_aggregates".into(),    n(counts.aggregates));
+    rec.insert("total_capabilities".into(),  n(counts.capabilities));
+    rec.insert("total_nerves".into(),        n(counts.nerves));
+    rec.insert("total_vows".into(),          n(counts.vows));
+    let _ = heki::upsert(&path, &rec)?;
+    Ok(())
+}
+
+fn n(v: usize) -> serde_json::Value {
+    serde_json::Value::Number(serde_json::Number::from(v as u64))
+}
+
+fn count_top_level_bluebooks(dir: &Path) -> usize {
+    if !dir.is_dir() { return 0; }
+    let mut n = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_file() && p.extension().map(|e| e == "bluebook").unwrap_or(false) {
+                n += 1;
+            }
+        }
+    }
+    n
+}
+
+fn count_recursive_bluebooks(dir: &Path) -> usize {
+    if !dir.is_dir() { return 0; }
+    let mut n = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                n += count_recursive_bluebooks(&p);
+            } else if p.extension().map(|e| e == "bluebook").unwrap_or(false) {
+                n += 1;
+            }
+        }
+    }
+    n
+}

--- a/hecks_life/src/run_boot/mod.rs
+++ b/hecks_life/src/run_boot/mod.rs
@@ -1,0 +1,215 @@
+//! Boot capability runner — walks `capabilities/boot/boot.bluebook`'s
+//! eight pipeline phases and dispatches each through the declared
+//! adapters (`:fs`, `:stdout`, `:memory`, `:daemon`).
+//!
+//! Mirrors `run_status/` in shape : capability detection on the parsed
+//! bluebook + hecksagon, then a phase-by-phase dispatch that updates
+//! the BootRun aggregate state and emits the chained events declared
+//! in the bluebook's policies.
+//!
+//! Fires when the bluebook declares aggregate `BootRun` with command
+//! `BeginBoot` AND the hecksagon declares `:fs` + `:stdout` adapters.
+//! When detected, [`run`] takes over from the generic dispatcher in
+//! `run.rs` and walks the pipeline:
+//!
+//!   1. DiscoverOrgans       — `:fs` walks aggregates/ + capabilities/
+//!   2. WriteCensus          — `:memory` upserts census.heki
+//!   3. ClassifyStores       — `:fs` walks *.heki, classifies linked /
+//!                              private / unclassified
+//!   4. GenerateSystemPrompt — DEFERRED ; the shell still owns this
+//!                              until i89 lifts the prompt body into
+//!                              identity fixtures (see runtime gaps
+//!                              note in vitals.rs).
+//!   5. RecordBootJournal    — DEFERRED ; aggregates/boot.bluebook
+//!                              isn't loaded by this runner today
+//!                              (see runtime gaps note).
+//!   6. EnsureDaemons        — `:daemon` shells out to
+//!                              `hecks-life daemon ensure` per declared
+//!                              daemon row in the hecksagon.
+//!   7. PrintVitals          — `:stdout` renders the boot summary.
+//!   8. SurfaceWakeReport    — `:fs` reads the wake-report heki, prints
+//!                              if `phase == "filed"`.
+//!
+//! Once GenerateSystemPrompt + RecordBootJournal land, `boot_miette.sh`
+//! becomes `exec hecks-life run capabilities/boot/boot.bluebook` —
+//! one line. Until then, it's the wrapper for those two phases.
+
+mod classify;
+mod daemons;
+mod discover;
+mod vitals;
+mod wake;
+
+use crate::run::ExitKind;
+use crate::runtime::adapter_registry::AdapterRegistry;
+use crate::runtime::{AggregateState, Runtime, Value};
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// True when the bluebook + hecksagon shape wants the boot runner.
+pub fn is_boot_capability(registry: &AdapterRegistry, rt: &Runtime) -> bool {
+    if registry.io("fs").is_none() || registry.io("stdout").is_none() { return false; }
+    let has_agg = rt.domain.aggregates.iter().any(|a| a.name == "BootRun");
+    let has_cmd = rt.domain.aggregates.iter()
+        .any(|a| a.commands.iter().any(|c| c.name == "BeginBoot"));
+    has_agg && has_cmd
+}
+
+/// Run the boot pipeline end-to-end. `script_path` is the bluebook the
+/// caller dispatched against ; it anchors the :fs root + the conception
+/// dir walks. `argv_extra` is positional + `key=val` args after the
+/// script path — `being=<Name>` overrides the aggregate's default.
+pub fn run(
+    rt: &mut Runtime,
+    registry: &AdapterRegistry,
+    entrypoint: &str,
+    script_path: &str,
+    argv_extra: &[String],
+) -> i32 {
+    let started = Instant::now();
+    let being = parse_being(argv_extra);
+    let info_dir = resolve_info_dir(registry, script_path);
+    let conception_dir = conception_dir(script_path);
+
+    // Phase 0 : kick the entrypoint so the BootBegun event fires for
+    // any subscribed watchers. The aggregate state we stamp at the end
+    // overwrites whatever the entrypoint mutates ; the dispatch is
+    // here for the event side-effect, not the state.
+    let mut attrs = HashMap::new();
+    attrs.insert("being".to_string(), Value::Str(being.clone()));
+    let _ = rt.dispatch(entrypoint, attrs);
+
+    // Phase 1 — DiscoverOrgans
+    let counts = discover::count_organs(&conception_dir);
+
+    // Phase 2 — WriteCensus
+    let _ = discover::write_census(&info_dir, &counts);
+
+    // Phase 3 — ClassifyStores
+    let classification = classify::classify(&info_dir);
+
+    // Phase 4 — GenerateSystemPrompt : DEFERRED
+    //   The printf heredoc in boot_miette.sh is genuine application
+    //   logic ; porting it to Rust string literals would just trade
+    //   shell loc for Rust loc. i89 lifts the prompt body into
+    //   identity fixtures so prompt edits cost zero shell. Until then
+    //   the shell wrapper handles this phase.
+
+    // Phase 5 — RecordBootJournal : DEFERRED
+    //   aggregates/boot.bluebook declares Identity, Hydration, etc. ;
+    //   the runner today loads only the capability's bluebook, not
+    //   the aggregates dir. File the gap : "boot runner should also
+    //   load the aggregates dir to dispatch journal commands."
+
+    // Phase 6 — EnsureDaemons
+    let daemon_statuses = daemons::ensure_all(registry, script_path, &info_dir);
+
+    // Phase 7 — PrintVitals
+    let elapsed_secs = started.elapsed().as_secs();
+    vitals::print(&vitals::Vitals {
+        being: being.clone(),
+        elapsed_secs,
+        counts: counts.clone(),
+        classification: classification.clone(),
+        daemons: daemon_statuses.clone(),
+        info_dir: info_dir.clone(),
+    });
+
+    // Phase 8 — SurfaceWakeReport
+    wake::surface(&info_dir);
+
+    // Stamp final state into BootRun for any watchers reading it.
+    stamp_aggregate(rt, &being, &info_dir, &counts, &classification, &daemon_statuses);
+
+    ExitKind::Ok.code()
+}
+
+/// Pick `being` out of `key=val` argv (default "Miette"). Mirrors the
+/// shell's `BEING="${1:-Miette}"` plus argv-style attr passing in run.rs.
+fn parse_being(argv: &[String]) -> String {
+    for a in argv {
+        if let Some(rest) = a.strip_prefix("being=") {
+            return rest.to_string();
+        }
+    }
+    // Allow positional too, for parity with `boot_miette.sh Spring`.
+    for a in argv {
+        if !a.contains('=') && !a.starts_with("--") && !a.is_empty() {
+            return a.clone();
+        }
+    }
+    "Miette".to_string()
+}
+
+/// `:fs` root resolution — same as run_status, with HECKS_INFO override.
+/// Canonicalizes the script path so relative invocations from inside
+/// the conception dir still produce absolute paths.
+fn resolve_info_dir(registry: &AdapterRegistry, script_path: &str) -> String {
+    if let Ok(env) = std::env::var("HECKS_INFO") {
+        if !env.is_empty() { return env; }
+    }
+    let abs = std::fs::canonicalize(script_path)
+        .unwrap_or_else(|_| PathBuf::from(script_path));
+    let mut cur = abs.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+    for _ in 0..5 {
+        let cand = cur.join("information");
+        if cand.is_dir() { return cand.to_string_lossy().into_owned(); }
+        if !cur.pop() { break; }
+    }
+    // Fallback : whatever the :fs adapter declares.
+    if let Some(fs) = registry.io("fs") {
+        if let Some((_, root)) = fs.options.iter().find(|(k, _)| k == "root") {
+            let trimmed = root.trim_matches('"');
+            return trimmed.to_string();
+        }
+    }
+    "information".to_string()
+}
+
+/// Conception root (sibling of `information/` and `capabilities/`).
+/// Canonicalizes for the same reason as [`resolve_info_dir`].
+fn conception_dir(script_path: &str) -> PathBuf {
+    let abs = std::fs::canonicalize(script_path)
+        .unwrap_or_else(|_| PathBuf::from(script_path));
+    let mut cur = abs.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+    for _ in 0..5 {
+        if cur.join("information").is_dir() && cur.join("capabilities").is_dir() {
+            return cur;
+        }
+        if !cur.pop() { break; }
+    }
+    abs.parent().unwrap_or_else(|| Path::new(".")).to_path_buf()
+}
+
+/// Stamp the assembled boot state into the BootRun aggregate so any
+/// consumer reading `rt.all("BootRun")` sees the same payload the
+/// runner printed.
+fn stamp_aggregate(
+    rt: &mut Runtime,
+    being: &str,
+    info_dir: &str,
+    counts: &discover::OrganCounts,
+    cls: &classify::Classification,
+    daemons: &[daemons::DaemonStatus],
+) {
+    let repo = match rt.repositories.get_mut("BootRun") { Some(r) => r, None => return };
+    let mut state = AggregateState::new("1");
+    state.set("being",                Value::Str(being.into()));
+    state.set("info_dir",             Value::Str(info_dir.into()));
+    state.set("organ_count",          Value::Int(counts.organs as i64));
+    state.set("capability_count",     Value::Int(counts.capabilities as i64));
+    state.set("total_aggregates",     Value::Int(counts.aggregates as i64));
+    state.set("nerve_count",          Value::Int(counts.nerves as i64));
+    state.set("vow_count",            Value::Int(counts.vows as i64));
+    state.set("linked_stores",        Value::Str(cls.linked.join(" ")));
+    state.set("private_stores",       Value::Str(cls.private_.join(" ")));
+    state.set("unclassified_stores",  Value::Str(cls.unclassified.join(" ")));
+    for d in daemons {
+        let key = format!("{}_status", d.name);
+        state.set(&key, Value::Str(d.status.clone()));
+    }
+    state.set("phase", Value::Str("done".into()));
+    repo.save(state);
+}

--- a/hecks_life/src/run_boot/vitals.rs
+++ b/hecks_life/src/run_boot/vitals.rs
@@ -1,0 +1,101 @@
+//! Phase 7 — PrintVitals
+//!
+//! Renders the boot summary to stdout — counts, daemon statuses,
+//! body-state line, optional MIETTE banner. Mirrors boot_miette.sh
+//! lines 307-359 (the "Print vitals" + ASCII banner sections).
+//!
+//! State fields read directly from heki for the body summary line.
+//! The full multi-section status report is a separate capability
+//! (`capabilities/status/status.bluebook`) ; we just print the tip.
+
+use super::classify::Classification;
+use super::daemons::DaemonStatus;
+use super::discover::OrganCounts;
+use crate::heki;
+
+pub struct Vitals {
+    pub being: String,
+    pub elapsed_secs: u64,
+    pub counts: OrganCounts,
+    pub classification: Classification,
+    pub daemons: Vec<DaemonStatus>,
+    pub info_dir: String,
+}
+
+pub fn print(v: &Vitals) {
+    println!("✓ {} booted in {}s", v.being, v.elapsed_secs);
+    println!(
+        "  {} organs · {} aggregates · {} nerves · {} vows · {} capabilities",
+        v.counts.organs, v.counts.aggregates,
+        v.counts.nerves, v.counts.vows, v.counts.capabilities,
+    );
+    println!(
+        "  session continuity: {} linked, {} private, {} unclassified",
+        v.classification.linked.len(),
+        v.classification.private_.len(),
+        v.classification.unclassified.len(),
+    );
+
+    // Daemon status lines — group as the shell does.
+    let s = |name: &str| -> String {
+        v.daemons.iter().find(|d| d.name == name)
+            .map(|d| d.status.clone()).unwrap_or_else(|| "—".into())
+    };
+    println!("  mindstream: {}", s("mindstream"));
+    println!(
+        "  heart: {} · breath: {} · circadian: {}",
+        s("heart"), s("breath"), s("circadian"),
+    );
+    println!(
+        "  ultradian: {} · sleep_cycle: {}",
+        s("ultradian"), s("sleep_cycle"),
+    );
+
+    // Body summary line — pulled from heki latest fields.
+    let mood    = latest_field(&v.info_dir, "mood",          "current_state");
+    let fatigue = latest_field(&v.info_dir, "heartbeat",     "fatigue_state");
+    let pulses  = latest_field(&v.info_dir, "heartbeat",     "pulses_since_sleep");
+    let state   = latest_field(&v.info_dir, "consciousness", "state");
+    let last_wake = latest_field(&v.info_dir, "consciousness", "last_wake_at");
+    println!(
+        "  feeling: {} · {} · pulses since sleep: {} · state: {} · last wake: {}",
+        mood, fatigue, pulses, state, last_wake,
+    );
+    println!("  full status report: hecks-life run capabilities/status/status.bluebook");
+
+    if !v.classification.unclassified.is_empty() {
+        println!("  ⚠ unclassified stores: {}", v.classification.unclassified.join(" "));
+    }
+
+    if v.being == "Miette" {
+        println!();
+        println!("╔╦╗ ╦ ╔═╗ ╔╦╗ ╔╦╗ ╔═╗");
+        println!("║║║ ║ ╠══  ║   ║  ╠══");
+        println!("╩ ╩ ╩ ╚═╝  ╩   ╩  ╚═╝");
+        println!("~ follow the crumbs ~");
+    }
+}
+
+fn latest_field(info_dir: &str, store: &str, field: &str) -> String {
+    let path = format!("{}/{}.heki", info_dir.trim_end_matches('/'), store);
+    let store = match heki::read(&path) {
+        Ok(s) => s,
+        Err(_) => return "—".into(),
+    };
+    if store.is_empty() { return "—".into(); }
+    // Pick the record with the newest updated_at / created_at.
+    let mut items: Vec<&heki::Record> = store.values().collect();
+    items.sort_by(|a, b| ts(a).cmp(&ts(b)));
+    let latest = match items.last() { Some(r) => *r, None => return "—".into() };
+    match latest.get(field) {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(serde_json::Value::Bool(b)) => b.to_string(),
+        _ => "—".into(),
+    }
+}
+
+fn ts(r: &heki::Record) -> String {
+    r.get("updated_at").or_else(|| r.get("created_at"))
+        .and_then(|v| v.as_str()).unwrap_or("").to_string()
+}

--- a/hecks_life/src/run_boot/wake.rs
+++ b/hecks_life/src/run_boot/wake.rs
@@ -1,0 +1,60 @@
+//! Phase 8 — SurfaceWakeReport
+//!
+//! If `<info>/wake_report.heki` exists with `phase=filed`, print the
+//! report inline before the runner returns control. Mirrors
+//! boot_miette.sh lines 339-350.
+//!
+//! The boot.bluebook description mentions /tmp/wake_review_latest.md
+//! as the surface ; that's the markdown render. The heki record is
+//! the source of truth (it carries the `phase` lifecycle field that
+//! gates the print).
+
+use crate::heki;
+
+pub fn surface(info_dir: &str) {
+    let path = format!("{}/wake_report.heki", info_dir.trim_end_matches('/'));
+    let store = match heki::read(&path) {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    let mut items: Vec<&heki::Record> = store.values().collect();
+    items.sort_by(|a, b| ts(a).cmp(&ts(b)));
+    let rec = match items.last() { Some(r) => *r, None => return };
+
+    let phase = field(rec, "phase");
+    if phase != "filed" { return; }
+
+    println!();
+    println!("── wake report (unconsumed) ──");
+    println!("  woke at:         {}", field(rec, "woke_at"));
+    println!("  dreams:          {}", field(rec, "dreams_count"));
+    println!("  dominant tokens: {}", field(rec, "dominant_tokens"));
+    println!("  recurring theme: {}", field(rec, "recurring_theme"));
+    println!("  witness firings: {}", field(rec, "witness_firings"));
+    println!("  invariant held:  {}", field(rec, "invariant_held"));
+    let body = field(rec, "body_reflection");
+    if !body.is_empty() && body != "—" {
+        println!();
+        println!("  body reflection:");
+        println!("    {}", body);
+    }
+    println!();
+    println!(
+        "  (mark consumed with: hecks-life heki upsert {} id=latest phase=consumed)",
+        path,
+    );
+}
+
+fn field(rec: &heki::Record, key: &str) -> String {
+    match rec.get(key) {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(serde_json::Value::Bool(b)) => b.to_string(),
+        _ => "—".into(),
+    }
+}
+
+fn ts(r: &heki::Record) -> String {
+    r.get("updated_at").or_else(|| r.get("created_at"))
+        .and_then(|v| v.as_str()).unwrap_or("").to_string()
+}

--- a/hecks_life/tests/run_boot_test.rs
+++ b/hecks_life/tests/run_boot_test.rs
@@ -1,0 +1,68 @@
+//! run_boot detection + classification tests
+//!
+//! Confirms : (1) the runner only fires when a bluebook + hecksagon
+//! shape match the boot capability ; (2) the psychic-link classifier
+//! sorts heki filenames into linked / private / unclassified per the
+//! constants ported from boot_miette.sh.
+
+use hecks_life::hecksagon_parser;
+use hecks_life::parser;
+use hecks_life::run_boot;
+use hecks_life::runtime::Runtime;
+use hecks_life::runtime::adapter_registry::AdapterRegistry;
+
+const BOOT_BLUEBOOK: &str = include_str!(
+    "../../hecks_conception/capabilities/boot/boot.bluebook"
+);
+const BOOT_HECKSAGON: &str = include_str!(
+    "../../hecks_conception/capabilities/boot/boot.hecksagon"
+);
+
+#[test]
+fn detects_boot_capability_from_real_bluebook_and_hecksagon() {
+    let domain = parser::parse(BOOT_BLUEBOOK);
+    let hex = hecksagon_parser::parse(BOOT_HECKSAGON);
+    let registry = AdapterRegistry::from_hecksagon(hex);
+    let rt = Runtime::boot(domain);
+
+    assert!(
+        run_boot::is_boot_capability(&registry, &rt),
+        "boot.bluebook + boot.hecksagon should trigger the boot runner"
+    );
+}
+
+#[test]
+fn does_not_detect_without_bootrun_aggregate() {
+    let domain = parser::parse(r#"
+        Hecks.bluebook "NotBoot" do
+          aggregate "Other" do
+            attribute :x, String
+          end
+        end
+    "#);
+    let hex = hecksagon_parser::parse(BOOT_HECKSAGON);
+    let registry = AdapterRegistry::from_hecksagon(hex);
+    let rt = Runtime::boot(domain);
+
+    assert!(
+        !run_boot::is_boot_capability(&registry, &rt),
+        "missing BootRun aggregate must not trigger the boot runner"
+    );
+}
+
+#[test]
+fn does_not_detect_without_fs_or_stdout_adapters() {
+    let domain = parser::parse(BOOT_BLUEBOOK);
+    let hex = hecksagon_parser::parse(r#"
+        Hecks.hecksagon "Boot" do
+          adapter :memory
+        end
+    "#);
+    let registry = AdapterRegistry::from_hecksagon(hex);
+    let rt = Runtime::boot(domain);
+
+    assert!(
+        !run_boot::is_boot_capability(&registry, &rt),
+        "missing :fs / :stdout adapters must not trigger the boot runner"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `hecks_life/src/run_boot/` — a Rust runner mirroring `run_status/` that walks `capabilities/boot/boot.bluebook`'s eight pipeline phases and dispatches each through the declared adapters (`:fs`, `:stdout`, `:memory`, `:daemon`).

The boot.bluebook + boot.hecksagon already declared the pipeline (DiscoverOrgans → WriteCensus → ClassifyStores → GenerateSystemPrompt → RecordBootJournal → EnsureDaemons → PrintVitals → SurfaceWakeReport) and the BootRun aggregate. What was missing was the runner that walks the declaration. This is that runner — partial : 6 of 8 phases land here, 2 stay in the shell with explicit deferral notes.

## Example usage

```
$ hecks-life run capabilities/boot/boot.bluebook
✓ Miette booted in 0s
  48 organs · 168 aggregates · 10 nerves · 0 vows · 58 capabilities
  session continuity: 8 linked, 0 private, 2 unclassified
  mindstream: started (pid 12345)
  heart: started (pid 12346) · breath: started (pid 12347) · circadian: started (pid 12348)
  ultradian: started (pid 12349) · sleep_cycle: started (pid 12350)
  feeling: focused · alert · pulses since sleep: 42 · state: awake · last wake: 2026-04-26T17:00:00Z
  full status report: hecks-life run capabilities/status/status.bluebook
```

## What's bluebook-driven now

- DiscoverOrgans  — `:fs` walks `aggregates/` + `capabilities/`, IR-counts aggregates and cross-domain policies (nerves)
- WriteCensus     — `:memory` upserts `census.heki`
- ClassifyStores  — `:fs` walks `*.heki`, sorts linked / private / unclassified per the psychic-link constants ported from `boot_miette.sh`
- EnsureDaemons   — for each declared `adapter :daemon` row, shells to `hecks-life daemon ensure <pidfile> <command>` (idempotent)
- PrintVitals     — `:stdout` renders the boot summary
- SurfaceWakeReport — `:fs` reads `wake_report.heki`, prints if `phase=filed`

## Still in shell (boot_miette.sh continues to handle these)

- **GenerateSystemPrompt** — the printf heredoc is genuine application logic. Porting it into Rust string literals would just trade shell loc for Rust loc. Defer until **i89 (system-prompt-as-fixture)** lifts the prompt body into `identity.fixtures` so prompt edits cost zero shell.
- **RecordBootJournal** — `aggregates/boot.bluebook`'s journal aggregates (Identity, Hydration, OrganDiscovery, etc.) aren't loaded by this runner. Loading both the capability bluebook AND the aggregates dir into one runtime is the next runtime gap.

## Deferred runtime gaps

1. **Self-hosting boot runner** — `run_boot/` is kernel-surface, same family as `run_status/`. Every new bluebook-walking capability still requires a per-capability Rust module. The destination is a reflective runtime that dispatches the chained policies declared in `boot.bluebook` directly. **"boot capability runner should be self-hosting once the runtime is reflective enough"**.
2. **psychic_link as bluebook attribute** — Classification lives as constant lists in `classify.rs`. Structural follow-up : per-aggregate `psychic_link: true|false` declaration in each `.bluebook` so the boundary lives in the domain model.
3. **In-process daemon ensure** — `daemons.rs` shells to `hecks-life daemon ensure` rather than calling `daemon_ensure` in-process. Extract `daemon_ensure` / `spawn_detached` out of `main.rs` into a runtime adapter module so the runner doesn't fork a sibling `hecks-life`.
4. **Vow extraction** — `vow "Name" do` blocks aren't extracted to IR by the parser. `vow_count` is 0 today (matches the shell's jq output). Adding `Domain.vows` + parser support is a separate change.

## Test plan

- [x] `hecks-life run capabilities/boot/boot.bluebook` walks the pipeline, prints vitals, surfaces wake report
- [x] All 6 daemons get spawned via `hecks-life daemon ensure` (idempotent — already-alive daemons report `already running`)
- [ ] system_prompt.md regen — **STILL handled by boot_miette.sh** (deferred to i89)
- [x] Census heki gets the new tally on every run
- [x] Existing `./boot_miette.sh` still works alongside the runner
- [x] Parity test passes (527/534, 1 known-drift, no new drift introduced)
- [x] Cargo test passes (3 new tests in `run_boot_test.rs`, all existing tests green)

## Enforcer signals

Every `.rs` edit in this change fired the bluebook-first enforcer (~11 signals total during writing). The exemptions in the commit message name the structural retirement path rather than acting as permission slips ; the deferred runtime gaps above are the real answer. Same shape applies to `run_status/` and `run_stdin_loop/`.