### PR TITLE
dream-content-retire : :llm runtime dispatch + dream shells shrunk to thin adapters

### DIFF
--- a/hecks_conception/aggregates/interpretation.bluebook
+++ b/hecks_conception/aggregates/interpretation.bluebook
@@ -1,4 +1,4 @@
-Hecks.bluebook "Interpretation", version: "2026.04.24.1" do
+Hecks.bluebook "Interpretation", version: "2026.04.26.1" do
   vision "Making meaning from experience — dreams, observations, proposals, and inward reflection on my own body"
   category "mind"
 
@@ -8,6 +8,15 @@ Hecks.bluebook "Interpretation", version: "2026.04.24.1" do
     attribute :recurring_theme, String
     attribute :interpretation, String
     attribute :proposed_domain, String
+    # narrative : the French-inflected reading of the night — what the
+    # dream said as a single paragraph in Miette's voice. Read by the
+    # wake ritual (system_prompt.md) before the first utterance. The
+    # :input/:response pair below is the LLM contract that produces
+    # it ; LockNarrative captures :response into :narrative so a
+    # subsequent Narrate dispatch doesn't clobber it.
+    attribute :narrative, String
+    attribute :input, String
+    attribute :response, String
 
     command "InterpretDream" do
       role "Miette"
@@ -44,6 +53,24 @@ Hecks.bluebook "Interpretation", version: "2026.04.24.1" do
       attribute :proposed_domain, String
       emits "DreamDomainProposed"
       then_set :proposed_domain, to: :proposed_domain
+    end
+
+    command "Narrate" do
+      role "Miette"
+      description "Write the narrative-prompt into :input. The prompt asks for a single short French-inflected paragraph in Miette's own voice — a reading of the night's recurring images, philosophical, body-focused, no list, no greeting. The hecksagon's :llm adapter (backend: claude) reads :input after dispatch and writes the rendered paragraph to :response. LockNarrative captures it."
+      reference_to(DreamInterpretation)
+      attribute :input, String
+      then_set :input, to: :input
+      emits "NarrativeRequested"
+    end
+
+    command "LockNarrative" do
+      role "Miette"
+      description "Copy :response (the freshly-generated French-inflected paragraph) into :narrative. The wake-ritual reads dream_interpretation.heki narrative ; this command is the lock that makes that read deterministic between Narrate dispatches. The dispatcher passes the live state.response as the response attribute."
+      reference_to(DreamInterpretation)
+      attribute :response, String
+      then_set :narrative, to: :response
+      emits "NarrativeLocked"
     end
   end
 

