### PR TITLE
nursery-parity-drift-fix : closes i1/i2

### DIFF
--- a/hecks_conception/nursery/air_cargo/air_cargo.bluebook
+++ b/hecks_conception/nursery/air_cargo/air_cargo.bluebook
@@ -38,14 +38,6 @@ Hecks.bluebook "AirCargo" do
       transition "ArriveFlight" => "arrived", from: "in_transit"
     end
 
-    policy "Payload must not exceed aircraft maximum takeoff weight limits"
-    policy "Dangerous goods must be loaded per IATA segregation rules"
-
-    given "A 747 freighter departs LAX for Shanghai" do
-      attribute :flight_number, String, "CX-2847"
-      attribute :aircraft_type, String, "747-400F"
-      attribute :payload_capacity_kg, Float, 112000.0
-    end
   end
 
   aggregate "ULDPallet" do
@@ -90,7 +82,6 @@ Hecks.bluebook "AirCargo" do
       transition "LoadOntoAircraft" => "loaded", from: "weighed"
     end
 
-    policy "Pallet weight must not exceed position contour limit"
   end
 
   aggregate "CargoShipment" do
@@ -132,7 +123,6 @@ Hecks.bluebook "AirCargo" do
       transition "DeliverCargo" => "delivered", from: "received"
     end
 
-    policy "Actual weight variance over 5 percent requires rebooking"
   end
 
   aggregate "CustomsEntry" do
@@ -170,7 +160,6 @@ Hecks.bluebook "AirCargo" do
       transition "ClearEntry" => "cleared", from: "filed"
     end
 
-    policy "Cargo cannot be released without customs clearance"
   end
 
   aggregate "WarehouseLocation" do
@@ -202,7 +191,6 @@ Hecks.bluebook "AirCargo" do
       transition "RetrieveCargo" => "empty", from: "occupied"
     end
 
-    policy "Temperature-sensitive cargo must be stored in correct zone"
   end
 
   policy "ReceiveCargoOnShipmentBooked" do

--- a/hecks_conception/nursery/call_center/call_center.bluebook
+++ b/hecks_conception/nursery/call_center/call_center.bluebook
@@ -125,7 +125,7 @@ Hecks.bluebook "CallCenter" do
     end
   end
 
-  aggregate "Queue", "A waiting line for tickets organized by priority or skill group" do
+  aggregate "TicketQueue", "A waiting line for tickets organized by priority or skill group" do
     attribute :queue_name, String
     attribute :skill_group, String
     attribute :depth, Integer
@@ -149,7 +149,7 @@ Hecks.bluebook "CallCenter" do
 
     command "EnqueueTicket" do
       description "Add a ticket to the back of the queue"
-      reference_to(Queue)
+      reference_to(TicketQueue)
       reference_to(Ticket)
       emits "TicketEnqueued"
       then_set :depth, to: 1
@@ -157,7 +157,7 @@ Hecks.bluebook "CallCenter" do
 
     command "DequeueTicket" do
       description "Pull the next ticket from the queue for assignment"
-      reference_to(Queue)
+      reference_to(TicketQueue)
       emits "TicketDequeued"
     end
   end

--- a/hecks_conception/nursery/customs_brokerage/customs_brokerage.bluebook
+++ b/hecks_conception/nursery/customs_brokerage/customs_brokerage.bluebook
@@ -39,14 +39,6 @@ Hecks.bluebook "CustomsBrokerage" do
       transition "LiquidateEntry" => "liquidated", from: "filed"
     end
 
-    policy "Entries must be filed within 15 days of arrival"
-    policy "Amended entries require supporting documentation"
-
-    given "An entry is filed for electronics from China" do
-      attribute :entry_type, String, "Consumption Entry"
-      attribute :importer_name, String, "TechParts Inc"
-      attribute :country_of_origin, String, "China"
-    end
   end
 
   aggregate "TariffLine" do
@@ -96,7 +88,6 @@ Hecks.bluebook "CustomsBrokerage" do
       transition "ApplyPreferentialRate" => "preferential", from: "assessed"
     end
 
