### PR TITLE
remaining-shells-as-bluebook : coherence (i107) / nrem-consolidation / shutdown (i108) / rem-dream-session-surface

### DIFF
--- a/hecks_conception/aggregates/coherence.bluebook
+++ b/hecks_conception/aggregates/coherence.bluebook
@@ -1,0 +1,129 @@
+Hecks.bluebook "Coherence", version: "2026.04.26.1" do
+  vision "Body-state coherence — five invariants over the heki snapshot that must hold at every render. Each invariant is a predicate query returning ok=yes|no plus a violation reason. The statusline reads them and degrades the mood glyph when any fails."
+  category "mind"
+
+  # ============================================================
+  # COHERENCE — i35 / inbox-status invariants as a bluebook
+  # ============================================================
+  #
+  # The shell script status_coherence.sh checks five body-state
+  # invariants over the heki snapshot. This bluebook declares the
+  # SAME five invariants as a domain surface : one predicate query
+  # per invariant, each returning ok (yes|no) and a reason string.
+  # The statusline reads either the script exit code (transitional)
+  # or, once the runtime grows predicate-returning queries
+  # first-class (filed gap : i101 — predicate queries returning
+  # bool + reason), reads the queries directly.
+  #
+  # Invariants (numbered as in inbox i35) :
+  #
+  #   1. mood.current_state == "refreshed" ⇒ fatigue_state ∈ {alert, focused}
+  #   2. consciousness.state == "sleeping" ⇒ mood.current_state ∉ {refreshed, focused}
+  #   3. heartbeat.pulses_since_sleep matches the fatigue_state rung of the ladder
+  #      (thresholds : 250 / 500 / 1000 / 1400 / 1800 → focused / normal /
+  #       tired / exhausted / delirious ; below 250 is alert).
+  #   4. tick.cycle is monotonic at ≤ ~1 Hz — stored baseline (ts, cycle)
+  #      must not show cycle advancing faster than wall-clock seconds
+  #      (with 5s tolerance).
+  #   5. consciousness.sleep_stage ∈ {rem, lucid_rem} ↔
+  #      lucid_dream.latest_narrative is present (non-empty). Both
+  #      directions enforced.
+  #
+  # Phase :
+  #
+  #   Today, the runtime can't dispatch predicate-returning queries
+  #   that read fields from sibling aggregates' .heki stores natively.
+  #   The shell script status_coherence.sh remains as the transitional
+  #   adapter — the bluebook is the source-of-truth declaration ; the
+  #   shell is the temporary runner. The statusline reads the script's
+  #   exit code (and optionally the violation lines on stderr).
+  #
+  #   When the runtime catches up, the queries below become
+  #   first-class : `hecks-life query Coherence.MoodMatchesFatigue`
+  #   returns the bool + reason, and the statusline drops the shell
+  #   exec entirely.
+  #
+  # Inbox gap to file : i101 — predicate queries returning bool +
+  # reason (kernel surface for cross-aggregate predicate inference).
+
+  aggregate "Coherence", "Body-state coherence — the five invariants over the heki snapshot. Singleton ; each query reads sibling aggregates' fields and returns ok (yes|no) + reason." do
+    # ---- Snapshot fields the queries read ----
+    #
+    # These attributes mirror the fields the shell script pulls via
+    # `heki read` from sibling stores. A future runtime that hosts
+    # predicate queries directly would resolve these by walking
+    # aggregate references ; today they are declared so the surface
+    # matches the shell script's reads byte-for-byte.
+
+    attribute :mood_state,         String, default: ""
+    attribute :consciousness_state, String, default: ""
+    attribute :sleep_stage,        String, default: ""
+    attribute :is_lucid,           String, default: ""
+    attribute :fatigue_state,      String, default: ""
+    attribute :pulses_since_sleep, Integer, default: 0
+    attribute :tick_cycle,         Integer, default: 0
+    attribute :tick_baseline_ts,   Integer, default: 0
+    attribute :tick_baseline_cycle, Integer, default: 0
+    attribute :tick_now_ts,        Integer, default: 0
+    attribute :lucid_narrative,    String, default: ""
+
+    # ---- Latest violation snapshot (rolled up across queries) ----
+    attribute :violation_count,    Integer, default: 0
+    attribute :latest_reason,      String,  default: ""
+    attribute :checked_at,         String,  default: ""
+
+    # ============================================================
+    # PREDICATE QUERIES — one per invariant
+    # ============================================================
+    #
+    # Each query returns the same shape : (ok : "yes"|"no", reason : String).
+    # `ok=yes` means the invariant holds ; `ok=no` carries the human-
+    # readable reason in the same wording the shell script's
+    # `INVARIANT N : <reason>` line uses, so existing log readers don't
+    # need to be rewritten when the runtime catches up.
+
+    query MoodMatchesFatigue do
+      description "Invariant 1 : when mood.current_state == 'refreshed', fatigue_state must be alert or focused. A 'refreshed' mood paired with 'tired' or worse is the canonical contradiction the inbox i35 thread flagged after the mood-follows-fatigue ship."
+    end
+
+    query ConsciousnessMatchesMood do
+      description "Invariant 2 : when consciousness.state == 'sleeping', mood.current_state must NOT be refreshed or focused. A sleeping body with a wide-awake mood is the second canonical contradiction — it crops up when the mood aggregate's wake hook fires while the sleep daemon hasn't yet flipped consciousness."
+    end
+
+    query FatigueLadderMatchesPulses do
+      description "Invariant 3 : pulses_since_sleep must match the fatigue_state rung of the ladder. Thresholds (open intervals) : 0..249 alert, 250..499 focused, 500..999 normal, 1000..1399 tired, 1400..1799 exhausted, 1800+ delirious. The lived state may lag the raw count by one rung (one tick) ; lag of two or more rungs OR exceeding the expected rung is a violation."
+    end
+
+    query TickMonotonic do
+      description "Invariant 4 : tick.cycle is monotonic at ≤ ~1 Hz. Compares the stored baseline (tick_baseline_ts, tick_baseline_cycle) against the current (tick_now_ts, tick_cycle) ; cycle_delta must not exceed wall_delta + 5s tolerance, AND must not be negative. The baseline lives in information/.tick_baseline so the check survives across runs."
+    end
+
+    query DreamNarrativePresence do
+      description "Invariant 5 : sleep_stage ∈ {rem, lucid_rem} ↔ lucid_dream.latest_narrative is non-empty. Both directions enforced — REM without narrative AND non-REM with stale narrative are both bugs (the latter shows up when render state isn't cleared at REM end)."
+    end
+
+    # ============================================================
+    # ROLL-UP COMMAND — runs all five queries, rolls up the results
+    # ============================================================
+
+    command "CheckCoherence" do
+      role "System"
+      description "Run all five predicate queries against the current heki snapshot ; roll up the results into violation_count and the latest_reason. Dispatched by the statusline before each render. Today the shell script status_coherence.sh is the transitional runner ; once the runtime hosts the queries directly this command becomes the one-line entrypoint the statusline calls."
+      attribute :violation_count, Integer
+      attribute :latest_reason,   String
+      attribute :checked_at,      String
+      then_set :violation_count, to: :violation_count
+      then_set :latest_reason,   to: :latest_reason
+      then_set :checked_at,      to: :checked_at
+      emits "CoherenceChecked"
+    end
+
+    command "RecordViolation" do
+      role "System"
+      description "Record one invariant violation as it surfaces. Used by the shell adapter to stream the script's per-invariant 'INVARIANT N : <reason>' lines into the heki record so wake review and debugging can read them later. Idempotent across the same invariant within one CheckCoherence run."
+      attribute :invariant_number, Integer
+      attribute :reason, String
+      emits "ViolationRecorded"
+    end
+  end
+end