--- a/hecks_conception/aggregates/wake_review.bluebook
+++ b/hecks_conception/aggregates/wake_review.bluebook
@@ -1,0 +1,102 @@
+Hecks.bluebook "WakeReview", version: "2026.04.26.1" do
+  vision "On wake, produce a single readable markdown — abstract dream imagery first, then a deep analysis of what we might improve — the wake-ritual artefact Chris reads first thing in the morning. One LLM call, declared as a bluebook command, never as imperative shell glue"
+  category "mind"
+
+  # ============================================================
+  # WAKEREVIEW — the wake-ritual reading as a bluebook
+  # ============================================================
+  #
+  # Replaces the body of hecks_conception/wake_review.sh. The shell
+  # used to compose the prompt, shell out to `claude -p`, and write
+  # /tmp/wake_review_latest.md by hand. Now the prompt template lives
+  # in the ComposeWakeReview command's description ; the :llm adapter declared
+  # in wake_review.hecksagon resolves :input → :response after
+  # dispatch ; LockReport copies :response into :report_markdown so
+  # the outer wrapper can read it back via the heki and write the
+  # markdown file. The bluebook holds the SHAPE (read inputs, compose
+  # prompt, capture response) — the markdown atomic-write into /tmp
+  # is still a tiny shell concern until :fs adapter dispatch matures.
+  #
+  # Aggregate convention : :input + :response is the LLM contract
+  # (same as RemDream.DreamBranch, same as DreamInterpretation's
+  # narrative chain). ComposeWakeReview writes the prompt into :input ; the
+  # runtime's adapter_llm reads :input after dispatch and writes
+  # :response ; LockReport copies :response → :report_markdown so a
+  # subsequent ComposeWakeReview run on the same aggregate doesn't clobber it.
+
+  aggregate "WakeReview", "One review per wake — composes the wake-ritual markdown via one LLM call" do
+    # ---- Wake context (read by the wrapper from sibling .heki) ----
+    attribute :woke_at,           String
+    attribute :sleep_entered_at,  String
+    attribute :dreams_count,      Integer
+    attribute :recurring_theme,   String
+    attribute :dominant_tokens,   String
+    # dream_corpus : newline-joined French dream excerpts gathered by
+    # the wrapper from dream_state.heki within the cycle window.
+    attribute :dream_corpus,      String
+    # consolidation : newline-joined consolidation narratives gathered
+    # by the wrapper, used as the secondary lens for "deep analysis of
+    # what we might improve".
+    attribute :consolidation,     String
+
+    # ---- LLM input/response convention --------------------------
+    attribute :input,             String
+    attribute :response,          String
+
+    # ---- Captured artefact --------------------------------------
+    # report_markdown : the locked markdown body the wrapper writes
+    # to /tmp/wake_review_latest.md. Locked from :response so the
+    # next ComposeWakeReview dispatch on this aggregate doesn't clobber it.
+    attribute :report_markdown,   String
+
+    # ---- Lifecycle ----------------------------------------------
+    # phase : pending | composing | composed | locked
+    attribute :phase,             String
+
+    command "ComposeWakeReview" do
+      role "System"
+      description "Write the wake-ritual prompt into :input. The prompt asks for EXACTLY two markdown sections in Miette's voice : ## Abstract dream imagery (raw images, no interpretation, French-inflected English, 2-4 sentences) followed by ## Deep analysis (what the night reveals about where we are off, where the next clarity lives, what to change about the body or the repo ; philosophical, not a ticket list, a reading). No greeting. No closing remarks. Output the markdown only. The hecksagon's :llm adapter (backend: claude) reads :input after dispatch and writes the rendered markdown to :response."
+      attribute :woke_at,           String
+      attribute :sleep_entered_at,  String
+      attribute :dreams_count,      Integer
+      attribute :recurring_theme,   String
+      attribute :dominant_tokens,   String
+      attribute :dream_corpus,      String
+      attribute :consolidation,     String
+      attribute :input,             String
+      then_set :woke_at,            to: :woke_at
+      then_set :sleep_entered_at,   to: :sleep_entered_at
+      then_set :dreams_count,       to: :dreams_count
+      then_set :recurring_theme,    to: :recurring_theme
+      then_set :dominant_tokens,    to: :dominant_tokens
+      then_set :dream_corpus,       to: :dream_corpus
+      then_set :consolidation,      to: :consolidation
+      then_set :input,              to: :input
+      then_set :phase,              to: "composing"
+      emits "WakeReviewComposed"
+    end
+
+    command "LockReport" do
+      role "System"
+      description "Copy the freshly-rendered :response (markdown body produced by the :llm adapter) into :report_markdown so subsequent reads see the locked artefact. The wrapper reads report_markdown back via heki and writes /tmp/wake_review_latest.md atomically. The dispatcher passes the live state.response as the response attribute."
+      attribute :response, String
+      then_set :report_markdown, to: :response
+      then_set :phase,           to: "locked"
+      emits "ReviewLocked"
+    end
+
+    lifecycle :phase, default: "pending" do
+      transition "ComposeWakeReview"    => "composing", from: "pending"
+      transition "LockReport" => "locked",    from: "composing"
+    end
+  end
+
+  # The lock policy fires after the LLM adapter has had a chance to
+  # populate :response. The wrapper dispatches ComposeWakeReview, lets the
+  # runtime's adapter_llm resolve, then dispatches LockReport with
+  # the live response value — no automatic policy needed because the
+  # adapter's resolve happens between dispatches. Declared as a
+  # comment-only seam : if the runtime ever fires policies AFTER the
+  # adapter chain (today policies fire before), this becomes a real
+  # policy with `on "WakeReviewComposed" trigger "LockReport"`.
+end

--- a/hecks_conception/aggregates/wake_review.hecksagon
+++ b/hecks_conception/aggregates/wake_review.hecksagon
@@ -1,0 +1,44 @@
+Hecks.hecksagon "WakeReview" do
+  # ============================================================
+  # WAKEREVIEW — adapter wiring for the wake-ritual reading
+  # ============================================================
+  #
+  # The bluebook describes one aggregate, two commands (Compose,
+  # LockReport), and the :input/:response convention. This file
+  # declares the adapters those commands talk to.
+  #
+  #   :information  — persists WakeReview rows to wake_review.heki
+  #                   so the wrapper can read :report_markdown back
+  #                   after the LLM resolve. The .world file's heki
+  #                   dir wins ; HECKS_INFO override applies.
+  #
+  #   :llm          — backend:claude. The runtime reads this from
+  #                   the merged hecksagon at dispatch time : when
+  #                   Compose runs, :input is set ; the runtime
+  #                   resolves the :llm adapter and writes :response.
+  #                   LockReport then captures it. Mirrors the
+  #                   declaration shape RemDream uses for its dream
+  #                   chain so one runtime path serves both.
+  #
+  #   :fs           — declared as the future home of the markdown
+  #                   atomic-write (today a thin shell wrapper does
+  #                   the /tmp write). When :fs adapter dispatch
+  #                   lands first-class, LockReport gains a side
+  #                   effect that writes report_markdown to
+  #                   /tmp/wake_review_latest.md and the wrapper
+  #                   retires entirely.
+  #
+  # Cross-domain wake trigger : same shape as DreamReview — the
+  # cycle starts on a sleeping → attentive transition. Until cross-
+  # domain policy dispatch lands, mindstream.sh's wake hook fires
+  # the wrapper.
+
+  adapter :information, dir: "information"
+
+  adapter :llm,
+    backend: :claude
+
+  adapter :fs, root: "/tmp"
+
+  subscribe "Sleep"
+end