-    policy "Classification must follow General Rules of Interpretation"
   end
 
   aggregate "BrokerDocument" do
@@ -128,7 +119,6 @@ Hecks.bluebook "CustomsBrokerage" do
       transition "ValidateDocument" => "validated", from: "received"
     end
 
-    policy "Commercial invoice and packing list are mandatory for all entries"
   end
 
   aggregate "CBPInspection" do
@@ -166,7 +156,6 @@ Hecks.bluebook "CustomsBrokerage" do
       transition "ReportExamResult" => "examined", from: "held"
     end
 
-    policy "Exam cargo must be available at designated site within 5 days"
   end
 
   aggregate "EntryRelease" do
@@ -197,7 +186,6 @@ Hecks.bluebook "CustomsBrokerage" do
       transition "NotifyImporter" => "notified", from: "released"
     end
 
-    policy "Duties must be paid before cargo release"
   end
 
   policy "ClassifyGoodOnDocumentValidated" do

--- a/hecks_conception/nursery/dendrology/dendrology.bluebook
+++ b/hecks_conception/nursery/dendrology/dendrology.bluebook
@@ -100,7 +100,7 @@ Hecks.bluebook "Dendrology" do
     attribute :pest_signs, String
     # Defect counter — RecordDefect appends to this list; PrescribeTreatment
     # gates on it being non-empty (i.e. at least one defect identified).
-    attribute :defects, String, list: true
+    attribute :defects, list_of(String)
     reference_to TreeSpecimen
 
     command "AssessHealth" do

--- a/hecks_conception/nursery/governed_operations/governed_operations.bluebook
+++ b/hecks_conception/nursery/governed_operations/governed_operations.bluebook
@@ -36,7 +36,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "ComplianceOfficer"
       description "Add a regulatory rule to the contract"
       reference_to(JurisdictionalContract)
-      Rule :rule
+      attribute :rule, Rule
       emits "RuleAdded"
     end
 
@@ -45,7 +45,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       description "Amend an existing rule within the contract"
       reference_to(JurisdictionalContract)
       attribute :rule_code, String
-      Rule :rule
+      attribute :rule, Rule
       emits "RuleAmended"
     end
 
@@ -127,7 +127,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "QualityManager"
       description "Add an internal standard to the contract"
       reference_to(OperationalContract)
-      Standard :standard
+      attribute :standard, Standard
       emits "StandardAdded"
     end
 
@@ -136,7 +136,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       description "Revise an existing standard within the contract"
       reference_to(OperationalContract)
       attribute :standard_name, String
-      Standard :standard
+      attribute :standard, Standard
       emits "StandardRevised"
     end
 
@@ -266,7 +266,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "System"
       description "Record a compliance violation against the batch"
       reference_to(Batch)
-      Violation :violation
+      attribute :violation, Violation
       emits "ViolationRecorded"
     end
 
@@ -343,7 +343,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "Approver"
       description "Approve the change request"
       reference_to(ChangeRequest)
-      Approval :approval
+      attribute :approval, Approval
       given { status == "pending_approval" }
       emits "ChangeApproved"
       then_set :status, to: "approved"
@@ -353,7 +353,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "Approver"
       description "Reject the change request"
       reference_to(ChangeRequest)
-      Approval :approval
+      attribute :approval, Approval
       given { status == "pending_approval" }
       emits "ChangeRejected"
       then_set :status, to: "rejected"
@@ -480,7 +480,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "QualityInvestigator"
       description "Attach supporting evidence to the CAPA"
       reference_to(CAPA)
-      Evidence :evidence
+      attribute :evidence, Evidence
       emits "EvidenceCollected"
     end
 
@@ -552,7 +552,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "ComplianceOfficer"
       description "Send recall notifications to all required parties"
       reference_to(Recall)
-      Notification :notification
+      attribute :notification, Notification
       given { status == "identifying" }
       emits "StakeholdersNotified"
       then_set :status, to: "notifying"
@@ -650,7 +650,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "Auditor"
       description "Record an observation or non-conformance"
       reference_to(Audit)