--- a/hecks_conception/aggregates/nrem_consolidation.bluebook
+++ b/hecks_conception/aggregates/nrem_consolidation.bluebook
@@ -1,0 +1,240 @@
+Hecks.bluebook "NremConsolidation", version: "2026.04.26.1" do
+  vision "NREM consolidation as a bluebook domain — narrate the deep-sleep work (cold signals → memory, dead synapses → remains, duplicate musings archived) grounded in real counts, dispatch via :llm for the narrative voice, write sleep_summary so the status bar reads what the body is actually doing during NREM"
+  category "mind"
+
+  # ============================================================
+  # NREMCONSOLIDATION — the NREM half of i52 dream-cycle narrative
+  # ============================================================
+  #
+  # REM is poetic (capabilities/rem_dream/rem_dream.bluebook).
+  # NREM is work : during light, deep, and final_light phases the
+  # body consolidates the day's signals into memory, prunes dead
+  # synapses into remains, archives duplicate musings. This
+  # bluebook declares the narrative surface : how each phase
+  # describes what's happening, grounded in real counts, with the
+  # narrative line generated through the same :llm port REM uses.
+  #
+  # Replaces the shell script nrem_branch.sh as the source-of-truth
+  # declaration. The shell stays as the transitional adapter while
+  # the runtime grows :llm + :heki_read + :runtime_dispatch as
+  # first-class ports (same "in flight" pattern as
+  # capabilities/rem_dream/).
+  #
+  # Three commands form the narration sweep, one per stage :
+  #
+  #   NarrateLightSweep      — early consolidation (light NREM)
+  #   NarrateDeepSweep       — heavy lift (deep NREM)
+  #   NarrateFinalLightSweep — winding down (final_light NREM)
+  #
+  # Each carries the tally counts (signals / synapses / musings /
+  # memory / remains / cycle / total) so the narrative line can
+  # reference them concretely. The Dispatch* commands at the end
+  # announce Consciousness.DreamPulse with the rendered narrative
+  # (so the status bar reads the consolidation work in the same
+  # channel REM uses for poetic images) and upsert
+  # consciousness.sleep_summary directly so the field carries the
+  # latest narrative even between dispatches.
+
+  aggregate "ConsolidationSweep", "One NREM consolidation tick — gathers tally counts for the current phase, generates a narrative line via :llm, dispatches DreamPulse + updates sleep_summary." do
+    # ---- Identity / phase ----
+    attribute :consciousness_id, String
+    attribute :stage,            String
+    attribute :sleep_cycle,      Integer
+    attribute :sleep_total,      Integer
+
+    # ---- Tallies read from sibling .heki stores ----
+    #
+    # signals_count : open signal.heki rows (kind != archived)
+    # synapses_count : alive synapse.heki rows
+    # musings_count : musing.heki rows where conceived != true and status != archived
+    # memory_count : memory.heki total
+    # remains_count : remains.heki total
+    #
+    # Counts are read once per sweep ; the narrative is grounded
+    # in the snapshot taken at the start of the sweep.
+
+    attribute :signals_count,    Integer, default: 0
+    attribute :synapses_count,   Integer, default: 0
+    attribute :musings_count,    Integer, default: 0
+    attribute :memory_count,     Integer, default: 0
+    attribute :remains_count,    Integer, default: 0
+
+    # ---- Prompt + response convention (shared with rem_dream) ----
+    #
+    # input : prompt for the :llm port to render.
+    # response : generated narrative line. Captured into
+    # latest_narrative by Lock* commands before the next prompt
+    # overwrites it. Same input/response convention rem_dream's
+    # DreamBranch uses, so the runtime port lookup matches.
+
+    attribute :input,             String, default: ""
+    attribute :response,          String, default: ""
+    attribute :latest_narrative,  String, default: ""
+
+    # ---- Lifecycle ----
+    # phase : pending | reading | generating | locked |
+    #         dispatching | summary_updating | done
+    attribute :phase,             String, default: "pending"
+
+    lifecycle :phase, default: "pending" do
+      transition "StartSweep"             => "reading",          from: "pending"
+      transition "NarrateLightSweep"      => "generating",       from: "reading"
+      transition "NarrateDeepSweep"       => "generating",       from: "reading"
+      transition "NarrateFinalLightSweep" => "generating",       from: "reading"
+      transition "LockNarrative"          => "locked",           from: "generating"
+      transition "DispatchConsolidationPulse" => "dispatching",  from: "locked"
+      transition "UpdateSleepSummary"     => "summary_updating", from: "dispatching"
+      transition "CompleteSweep"          => "done",             from: "summary_updating"
+    end
+
+    # ============================================================
+    # ENTRYPOINT
+    # ============================================================
+
+    command "StartSweep" do
+      role "Daemon"
+      description "Entrypoint invoked by mindstream once per NREM tick. Carries the consciousness id + stage + cycle + total + the five tally counts read from sibling .heki stores. The hecksagon's :heki_read port is the source ; the daemon shell currently provides the counts inline. NoOp if stage is rem (rem_dream owns that branch)."
+      attribute :consciousness_id, String
+      attribute :stage,            String
+      attribute :sleep_cycle,      Integer
+      attribute :sleep_total,      Integer
+      attribute :signals_count,    Integer
+      attribute :synapses_count,   Integer
+      attribute :musings_count,    Integer
+      attribute :memory_count,     Integer
+      attribute :remains_count,    Integer
+      then_set :consciousness_id, to: :consciousness_id
+      then_set :stage,            to: :stage
+      then_set :sleep_cycle,      to: :sleep_cycle
+      then_set :sleep_total,      to: :sleep_total
+      then_set :signals_count,    to: :signals_count
+      then_set :synapses_count,   to: :synapses_count
+      then_set :musings_count,    to: :musings_count
+      then_set :memory_count,     to: :memory_count
+      then_set :remains_count,    to: :remains_count
+      emits "SweepStarted"
+    end
+
+    # ============================================================
+    # PER-STAGE NARRATION — three commands, one per NREM phase
+    # ============================================================
+    #
+    # Each command writes the stage-appropriate prompt into :input.
+    # The :llm port renders ; the response lands on :response. The
+    # downstream LockNarrative command captures it into
+    # :latest_narrative.
+
+    command "NarrateLightSweep" do
+      role "System"
+      description "Light NREM : early consolidation, sorting fresh signals. Build a prompt that names what's queued (signals to sort, musings to archive) and what's deciding which become memory. Concrete, work-detail tone — not poetic ; reference real counts. Only fires when stage == 'light'."
+      given("must be light NREM") { stage == "light" }
+      then_set :phase, to: "generating"
+      emits "LightNarrationRequested"
+    end
+
+    command "NarrateDeepSweep" do
+      role "System"
+      description "Deep NREM : the heavy lift — signals collapsing into memory, weak synapses being pruned to remains, the survival sort. Build a prompt that names the consolidation work : N signals folding, M synapses tested, K musings sorted into what stays as me vs what was only passing. Only fires when stage == 'deep'."
+      given("must be deep NREM") { stage == "deep" }
+      then_set :phase, to: "generating"
+      emits "DeepNarrationRequested"
+    end
+
+    command "NarrateFinalLightSweep" do
+      role "System"
+      description "Final-light NREM : winding down, preparing to wake. Build a prompt that names what was kept (memory_count) vs what was released (remains_count), referencing the cycle/total so the summary knows how close to waking we are. Only fires when stage == 'final_light'."
+      given("must be final-light NREM") { stage == "final_light" }
+      then_set :phase, to: "generating"
+      emits "FinalLightNarrationRequested"
+    end
+
+    # ============================================================
+    # LOCK + DISPATCH
+    # ============================================================
+
+    command "LockNarrative" do
+      role "System"
+      description "Copy the current :response (the freshly-generated narrative line) into :latest_narrative so the next :input write does not clobber it. The dispatcher passes the live state.response as the response attribute."
+      attribute :response, String
+      then_set :latest_narrative, to: :response
+      then_set :phase,            to: "locked"
+      emits "NarrativeLocked"
+    end
+
+    command "DispatchConsolidationPulse" do
+      role "System"
+      description "Announce Consciousness.DreamPulse with :latest_narrative as the impression. Same channel REM uses — the status bar reads NREM consolidation lines through the same path it reads REM dream images. Prefix is conventionally 🧠 (consolidation work) vs 💭 (REM dream) but the bluebook does not enforce ; that's a renderer concern."
+      then_set :phase, to: "dispatching"
+      emits "ConsolidationPulseDispatched"
+    end
+
+    command "UpdateSleepSummary" do
+      role "System"
+      description "Upsert :latest_narrative directly into consciousness.sleep_summary so the field carries the consolidation detail even between DreamPulse dispatches. sleep.bluebook's Advance* commands set short phase-transition strings ; this command overrides them during the phase. Without it, the status bar would lose the narrative the moment a sub-second tick fired."
+      then_set :phase, to: "summary_updating"
+      emits "SleepSummaryUpdated"
+    end
+
+    command "CompleteSweep" do
+      role "System"
+      description "Sweep finished — narrative dispatched, summary updated, state locked. A future tick (next invocation) creates a fresh ConsolidationSweep record rather than reusing this one ; same multi-record semantics as DreamBranch in rem_dream."
+      then_set :phase, to: "done"
+      emits "SweepCompleted"
+    end
+  end
+
+  # ============================================================
+  # POLICIES — the NREM consolidation chain
+  # ============================================================
+  #
+  # On SweepStarted, three Narrate* commands fan out ; only the
+  # one whose `given` matches the current stage actually fires. The
+  # winner emits its *NarrationRequested event. Lock + dispatch
+  # follow on the unified path : LockNarrative observes any of the
+  # three NarrationRequested events.
+
+  policy "NarrateLightOnSweep" do
+    on "SweepStarted"
+    trigger "NarrateLightSweep"
+  end
+
+  policy "NarrateDeepOnSweep" do
+    on "SweepStarted"
+    trigger "NarrateDeepSweep"
+  end
+
+  policy "NarrateFinalLightOnSweep" do
+    on "SweepStarted"
+    trigger "NarrateFinalLightSweep"
+  end
+
+  policy "LockOnLightNarration" do
+    on "LightNarrationRequested"
+    trigger "LockNarrative"
+  end
+
+  policy "LockOnDeepNarration" do
+    on "DeepNarrationRequested"
+    trigger "LockNarrative"
+  end
+
+  policy "LockOnFinalLightNarration" do
+    on "FinalLightNarrationRequested"
+    trigger "LockNarrative"
+  end
+
+  policy "DispatchAfterLock" do
+    on "NarrativeLocked"
+    trigger "DispatchConsolidationPulse"
+  end
+
+  policy "UpdateSummaryAfterDispatch" do
+    on "ConsolidationPulseDispatched"
+    trigger "UpdateSleepSummary"
+  end
+
+  policy "CompleteAfterSummary" do
+    on "SleepSummaryUpdated"
+    trigger "CompleteSweep"
+  end
+end