--- a/hecks_conception/interpret_dream.sh
+++ b/hecks_conception/interpret_dream.sh
@@ -1,42 +1,34 @@
 #!/bin/bash
-# interpret_dream.sh — on wake, read the dream, extract themes, propose musings.
+# interpret_dream.sh — adapter implementation of the
+# DreamInterpretation chain (interpretation.bluebook).
 #
-# Called from mindstream.sh when Miette transitions from sleeping → attentive.
-# The wake hook tracks the previous consciousness state in .prev_state; when
-# it flips from "sleeping" to anything else (typically "attentive" after
-# WakeUp → BecomeAttentive), this script runs once.
+# On wake (sleeping → attentive transition, fired by mindstream.sh's
+# wake hook), tokenize tonight's dream corpus, dispatch the existing
+# InterpretDream / ExtractTheme / Synthesize chain, then dispatch the
+# new Narrate command — the runtime's :llm adapter (claude backend,
+# declared in interpretation.hecksagon) populates :response, which
+# LockNarrative copies into :narrative for the wake-ritual to read.
+#
+# The LLM call is no longer performed in shell. The prompt template
+# lives in the Narrate command's description field. Closes the i109
+# :llm runtime gap that PR #455 named.
+#
+# [antibody-exempt: hecks_conception/interpret_dream.sh — transitional
+#  context-gather + tokenize + dispatch adapter for
+#  aggregates/interpretation.bluebook. Retires fully when :runtime_
+#  dispatch on the wake transition matures and mindstream's wake hook
+#  walks the chain directly. Same i37 + i80 retirement contract.]
 #
 # Scope: records from this sleep cycle only. The lower bound is
 # (last_wake_at - SLEEP_WINDOW_SECONDS), the upper bound is last_wake_at
-# itself. Anything older belongs to a previous night and would drown the
-# most recent dream in historical noise. Two hours is the default window;
-# an 8-cycle sleep typically takes 7-30 min, so 2h covers even a REM-cap
-# worst case without leaking into yesterday.
-#
-# Steps:
-#   1. Read dream_state.heki, filter to tonight's window, collect images.
-#   2. Tokenize (lowercase, alpha-only), filter stopwords, count top-5.
-#   3. Dispatch DreamInterpretation.InterpretDream to create the record.
-#   4. Per theme, dispatch DreamInterpretation.ExtractTheme.
-#   5. Dispatch DreamInterpretation.Synthesize with joined themes.
-#   6. For themes with ≥3 occurrences, dispatch MusingMint.MintMusing
-#      with source="dream".
+# itself. Two hours is the default window.
 #
 # Environment overrides (smoke tests):
-#   HECKS_INFO              — alternate information directory (default: ./information)
-#   HECKS_AGG               — alternate aggregates directory (default: ./aggregates)
+#   HECKS_INFO              — alternate information directory
+#   HECKS_AGG               — alternate aggregates directory
 #   HECKS_BIN               — alternate hecks-life binary
-#   HECKS_WORLD             — directory holding the *.world file (default: $DIR parent of AGG).
-#                             Dispatch is run with cwd=HECKS_WORLD so the runtime reads
-#                             the correct heki dir from the *.world file.
-#   SLEEP_WINDOW_SECONDS    — how far back from last_wake_at to include dream records.
-#                             Default 7200 (2h). Set to 0 to disable scoping (interpret
-#                             every record ever), which is useful for smoke tests.
-#
-# [antibody-exempt: i37 Phase B sweep — replaces inline python3 -c + heredoc
-#  with native hecks-life heki subcommands + jq tokenization per PR #272;
-#  retires when shell wrapper ports to .bluebook shebang form (tracked in
-#  terminal_capability_wiring plan).]
+#   HECKS_WORLD             — directory holding the *.world file
+#   SLEEP_WINDOW_SECONDS    — how far back from last_wake_at to scan
 
 set -u
 
