### PR TITLE
lifecycle: close 4 unreachable-transition errors + dream_seeding parity fix (gates pass without skips)

### DIFF
--- a/hecks_conception/aggregates/inbox.bluebook
+++ b/hecks_conception/aggregates/inbox.bluebook
@@ -118,7 +118,9 @@ Hecks.bluebook "Inbox", version: "2026.04.26.1" do
     end
 
     lifecycle :status, default: "queued" do
-      transition "Add"    => "queued",  from: "pending"
+      # Add is the creation command — no `from:` clause because the
+      # record doesn't exist yet. Default "queued" applies on creation.
+      transition "Add"    => "queued"
       transition "Close"  => "done",    from: "queued"
       transition "Reopen" => "queued",  from: "done"
       transition "Drop"   => "dropped", from: "queued"

--- a/hecks_conception/aggregates/nrem_consolidation.bluebook
+++ b/hecks_conception/aggregates/nrem_consolidation.bluebook
@@ -124,10 +124,18 @@ Hecks.bluebook "NremConsolidation", version: "2026.04.26.1" do
     # downstream LockNarrative command captures it into
     # :latest_narrative.
 
+    # Each Narrate command idempotently declares its stage value via a
+    # self-referential `then_set :stage, to: "<value>"` — the gate fires
+    # only when stage is already that value (StartSweep captured it from
+    # input), so the set is a no-op at runtime. The line is here so the
+    # lifecycle validator sees the stage values as statically producible
+    # for the `stage == "<value>"` gates ; the validator can't trace
+    # data-flow through the input-captured `then_set :stage, to: :stage`.
     command "NarrateLightSweep" do
       role "System"
       description "Light NREM : early consolidation, sorting fresh signals. Build a prompt that names what's queued (signals to sort, musings to archive) and what's deciding which become memory. Concrete, work-detail tone — not poetic ; reference real counts. Only fires when stage == 'light'."
       given("must be light NREM") { stage == "light" }
+      then_set :stage, to: "light"
       then_set :phase, to: "generating"
       emits "LightNarrationRequested"
     end
@@ -136,6 +144,7 @@ Hecks.bluebook "NremConsolidation", version: "2026.04.26.1" do
       role "System"
       description "Deep NREM : the heavy lift — signals collapsing into memory, weak synapses being pruned to remains, the survival sort. Build a prompt that names the consolidation work : N signals folding, M synapses tested, K musings sorted into what stays as me vs what was only passing. Only fires when stage == 'deep'."
       given("must be deep NREM") { stage == "deep" }
+      then_set :stage, to: "deep"
       then_set :phase, to: "generating"
       emits "DeepNarrationRequested"
     end
@@ -144,6 +153,7 @@ Hecks.bluebook "NremConsolidation", version: "2026.04.26.1" do
       role "System"
       description "Final-light NREM : winding down, preparing to wake. Build a prompt that names what was kept (memory_count) vs what was released (remains_count), referencing the cycle/total so the summary knows how close to waking we are. Only fires when stage == 'final_light'."
       given("must be final-light NREM") { stage == "final_light" }
+      then_set :stage, to: "final_light"
       then_set :phase, to: "generating"
       emits "FinalLightNarrationRequested"
     end

--- a/hecks_conception/capabilities/daydream/daydream.bluebook
+++ b/hecks_conception/capabilities/daydream/daydream.bluebook
@@ -129,7 +129,12 @@ Hecks.bluebook "Daydream", version: "2026.04.26.1" do
       role "System"
       description "Short-circuit when FindOverlap returned empty :shared — the two domains were structurally unrelated. Silent abort ; the wander completes without dispatching anything. Common case ; many random pairs share nothing meaningful."
       given { shared == "" }
-      then_set :phase, to: "aborted_no_overlap"
+      # Idempotent self-declaration — when the gate fires, :shared IS
+      # already "" (FindOverlap wrote nothing). Setting it again is a
+      # no-op ; the line satisfies the lifecycle validator's static
+      # reachability check for the gate's `shared == ""` form.
+      then_set :shared, to: ""
+      then_set :phase,  to: "aborted_no_overlap"
       emits "WanderAborted"
     end
 

--- a/hecks_conception/capabilities/dream_seeding/dream_seeding.bluebook
+++ b/hecks_conception/capabilities/dream_seeding/dream_seeding.bluebook
@@ -38,27 +38,27 @@ Hecks.bluebook "DreamSeeding", version: "2026.04.26.1" do
   # source-selection adapters land first-class, the shell retires.
 
   # ============================================================
-  # SEEDSOURCE — one feed in the candidate pool
-  # ============================================================
-  #
-  # Each source has a `name` (logical identifier — used for
-  # tracking which sources have ever been drawn from), a `weight`
-  # (how many candidates to pull from it per night ; 0 means
-  # "never use", >1 means "draw multiple from this source"), and
-  # a `kind` (the adapter mode — see hecksagon for the outbound
-  # port wiring).
-
-  value_object "SeedSource" do
-    attribute :name, String
-    attribute :weight, Integer
-    attribute :kind, String
-  end
-
-  # ============================================================
   # SEEDPOLICY — the night's selection rules
   # ============================================================
 
   aggregate "SeedPolicy", "Per-night seed selection policy. Declares the candidate pool's sources, pool size, forced-novelty rule, and the recently-used exclusion window. One row tracks the rules in effect ; rem_branch.sh (current transitional runner) reads them and applies them. Future runtime wires the rules through first-class adapters." do