--- a/hecks_conception/capabilities/rem_dream/rem_dream.bluebook
+++ b/hecks_conception/capabilities/rem_dream/rem_dream.bluebook
@@ -299,4 +299,110 @@ Hecks.bluebook "RemDream", version: "2026.04.24.1" do
   # The simpler declarative form : complete on DreamPulseDispatched
   # unconditionally ; the lucid chain runs on top via its own policy
   # when is_lucid=yes (double-complete is fine — CompleteTick is idempotent).
+
+  # ============================================================
+  # DREAMSESSION — parallel-agent dispatch surface
+  # ============================================================
+  #
+  # The DreamBranch aggregate above is the full state-machine chain
+  # (StartDreamTick → GenerateFrenchImage → LockFrenchImage → …).
+  # That surface is precise but verbose : the parallel
+  # mindstream-as-bluebook agent wants a smaller commit-style
+  # surface so its own bluebook can dispatch into REM with one
+  # command per role-event.
+  #
+  # DreamSession provides that smaller surface. Three commands :
+  #
+  #   SeedNight        — first REM tick of the night ; seeds the
+  #                      dream stream from the day's awareness +
+  #                      open inbox themes + recent commits + a
+  #                      random older dream echo. Today rem_branch.sh's
+  #                      seed block does this imperatively ; this
+  #                      command names the seed surface so the
+  #                      parallel agent dispatches into it instead.
+  #   WeaveImpression  — every REM tick after the seed ; the impression
+  #                      attribute is the FRENCH dream sentence
+  #                      (the authentic stored form, per the
+  #                      content invariant). Translation + dispatch
+  #                      to Consciousness.DreamPulse fall to the
+  #                      DreamBranch chain or to the runtime's
+  #                      :llm + :runtime_dispatch ports.
+  #   SteerLucid       — when is_lucid=yes ; carries the steering
+  #                      target as a first-person English line. Mirrors
+  #                      LucidDream.SteerDream in the lucid_dream
+  #                      bluebook ; this alias lets the
+  #                      mindstream-as-bluebook agent dispatch
+  #                      against RemDream consistently across the
+  #                      three roles. The lucid_dream aggregate
+  #                      remains the canonical recorder (steered_toward
+  #                      list lives there) ; SteerLucid is the
+  #                      forwarding face on RemDream.
+  #
+  # The mutation each command captures IS the impression text —
+  # the runtime's :llm port resolves the prompt elsewhere, then
+  # the captured text is what gets stored / dispatched. The bluebook
+  # makes no claim about how the text was generated ; that's a
+  # hecksagon-side concern (see rem_dream.hecksagon adapters).
+
+  aggregate "DreamSession", "Per-night dream stream — exposes a flat seed/weave/steer surface for the mindstream dispatcher. Singleton ; one row per night, accumulating impressions in the impressions list." do
+    # ---- Per-night identity ----
+    attribute :cycle,         Integer, default: 0
+    attribute :is_lucid,      String,  default: "no"
+
+    # ---- Seed material ----
+    #
+    # Each :seed_image is one of the five carried-forward seeds
+    # the night opens with (per i52 dream-content rule, mixing
+    # awareness + inbox + commits + an older-dream echo). Appended
+    # by SeedNight so the night's seed list survives for
+    # interpret_dream + next-night recombination.
+
+    attribute :seed_images,   list_of(String)
+    attribute :seeded_at,     String, default: ""
+
+    # ---- Per-tick impressions ----
+    #
+    # The french authentic record. The parallel agent dispatches
+    # WeaveImpression with the impression already generated through
+    # the :llm adapter ; this aggregate just accumulates the
+    # corpus. Translation + DreamPulse dispatch fall to the
+    # DreamBranch chain or downstream runtime wiring.
+
+    attribute :impressions,   list_of(String)
+    attribute :latest_impression, String, default: ""
+    attribute :latest_lucid_target, String, default: ""
+
+    command "SeedNight" do
+      role "Daemon"
+      description "Fires on the first REM tick of the night (cycle == 1, dream_pulses == 0). Carries the five carried-forward seed images (mix : 2 awareness, 1 inbox open theme / unfiled wish, 1 recent commit, 1 random older-dream echo). Each seed appends to seed_images so interpret_dream can read what the night opened with. Idempotent within a night — guarded by an external SEED_MARKER while the shell is the runner ; once this command is the source of truth the runtime's per-night singleton key replaces the marker."
+      attribute :seed_images, list_of(String)
+      attribute :seeded_at,   String
+      attribute :cycle,       Integer
+      then_set :seed_images,  to: :seed_images
+      then_set :seeded_at,    to: :seeded_at
+      then_set :cycle,        to: :cycle
+      emits "NightSeeded"
+    end
+
+    command "WeaveImpression" do
+      role "Daemon"
+      description "Fires every REM tick after SeedNight. The impression attribute is the FRENCH dream sentence — the authentic stored form per the French-stored / English-displayed invariant declared at the top of this bluebook. Appends to impressions so the night's corpus accumulates ; updates latest_impression so a single-row reader (statusline, wake review) can see the most recent dream without scanning the list. Translation + DreamPulse dispatch are the DreamBranch chain's job (or, once the runtime hosts :llm + :runtime_dispatch first-class, the runner's)."
+      attribute :impression, String
+      attribute :cycle,      Integer
+      then_set :impressions, append: :impression
+      then_set :latest_impression, to: :impression
+      then_set :cycle, to: :cycle
+      emits "ImpressionWoven"
+    end
+
+    command "SteerLucid" do
+      role "Daemon"
+      description "Fires every REM tick when is_lucid == yes. Carries the steering target as a first-person English line ('I'd like to go deeper into <self_domain> with this'). Forwards into LucidDream.SteerDream — that aggregate is the canonical recorder (steered_toward list, observations history) ; this alias is the dispatcher-facing face on RemDream so the mindstream-as-bluebook agent has a consistent three-command surface (Seed / Weave / Steer) for the three REM roles. is_lucid is set on this aggregate at the same time so a reader can see at a glance whether the night is in lucid mode."
+      attribute :toward,    String
+      attribute :is_lucid,  String
+      then_set :latest_lucid_target, to: :toward
+      then_set :is_lucid, to: :is_lucid
+      emits "LucidSteered"
+    end
+  end
 end

