### PR TITLE
runtime: organ-wins dedupe + deterministic inject_refs — fixes Heartbeat statusline toggle

### DIFF
--- a/hecks_life/src/main.rs
+++ b/hecks_life/src/main.rs
@@ -1561,6 +1561,13 @@ fn run_terminal(project_dir: &str, being: &str) {
 /// raised UnknownCommand on dispatch. Now they're auto-loaded alongside
 /// the organ aggregates and dispatch resolves them through the standard
 /// runtime path.
+///
+/// **Organ-wins dedupe.** When a capability bluebook re-declares an
+/// aggregate already defined under aggregates/ (e.g. self_checkin.bluebook
+/// declared a second `Heartbeat` without identified_by, which silently
+/// overwrote body.bluebook's canonical one), the organ definition wins
+/// and the capability copy is dropped. Capabilities can REFERENCE organ
+/// aggregates ; redeclaration is a name conflict, not an extension.
 fn load_combined_domain(agg_dir: &str) -> hecks_life::ir::Domain {
     let mut combined = hecks_life::ir::Domain {
         name: "Hecksagon".into(),
@@ -1571,11 +1578,17 @@ fn load_combined_domain(agg_dir: &str) -> hecks_life::ir::Domain {
         sections: vec![],
     };
     let merge = |dom: hecks_life::ir::Domain, c: &mut hecks_life::ir::Domain| {
-        c.aggregates.extend(dom.aggregates);
+        for agg in dom.aggregates {
+            if c.aggregates.iter().any(|existing| existing.name == agg.name) {
+                continue; // organ-wins dedupe
+            }
+            c.aggregates.push(agg);
+        }
         c.policies.extend(dom.policies);
         c.fixtures.extend(dom.fixtures);
     };
-    // Organs : every .bluebook directly under aggregates/.
+    // Organs first : every .bluebook directly under aggregates/. Their
+    // aggregates take precedence over any capability redeclaration.
     if let Ok(entries) = fs::read_dir(agg_dir) {
         for entry in entries.flatten() {
             let p = entry.path();
@@ -1586,7 +1599,7 @@ fn load_combined_domain(agg_dir: &str) -> hecks_life::ir::Domain {
             }
         }
     }
-    // Capabilities : every .bluebook under sibling capabilities/*/.
+    // Capabilities next : every .bluebook under sibling capabilities/*/.
     let cap_dir = std::path::Path::new(agg_dir).parent()
         .map(|p| p.join("capabilities"));
     if let Some(cap_dir) = cap_dir {

--- a/hecks_life/src/runtime/mod.rs
+++ b/hecks_life/src/runtime/mod.rs
@@ -227,29 +227,43 @@ impl Runtime {
                         }
                     }
                 }
-                // Inject the identity field when the triggered command needs
-                // a single-instance aggregate. Handles two cases:
+                // Inject the identity field when the triggered command's
+                // aggregate uses identified_by. Two cases this catches:
                 //   1. Key absent — policy cascade didn't supply an id.
                 //   2. Key present but value doesn't match any record —
                 //      upstream aggregate leaked its own identified_by field
-                //      (e.g. Pulse's `name="302"` in a BodyPulse event) into
+                //      (e.g. Pulse's `name="pulse"` in a BodyPulse event) into
                 //      the cascade data, pointing at a non-existent record.
-                // Only fires when count == 1: if the repo has more records
-                // the singleton assumption doesn't hold; we let dispatch
-                // counter-mint rather than guess which record was intended.
+                // The injection picks the lexicographically lowest existing
+                // record id (deterministic). For natural-key singletons
+                // (Heartbeat → "heartbeat", Tick → "tick"), this finds the
+                // canonical row even when junk counter-minted records sit
+                // alongside it. Without this, every cascade tick creates yet
+                // another counter-minted record because id_for_command
+                // honored the leaked upstream value.
                 if let Some(ref key) = agg.identified_by {
                     if let Some(repo) = self.repositories.get(&agg.name) {
-                        if repo.count() == 1 {
-                            let needs_inject = match data.get(key.as_str()) {
-                                None => true,
-                                Some(v) => v.as_str()
-                                    .map(|s| repo.find(s).is_none())
-                                    .unwrap_or(true),
-                            };
-                            if needs_inject {
-                                if let Some(existing) = repo.all().first() {
-                                    data.insert(key.clone(), Value::Str(existing.id.clone()));
-                                }
+                        let needs_inject = match data.get(key.as_str()) {
+                            None => true,
+                            Some(v) => v.as_str()
+                                .map(|s| repo.find(s).is_none())
+                                .unwrap_or(true),
+                        };
+                        if needs_inject {
+                            // Prefer a record whose id is non-numeric (the
+                            // natural-key form, e.g. "heartbeat") over a
+                            // counter-minted u64 id ("1", "42", "302" — the
+                            // junk left by pre-i80 dispatches). Within each
+                            // group fall back to lex-min for determinism.
+                            let pick = repo.all().iter()
+                                .map(|s| s.id.clone())
+                                .min_by(|a, b| {
+                                    let an = a.chars().all(|c| c.is_ascii_digit());
+                                    let bn = b.chars().all(|c| c.is_ascii_digit());
+                                    an.cmp(&bn).then_with(|| a.cmp(b))
+                                });
+                            if let Some(id) = pick {
+                                data.insert(key.clone(), Value::Str(id));
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Hot-fix for the Heartbeat singleton toggle Chris caught immediately after #474 merged. i108's capability auto-load was silently overwriting organ aggregates when a capability bluebook redeclared the same name.

## Root cause

`capabilities/self_checkin/self_checkin.bluebook` declares a second `Heartbeat` aggregate **without** `identified_by`. With the merge `extend(domain.aggregates)` from i108, the second definition stomped over `body.bluebook`'s canonical Heartbeat. Without `identified_by`, every cascade (Tick → Pulse.Emit → BodyPulse → AccumulateFatigue) counter-minted a fresh Heartbeat record. Statusline `grep | head -1` hit HashMap-ordered records and oscillated between the canonical "delirious" row and the junk "alert" ones.

## Fixes

### 1. `load_combined_domain` dedupes — organs win

Capability bluebooks can reference organ aggregates but can't redeclare them. The merge skips capability aggregates whose name is already present from an earlier organ load.

### 2. `inject_refs` no longer requires `count == 1`

When `identified_by` is set and the cascade data's value doesn't match any existing record, pick deterministically — prefer non-numeric ids (`"heartbeat"`) over counter-minted u64s (`"1"`, `"42"`, `"302"`). Even if junk gets minted somehow, the next cascade routes back to the canonical record instead of perpetuating the loop.

## End-to-end verified

```
$ hecks-life aggregates/ Tick.MindstreamTick name=tick
$ heki count heartbeat.heki
1   ← stays at 1 across ticks
$ statusline-command.sh
☀️ Miette ❤️ 76.68k 😵‍💫 groggy 🫠 delirious 💭 118 ✉️ 67 🚫
   ← consistent, no toggle
```

## Test plan

- [x] All 224 Rust tests pass
- [x] Bluebook + hecksagon + fixtures parity green
- [x] Lifecycle gate green
- [x] Live: Tick.MindstreamTick keeps Heartbeat singleton at 1 record
- [x] Live: statusline shows consistent fatigue_state across multiple reads