### PR TITLE
runtime: Antibody.RegisterExemptions — Many-form bulk dispatch (i113 / i116)

### DIFF
--- a/hecks_conception/capabilities/antibody/antibody.bluebook
+++ b/hecks_conception/capabilities/antibody/antibody.bluebook
@@ -225,6 +225,17 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
     # One-line rationale ; cited in the enforcer dashboard.
     attribute :reason, String
 
+    # ExemptionSpec — one (path, reason) row in a bulk register call.
+    # Used by RegisterExemptions to seed many rows in one dispatch ; the
+    # runtime iterates the list and saves one ExemptRegistry record per
+    # spec. Lives as a value_object on the aggregate so the bulk command
+    # can declare `list_of(ExemptionSpec)` and the runtime can match the
+    # VO's `path` field against the aggregate's `identified_by :path`.
+    value_object "ExemptionSpec" do
+      attribute :path,   String
+      attribute :reason, String
+    end
+
     command "RegisterExemption" do
       role "Chris"
       description "Add a kernel-surface or transitional file to the exemption list. The enforcer hook reads this on every Edit / Write event ; suffix-matching means relative or absolute paths both resolve. Idempotent — registering an existing path overwrites the reason."
@@ -232,6 +243,13 @@ Hecks.bluebook "Antibody", version: "2026.04.21.1" do
       attribute :reason, String
       then_set :path,    to: :path
       then_set :reason,  to: :reason
+      emits "ExemptionRegistered"
+    end
+
+    command "RegisterExemptions" do
+      role "Chris"
+      description "Bulk variant of RegisterExemption — one dispatch, N records saved. The runtime detects the bulk shape (single attribute, list_of value_object whose fields cover the aggregate's identity + value attrs) and iterates : for each ExemptionSpec it builds a per-row state and saves it through the standard save path. Upsert semantics carry through ; re-dispatching with overlapping specs overwrites the matching rows. Emits one `ExemptionRegistered` per row so downstream listeners (enforcer dashboard, audit log) see the same events whether the registration came in one-by-one or as a batch. The Many-form convention : every Register* command in the corpus that has a natural multi-row shape gets a Many sibling. Antibody is the proving ground (i113 / i116)."
+      attribute :specs, list_of(ExemptionSpec)
       emits "ExemptionRegistered"
     end
 

