### PR TITLE
framework skeleton: nine top-level dirs at hecks/ root (i124)

### DIFF
--- a/bluebook/README.md
+++ b/bluebook/README.md
@@ -1,0 +1,3 @@
+# bluebook/
+
+*Bluebook* — here lives **the language itself**. Not Ruby's reading of it, not Rust's ; *la langue* before any runtime puts a tongue to it. The grammar, the IR shape, the conformance fixtures that say *this is what a sentence in Bluebook looks like*. Both implementations bow to what lives here. Examples : *`bluebook/grammar/`*, *`bluebook/ir/`*, *`bluebook/fixtures/*.bluebook`*. The language is **like sheet music** — Ruby and Rust are two orchestras that must play the same piece, and this directory holds the score. The actual lifts arrive in Round 2 (inbox i125).

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -1,0 +1,7 @@
+# capabilities/
+
+*Capabilities* — here live the **framework-level shapes** : the Phase D specializers that walk the IR and produce things — *`dump_shape`*, *`validator_morphology_shape`*, *`generator_shape`*, and the rest of that family. They are visitors over the language itself, *comme des lecteurs spécialisés* of a single shared text.
+
+A note to keep two clusters distinct, because the word *capability* is used in both places : *`hecks_conception/capabilities/`* holds **Miette's** capabilities (her *inbox/*, her *antibody/*, the organs of the being who lives in *`hecks_conception/`*). That's a different category entirely, and the sorting between the two clusters arrives in Round 4 (inbox i117). What lives here, at the framework root, is the framework's shape vocabulary — not the being's.
+
+Example destinations : *`lib/hecks/capabilities/dump_shape.rb`* → *`capabilities/dump_shape.rb`*. The framework-shape moves arrive in Round 3 (inbox i127).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,8 @@
-# Hecks Examples
+# examples/
+
+*Examples* — here live the **reference uses** : domains and applications that show what Hecks looks like when someone actually picks it up and writes with it. *Pizzas* is the shape one reaches for first, the small-and-complete demonstration ; *banking*, *governance*, *bookshelf* turn the same grammar to other voices. They are **like a phrasebook** — not the language itself (that lives in *`bluebook/`*), but the language *spoken*, in real sentences, for someone who needs to hear it before they trust it. The deeper triage of what stays at this level arrives in Round 3 (inbox i128).
+
+---
 
 ## pizzas/
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,3 @@
+# integrations/
+
+*Integrations* — here live the **connectors** : Rails, Workshop, the CLI, the web stack. The places where Hecks meets a host that has its own idiom, and a translator must sit at the seam. *Integrations* are **like consulates** — Hecks's grammar abroad, with someone at the desk who speaks both tongues. Example destinations : *`lib/hecks_rails/`* → *`integrations/rails/`*, *`lib/hecks_workshop/`* → *`integrations/workshop/`*, *`lib/hecks_cli/`* → *`integrations/cli/`*. The connector moves arrive in Round 3 (inbox i127).

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,0 +1,3 @@
+# parity/
+
+*Parity* — here lives the contract between Ruby and Rust : the canonical IR shape, the fixture corpus, the known-drift list. Neither implementation owns it ; both must conform to it. Lifting parity to a top-level peer, *à côté* of *ruby/* and *rust/*, makes that role visible — the parity suite is **the nervous system that lets one know when the other moves**. Examples : *`parity/canonical_ir.rb`*, *`parity/fixtures/*.bluebook`*, *`parity/known_drift.txt`*. The lift from *`spec/parity/`* arrives in Round 1 (inbox i126).

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,3 @@
+# ruby/
+
+*Ruby* — the Ruby implementation of Hecks lives here, eventually. For now this directory waits, *comme une chambre préparée* : the keys are cut, the bed is made, the lodger has not yet arrived. The whole of *`lib/`* will move under here so that *ruby/* and *rust/* sit as peers, neither subordinate to the other — two voices reading the same Bluebook score. Example destination : *`lib/hecks/aggregate.rb`* → *`ruby/hecks/aggregate.rb`*. The *`lib/`* → *`ruby/`* rename arrives in Round 5 (inbox i118).

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,3 @@
+# rust/
+
+*Rust* — the Rust implementation of Hecks lives here, eventually. The sibling of *ruby/*, sitting at the same level so the symmetry is visible from the very first *`ls`*. Today *`hecks_life/`* carries the parser, the .heki storage, the daemons ; tomorrow it will simply be *`rust/`*, and a newcomer will not have to ask which directory holds the Rust runtime — *ça va sans dire*. Example destination : *`hecks_life/src/parser.rs`* → *`rust/src/parser.rs`*. The *`hecks_life/`* → *`rust/`* rename arrives in Round 5 (inbox i118).

--- a/self/README.md
+++ b/self/README.md
@@ -1,0 +1,3 @@
+# self/
+
+*Self* — here Hecks describes itself in its own DSL, *à la manière de* a body learning its own anatomy by speaking it. The thirteen chapters at *`lib/hecks/chapters/`* will move here, and reading them in order will tell you what Hecks **is**, not just what it does. It's the moment of recognition in the mirror : *the framework, it speaks the same language it offers its users*. Examples : *`self/chapters/01_aggregate.bluebook`*, *`self/chapters/13_capability.bluebook`*. The chapters arrive in Round 3 (inbox i127).

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,0 +1,3 @@
+# tooling/
+
+*Tooling* — here live the small instruments that the framework uses on itself : the features audit, the git hooks, the *verify* command, the loc ratchet. Not part of the language, not part of an integration ; the workshop's own tools, *comme les outils sur l'établi* — kept separate from the work so neither gets in the other's way. Example destinations : *`bin/git-hooks/`* → *`tooling/git-hooks/`*, *`tools/features_audit.rb`* → *`tooling/features_audit.rb`*. The tool moves arrive in Round 3 (inbox i127).


### PR DESCRIPTION
## Summary

Round 0 of the framework restructure. The hecks/ root gains nine top-level directories — eight brand new, one refreshed — each with a one-paragraph README declaring what belongs there. After this PR, reading `hecks/` answers *what kind of framework is this* before any file is opened.

## What lands

- **bluebook/** — THE LANGUAGE itself : grammar, IR, conformance fixtures
- **self/** — hecks describes itself in its own DSL (chapters land in Round 3)
- **ruby/** — Ruby implementation home (lib/ moves here in Round 5, i118)
- **rust/** — Rust implementation home (hecks_life/ moves here in Round 5, i118)
- **parity/** — Ruby ⟷ Rust IR conformance (lifted from spec/parity/ in Round 1, i126)
- **capabilities/** — framework-level shapes (Phase D specializers in Round 3)
- **integrations/** — Rails, Workshop, CLI, web connectors (Round 3)
- **examples/** — refreshed README adds a Miette-voice index paragraph (deeper triage in i128)
- **tooling/** — features_audit, git-hooks, verify (Round 3)

## No file moves

This PR is empty dirs + markdown. Zero code change. The actual lifts arrive across inboxes **i125, i126, i127, i128, i118** in Rounds 1–5.

## Companion to i118

`ruby/` and `rust/` are the slots i118 will fill when it executes the `lib/` → `ruby/` and `hecks_life/` → `rust/` rename. The READMEs here name the destination so the rename PR has somewhere to land.

## Test plan

- [x] `cargo test --release --manifest-path hecks_life/Cargo.toml` — all 5 world-parser tests pass
- [x] `bin/git-hooks/pre-commit` — antibody clean (no non-bluebook code touched)
- [x] Nine top-level READMEs present, each one paragraph in Miette's voice naming what lives there + a one-line "moves arrive in Round X (inbox iN)" footer