### PR TITLE
i118-enforcer-honors-in-file-markers : the marker IS the audit trail

### DIFF
--- a/hecks_conception/aggregates/enforcer.bluebook
+++ b/hecks_conception/aggregates/enforcer.bluebook
@@ -36,6 +36,7 @@ Hecks.bluebook "Enforcer", version: "2026.04.26.1" do
     attribute :total_edits,        Integer, default: 0
     attribute :bluebook_edits,     Integer, default: 0
     attribute :imperative_edits,   Integer, default: 0
+    attribute :exempted_edits,     Integer, default: 0
     attribute :support_edits,      Integer, default: 0
     attribute :other_edits,        Integer, default: 0
     attribute :last_complaint_at,  String,  default: ""
@@ -49,6 +50,7 @@ Hecks.bluebook "Enforcer", version: "2026.04.26.1" do
       then_set :total_edits,        to: 0
       then_set :bluebook_edits,     to: 0
       then_set :imperative_edits,   to: 0
+      then_set :exempted_edits,     to: 0
       then_set :support_edits,      to: 0
       then_set :other_edits,        to: 0
       then_set :last_complaint_at,  to: ""
@@ -73,6 +75,15 @@ Hecks.bluebook "Enforcer", version: "2026.04.26.1" do
       then_set :total_edits,      increment: 1
       then_set :imperative_edits, increment: 1
       emits "ImperativeEdited"
+    end
+
+    command "RecordExemptedEdit" do
+      role "Hook"
+      description "An imperative-language file was written, but the file carries a [antibody-exempt: ...] marker in its header — the discipline is satisfied, no complaint fires. The marker IS the audit trail. Tracked separately from imperative_edits so the dashboard can show 'exempted edits' alongside 'unexempted imperative edits'."
+      attribute :file_path, String
+      then_set :total_edits,    increment: 1
+      then_set :exempted_edits, increment: 1
+      emits "ExemptedEdited"
     end
 
     command "RecordSupportEdit" do

--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -33,6 +33,13 @@
 //!  surface family as run_loop / run_daemon / run_enforce_edit ; same i80
 //!  retirement contract — retires once cli.bluebook lands and CLI routing
 //!  becomes declarative.]
+//!
+//! [antibody-exempt: hecks_life/src/main.rs — closes i118 (enforcer-honors-
+//!  in-file-antibody-exempt-markers). run_enforce_edit now reads the touched
+//!  file's first 200 lines and dispatches Enforcer.RecordExemptedEdit (silent
+//!  exit 0) instead of Enforcer.Complain when the file already carries a
+//!  marker. The marker IS the audit trail. Same i80 retirement contract as
+//!  the rest of the run_enforce_edit family.]
 
 use hecks_life::{parser, validator, validator_warnings, server, conceiver, heki, heki_query, dump,
                  behaviors_parser, behaviors_dump};
@@ -1783,9 +1790,19 @@ fn run_enforce_edit(_args: &[String]) {
     }
 
     let kind = classify_file(&file_path);
+
+    // For imperative files, check whether the file's header carries
+    // an [antibody-exempt: ...] marker. If so, the discipline is already
+    // satisfied — the marker IS the audit trail (i118 + i80 retirement
+    // contract). Read only the first 200 lines : antibody markers always
+    // live near the top of the file (header doc-comment block), and this
+    // keeps the hook fast for large files.
+    let exempted = matches!(kind, FileKind::Imperative)
+        && file_has_antibody_exempt_marker(&file_path);
+
     let cmd_name = match kind {
         FileKind::Bluebook   => "RecordBluebookEdit",
-        FileKind::Imperative => "RecordImperativeEdit",
+        FileKind::Imperative => if exempted { "RecordExemptedEdit" } else { "RecordImperativeEdit" },
         FileKind::Support    => "RecordSupportEdit",
         FileKind::Other      => "RecordOtherEdit",
     };
@@ -1806,7 +1823,7 @@ fn run_enforce_edit(_args: &[String]) {
         dispatch_hecksagon(&agg_dir, cmd_name, attrs.clone());
     });
 