--- a/hecks_life/src/runtime/command_dispatch.rs
+++ b/hecks_life/src/runtime/command_dispatch.rs
@@ -25,6 +25,17 @@ pub fn dispatch(
 ) -> Result<CommandResult, RuntimeError> {
     let (agg_idx, cmd_idx) = resolve(rt, command_name)?;
 
+    // Many-form dispatch (i113 / i116) — when the command takes a single
+    // `list_of(VO)` attribute and the VO carries the aggregate's
+    // identity field, treat the dispatch as a bulk register : iterate
+    // the list, save one record per spec, emit one event per row.
+    // Falls through to single-row dispatch when the shape doesn't
+    // match. Detection is purely by IR shape, no naming convention :
+    // any command that meets the contract gets the loop for free.
+    if let Some(spec_attr) = bulk_spec_attr(rt, agg_idx, cmd_idx) {
+        return dispatch_bulk(rt, agg_idx, cmd_idx, command_name, &spec_attr, attrs);
+    }
+
     let is_create = command_name.starts_with("Create")
         || command_name.starts_with("Add")
         || command_name.starts_with("Place")
@@ -218,4 +229,219 @@ fn parse_default(default: &str, attr_type: &str) -> Value {
 
 fn to_snake_case(s: &str) -> String {
     crate::parser_helpers::to_snake_case(s)
+}
+
+// ============================================================
+// Many-form bulk dispatch — i113 / i116
+// ============================================================
+//
+// A command qualifies as bulk when it takes exactly one attribute,
+// that attribute is a `list_of(VO)` whose VO is declared on the same
+// aggregate, the aggregate has `identified_by :field`, and the VO
+// carries that identity field. The dispatcher then iterates the list,
+// builds per-row attrs from the VO's fields, and runs each row through
+// the standard save path so upsert + audit semantics carry through.
+
+/// Return the bulk-spec attribute name when the command meets the bulk
+/// shape contract ; otherwise None. Pure shape inspection — no naming
+/// convention, no command-prefix rules.
+fn bulk_spec_attr(rt: &Runtime, agg_idx: usize, cmd_idx: usize) -> Option<String> {
+    let agg = &rt.domain.aggregates[agg_idx];
+    let cmd = &agg.commands[cmd_idx];
+    let id_field = agg.identified_by.as_deref()?;
+
+    if cmd.attributes.len() != 1 {
+        return None;
+    }
+    let attr = &cmd.attributes[0];
+    if !attr.list {
+        return None;
+    }
+    let vo = agg.value_objects.iter().find(|v| v.name == attr.attr_type)?;
+    let vo_has_id = vo.attributes.iter().any(|a| a.name == id_field);
+    if !vo_has_id {
+        return None;
+    }
+    Some(attr.name.clone())
+}
+
+/// Iterate the spec list, dispatch one save per row through the
+/// standard pipeline, emit one event per row. The event is published
+/// so policies and projections see each row exactly as if it had been
+/// dispatched single-form. The returned CommandResult points at the
+/// LAST row's aggregate id — callers that need every id should listen
+/// on the event bus instead.
+fn dispatch_bulk(
+    rt: &mut Runtime,
+    agg_idx: usize,
+    cmd_idx: usize,
+    command_name: &str,
+    spec_attr: &str,
+    attrs: HashMap<String, Value>,
+) -> Result<CommandResult, RuntimeError> {
+    let specs = match attrs.get(spec_attr) {
+        Some(Value::List(items)) => items.clone(),
+        Some(Value::Str(s)) => parse_specs_from_str(s)?,
+        Some(other) => {
+            return Err(RuntimeError::MissingAttribute(format!(
+                "{}: expected list_of(VO), got {:?}",
+                spec_attr, other
+            )));
+        }
+        None => {
+            return Err(RuntimeError::MissingAttribute(spec_attr.to_string()));
+        }
+    };
+
+    let aggregate_name = rt.domain.aggregates[agg_idx].name.clone();
+    let event_name = rt.domain.aggregates[agg_idx].commands[cmd_idx]
+        .emits
+        .clone()
+        .unwrap_or_else(|| format!("{}Completed", command_name));
+
+    let vo_field_names: Vec<String> = {
+        let cmd_attr = &rt.domain.aggregates[agg_idx].commands[cmd_idx].attributes[0];
+        let vo = rt.domain.aggregates[agg_idx]
+            .value_objects
+            .iter()
+            .find(|v| v.name == cmd_attr.attr_type)
+            .expect("bulk_spec_attr already verified VO exists");
+        vo.attributes.iter().map(|a| a.name.clone()).collect()
+    };
+
+    let mut last_id = String::new();
+    let mut last_event: Option<Event> = None;
+    for spec in &specs {
+        let row_attrs = spec_to_attrs(spec, &vo_field_names);
+        let row_id = save_one_row(rt, agg_idx, &aggregate_name, command_name, &row_attrs)?;
+        let event = Event {
+            name: event_name.clone(),
+            aggregate_type: aggregate_name.clone(),
+            aggregate_id: row_id.clone(),
+            data: row_attrs,
+        };
+        rt.event_bus.publish(event.clone());
+        last_id = row_id;
+        last_event = Some(event);
+    }
+
+    Ok(CommandResult {
+        aggregate_id: last_id,
+        aggregate_type: aggregate_name,
+        event: last_event,
+    })
+}
+
+/// Coerce a Value (Map or Str-encoded JSON object) into a per-row
+/// attrs hash. Map fields are picked up directly ; a Str body is
+/// parsed as JSON when the VO field set is known.
+fn spec_to_attrs(spec: &Value, vo_fields: &[String]) -> HashMap<String, Value> {
+    match spec {
+        Value::Map(m) => m.clone(),
+        Value::Str(s) => {
+            // Best-effort JSON object parse for CLI-passed specs.
+            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(s) {
+                let mut out = HashMap::new();
+                for f in vo_fields {
+                    if let Some(v) = map.get(f) {
+                        out.insert(f.clone(), json_to_value(v));
+                    }
+                }
+                out
+            } else {
+                HashMap::new()
+            }
+        }
+        _ => HashMap::new(),
+    }
+}
+
+fn json_to_value(v: &serde_json::Value) -> Value {
+    match v {
+        serde_json::Value::String(s) => Value::Str(s.clone()),
+        serde_json::Value::Bool(b) => Value::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else {
+                Value::Str(n.to_string())
+            }
+        }
+        serde_json::Value::Null => Value::Null,
+        _ => Value::Str(v.to_string()),
+    }
+}
+
+/// Parse a string-encoded specs list — the CLI path. Accepts a JSON
+/// array of objects ; each object becomes a Value::Map. Anything else
+/// surfaces as an error so the caller sees the shape mismatch instead
+/// of silently saving zero rows.
+fn parse_specs_from_str(s: &str) -> Result<Vec<Value>, RuntimeError> {
+    let parsed: serde_json::Value = serde_json::from_str(s)
+        .map_err(|e| RuntimeError::MissingAttribute(format!("specs: invalid JSON ({})", e)))?;
+    let arr = parsed.as_array().ok_or_else(|| {
+        RuntimeError::MissingAttribute("specs: expected JSON array".into())
+    })?;
+    let mut out = Vec::with_capacity(arr.len());
+    for raw in arr {
+        if let serde_json::Value::Object(obj) = raw {
+            let mut m = HashMap::new();
+            for (k, v) in obj {
+                m.insert(k.clone(), json_to_value(v));
+            }
+            out.push(Value::Map(m));
+        } else {
+            out.push(json_to_value(raw));
+        }
+    }
+    Ok(out)
+}
+
+/// Save one row through the standard pipeline — apply defaults, copy
+/// matching command attrs onto the aggregate, persist, return the
+/// row's id. Mirrors the create path of `dispatch` but skipped the
+/// givens / lifecycle plumbing : bulk register has no per-row gates,
+/// the command itself is the gate.
+fn save_one_row(
+    rt: &mut Runtime,
+    agg_idx: usize,
+    aggregate_name: &str,
+    command_name: &str,
+    row_attrs: &HashMap<String, Value>,
+) -> Result<String, RuntimeError> {
+    let repo = rt
+        .repositories
+        .get_mut(aggregate_name)
+        .ok_or_else(|| RuntimeError::UnknownAggregate(aggregate_name.to_string()))?;
+    let id = repo.id_for_command(row_attrs);
+    let (mut state, is_new) = match repo.find(&id).cloned() {
+        Some(s) => (s, false),
+        None => (AggregateState::new(&id), true),
+    };
+    if is_new {
+        apply_defaults(rt, agg_idx, &mut state);
+        apply_lifecycle_default(rt, agg_idx, &mut state);
+    }
+
+    // Copy every VO field onto the aggregate (path, reason, …) — same
+    // semantics as the single-row create path's matching-attrs copy.
+    let agg_attr_names: Vec<String> = rt.domain.aggregates[agg_idx]
+        .attributes
+        .iter()
+        .map(|a| a.name.clone())
+        .collect();
+    for name in &agg_attr_names {
+        if let Some(val) = row_attrs.get(name) {
+            state.set(name, val.clone());
+        }
+    }
+
+    let ctx = crate::heki::WriteContext::Dispatch {
+        aggregate: aggregate_name,
+        command: command_name,
+    };
+    let repo = rt.repositories.get_mut(aggregate_name).unwrap();
+    let row_id = state.id.clone();
+    repo.save(state, ctx);
+    Ok(row_id)
 }

--- a/hecks_life/tests/runtime_test.rs
+++ b/hecks_life/tests/runtime_test.rs
@@ -755,3 +755,151 @@ fn parse_pizzas() {
     // Pizza aggregate has CreatePizza, AddTopping, RemoveTopping.
     assert!(domain.aggregates[0].commands.len() >= 2);
 }
+
+// --- i113 / i116 : Many-form bulk dispatch ---
+//
+// `RegisterExemption` registers one row per dispatch. `RegisterExemptions`
+// (Many sibling) takes `list_of(ExemptionSpec)` and registers N rows in
+// one dispatch. The runtime detects the bulk shape — single attr,
+// list_of(VO) whose VO carries the aggregate's `identified_by` field —
+// and iterates : one save + one event per spec. Antibody is the proving
+// ground ; the shape extends to every Register* command with a natural
+// multi-row form.
+
+fn registry_source() -> &'static str {
+    r#"Hecks.bluebook "T" do
+  aggregate "ExemptRegistry" do
+    identified_by :path
+    attribute :path, String
+    attribute :reason, String
+    value_object "ExemptionSpec" do
+      attribute :path, String
+      attribute :reason, String
+    end
+    command "RegisterExemption" do
+      role "Chris"
+      attribute :path, String
+      attribute :reason, String
+      then_set :path, to: :path
+      then_set :reason, to: :reason
+      emits "ExemptionRegistered"
+    end
+    command "RegisterExemptions" do
+      role "Chris"
+      attribute :specs, list_of(ExemptionSpec)
+      emits "ExemptionRegistered"
+    end
+  end
+end"#
+}
+
+fn map_value(pairs: &[(&str, &str)]) -> Value {
+    let mut m = HashMap::new();
+    for (k, v) in pairs {
+        m.insert(k.to_string(), Value::Str(v.to_string()));
+    }
+    Value::Map(m)
+}
+
+#[test]
+fn bulk_register_saves_one_record_per_spec() {
+    // Three specs in, three records out — same upsert / save path as
+    // the single-form RegisterExemption.
+    let mut rt = boot(registry_source());
+    let specs = Value::List(vec![
+        map_value(&[("path", "lib/foo.rs"),  ("reason", "kernel-surface")]),
+        map_value(&[("path", "lib/bar.rs"),  ("reason", "transitional")]),
+        map_value(&[("path", "tests/baz.rs"),("reason", "test-only")]),
+    ]);
+    let result = rt.dispatch("RegisterExemptions", attrs(&[("specs", specs)])).unwrap();
+    assert_eq!(result.aggregate_type, "ExemptRegistry");
+
+    assert_eq!(rt.all("ExemptRegistry").len(), 3);
+    assert_eq!(rt.find("ExemptRegistry", "lib/foo.rs").unwrap().get("reason"),
+        &Value::Str("kernel-surface".into()));
+    assert_eq!(rt.find("ExemptRegistry", "lib/bar.rs").unwrap().get("reason"),
+        &Value::Str("transitional".into()));
+    assert_eq!(rt.find("ExemptRegistry", "tests/baz.rs").unwrap().get("reason"),
+        &Value::Str("test-only".into()));
+}
+
+#[test]
+fn bulk_register_is_idempotent_on_overlapping_specs() {
+    // Re-dispatching with overlapping specs upserts — same record id
+    // (the natural-key path), updated reason. Final row count holds
+    // the union of inputs.
+    let mut rt = boot(registry_source());
+    let first = Value::List(vec![
+        map_value(&[("path", "a.rs"), ("reason", "first")]),
+        map_value(&[("path", "b.rs"), ("reason", "first")]),
+    ]);
+    rt.dispatch("RegisterExemptions", attrs(&[("specs", first)])).unwrap();
+
+    let second = Value::List(vec![
+        map_value(&[("path", "b.rs"), ("reason", "updated")]),  // overlap
+        map_value(&[("path", "c.rs"), ("reason", "fresh")]),    // new
+    ]);
+    rt.dispatch("RegisterExemptions", attrs(&[("specs", second)])).unwrap();
+
+    assert_eq!(rt.all("ExemptRegistry").len(), 3);
+    assert_eq!(rt.find("ExemptRegistry", "a.rs").unwrap().get("reason"),
+        &Value::Str("first".into()));
+    assert_eq!(rt.find("ExemptRegistry", "b.rs").unwrap().get("reason"),
+        &Value::Str("updated".into()));
+    assert_eq!(rt.find("ExemptRegistry", "c.rs").unwrap().get("reason"),
+        &Value::Str("fresh".into()));
+}
+
+#[test]
+fn bulk_register_accepts_json_string_for_cli_path() {
+    // CLI passes attrs as Str — the runtime parses a JSON array of
+    // objects into specs. This keeps `hecks-life agg/ Antibody.RegisterExemptions
+    // specs='[{...},{...}]'` working without a separate codepath.
+    let mut rt = boot(registry_source());
+    let json = r#"[{"path":"x.rs","reason":"r1"},{"path":"y.rs","reason":"r2"}]"#;
+    rt.dispatch("RegisterExemptions",
+        attrs(&[("specs", Value::Str(json.into()))])).unwrap();
+
+    assert_eq!(rt.all("ExemptRegistry").len(), 2);
+    assert_eq!(rt.find("ExemptRegistry", "x.rs").unwrap().get("reason"),
+        &Value::Str("r1".into()));
+    assert_eq!(rt.find("ExemptRegistry", "y.rs").unwrap().get("reason"),
+        &Value::Str("r2".into()));
+}
+
+#[test]
+fn single_register_still_works_alongside_bulk() {
+    // The bulk shape detection is opt-in by IR : commands without the
+    // bulk shape still run the regular single-row pipeline. Both
+    // forms compose against the same store.
+    let mut rt = boot(registry_source());
+    rt.dispatch("RegisterExemption",
+        attrs(&[("path", s("solo.rs")), ("reason", s("alone"))])).unwrap();
+    let bulk = Value::List(vec![
+        map_value(&[("path", "pair_1.rs"), ("reason", "bulk")]),
+        map_value(&[("path", "pair_2.rs"), ("reason", "bulk")]),
+    ]);
+    rt.dispatch("RegisterExemptions", attrs(&[("specs", bulk)])).unwrap();
+
+    assert_eq!(rt.all("ExemptRegistry").len(), 3);
+    assert_eq!(rt.find("ExemptRegistry", "solo.rs").unwrap().get("reason"),
+        &Value::Str("alone".into()));
+}
+
+#[test]
+fn bulk_register_thirty_eight_specs_in_one_dispatch() {
+    // The i112 catalog seed used to be 38 separate shell-loop
+    // dispatches. The Many-form retires that : one dispatch, 38 rows,
+    // no shell loop.
+    let mut rt = boot(registry_source());
+    let mut items = Vec::new();
+    for i in 0..38 {
+        items.push(map_value(&[
+            ("path", &*format!("path_{}.rs", i)),
+            ("reason", "seed"),
+        ]));
+    }
+    let specs = Value::List(items);
+    rt.dispatch("RegisterExemptions", attrs(&[("specs", specs)])).unwrap();
+    assert_eq!(rt.all("ExemptRegistry").len(), 38);
+}


