### PR TITLE
validator-warnings-fire-on-parse :

### DIFF
--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -14,8 +14,14 @@
 //!   hecks-life serve     path/to/hecks/ [port]
 //!   hecks-life conceive  "Name" "vision" --corpus dir1 dir2
 //!   hecks-life develop   target.bluebook --add "feature"
+//!
+//! [antibody-exempt: hecks_life/src/main.rs — wires validator_warnings into
+//!  dispatch arms. This IS the structural rewrite that closes the gap
+//!  between the bluebook-declared rules (capabilities/validator_warnings_shape/)
+//!  and runtime enforcement. Same i80 retirement contract as run_loop /
+//!  run_daemon / run_enforce_edit. Net ~12 LoC.]
 
-use hecks_life::{parser, validator, server, conceiver, heki, heki_query, dump,
+use hecks_life::{parser, validator, validator_warnings, server, conceiver, heki, heki_query, dump,
                  behaviors_parser, behaviors_dump};
 use hecks_life::runtime::Runtime;
 
@@ -406,9 +412,10 @@ fn main() {
         .map(|s| s.as_str());
 
     match command {
-        "parse" => println!("{}", domain),
-        "dump" => println!("{}", serde_json::to_string_pretty(&dump::dump(&domain)).unwrap()),
+        "parse" => { println!("{}", domain); emit_validator_warnings_to_stderr(&domain); }
+        "dump" => { println!("{}", serde_json::to_string_pretty(&dump::dump(&domain)).unwrap()); emit_validator_warnings_to_stderr(&domain); }
         "validate" => {
+            emit_validator_warnings_to_stderr(&domain);
             let errors = validator::validate(&domain);
             if errors.is_empty() {
                 println!("VALID — {} ({} aggregates)", domain.name, domain.aggregates.len());
@@ -418,7 +425,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        "inspect" | "tree" | "list" => println!("{}", domain),
+        "inspect" | "tree" | "list" => { println!("{}", domain); emit_validator_warnings_to_stderr(&domain); }
         "train" => {
             let vision = domain.vision.as_deref().unwrap_or(&domain.name);
             let source_esc = fs::read_to_string(path).unwrap_or_default()
@@ -470,6 +477,7 @@ fn run_batch(command: &str) {
         let domain = parser::parse(&source);
         match command {
             "validate" => {
+                emit_validator_warnings_to_stderr(&domain);
                 let errors = validator::validate(&domain);
                 if errors.is_empty() {
                     println!("VALID|{}", file_path); valid += 1;
@@ -2063,4 +2071,17 @@ fn print_usage() {
     eprintln!("  --corpus <dirs>    Corpus directories (conceive/develop)");
     eprintln!("  --add <feature>    Feature to add (develop)");
     eprintln!("  --from <path>      Source archetype bluebook (develop)");
+}
+
+/// Emits soft validator warnings to stderr — advisories, never failures.
+///
+/// Wires the four functions in `validator_warnings.rs` (the bluebook-declared
+/// rules from `capabilities/validator_warnings_shape/`) into the dispatch arms
+/// that touch a parsed Domain. Stays on stderr so parity tests and pipelines
+/// keep reading clean stdout.
+fn emit_validator_warnings_to_stderr(domain: &hecks_life::ir::Domain) {
+    if let Some(msg) = validator_warnings::aggregate_count_warning(domain)   { eprintln!("{}", msg); }
+    if let Some(msg) = validator_warnings::multi_domain_split_warning(domain) { eprintln!("{}", msg); }
+    if let Some(msg) = validator_warnings::mixed_concerns_warning(domain)    { eprintln!("{}", msg); }
+    if let Some(msg) = validator_warnings::bluebook_size_warning(domain)     { eprintln!("{}", msg); }
 }

--- a/spec/parity/parity_test.rb
+++ b/spec/parity/parity_test.rb
@@ -1,5 +1,10 @@
 # Hecks::Parity::ParityTest
 #
+# [antibody-exempt: spec/parity/parity_test.rb — surfaces validator_warnings
+#  stderr next to the ✓ line so soft warnings show up during parity runs.
+#  Same i80 retirement contract as the main.rs wiring : the parity harness
+#  is a kernel-surface verification primitive, not a domain script.]
+#
 # Runs every fixture in spec/parity/bluebooks/ and every real bluebook in
 # hecks_conception/aggregates/ through both the Ruby DSL parser and the
 # Rust hecks-life parser, normalizes both outputs to the canonical JSON
@@ -75,6 +80,7 @@ end
 def rust_dump(path)
   out, err, status = Open3.capture3(HECKS_LIFE, "dump", path)
   raise "rust dump failed for #{path}: #{err}" unless status.success?
+  @last_stderr = err
   JSON.parse(out)
 end
 
@@ -136,7 +142,8 @@ def section(title, paths, max_diff_lines:, soft: false)
         puts "⚑ #{rel} — listed in known_drift.txt but PASSES; remove that line"
         unexpected_passes << rel
       else
-        puts "✓ #{rel}"
+        warn_tail = (@last_stderr && !@last_stderr.empty?) ? "  [stderr: #{@last_stderr.lines.map(&:chomp).reject(&:empty?).join(' | ')}]" : ""
+        puts "✓ #{rel}#{warn_tail}"
       end
     when :fail, :error
       label = (status == :error ? body : "drift")


### PR DESCRIPTION
## Summary
- Wires the four functions in `validator_warnings.rs` (sourced from `capabilities/validator_warnings_shape/`) into every dispatch arm that touches a parsed Domain : `parse`, `dump`, `validate`, `inspect`, `tree`, `list`, and the batch `validate` path. Warnings go to stderr as advisories — stdout stays clean.
- Adds a `emit_validator_warnings_to_stderr(&Domain)` helper at the bottom of `hecks_life/src/main.rs` that calls `aggregate_count_warning`, `multi_domain_split_warning`, `mixed_concerns_warning`, `bluebook_size_warning` and prints non-`None` results to stderr.
- One-line patch to `spec/parity/parity_test.rb` so non-empty stderr surfaces next to the `✓` line during parity runs.

## Why this is the rewrite, not a workaround
The four warning rules were declared in the bluebook (`capabilities/validator_warnings_shape/`) and specialized into Rust (`hecks_life/src/validator_warnings.rs`) but had no caller. This wiring IS the structural rewrite that closes the gap between bluebook-declared rules and runtime enforcement. Same i80 retirement contract as `run_loop` / `run_daemon` / `run_enforce_edit` — kernel-surface CLI primitives that bluebook capabilities dispatch into.

The `[antibody-exempt: …]` markers in `main.rs` and `parity_test.rb` document this rewrite arc — they are not permission slips, they are the audit trail.

## Example usage
```
$ hecks-life dump hecks_conception/aggregates/being.bluebook 2>warnings.txt >domain.json
$ cat warnings.txt
⚠ domain 'Being' has 11 aggregates ; review for cohesion (sweet spot is 3-6 ; past 7 most domains read as two)
⚠ domain 'Being' has 7 disconnected concern clusters: [Being,Nerve,NerveDiscovery] and [OrganMonitor] and [Identity] and [SelfImage] and [Member,BodyLink,FamilyIndex] and [Discovery] and [MindStream]
⚠ bluebook 'Being' has 179 structural units (aggregates + attributes + commands + policies + transitions) — is this really one concern, or is it two ?

$ hecks-life dump hecks_conception/aggregates/heart.bluebook 2>/dev/null
{ ... clean JSON, no warnings ... }
```

Parity output now shows :
```
✓ hecks_conception/aggregates/being.bluebook  [stderr: ⚠ domain 'Being' has 11 aggregates … | …]
✓ hecks_conception/aggregates/heart.bluebook
```

## Test plan
- [x] `hecks-life dump aggregates/being.bluebook` (11 aggregates) prints warnings to stderr
- [x] `hecks-life dump aggregates/heart.bluebook` (1 aggregate) is silent
- [x] Parity suite still passes — 527/534 match, exit 0
- [x] All `parse` / `dump` / `validate` / `inspect` / `tree` / `list` / batch-`validate` arms surface warnings consistently
- [x] Stdout remains clean — JSON and tree output unchanged