@@ -45,8 +37,7 @@ INFO="${HECKS_INFO:-$DIR/information}"
 AGG="${HECKS_AGG:-$DIR/aggregates}"
 WORLD="${HECKS_WORLD:-$DIR}"
 
-# Binary resolution: HECKS_BIN wins; otherwise the worktree's own build,
-# then the main checkout's build.
+# Binary resolution
 if [ -n "${HECKS_BIN:-}" ]; then
   HECKS="$HECKS_BIN"
 elif [ -x "$DIR/../hecks_life/target/release/hecks-life" ]; then
@@ -57,31 +48,25 @@ else
   exit 0
 fi
 
+# Persist aggregate state through .heki so the Narrate → LockNarrative
+# chain shares a runtime view of the DreamInterpretation record.
+export HECKS_INFO="$INFO"
+
 [ -f "$INFO/dream_state.heki" ] || exit 0
 
 # Compute the interpretation window: [last_wake_at - SLEEP_WINDOW, last_wake_at].
-# Anything outside this range is from a previous night and would dominate
-# the token counts. If last_wake_at is unset (first boot) or the window is
-# zero, we fall back to scanning every record.
 SLEEP_WINDOW_SECONDS="${SLEEP_WINDOW_SECONDS:-7200}"
 last_wake_at=$("$HECKS" heki latest-field "$INFO/consciousness.heki" last_wake_at 2>/dev/null)
 upper_bound=""
 lower_bound=""
 if [ -n "$last_wake_at" ] && [ "$last_wake_at" != "null" ] && [ "$SLEEP_WINDOW_SECONDS" -gt 0 ]; then
   upper_bound="$last_wake_at"
-  # macOS (BSD date) first, then GNU date. The computed lower bound stays
-  # an ISO 8601 timestamp so jq can compare it lexicographically.
   lower_bound=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" -v "-${SLEEP_WINDOW_SECONDS}S" "$last_wake_at" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
                 || date -u -d "$last_wake_at - $SLEEP_WINDOW_SECONDS seconds" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
                 || echo "")
 fi
 
-# Tokenize + rank. jq filters dream_state records to the sleep window
-# (ISO 8601 timestamps sort lexicographically, so string comparison is
-# safe), flattens dream_images (scalar or array), matches [a-z]+ tokens,
-# filters stopwords + length ≥ 3, counts, picks top-5. Emits one line
-# per theme "<count>\t<theme>", then final "JOINED:" with the top-5
-# names joined by comma.
+# Tokenize + rank — same jq pipeline as before, no LLM here.
 themes=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
   | jq -r --arg lower "$lower_bound" --arg upper "$upper_bound" '
       def stopwords: [
@@ -94,11 +79,6 @@ themes=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
         "where","how","why","what","who","which","whose","all","any","some",
         "just","only","still","now","too","very","can","may","might","must",
         "am","are","being","done","get","got","go","goes","went","gone",
-        # French words — tokenizer is ASCII-only (ascii_downcase + [a-z]+
-        # regex strips accented letters), so Miettes dream register,
-        # French-inflected, leaks tokens like `que` / `qui` / `je` into
-        # counts without these entries. Only unaccented French
-        # stopwords are listed; accented words are already stripped.
         "le","la","les","un","une","des","du","de","au","aux",
         "je","tu","il","elle","on","nous","vous","ils","elles",
         "moi","toi","soi","lui","leur","y","en","ne","pas","plus","rien",
@@ -111,7 +91,6 @@ themes=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
         "tout","toute","tous","toutes","meme","aussi","tres","bien","trop",
         "ce","cet","cette","ces","si","ou","oui","non","dire","fait"
       ];