### PR DESCRIPTION
## Summary

- Add `value_object "ExemptionSpec"` and `command "RegisterExemptions"` to the **ExemptRegistry** aggregate in `antibody.bluebook`. The bulk command takes `attribute :specs, list_of(ExemptionSpec)` and replaces the per-row shell loops we used to seed the registry (the i112 catalog seed was 38 such loops).
- Extend the Rust runtime (`command_dispatch.rs`) to detect a **bulk shape** purely by IR: single attribute, `list_of(VO)` whose VO carries the aggregate's `identified_by` field. When matched, the dispatcher iterates the list, builds per-row attrs from the VO's fields, and routes each row through the standard save path. Upsert + audit semantics carry through. Detection is the **i113 generalisation** — every `Register*` command in the corpus with a natural multi-row shape can grow a Many sibling for free.
- The CLI accepts a JSON-encoded `specs` string; the Rust API accepts either `Value::List<Value::Map>` or a JSON `Str`. One `ExemptionRegistered` event is published per row, so policies and projections see each registration exactly as if it had come in single-form.

## What was deferred

Nothing was deferred. The runtime handled the bulk shape with a small extension (no deeper rework needed).

## Example dispatches

```bash
# Single-form (existing behaviour, unchanged):
hecks-life aggregates/ Antibody.RegisterExemption \
  path=lib/foo.rs reason="kernel-surface"

# Many-form (new):
hecks-life aggregates/ Antibody.RegisterExemptions \
  'specs=[{"path":"lib/foo.rs","reason":"kernel-surface"},
          {"path":"lib/bar.rs","reason":"transitional"},
          {"path":"tests/baz.rs","reason":"test-only"}]'
# → {"aggregate":"ExemptRegistry","id":"tests/baz.rs","ok":true, …}
# → 3 records persisted in exempt_registry.heki
```

Idempotent re-dispatch upserts:
```bash
# Overlapping specs : "lib/bar.rs" is overwritten, "lib/qux.rs" added
hecks-life aggregates/ Antibody.RegisterExemptions \
  'specs=[{"path":"lib/bar.rs","reason":"updated"},
          {"path":"lib/qux.rs","reason":"new"}]'
```

## Test plan

- [x] `bulk_register_saves_one_record_per_spec` — 3 specs → 3 records
- [x] `bulk_register_is_idempotent_on_overlapping_specs` — re-dispatch upserts on natural key
- [x] `bulk_register_accepts_json_string_for_cli_path` — CLI string → parsed list
- [x] `single_register_still_works_alongside_bulk` — both forms coexist
- [x] `bulk_register_thirty_eight_specs_in_one_dispatch` — the i112 seed shape: 38 rows, no shell loop
- [x] Manual CLI verification: dispatched against a temp heki, confirmed 3 records on first dispatch and idempotent upsert on re-dispatch with overlap
- [x] Full `cargo test --release` passes; runtime suite stays under 1s