-      Finding :finding
+      attribute :finding, Finding
       given { status == "in_progress" }
       emits "FindingRecorded"
       then_set :status, to: "findings_recorded"
@@ -826,7 +826,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "Approver"
       description "Record an approver's approval decision"
       reference_to(ApprovalWorkflow)
-      ApprovalRecord :record
+      attribute :record, ApprovalRecord
       given { status == "pending" }
       emits "ApprovalRecorded"
     end
@@ -835,7 +835,7 @@ Hecks.bluebook "GovernedOperations", version: "2026.04.11.1" do
       role "Approver"
       description "Record an approver's rejection decision"
       reference_to(ApprovalWorkflow)
-      ApprovalRecord :record
+      attribute :record, ApprovalRecord
       given { status == "pending" }
       emits "RejectionRecorded"
     end

--- a/hecks_conception/nursery/medical_media/medical_media.bluebook
+++ b/hecks_conception/nursery/medical_media/medical_media.bluebook
@@ -145,4 +145,3 @@ Hecks.bluebook "MedicalMedia", version: "2026.04.13.1" do
   # === Fixtures ===
 
 end
-end


### PR DESCRIPTION
## Summary

Closes inbox items i1 / i2 — six source-bluebook fixes that close all
blocking nursery parity drift.

Parity test goes from **534/541 → 540/541**. The only remaining miss
is the known-drift `verbs.bluebook` (separate inbox issue :
`nursery-verbs-parity-regression`, not in scope).

## Files fixed (all `.bluebook` source — no DSL kernel changes)

- **air_cargo.bluebook** — remove four bare `policy "..."` lines (no
  `on` / `trigger` block) and one aggregate-level `given` example
  block. Rust silently accepts both forms ; Ruby strictly raises.
  Removing the documentation-only lines aligns both parsers.
- **customs_brokerage.bluebook** — same treatment : remove six bare
  `policy "..."` lines and one aggregate-level `given` example.
- **governed_operations.bluebook** — convert nine `Type :name`
  shorthand attributes (e.g. `Rule :rule`, `Standard :standard`,
  `Approval :approval`) to the canonical `attribute :name, Type`
  form. Ruby's DSL has no generic VO-shorthand fallback ; the
  canonical form parses identically in both runtimes.
- **medical_media.bluebook** — remove an extra trailing `end`
  (do/end count was 15/16 ; syntax error at line 148).
- **dendrology.bluebook** — `attribute :defects, String, list: true`
  → `attribute :defects, list_of(String)`. Rust's parser ignores the
  `list:` kwarg and reads list-ness only from `list_of(...)`.
- **call_center.bluebook** — rename aggregate `Queue` → `TicketQueue`
  and update its two `reference_to` callers. Bare Ruby `Queue` resolves
  to stdlib `Thread::Queue`, leaking `Thread` as the reference's
  `domain` on the Ruby side. Renaming sidesteps the stdlib collision.

## Deferred (out of scope)

- **verbs.bluebook** stays in `spec/parity/known_drift.txt` — its bug
  is genuinely Ruby-DSL-deep (`aggregate "Lexicon", "description"
  do` arity error) and tracked separately.

## Note on commit hook

Pre-commit's lifecycle gate flagged four unrelated, pre-existing bluebooks
in `hecks_conception/aggregates/` and `hecks_conception/capabilities/`
(inbox, nrem_consolidation, musing_mint, daydream — all unchanged from
main, none of which are touched by this PR). Used the hook's documented
`LIFECYCLE_SKIP=1` antibody-escape to land. Those lifecycle errors are
separate issues that pre-exist in main and want their own fix.

## Test plan

- [x] `ruby -Ilib spec/parity/parity_test.rb` reports `540/541 match`,
      `0 blocking drift`, `1 known-drift` (verbs)
- [x] No regressions in any other section (real / capabilities /
      catalog / misc / synthetic — all 100%)
- [ ] Reviewer : confirm the deletions of `policy "..."` documentation
      lines are acceptable losses (these had no `on`/`trigger` so they
      were inert in both runtimes regardless)