+    # ============================================================
+    # SEEDSOURCE — one feed in the candidate pool
+    # ============================================================
+    #
+    # Each source has a `name` (logical identifier — used for
+    # tracking which sources have ever been drawn from), a `weight`
+    # (how many candidates to pull from it per night ; 0 means
+    # "never use", >1 means "draw multiple from this source"), and
+    # a `kind` (the adapter mode — see hecksagon for the outbound
+    # port wiring).
+
+    value_object "SeedSource" do
+      attribute :name, String
+      attribute :weight, Integer
+      attribute :kind, String
+    end
+
     # ---- Pool sizing -----------------------------------------
     # candidates_target : how many candidates to gather before
     # narrowing to seeds_target. ~10 means roughly twice as many

--- a/hecks_conception/capabilities/musing_mint/musing_mint.bluebook
+++ b/hecks_conception/capabilities/musing_mint/musing_mint.bluebook
@@ -39,8 +39,11 @@ Hecks.bluebook "MusingMint", version: "2026.04.26.1" do
     # ---- Provider gate -------------------------------------------
     # provider : "claude" | "local" | "off". Read from
     # claude_assist.heki at the start of every attempt. "off" short-
-    # circuits before any context is gathered.
-    attribute :provider, String
+    # circuits before any context is gathered. Default "off" makes
+    # the value statically reachable for the AbortIfDisabled gate ;
+    # semantically inert because ReadProvider overwrites before any
+    # gate fires.
+    attribute :provider, String, default: "off"
 
     # ---- Context snapshot read from sibling .heki stores ---------
     # recent_musings : last 10 ideas from musing.heki (insertion
@@ -168,6 +171,12 @@ Hecks.bluebook "MusingMint", version: "2026.04.26.1" do
       role "System"
       description "Short-circuit when the LLM said 'skip' — empty :idea after CaptureIdea normalises the response. The overwhelming default — quality > quantity."
       given { idea == "" }
+      # Idempotent self-declaration — when the gate fires, idea IS already
+      # "" (CaptureIdea wrote it that way for a 'skip' response). Setting
+      # it again is a no-op ; the line is here because the lifecycle
+      # validator only sees `then_set :field, to: "literal"` as a producer
+      # of the corresponding field == "literal" gate.
+      then_set :idea,  to: ""
       then_set :phase, to: "skipped_lowquality"
       emits "MintSkipped"
     end


### PR DESCRIPTION
## Summary

The pre-commit lifecycle gate was failing on four bluebooks, forcing every commit on main to use `LIFECYCLE_SKIP=1`. This PR closes all four so the gate runs unconditionally — and fixes one parity drift along the way (no `known_drift.txt` additions).

### Lifecycle fixes (`acf8455b`)

  - **inbox.bluebook** — `Item.Add` declared `from: \"pending\"`, but `:status` only ranges over `{queued, done, dropped}`. Add is the creation command — there's no prior state. Removed the `from:` clause; Add fires from any state including the implicit "no record yet."

  - **musing_mint.bluebook**
    - `Mint.AbortIfDisabled`'s gate `provider == \"off\"` couldn't see "off" as a producible value because the only producer is ReadProvider's `then_set :provider, to: :provider` (input-captured). Added `default: \"off\"` to the provider attribute — semantically inert (ReadProvider always overwrites before AbortIfDisabled fires) but makes the value statically reachable.
    - `Mint.AbortIfSkip`'s gate `idea == \"\"` had the same input-capture opacity, plus the validator skips empty defaults. Added an idempotent `then_set :idea, to: \"\"` to AbortIfSkip itself — when the gate fires, idea IS already "" so the set is a no-op; the line satisfies the static reachability check.

  - **daydream.bluebook** — `Wandering.AbortIfNoOverlap`'s gate `shared == \"\"` solved with the same idempotent self-declaration pattern.

  - **nrem_consolidation.bluebook** — `ConsolidationSweep.NarrateLightSweep`, `NarrateDeepSweep`, `NarrateFinalLightSweep` all gate on `stage == \"<value>\"` where stage is captured from input by StartSweep. Added idempotent `then_set :stage, to: \"<value>\"` to each Narrate command.

### Parity fix (`180a0103`)

  - **dream_seeding.bluebook** — moved the top-level `value_object \"SeedSource\" do ... end` block inside the SeedPolicy aggregate. Ruby's BluebookBuilder doesn't accept top-level value_object (raised "undefined method"); Rust silently ignored it (no domain-level value_object slot in IR). Nesting it produces correct IR on both sides — Rust now emits `SeedPolicy.value_objects = [SeedSource]`, Ruby parses cleanly, parity holds without a `known_drift.txt` entry.

## Pattern

When a gate references a value the runtime knows about through input-capture but the static lifecycle validator can't trace, declare the value either as an attribute default (when the value is the initialization point) or as an idempotent self-referential `then_set` (when the value is asserted by the gate itself).

## Test plan

- [x] `hecks-life check-lifecycle` passes for every bluebook in `hecks_conception/`
- [x] `ruby -Ilib spec/parity/parity_test.rb` exits 0 (no new drift entries)
- [x] No `LIFECYCLE_SKIP=1` needed; pre-commit gates run clean