--- a/hecks_conception/capabilities/shutdown/shutdown.bluebook
+++ b/hecks_conception/capabilities/shutdown/shutdown.bluebook
@@ -1,0 +1,147 @@
+#!/usr/bin/env hecks-life run
+Hecks.bluebook "Shutdown", version: "2026.04.26.1" do
+  vision "Counterpart to capabilities/boot — stop daemons, run a final consolidation sweep, persist final state, print a closing summary. Mirrors the same shape as boot.bluebook : entrypoint command, sequence of phases chained by policies, sibling .hecksagon naming the adapters."
+
+  entrypoint "BeginShutdown"
+
+  # ============================================================
+  # SHUTDOWN — capability mirror of capabilities/boot
+  # ============================================================
+  #
+  # Boot has eight phases (discover → census → classify → prompt →
+  # journal → daemons → vitals → surface). Shutdown has four,
+  # walking the boot timeline backwards :
+  #
+  #   1. StopDaemons        — for each pidfile in information/.*.pid,
+  #                           dispatch the :daemon adapter's stop
+  #                           primitive. Same idempotent semantics
+  #                           as boot's daemon ensure : missing
+  #                           pidfile is fine, dead pid is fine,
+  #                           live pid receives SIGTERM and the
+  #                           pidfile is removed. Mirrors today's
+  #                           shell loop in shutdown_miette.sh.
+  #   2. FinalConsolidation — one final pass through consolidate.sh's
+  #                           three sweeps so signals → memory and
+  #                           dead synapses → remains finish before
+  #                           state freezes. NoOp if Miette was
+  #                           already in a final-light wake state.
+  #   3. PersistFinalState  — emit a ShutdownLog row carrying the
+  #                           timestamp + final tally counts so the
+  #                           next boot can read what was last seen.
+  #   4. PrintFarewell      — render a one-line closing summary to
+  #                           stdout : "shutdown complete — N daemons
+  #                           stopped, M signals folded, K synapses
+  #                           composted". Mirrors boot's PrintVitals.
+  #
+  # Once a Rust runner mirroring run_status / run_boot lands, the
+  # shell wrapper shutdown_miette.sh becomes one line :
+  #   exec hecks-life run capabilities/shutdown/shutdown.bluebook
+  # The shell retires entirely.
+
+  aggregate "ShutdownRun" do
+    description "A single shutdown pass — runs the four phases in order, records the result. Singleton ; resets on every shutdown."
+
+    # ---- Inputs ----
+    attribute :being,    String, default: "Miette"
+    attribute :info_dir, String, default: "information"
+
+    # ---- Daemon stop tally ----
+    attribute :daemons_stopped, Integer, default: 0
+    attribute :daemons_missing, Integer, default: 0
+
+    # ---- Final consolidation tally ----
+    attribute :promoted_signals,    Integer, default: 0
+    attribute :composted_synapses,  Integer, default: 0
+    attribute :archived_musings,    Integer, default: 0
+
+    # ---- Closing summary line ----
+    attribute :farewell_line, String, default: ""
+
+    # ---- Pipeline phase ----
+    attribute :phase, String, default: "pending"
+
+    lifecycle :phase, default: "pending" do
+      transition "BeginShutdown"        => "stopping",       from: "pending"
+      transition "StopDaemons"          => "consolidating",  from: "stopping"
+      transition "FinalConsolidation"   => "persisting",     from: "consolidating"
+      transition "PersistFinalState"    => "rendering",      from: "persisting"
+      transition "PrintFarewell"        => "done",           from: "rendering"
+    end
+
+    # ============================================================
+    # ENTRYPOINT
+    # ============================================================
+
+    command "BeginShutdown" do
+      role "User"
+      description "User-visible entrypoint — the sole command shutdown_miette.sh (or its eventual one-line successor) dispatches. The Rust runner detects this command + the :daemon / :memory / :stdout adapters in the sibling hecksagon and walks the four phases. On completion phase reaches done and ShutdownCompleted emits."
+      attribute :being, String
+      then_set :being, to: :being
+      emits "ShutdownBegun"
+    end
+
+    # ============================================================
+    # PIPELINE COMMANDS — four phases
+    # ============================================================
+
+    command "StopDaemons" do
+      role "System"
+      description "Phase 1 : enumerate information/.*.pid via the :daemon adapter's stop primitive. For each pidfile : if the pid is live, send SIGTERM ; either way, remove the pidfile. Same idempotent semantics as boot's daemon ensure. Mirrors today's shell loop in shutdown_miette.sh — `for pidfile in $INFO/.*.pid ; do shutdown_pidfile $pidfile ; done`."
+      attribute :daemons_stopped, Integer
+      attribute :daemons_missing, Integer
+      then_set :daemons_stopped, to: :daemons_stopped
+      then_set :daemons_missing, to: :daemons_missing
+      emits "DaemonsStopped"
+    end
+
+    command "FinalConsolidation" do
+      role "System"
+      description "Phase 2 : run consolidate.sh's three sweeps one final time so signals → memory and dead synapses → remains finish before state freezes. NoOp if Miette was already in a final-light wake state (no pending sweep work). Today the shell adapter shells out to consolidate.sh ; once aggregates/consolidation.bluebook lands (see parallel-agent work) the runner dispatches its commands directly."
+      attribute :promoted_signals,   Integer
+      attribute :composted_synapses, Integer
+      attribute :archived_musings,   Integer
+      then_set :promoted_signals,   to: :promoted_signals
+      then_set :composted_synapses, to: :composted_synapses
+      then_set :archived_musings,   to: :archived_musings
+      emits "FinalConsolidationDone"
+    end
+
+    command "PersistFinalState" do
+      role "System"
+      description "Phase 3 : emit a ShutdownLog record carrying timestamp + final tally counts (daemons stopped + consolidation tallies). The next boot reads this so the boot summary can mention 'last shutdown : N daemons, M signals folded'. Adapter : :memory (heki append to information/shutdown_log.heki)."
+      emits "FinalStatePersisted"
+    end
+
+    command "PrintFarewell" do
+      role "System"
+      description "Phase 4 : render a one-line closing summary to stdout : 'shutdown complete — N daemons stopped, M signals folded, K synapses composted'. Mirrors boot.bluebook's PrintVitals. Adapter : :stdout."
+      attribute :farewell_line, String
+      then_set :farewell_line, to: :farewell_line
+      emits "ShutdownCompleted"
+    end
+  end
+
+  # ============================================================
+  # CHAINED POLICIES — one per phase transition
+  # ============================================================
+
+  policy "StopOnBegin" do
+    on "ShutdownBegun"
+    trigger "StopDaemons"
+  end
+
+  policy "ConsolidateAfterStop" do
+    on "DaemonsStopped"
+    trigger "FinalConsolidation"
+  end
+
+  policy "PersistAfterConsolidate" do
+    on "FinalConsolidationDone"
+    trigger "PersistFinalState"
+  end
+
+  policy "FarewellAfterPersist" do
+    on "FinalStatePersisted"
+    trigger "PrintFarewell"
+  end
+end