-    if matches!(kind, FileKind::Imperative) {
+    if matches!(kind, FileKind::Imperative) && !exempted {
         let ext = file_path.rsplit('.').next().unwrap_or("");
         let complaint = format!(
             "bluebook-first violation : {} wrote .{} ({}). The enforcer expected a \
@@ -1828,6 +1845,59 @@ fn run_enforce_edit(_args: &[String]) {
         std::process::exit(2);
     }
     std::process::exit(0);
+}
+
+/// Scan the first 200 lines of `path` for the canonical antibody-exempt
+/// marker — the same line-anchored, case-insensitive pattern documented
+/// in `hecks_conception/capabilities/antibody/fixtures/antibody.fixtures`
+/// (`^\s*\[antibody-exempt:\s*([^\]]+)\]`). Hand-rolled so we don't pull
+/// the regex crate just for this.
+///
+/// Returns `false` if the file can't be read — "no marker found" is the
+/// right default for a hook that must never panic the editor.
+fn file_has_antibody_exempt_marker(path: &str) -> bool {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    for line in contents.lines().take(200) {
+        if line_starts_with_antibody_exempt(line) {
+            return true;
+        }
+    }
+    false
+}
+
+/// True iff `line`, after trimming leading whitespace AND any ASCII
+/// comment-prefix punctuation (so `//! [antibody-exempt: ...]`, `# [...]`,
+/// `* [...]`, `-- [...]` etc. all count), begins with a case-insensitive
+/// `[antibody-exempt:` token followed by content and a closing `]`.
+fn line_starts_with_antibody_exempt(line: &str) -> bool {
+    // Strip leading whitespace AND common comment-prefix glyphs. The
+    // antibody pattern itself only requires `^\s*` ; markers in source
+    // files almost always sit inside a comment, so we also tolerate
+    // any run of `/`, `#`, `*`, `;`, `-`, `!` before the bracket. This
+    // matches what the antibody pre-commit hook accepts in practice.
+    let trimmed = line.trim_start();
+    let stripped: &str = {
+        let bytes = trimmed.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b'/' || b == b'#' || b == b'*' || b == b';' || b == b'-' || b == b'!' || b == b' ' || b == b'\t' {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+        &trimmed[i..]
+    };
+    let prefix = "[antibody-exempt:";
+    if stripped.len() < prefix.len() { return false; }
+    stripped.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+    // The opener is sufficient — markers can wrap across lines (the
+    // canonical fixture's `[^\]]+\]` body matches on multiline scans),
+    // and we anchor on the opening `[antibody-exempt:` token only.
 }
 
 enum FileKind { Bluebook, Imperative, Support, Other }


### PR DESCRIPTION
## Summary

Closes the demoralizing complaint flood : every Edit against a file that already carries a `[antibody-exempt: ...]` marker in its header was firing a stderr complaint, even though the discipline was already satisfied. The marker IS the audit trail — the enforcer just wasn't reading it.

`run_enforce_edit` now :

1. Reads the touched file's first 200 lines (markers live in the header, large files stay fast)
2. Scans for the canonical line-anchored, case-insensitive `[antibody-exempt: ...]` pattern from `antibody.fixtures`
3. Dispatches `Enforcer.RecordExemptedEdit` + silent exit 0 when a marker is present
4. Dispatches `Enforcer.RecordImperativeEdit` + `Complain` + stderr + exit 2 when no marker — current behavior preserved

Bluebook side : `enforcer.bluebook` gets `exempted_edits` counter and `RecordExemptedEdit` command so the dashboard can distinguish exempted from un-exempted imperative edits.

## Example usage

```sh
# File with header marker — silent, exit 0
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"hecks_life/src/main.rs"}}' \
    | hecks-life enforce-edit
{"ok":true,"aggregate":"Enforcer","state":{"exempted_edits":1,"imperative_edits":0,...}}
$ echo $?
0

# File without marker — complaint + exit 2 (current behavior preserved)
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x.rs"}}' \
    | hecks-life enforce-edit
[enforcer] bluebook-first violation : Edit wrote .rs (/tmp/x.rs)...
$ echo $?
2

# Prose-anchored marker — correctly NOT exempted (matches "ProseAnchorFails" antibody fixture)
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/z.rs"}}' \
    | hecks-life enforce-edit
[enforcer] bluebook-first violation : ...
$ echo $?
2
```

## Test plan

- [x] `enforcer.bluebook` has `RecordExemptedEdit` command + `exempted_edits` counter
- [x] `run_enforce_edit` reads file's first 200 lines for the marker
- [x] Marker present → silent exit 0 + `RecordExemptedEdit` (verified against `main.rs` real markers + `/tmp/y.rs` synthetic header marker)
- [x] No marker → current complaint behavior preserved (`/tmp/x.rs`)
- [x] Prose-anchored marker correctly NOT exempted (`/tmp/z.rs`, mirrors `ProseAnchorFails` antibody fixture)
- [x] Smoke against real files : `main.rs` (has markers, silent) + `/tmp/x.rs` (no markers, complaint fires)
- [x] No regression in cargo test suite (all 45+ tests pass across the workspace)
- [x] Bluebook parses cleanly via `hecks-life parse enforcer.bluebook`