### PR TITLE
runtime: silence Repository::load_persisted by default — fix narrow PostToolUse hook output

### DIFF
--- a/hecks_life/src/runtime/repository.rs
+++ b/hecks_life/src/runtime/repository.rs
@@ -67,7 +67,14 @@ impl Repository {
             }
             self.store.insert(id, state);
         }
-        if !self.store.is_empty() {
+        // Quiet by default — every dispatch boots a fresh runtime and
+        // would otherwise spam dozens of "loaded N records from disk"
+        // lines (visible especially in the narrow PostToolUse hook
+        // output column). Set HECKS_REPO_VERBOSE=1 to see them when
+        // debugging boot-time loading.
+        if !self.store.is_empty()
+            && std::env::var("HECKS_REPO_VERBOSE").ok().as_deref() == Some("1")
+        {
             eprintln!("  loaded {} {} records from disk",
                 self.store.len(), self.aggregate_type);
         }


### PR DESCRIPTION
## Summary

The PostToolUse enforce-edit hook output renders in a narrow right-column. Every dispatch boots a fresh runtime which loads ~40 aggregate repos. Each non-empty load printed a `loaded N records from disk` line to stderr — which produced a 40-line wall in the narrow column, burying the actual hook result.

Now quiet by default; opt in with `HECKS_REPO_VERBOSE=1` when debugging boot-time loading.

## Before

```
PostToolUse:Edit hook returned       ⎿  [/Users/christopheryoung/Projects/h
     blocking error                          ecks/hecks_life/target/release/heck
                                             s-life enforce-edit]:   loaded 1610
                                              Encoding records from disk
                                               loaded 1079 Consolidation records
                                              from disk
                                               loaded 4 Ultradian records from
                                             disk
                                             [...40 more lines of noise...]
```

## After

The hook output is just the single JSON state line — fits the column cleanly:

```
PostToolUse:Edit hook returned       ⎿  {"aggregate":"Enforcer","id":"278",
     blocking error                          "ok":true,"state":{...}}
```

## Pairs with #476

The new heki `WriteContext` audit channel (in PR #476) is also gated by `HECKS_HEKI_AUDIT=1`. Both audit feeds now respect their respective env var so verbose runtime debug output stays opt-in.

## Test plan

- [x] `enforce-edit` quiet by default
- [x] `HECKS_REPO_VERBOSE=1 enforce-edit` shows load messages (debugging path preserved)
- [x] All 224 Rust tests still pass