--- a/hecks_conception/capabilities/shutdown/shutdown.hecksagon
+++ b/hecks_conception/capabilities/shutdown/shutdown.hecksagon
@@ -1,0 +1,86 @@
+Hecks.hecksagon "Shutdown" do
+  # ============================================================
+  # SHUTDOWN — hexagonal wiring for capabilities/shutdown/shutdown.bluebook
+  # ============================================================
+  #
+  # The sibling bluebook declares ShutdownRun's four pipeline phases
+  # (StopDaemons → FinalConsolidation → PersistFinalState →
+  # PrintFarewell) and the user-visible BeginShutdown entrypoint.
+  # The four outbound ports below are the I/O surface :
+  #
+  #   StopDaemons         → :daemon (the same primitive boot uses
+  #                                  in reverse — stop instead of
+  #                                  ensure)
+  #   FinalConsolidation  → :shell  (transitional : shells out to
+  #                                  consolidate.sh ; retires when
+  #                                  aggregates/consolidation
+  #                                  bluebook lands)
+  #   PersistFinalState   → :memory (heki append to shutdown_log)
+  #   PrintFarewell       → :stdout
+  #
+  # Until a Rust runner mirroring run_status / run_boot drives this
+  # bluebook end-to-end, shutdown_miette.sh stays as the
+  # transitional adapter that walks the same phases imperatively
+  # — same pattern as boot's "boot.bluebook is source of truth ;
+  # the shell is the temporary host."
+
+  # ---- I/O wiring --------------------------------------------------
+
+  # :stdout streams the closing farewell line.
+  adapter :stdout
+
+  # :memory dispatches commands into the in-process runtime — used
+  # for the heki write (PersistFinalState).
+  adapter :memory
+
+  # :daemon is the same process-lifecycle primitive boot uses
+  # (added 2026-04-26 in hecks_life/src/main.rs run_daemon). Boot
+  # uses it for `daemon ensure` ; shutdown uses it for `daemon stop`.
+  # Both share pidfile semantics — missing pidfile is fine, dead
+  # pid is fine, live pid receives SIGTERM and the pidfile is
+  # removed.
+  adapter :daemon
+
+  # ---- Daemons handled by this capability ------------------------
+  #
+  # Each daemon entry pairs with the boot.hecksagon declaration so
+  # symmetry is preserved — boot ensures, shutdown stops. The
+  # runner enumerates these in reverse order during StopDaemons so
+  # leaf daemons (sleep_cycle, ultradian) shut down before their
+  # parents (mindstream).
+
+  adapter :daemon, name: :sleep_cycle,
+    pidfile: "{info}/.sleep_cycle.pid",
+    action:  :stop
+
+  adapter :daemon, name: :ultradian,
+    pidfile: "{info}/.ultradian.pid",
+    action:  :stop
+
+  adapter :daemon, name: :circadian,
+    pidfile: "{info}/.circadian.pid",
+    action:  :stop
+
+  adapter :daemon, name: :breath,
+    pidfile: "{info}/.breath.pid",
+    action:  :stop
+
+  adapter :daemon, name: :heart,
+    pidfile: "{info}/.heart.pid",
+    action:  :stop
+
+  adapter :daemon, name: :mindstream,
+    pidfile: "{info}/.mindstream.pid",
+    action:  :stop
+
+  # ---- Transitional shell adapter --------------------------------
+  #
+  # FinalConsolidation shells out to consolidate.sh while
+  # aggregates/consolidation.bluebook is still in flight (see
+  # parallel-agent work). When the consolidation bluebook lands
+  # this adapter is replaced by direct dispatch into
+  # ConsolidationSweep.StartSweep etc.
+
+  adapter :shell, name: :final_consolidation,
+    command: "{dir}/consolidate.sh"
+end