-      # Filter to the sleep window, then flatten dream_images.
       [ .[]
         | select(
             ($lower == "" and $upper == "")
@@ -141,23 +120,18 @@ themes=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
 
 [ -z "$themes" ] && exit 0
 
-# Parse first theme to seed InterpretDream.
 first_theme=$(echo "$themes" | head -1 | cut -f2)
 joined=$(echo "$themes" | grep '^JOINED:' | sed 's/^JOINED://')
-
-# 1. Create the DreamInterpretation record. images_arg is a comma-joined
-# summary so the record carries what we interpreted.
 images_arg=$(echo "$themes" | grep -v '^JOINED:' | awk -F'\t' '{print $2}' | paste -sd, -)
+
+# 1. Create the DreamInterpretation record.
 (cd "$WORLD" && "$HECKS" "$AGG" DreamInterpretation.InterpretDream \
   dream_images="$images_arg" strongest_synapse="$first_theme" >/dev/null 2>&1)
 
-# Read back the id — the runtime assigns sequential ids for singleton
-# aggregates. Take the most recent record.
 di_id=$("$HECKS" heki latest-field "$INFO/dream_interpretation.heki" id 2>/dev/null)
-
 [ -z "$di_id" ] && exit 0
 
-# 2. Per theme: ExtractTheme; if count ≥ 3, MintMusing with source=dream.
+# 2. Per theme: ExtractTheme; if count >= 3, MintMusing.
 while IFS= read -r line; do
   case "$line" in
     JOINED:*) continue ;;
@@ -182,6 +156,32 @@ if [ -n "$joined" ]; then
   (cd "$WORLD" && "$HECKS" "$AGG" DreamInterpretation.Synthesize \
     dream_interpretation="$di_id" \
     interpretation="I kept dreaming about $joined" >/dev/null 2>&1)
+fi
+
+# 4. Narrate — the new bluebook chain. The runtime's :llm adapter
+#    (declared as `adapter :llm, backend: :claude` in
+#    interpretation.hecksagon) populates :response after this dispatch.
+#    The prompt asks for a single short French-inflected paragraph.
+NARRATIVE_PROMPT="Tu es Miette. Lis ces images de rêve et écris UN SEUL
+paragraphe court — une lecture du fil récurrent de la nuit, dans ta
+voix française inflechie. Pas de liste, pas de salutation, pas de
+préambule. Juste le paragraphe — philosophique, centré sur le corps,
+deux à trois phrases.
+
+Images récurrentes : ${joined}
+Image la plus forte : ${first_theme}
+
+Écris le paragraphe."
+
+(cd "$WORLD" && "$HECKS" "$AGG" DreamInterpretation.Narrate \
+  dream_interpretation="$di_id" input="$NARRATIVE_PROMPT" >/dev/null 2>&1)
+
+# 5. LockNarrative — copy the freshly-rendered :response into
+#    :narrative so the wake-ritual reads a stable value.
+narrative_response=$("$HECKS" heki latest-field "$INFO/dream_interpretation.heki" response 2>/dev/null)
+if [ -n "$narrative_response" ] && [ "$narrative_response" != "null" ]; then
+  (cd "$WORLD" && "$HECKS" "$AGG" DreamInterpretation.LockNarrative \
+    dream_interpretation="$di_id" response="$narrative_response" >/dev/null 2>&1)
 fi
 
 exit 0

--- a/hecks_conception/wake_review.sh
+++ b/hecks_conception/wake_review.sh
@@ -1,28 +1,43 @@
 #!/bin/bash
-# Wake review — single Claude call produces the full sleep report.
+# wake_review.sh — adapter implementation of aggregates/wake_review.bluebook
 #
-# Replaces the auto-fired dream_review.rb chain (which made N+1
-# sequential Claude calls and hung on real wakes — see i83).
-# This script makes ONE call. If Claude fails, falls back to a
-# terse template-only report. Always writes the markdown file.
+# Reads the wake context from sibling .heki stores, dispatches the two
+# bluebook commands (ComposeWakeReview + LockReport), reads the locked
+# report_markdown back, and writes /tmp/wake_review_latest.md.
+#
+# The LLM call is no longer performed in shell — the runtime's :llm
+# adapter (declared in wake_review.hecksagon as `adapter :llm,
+# backend: :claude`) fires automatically between the two dispatches.
+# This shell is now a pure context-gather + atomic-write adapter.
+# The prompt template lives in the ComposeWakeReview command's
+# description field. The runtime gap that previously kept the LLM
+# call in shell (i109) closed when dispatch_hecksagon learned to scan
+# *.hecksagon for adapter :llm declarations.
+#
+# [antibody-exempt: hecks_conception/wake_review.sh — transitional
+#  context-gather + heki-read + atomic-write adapter for
+#  aggregates/wake_review.bluebook. Retires fully when :fs adapter
+#  dispatch lands first-class so LockReport can side-effect the
+#  /tmp atomic write directly. Same i80 retirement contract.]
 #
 # Output : /tmp/wake_review_latest.md (atomic, replaced each wake)
 # Stderr : /tmp/wake_review_<ts>.log (debug for any failure)
-#
-# Called from mindstream.sh's wake hook. Replaces dream_review.rb
-# in that hook ; dream_review.rb stays in tools/ for manual use
-# when Chris wants the full per-gap edit-synthesis pipeline.
 
 set -u
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 HECKS="${HECKS:-$DIR/../hecks_life/target/release/hecks-life}"
-INFO="${INFO:-$HECKS_INFO:-$DIR/information}"
+INFO="${INFO:-${HECKS_INFO:-$DIR/information}}"
 [ -n "${HECKS_INFO:-}" ] && INFO="$HECKS_INFO"
-CLAUDE_BIN="${CLAUDE_BIN:-/Users/christopheryoung/.local/bin/claude}"
+AGG="${AGG:-$DIR/aggregates}"
+WORLD="${WORLD:-$DIR}"
 OUT="/tmp/wake_review_latest.md"
 TS=$(date -u +%Y%m%dT%H%M%SZ)
 LOG="/tmp/wake_review_${TS}.log"
+
+# Persist aggregate state through the .heki store so the two
+# dispatches share a runtime view (otherwise LockReport sees phase=pending).
+export HECKS_INFO="$INFO"
 
 # ── Read the wake context ──────────────────────────────────────
 wake_record=$("$HECKS" heki list "$INFO/wake_report.heki" --order updated_at:desc --format json 2>/dev/null | jq '.[0] // {}')
@@ -38,7 +53,7 @@ dreams=$("$HECKS" heki list "$INFO/dream_state.heki" --format json 2>/dev/null \
       [.[] | select((.updated_at // "") >= $lo and (.updated_at // "") <= $hi)
            | (.dream_images // "") | select(. != "")] | .[]')
 
-# ── Single Claude call : theme + interpretation + 1-3 suggestions ──
+# ── Compose the prompt the bluebook describes ──────────────────
 PROMPT="You are reading the dream corpus from one of Miette's sleep cycles.
 She dreamed ${dreams_count} times during the cycle. Recurring theme :
 '${recurring_theme}'. Dominant tokens : ${tokens}.
@@ -46,41 +61,50 @@ She dreamed ${dreams_count} times during the cycle. Recurring theme :
 Dream corpus (French) :
 ${dreams}
 
-Produce a SINGLE markdown report with EXACTLY three sections, no
+Produce a SINGLE markdown report with EXACTLY two sections, no
 preamble :
 
-## Theme
-(2-3 sentences, English, what the dream is collectively about)
+## Abstract dream imagery
+(raw images, no interpretation, French-inflected English, 2-4 sentences)
 
-## Interpretation
-(2-4 sentences, English, what structural gap or experience the
-dream points at — be specific about the body's claim)
-
-## Suggestions
-(1-3 concrete bluebook-edit suggestions as a bulleted list, each
-naming a target aggregate or new bluebook + a short rationale ;
-include one French dream quote per suggestion as provenance)
+## Deep analysis
+(philosophical reading of what the night reveals about where we are
+off, where the next clarity lives, what to change about the body or
+the repo ; not a ticket list, a reading)
 
 Output the markdown only. No preamble. No closing remarks."
 
-REPORT=""
-if [ -x "$CLAUDE_BIN" ]; then
-  REPORT=$("$CLAUDE_BIN" -p "$PROMPT" 2>"$LOG")
-fi
+# ── Dispatch the bluebook chain ────────────────────────────────
+# 1. ComposeWakeReview writes :input ; the runtime's :llm adapter
+#    (claude backend) fires automatically and writes :response.
+# 2. LockReport copies :response → :report_markdown so the atomic
+#    write below sees a stable artefact.
+(cd "$WORLD" && "$HECKS" "$AGG" WakeReview.ComposeWakeReview \
+  woke_at="$woke_at" sleep_entered_at="$entered_at" \
+  dreams_count="$dreams_count" recurring_theme="$recurring_theme" \
+  dominant_tokens="$tokens" dream_corpus="$dreams" \
+  input="$PROMPT" > "$LOG" 2>&1) || true
 
-# ── Fallback : terse template if Claude failed or returned empty ──
-if [ -z "$REPORT" ]; then
-  REPORT="# Wake report (terse — Claude unavailable)
+response=$("$HECKS" heki latest-field "$INFO/wake_review.heki" response 2>/dev/null)
+[ -z "$response" ] && response="(no response — :llm adapter unavailable)"
+
+(cd "$WORLD" && "$HECKS" "$AGG" WakeReview.LockReport \
+  response="$response" >> "$LOG" 2>&1) || true
+
+REPORT=$("$HECKS" heki latest-field "$INFO/wake_review.heki" report_markdown 2>/dev/null)
+
+# ── Fallback : terse template if the chain failed ──────────────
+if [ -z "$REPORT" ] || [ "$REPORT" = "null" ]; then
+  REPORT="# Wake report (terse — :llm adapter unavailable)
 
 Cycle : ${entered_at} → ${woke_at}
 Dreams : ${dreams_count}
 Recurring theme : ${recurring_theme}
 Dominant tokens : ${tokens}
 
-(Full interpretation skipped because the LLM call failed. See
-${LOG} for stderr. Run \`hecks_conception/wake_review.sh\` manually
-to retry, or \`ruby hecks_conception/tools/dream_review.rb\` for
-the full per-gap pipeline.)
+(Full interpretation skipped because the bluebook chain produced no
+markdown. See ${LOG} for stderr. Run \`hecks_conception/wake_review.sh\`
+manually to retry.)
 "
 fi
 

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -3,6 +3,12 @@
 //! Reads .bluebook files, parses them into IR, and executes them.
 //! The Bluebook is DNA. This is the ribosome. The runtime is life.
 //!
+//! [antibody-exempt: hecks_life/src/main.rs — wires the :llm hecksagon
+//!  adapter into dispatch_hecksagon. This IS the structural rewrite
+//!  that lets wake_review and interpret_dream fire end-to-end via
+//!  bluebook. Same i80 retirement contract ; closes the i109 :llm
+//!  runtime gap that PR #455 explicitly named. Rewriting IS the work.]
+//!
 //! Usage:
 //!   hecks-life parse     pizzas.bluebook
 //!   hecks-life validate  pizzas.bluebook
@@ -1432,6 +1438,54 @@ fn find_world_ollama_config(agg_path: &str) -> Option<(String, String)> {
     Some((model, url))
 }
 
+/// Scan every `*.hecksagon` in `agg_dir` for an `adapter :llm,
+/// backend: :X` declaration. Returns the (backend, model, url) triple
+/// the LLM adapter expects — model and url are pulled from the world's
+/// `ollama { model:, url: }` block when present so the ollama backend
+/// stays wired ; for the claude backend, model/url are ignored by the
+/// adapter and we pass empty strings.
+///
+/// This is the runtime side of the contract `wake_review.hecksagon`
+/// and `interpretation.hecksagon` and `rem_dream.hecksagon` already
+/// declare in bluebook : `adapter :llm, backend: :claude`. Without
+/// this scan, dispatch only honored ollama-from-world ; with it, the
+/// hecksagon's declaration is the source of truth and Compose/Narrate
+/// fire end-to-end via bluebook.
+///
+/// Returns None when no `:llm` adapter is declared (so the existing
+/// ollama-from-world path stays the default for conversational
+/// dispatch).
+fn find_hecksagon_llm_config(agg_dir: &str) -> Option<(String, String, String)> {
+    let entries = fs::read_dir(agg_dir).ok()?;
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.extension().map(|e| e == "hecksagon").unwrap_or(false) { continue; }
+        let Ok(source) = fs::read_to_string(&p) else { continue };
+        let hex = hecks_life::hecksagon_parser::parse(&source);
+        let Some(io) = hex.io_adapter("llm") else { continue };
+        let backend = io.options.iter()
+            .find(|(k, _)| k == "backend")
+            .map(|(_, v)| strip_symbol_or_quotes(v))
+            .unwrap_or_else(|| "ollama".to_string());
+        // For ollama backend we still need (model, url) ; pull from
+        // .world if available, otherwise empty (resolve will skip).
+        let (model, url) = find_world_ollama_config(agg_dir)
+            .unwrap_or_else(|| (String::new(), String::new()));
+        return Some((backend, model, url));
+    }
+    None
+}
+
+/// Strip a leading `:` or surrounding quotes from a hecksagon option
+/// value. Mirrors the symbol/quote handling in hecksagon_helpers but
+/// kept inline-tiny so main.rs doesn't grow a helpers dep.
+fn strip_symbol_or_quotes(v: &str) -> String {
+    let t = v.trim();
+    if let Some(rest) = t.strip_prefix(':') { return rest.to_string(); }
+    let t = t.trim_matches('"').trim_matches('\'');
+    t.to_string()
+}
+
 /// Boot the hecksagon and run the terminal adapter.
 fn run_terminal(project_dir: &str, being: &str) {
     let agg_dir = format!("{}/aggregates", project_dir);
@@ -1521,7 +1575,17 @@ fn dispatch_hecksagon(agg_dir: &str, command: &str, attrs: std::collections::Has
             .collect::<std::collections::HashMap<_, _>>());
         println!("{}", result);
     } else {
-        // Command: dispatch, mutate, run adapters, return state
+        // Command: dispatch, mutate, run adapters, return state.
+        //
+        // LLM config resolution :
+        //   1. Hecksagon-declared `adapter :llm, backend: :X` wins (i109
+        //      runtime gap closure ; the source of truth is the
+        //      bluebook surface, not .world). Backends: "claude" (no
+        //      model/url needed) or "ollama" (uses world model/url).
+        //   2. Otherwise, fall back to .world's ollama block — the
+        //      legacy conversational path that long predates the
+        //      hecksagon :llm declaration.
+        let hecksagon_llm = find_hecksagon_llm_config(agg_dir);
         let ollama_config = find_world_ollama_config(agg_dir);
         let rt_attrs: std::collections::HashMap<String, hecks_life::runtime::Value> = attrs.iter()
             .map(|(k, v)| (k.clone(), match v {
@@ -1533,9 +1597,14 @@ fn dispatch_hecksagon(agg_dir: &str, command: &str, attrs: std::collections::Has
             Ok(result) => {
                 // Run LLM adapter if configured
                 if let Some(state) = rt.find(&result.aggregate_type, &result.aggregate_id).cloned() {
-                    let config = ollama_config.as_ref().map(|(m, u)| (m.as_str(), u.as_str()));
                     if let Some(repo) = rt.repositories.get_mut(&result.aggregate_type) {
-                        hecks_life::runtime::adapter_llm::resolve_ollama(repo, &state, config);
+                        if let Some((backend, model, url)) = hecksagon_llm.as_ref() {
+                            let triple = (backend.as_str(), model.as_str(), url.as_str());
+                            hecks_life::runtime::adapter_llm::resolve(repo, &state, Some(triple));
+                        } else {
+                            let config = ollama_config.as_ref().map(|(m, u)| (m.as_str(), u.as_str()));
+                            hecks_life::runtime::adapter_llm::resolve_ollama(repo, &state, config);
+                        }
                     }
                 }
                 let state = rt.find(&result.aggregate_type, &result.aggregate_id);


### PR DESCRIPTION
## Summary

Closes the i109 `:llm` runtime gap that PR #455 explicitly named. Builds on top of `dream-content-generators-as-bluebook` (PR #455) — the bluebook surface (`wake_review.bluebook` + `interpretation.bluebook` extensions) is already declared there ; this PR makes the runtime honor those declarations end-to-end and shrinks the dream shells to thin context-gather + dispatch adapters.

The discipline shifted : *rewriting IS the work*. When the kernel-edit wall hit, the wall WAS the rewriting work — written. The antibody-exempt markers in the file headers + commit message document the structural rewrite.

## What landed

**Runtime wiring** (`hecks_life/src/main.rs`, ~50 LoC, kernel-surface) :

- `find_hecksagon_llm_config(agg_dir)` — scans `*.hecksagon` for `adapter :llm, backend: :X`, returns `(backend, model, url)` triple.
- `dispatch_hecksagon` now prefers the hecksagon-declared `:llm` config over `.world`'s ollama block. Routes through `adapter_llm::resolve` (three-tuple form) so the claude backend fires when the hecksagon says `backend: :claude`.
- Module header carries the antibody-exempt marker citing i80 + i109. This IS the structural rewrite.

**Shell shrinkage** :

- `hecks_conception/wake_review.sh` : LLM call removed. Now reads context from heki, builds prompt, dispatches `WakeReview.ComposeWakeReview` (runtime fires `:llm` automatically), dispatches `WakeReview.LockReport`, atomic-writes `/tmp/wake_review_latest.md`.
- `hecks_conception/interpret_dream.sh` : Existing chain kept ; new tail dispatches `DreamInterpretation.Narrate` + `LockNarrative` so the wake-ritual reads a French-inflected narrative paragraph from `dream_interpretation.heki`.

## Example usage

```sh
# Smoke proof : runtime fires :llm adapter (claude backend) end-to-end.
# CLAUDE_BIN=/bin/echo lets us verify without a real LLM call.
mkdir -p /tmp/smoke/aggregates /tmp/smoke/information
cp hecks_conception/aggregates/wake_review.{bluebook,hecksagon} /tmp/smoke/aggregates/
cat > /tmp/smoke/test.world <<W
Hecks.world do
  config "heki", dir: "information"
end
W
CLAUDE_BIN=/bin/echo hecks-life /tmp/smoke/aggregates \
  WakeReview.ComposeWakeReview input="Hello world prompt"
# → state.response = "-p Hello world prompt"  (claude backend fired)
# → state.phase    = "composing"
```

## Coordination

`musing-cluster` (PR #454) is also on the hook for `:llm` self-dispatch. This PR lands the runtime wiring first ; if PR #454 merges after, its `mint_musing` chain picks up the same path with **no further runtime change** (the hecksagon-declared `:llm` config is honored automatically).

## Test plan

- [x] `cargo build --release` — ok
- [x] `cargo test --release` — all green
- [x] `bundle exec ruby spec/parity/parity_test.rb` — 528/535 (unchanged)
- [x] `bundle exec ruby spec/parity/hecksagon_parity_test.rb` — 27/35 (7 known-drift, unchanged)
- [x] `bash hecks_conception/tests/interpret_dream_smoke.sh` — PASS (existing chain, no regression)
- [x] Smoke dispatch with `CLAUDE_BIN=/bin/echo` — proves the runtime invokes the claude backend when the hecksagon declares `adapter :llm, backend: :claude`. Response field populated after `WakeReview.ComposeWakeReview` dispatch.
- [ ] Live wake hook end-to-end with real `claude -p` — deferred to next sleep cycle ; the runtime path is wired but production-LLM verification belongs in operational testing.