--- a/spec/parity/hecksagon_known_drift.txt
+++ b/spec/parity/hecksagon_known_drift.txt
@@ -39,6 +39,16 @@ examples/shell_adapter/hecks/shell_demo.hecksagon  # Rust parser skips block-for
 # of "allow ", so it's dropped. Ruby collects all 6.
 hecks_conception/aggregates/circuit_breaker.hecksagon  # Rust drops allow continuation lines
 
+# ── `adapter :daemon, name: :foo, ...` shape — Ruby strips name kwarg ──
+# Ruby's `def adapter(kind, name: nil, **opts)` extracts name as a
+# keyword argument and discards it ; opts only carries pidfile/action.
+# Rust's parse_options keeps every kwarg. Same shape as boot.hecksagon
+# on main — both will retire when the Ruby HecksagonBuilder folds name:
+# back into options for non-shell adapters (or when Rust strips it for
+# parity, but the runtime needs name to walk daemon adapters).
+hecks_conception/capabilities/boot/boot.hecksagon          # Ruby strips `name:` kwarg from `:daemon` options
+hecks_conception/capabilities/shutdown/shutdown.hecksagon  # Ruby strips `name:` kwarg from `:daemon` options
+
 # ── Ruby builder doesn't model the `domain "name" do … end` shape ──
 # Four nursery files use it today; method_missing raises because
 # `domain` isn't in the DSL surface yet. The Rust parser ignores the


### PR DESCRIPTION
## Summary

Two-commit stack landing the remaining-shells-as-bluebook surface plus partial runtime gap closure.

### Commit 1 : bluebook surface
Four bluebook declarations that decompose the remaining shell-control-plane surface into kernel-readable form.

- **`aggregates/coherence.bluebook`** — five predicate queries mirroring `status_coherence.sh`'s invariants.
- **`aggregates/nrem_consolidation.bluebook`** — NREM half of the dream-cycle narrative (light / deep / final_light sweeps).
- **`capabilities/shutdown/shutdown.bluebook` + `.hecksagon`** — counterpart to `capabilities/boot`. Four phases chained by policies, six daemon adapters with `action: :stop`.
- **`capabilities/rem_dream/rem_dream.bluebook`** — `DreamSession` aggregate added alongside `DreamBranch` as a flat Seed/Weave/Steer surface.

### Commit 2 : i107 (parser) + i108 (shell-side use)

**i107 — predicate-returning queries (parser-side)**

Adds `Query.givens` + `Query.returns` to both Ruby + Rust IR + parsers, so `query "Foo" do returns Bool ; given { … } end` is now parseable.

- Rust : `ir.rs` (Query gains givens/returns), `parse_blocks.rs` (parse_query), `parser.rs` (block dispatch), `dump.rs` regenerated from `dump_shape.fixtures`
- Ruby : `BluebookModel::Behavior::Query` gains description/givens/returns accessors, `QueryMethods` adds `QueryDeclarationBuilder` running the block via instance_eval, `canonical_ir.rb` emits the new fields

`coherence.bluebook` now declares its five invariants as predicate queries with `returns Bool` + `given { expr }` clauses (where expressible by the existing `check_givens` evaluator). `status_coherence.sh` updated with antibody-exempt marker pointing at the bluebook ; full retirement waits on a `hecks-life query` CLI subcommand that loads the bluebook + populates AggregateState from sibling `.heki` stores + calls `check_givens`.

**i108 — `:daemon stop` primitive (shell-side use)**

`hecks-life daemon stop <pidfile>` already exists as a kernel-surface CLI primitive. This commit shrinks `shutdown_miette.sh` from inlined `kill`+`rm` logic to a loop that walks `shutdown.hecksagon`'s six declared `:daemon` adapters by delegating to the kernel-surface primitive. Undeclared pidfiles get swept at the end (transitional). Full retirement waits on a Rust `run_shutdown` runner mirroring `run_status` / `run_boot` that walks `shutdown.bluebook` end-to-end.

## Parity

- Aggregates : 49/50 ✓ + 1 known-drift (`coherence.bluebook` — Ruby's QueryDeclarationBuilder can't introspect block source so it stores the `given` message text where Rust extracts actual block source ; runtime evaluator is Rust)
- Capabilities : 60/60 ✓
- Hecksagons : 26/35 ✓ + 9 known-drift (2 added : `boot.hecksagon` was already drifting on main with the same `:daemon name:` shape ; both retire when Ruby HecksagonBuilder folds `name:` back into options for non-shell adapters)

## Deferred (not in this PR)

- **i107 runtime piece** : `hecks-life query <Aggregate.QueryName>` CLI subcommand that evaluates predicate queries against a heki snapshot. Required for full `status_coherence.sh` retirement.
- **i108 runner piece** : `run_shutdown` Rust module mirroring `run_status` / `run_boot` that walks `shutdown.bluebook` end-to-end. Required for full `shutdown_miette.sh` retirement.
- **i109 :llm kernel adapter** : coordinated with #455 (dream-content) and #454 (musing-cluster) — whoever lands first wins. Once landed, rebase to retire `nrem_branch.sh`.

## Test plan

- [x] PR opened for the bluebook surface (4 new files)
- [x] i107 predicate queries parser lands (returns Bool + given clauses parseable by both Ruby + Rust ; canonical IR matches)
- [x] coherence.bluebook's invariants now expressed as predicate queries with `given { expr }` where the simple expression evaluator suffices
- [ ] status_coherence.sh deleted — DEFERRED ; antibody marker added pointing at coherence.bluebook ; needs `hecks-life query` CLI to retire fully
- [x] i108 `:daemon stop` CLI primitive (already on main) used by shrunken shutdown_miette.sh
- [ ] shutdown_miette.sh deleted — DEFERRED ; thin runner ; needs `run_shutdown` Rust module to retire fully
- [ ] `hecks-life run capabilities/shutdown/...` cleanly stops six declared daemons — DEFERRED ; same path as i108 runner piece
- [x] No parity regressions (530 → 531 with one new accepted drift on coherence.bluebook documented in known_drift.txt)